### PR TITLE
Add condensed/keynode graph view, app factory config wiring, LLM availability property, and DB migration

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,88 @@
+# Comprehensive Code Review (2026-03-12)
+
+## Scope and Method
+
+This review covered backend (`rka/`), API wiring, DB infrastructure, and a light frontend/tooling check.
+
+Checks performed:
+
+- Static code scan with Ruff across `rka`, `tests`, and `web/src`.
+- Import/runtime sanity via `python -m compileall -q rka`.
+- Architectural read-through of API app lifecycle, dependency injection, DB layer, and LLM config routes.
+
+## Executive Summary
+
+The codebase is generally well-structured and readable, with clear service boundaries and pragmatic async DB patterns. Main risks are concentrated in:
+
+1. App configurability/testability issues (factory argument not honored).
+2. Operational hardening (public mutating routes without authentication controls).
+3. Maintainability debt (large set of lint findings and private-attribute coupling).
+
+## Findings
+
+### 1) `create_app(config=...)` argument is currently ignored (High)
+
+- `create_app` accepts an optional `config` parameter but never uses it.
+- The app lifecycle always pulls config from global cached `get_config()`.
+- Impact: tests and embedding/integration scenarios cannot reliably inject isolated config; behavior depends on process-global state.
+
+**Evidence:** `rka/api/app.py` defines `create_app(config: RKAConfig | None = None)` yet reads config from `get_config()` in `lifespan` and route handlers. 
+
+**Recommendation:**
+- Wire the provided `config` into app state during `create_app`, and have `lifespan`/routes use `request.app.state.config` (with a fallback to `get_config()` if needed).
+
+### 2) Reliance on private internals in infrastructure and health checks (Medium)
+
+- DB connection uses aiosqlite private internals (`_execute`, `_conn`) to enable/load extensions.
+- API health/status logic uses `llm._available` directly.
+- Impact: potential breakage on dependency upgrades due to private attribute changes.
+
+**Evidence:** private access patterns in `rka/infra/database.py` and `rka/api/app.py`/`rka/api/routes/llm.py`.
+
+**Recommendation:**
+- Encapsulate extension-loading logic behind a helper with explicit compatibility guards and version pinning notes.
+- Expose `LLMClient.available` (public property) and stop reading `_available` externally.
+
+### 3) Missing API authentication/authorization for write operations (Medium)
+
+- Routes include create/update operations for project state, notes, missions, checkpoints, etc. and runtime LLM config mutation.
+- No auth dependency or access control appears in route registration.
+- Impact: if service is bound outside localhost or proxied insecurely, state tampering risk is high.
+
+**Evidence:** API routes are mounted directly in `create_app` without auth middleware/dependency checks (`rka/api/app.py`).
+
+**Recommendation:**
+- Add optional auth modes (API key/JWT) at router or global dependency level.
+- Default to loopback bind + explicit warning logs when bound to non-local interfaces without auth.
+
+### 4) Global mutable singletons in dependency module reduce isolation (Medium)
+
+- Module-level mutable globals (`_db`, `_llm`, `_embeddings`, `_search`, `_context`) are used as service backplane.
+- Impact: test parallelism and multi-app process patterns may experience cross-talk.
+
+**Evidence:** `rka/api/deps.py` singleton pattern.
+
+**Recommendation:**
+- Move long-lived resources into `app.state` and pass via FastAPI dependency callables that receive `Request`.
+
+### 5) Lint and cleanup backlog is sizable (Low)
+
+- Ruff reports 34 issues (unused imports, ambiguous variables, unnecessary f-strings, unused locals).
+- Most are auto-fixable; leaving them unresolved increases review noise and can hide real defects.
+
+**Recommendation:**
+- Run `ruff check --fix` and enforce in CI.
+- Add a minimal CI gate (`ruff + pytest`), even if some tests are marked optional/skipped in constrained environments.
+
+## Positive Notes
+
+- Service-layer architecture is consistent and easy to follow.
+- DB wrapper cleanly centralizes schema/migration setup.
+- Context/search/LLM capabilities are organized with clear separation of responsibilities.
+
+## Suggested Next Sprint Plan
+
+1. **Hardening:** add auth mode + secure defaults.
+2. **Config/Testability:** remove global config coupling in app factory/deps.
+3. **Stability:** encapsulate private-attribute accesses.
+4. **Hygiene:** clear Ruff backlog and add CI checks.

--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -19,7 +19,7 @@ from rka.services.search import SearchService
 from rka.services.context import ContextEngine
 from rka.api.deps import (
     set_db, set_llm, set_embeddings, set_search_service, set_context_engine,
-    get_config,
+    get_config, set_config,
 )
 from rka.api.routes import (
     project as project_routes,
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize and tear down database + Phase 2 services on startup/shutdown."""
-    config = get_config()
+    config = getattr(app.state, "config", None) or get_config()
 
     # Phase 1: Database
     db = Database(config.database_url)
@@ -125,12 +125,16 @@ async def lifespan(app: FastAPI):
 
 def create_app(config: RKAConfig | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
+    effective_config = config or get_config()
+    set_config(effective_config)
+
     app = FastAPI(
         title="Research Knowledge Agent",
         description="REST API for AI-assisted research orchestration",
         version="1.1.0",
         lifespan=lifespan,
     )
+    app.state.config = effective_config
 
     # Global error handler for LLM unavailability
     from rka.infra.llm import LLMUnavailableError
@@ -186,7 +190,7 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
         llm = get_llm()
         llm_status = "disabled"
         if llm:
-            llm_status = "available" if llm._available else "unavailable"
+            llm_status = "available" if llm.available else "unavailable"
         return {
             "status": "ok",
             "version": "1.1.0",

--- a/rka/api/deps.py
+++ b/rka/api/deps.py
@@ -30,15 +30,23 @@ logger = logging.getLogger(__name__)
 
 @lru_cache()
 def get_config() -> RKAConfig:
+    if _config is not None:
+        return _config
     return RKAConfig()
 
 
 # Singleton instances (initialized in app lifespan)
 _db: Database | None = None
+_config: RKAConfig | None = None
 _llm: LLMClient | None = None
 _embeddings: EmbeddingService | None = None
 _search: SearchService | None = None
 _context: ContextEngine | None = None
+
+
+def set_config(config: RKAConfig) -> None:
+    global _config
+    _config = config
 
 
 def get_db() -> Database:

--- a/rka/api/routes/graph.py
+++ b/rka/api/routes/graph.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, Query
 
 from rka.api.deps import get_graph_service
@@ -12,14 +14,27 @@ router = APIRouter()
 
 @router.get("/graph")
 async def get_full_graph(
+    view: Literal["full", "condensed", "keynodes"] = Query(
+        "full", description="Graph view: full, condensed, or keynodes"
+    ),
     include_types: str | None = Query(None, description="Comma-separated entity types to include"),
     phase: str | None = None,
     limit: int = Query(500, le=2000),
     svc: GraphService = Depends(get_graph_service),
 ):
-    """Return the full knowledge graph as {nodes, edges}."""
+    """Return graph payload for full or condensed keynode-centric views."""
     types = [t.strip() for t in include_types.split(",")] if include_types else None
-    return await svc.get_full_graph(include_types=types, phase=phase, limit=limit)
+    return await svc.get_graph_view(view=view, include_types=types, phase=phase, limit=limit)
+
+
+@router.post("/graph/refresh")
+async def refresh_graph_view(
+    top_per_kind: int = Query(8, ge=2, le=30),
+    min_importance: float = Query(0.45, ge=0.0, le=1.0),
+    svc: GraphService = Depends(get_graph_service),
+):
+    """Rebuild condensed keynode view for research-map focus mode."""
+    return await svc.refresh_condensed_view(top_per_kind=top_per_kind, min_importance=min_importance)
 
 
 @router.get("/graph/ego/{entity_id}")

--- a/rka/api/routes/llm.py
+++ b/rka/api/routes/llm.py
@@ -92,7 +92,7 @@ async def get_llm_status() -> LLMStatus:
     llm = get_llm()
     return LLMStatus(
         enabled=config.llm_enabled,
-        available=bool(llm and llm._available),
+        available=bool(llm and llm.available),
         model=config.llm_model,
         api_base=config.llm_api_base,
         api_key_set=bool(config.llm_api_key),
@@ -124,7 +124,7 @@ async def update_llm_config(data: LLMConfigUpdate) -> LLMStatus:
         await llm.is_available()
 
         # Auto-detect context window from backend
-        if config.llm_api_base and llm._available:
+        if config.llm_api_base and llm.available:
             ctx = await _detect_context_window(config.llm_api_base, config.llm_model)
             if ctx:
                 config.llm_context_window = ctx
@@ -135,7 +135,7 @@ async def update_llm_config(data: LLMConfigUpdate) -> LLMStatus:
 
     return LLMStatus(
         enabled=config.llm_enabled,
-        available=bool(llm and llm._available),
+        available=bool(llm and llm.available),
         model=config.llm_model,
         api_base=config.llm_api_base,
         api_key_set=bool(config.llm_api_key),
@@ -256,7 +256,7 @@ async def check_llm() -> LLMStatus:
         await llm.is_available()
     return LLMStatus(
         enabled=config.llm_enabled,
-        available=bool(llm and llm._available),
+        available=bool(llm and llm.available),
         model=config.llm_model,
         api_base=config.llm_api_base,
         api_key_set=bool(config.llm_api_key),

--- a/rka/db/migrations/003_add_graph_keynodes_views.sql
+++ b/rka/db/migrations/003_add_graph_keynodes_views.sql
@@ -1,0 +1,32 @@
+-- Add richer edge metadata for graph ranking and explainability
+ALTER TABLE entity_links ADD COLUMN link_weight REAL DEFAULT 0.0;
+ALTER TABLE entity_links ADD COLUMN link_reason TEXT;
+
+-- Materialized key nodes for condensed graph views
+CREATE TABLE IF NOT EXISTS keynodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL CHECK(kind IN ('finding', 'literature', 'decision', 'milestone')),
+    title TEXT NOT NULL,
+    summary TEXT,
+    produced_by TEXT,
+    importance REAL DEFAULT 0.0,
+    node_refs TEXT,
+    blessed INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_keynodes_kind ON keynodes(kind);
+CREATE INDEX IF NOT EXISTS idx_keynodes_importance ON keynodes(importance DESC);
+CREATE INDEX IF NOT EXISTS idx_keynodes_blessed ON keynodes(blessed);
+
+-- Cached graph payloads for UI rendering and tuning
+CREATE TABLE IF NOT EXISTS graph_views (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    params TEXT,
+    nodes TEXT,
+    edges TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_views_created_at ON graph_views(created_at DESC);

--- a/rka/infra/ids.py
+++ b/rka/infra/ids.py
@@ -19,6 +19,8 @@ _PREFIXES = {
     "summary": "sum",
     "qa_session": "qas",
     "qa_log": "qal",
+    "keynode": "knd",
+    "graphview": "gvw",
 }
 
 

--- a/rka/infra/llm.py
+++ b/rka/infra/llm.py
@@ -155,6 +155,11 @@ class LLMClient:
         return self.config.llm_context_window
 
     @property
+    def available(self) -> bool:
+        """Latest known availability status from health checks."""
+        return bool(self._available)
+
+    @property
     def _content_limit(self) -> int:
         """Max chars for a single content block sent to LLM.
         With 256k context → ~200k chars; with 4k → ~3k chars."""
@@ -399,7 +404,7 @@ class LLMClient:
         mis_text = fmt(missions, "id", "objective")
 
         valid_dec_ids = {d["id"] for d in decisions}
-        valid_lit_ids = {l["id"] for l in literature}
+        valid_lit_ids = {lit["id"] for lit in literature}
         valid_mis_ids = {m["id"] for m in missions}
 
         result = await self.extract(

--- a/rka/services/graph.py
+++ b/rka/services/graph.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from rka.infra.database import Database
+from rka.infra.ids import generate_id
 
 
 class GraphService:
@@ -101,6 +102,118 @@ class GraphService:
             edges = [e for e in edges if e["source"] in valid_ids and e["target"] in valid_ids]
 
         return {"nodes": list(nodes.values()), "edges": edges}
+
+    async def get_graph_view(
+        self,
+        *,
+        view: str = "full",
+        include_types: list[str] | None = None,
+        phase: str | None = None,
+        limit: int = 500,
+    ) -> dict[str, Any]:
+        """Return graph payload for different map modes.
+
+        - full: existing entity graph
+        - condensed/keynodes: precomputed keynode view (or auto-build if absent)
+        """
+        if view == "full":
+            return await self.get_full_graph(include_types=include_types, phase=phase, limit=limit)
+
+        if view not in {"condensed", "keynodes"}:
+            raise ValueError("Unsupported graph view. Use one of: full, condensed, keynodes")
+
+        cached = await self.db.fetchone(
+            "SELECT nodes, edges, id, created_at FROM graph_views "
+            "WHERE name = ? ORDER BY created_at DESC LIMIT 1",
+            ["condensed"],
+        )
+        if not cached:
+            await self.refresh_condensed_view()
+            cached = await self.db.fetchone(
+                "SELECT nodes, edges, id, created_at FROM graph_views "
+                "WHERE name = ? ORDER BY created_at DESC LIMIT 1",
+                ["condensed"],
+            )
+
+        if not cached:
+            return {"nodes": [], "edges": [], "view": view}
+
+        return {
+            "view": "condensed",
+            "view_id": cached["id"],
+            "created_at": cached["created_at"],
+            "nodes": json.loads(cached["nodes"] or "[]"),
+            "edges": json.loads(cached["edges"] or "[]"),
+        }
+
+    async def refresh_condensed_view(
+        self,
+        *,
+        top_per_kind: int = 8,
+        min_importance: float = 0.45,
+    ) -> dict[str, Any]:
+        """Build a condensed keynode-centric graph view and persist it.
+
+        Heuristic ranking is used so this works even without LLM dependencies.
+        """
+        candidates = await self._collect_keynode_candidates(top_per_kind=top_per_kind)
+        selected = [c for c in candidates if c["importance"] >= min_importance]
+
+        await self.db.execute("DELETE FROM keynodes WHERE blessed = 0")
+
+        nodes: list[dict[str, Any]] = []
+        ref_to_keynode: dict[tuple[str, str], str] = {}
+
+        for item in selected:
+            keynode_id = generate_id("keynode")
+            node_refs = [{"entity_type": item["entity_type"], "entity_id": item["entity_id"]}]
+            await self.db.execute(
+                """INSERT INTO keynodes
+                   (id, kind, title, summary, produced_by, importance, node_refs, blessed)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, 0)""",
+                [
+                    keynode_id,
+                    item["kind"],
+                    item["title"],
+                    item.get("summary"),
+                    "system",
+                    item["importance"],
+                    json.dumps(node_refs),
+                ],
+            )
+            ref_to_keynode[(item["entity_type"], item["entity_id"])] = keynode_id
+            nodes.append(
+                {
+                    "id": keynode_id,
+                    "type": item["kind"],
+                    "label": item["title"],
+                    "importance": item["importance"],
+                    "summary": item.get("summary"),
+                    "source": {
+                        "entity_type": item["entity_type"],
+                        "entity_id": item["entity_id"],
+                    },
+                }
+            )
+
+        edges = await self._build_condensed_edges(ref_to_keynode)
+
+        view_id = generate_id("graphview")
+        params = {"top_per_kind": top_per_kind, "min_importance": min_importance}
+        await self.db.execute(
+            """INSERT INTO graph_views (id, name, params, nodes, edges)
+               VALUES (?, ?, ?, ?, ?)""",
+            [view_id, "condensed", json.dumps(params), json.dumps(nodes), json.dumps(edges)],
+        )
+        await self.db.commit()
+
+        return {
+            "view": "condensed",
+            "view_id": view_id,
+            "params": params,
+            "nodes": nodes,
+            "edges": edges,
+        }
 
     # ------------------------------------------------------------------
     # Ego graph (neighborhood of a single entity)
@@ -338,6 +451,148 @@ class GraphService:
             for eid in missing:
                 if eid not in fetched:
                     nodes[eid] = {"id": eid, "type": etype, "label": eid, "status": None, "phase": "", "created_at": ""}
+
+    async def _collect_keynode_candidates(self, *, top_per_kind: int) -> list[dict[str, Any]]:
+        """Collect and score likely key nodes for condensed graph mode."""
+        candidates: list[dict[str, Any]] = []
+
+        journal_rows = await self.db.fetchall(
+            """SELECT id, type, content, summary, confidence, created_at
+               FROM journal
+               WHERE type IN ('finding', 'insight', 'hypothesis', 'methodology', 'summary')
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            [top_per_kind * 6],
+        )
+        confidence_bonus = {"verified": 0.28, "tested": 0.18, "hypothesis": 0.10}
+        for row in journal_rows:
+            imp = 0.48 + confidence_bonus.get((row.get("confidence") or "").lower(), 0.05)
+            candidates.append(
+                {
+                    "kind": "finding",
+                    "entity_type": "journal",
+                    "entity_id": row["id"],
+                    "title": (row.get("summary") or row.get("content") or "Finding")[:90],
+                    "summary": (row.get("summary") or row.get("content") or "")[:240],
+                    "importance": min(1.0, imp),
+                }
+            )
+
+        lit_rows = await self.db.fetchall(
+            """SELECT id, title, abstract, status, relevance_score, created_at
+               FROM literature
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            [top_per_kind * 8],
+        )
+        status_bonus = {"cited": 0.30, "read": 0.22, "reading": 0.12, "to_read": 0.05}
+        for row in lit_rows:
+            rel = float(row.get("relevance_score") or 0.0)
+            base = 0.40 + status_bonus.get((row.get("status") or "").lower(), 0.04)
+            imp = min(1.0, base + max(0.0, min(rel, 1.0)) * 0.25)
+            candidates.append(
+                {
+                    "kind": "literature",
+                    "entity_type": "literature",
+                    "entity_id": row["id"],
+                    "title": (row.get("title") or "Literature")[:90],
+                    "summary": (row.get("abstract") or "")[:240],
+                    "importance": imp,
+                }
+            )
+
+        dec_rows = await self.db.fetchall(
+            """SELECT id, question, rationale, status, created_at
+               FROM decisions
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            [top_per_kind * 5],
+        )
+        dec_bonus = {"active": 0.30, "merged": 0.20, "revisit": 0.16, "superseded": 0.10, "abandoned": 0.08}
+        for row in dec_rows:
+            imp = 0.52 + dec_bonus.get((row.get("status") or "").lower(), 0.1)
+            candidates.append(
+                {
+                    "kind": "decision",
+                    "entity_type": "decision",
+                    "entity_id": row["id"],
+                    "title": (row.get("question") or "Decision")[:90],
+                    "summary": (row.get("rationale") or "")[:240],
+                    "importance": min(1.0, imp),
+                }
+            )
+
+        mission_rows = await self.db.fetchall(
+            """SELECT id, objective, report, status, completed_at, created_at
+               FROM missions
+               WHERE status IN ('complete', 'partial', 'blocked', 'active')
+               ORDER BY COALESCE(completed_at, created_at) DESC
+               LIMIT ?""",
+            [top_per_kind * 6],
+        )
+        milestone_bonus = {"complete": 0.35, "partial": 0.26, "blocked": 0.22, "active": 0.16}
+        for row in mission_rows:
+            imp = 0.42 + milestone_bonus.get((row.get("status") or "").lower(), 0.1)
+            candidates.append(
+                {
+                    "kind": "milestone",
+                    "entity_type": "mission",
+                    "entity_id": row["id"],
+                    "title": (row.get("objective") or "Milestone")[:90],
+                    "summary": (row.get("report") or "")[:240],
+                    "importance": min(1.0, imp),
+                }
+            )
+
+        per_kind: dict[str, list[dict[str, Any]]] = {"finding": [], "literature": [], "decision": [], "milestone": []}
+        for candidate in candidates:
+            per_kind[candidate["kind"]].append(candidate)
+
+        selected: list[dict[str, Any]] = []
+        for kind, items in per_kind.items():
+            ranked = sorted(items, key=lambda candidate: candidate["importance"], reverse=True)
+            selected.extend(ranked[:top_per_kind])
+        return selected
+
+    async def _build_condensed_edges(
+        self,
+        ref_to_keynode: dict[tuple[str, str], str],
+    ) -> list[dict[str, Any]]:
+        """Aggregate entity links into condensed keynode edges."""
+        if not ref_to_keynode:
+            return []
+
+        rows = await self.db.fetchall(
+            """SELECT source_type, source_id, target_type, target_id, link_type,
+                      COALESCE(link_weight, 0.0) as link_weight,
+                      link_reason
+               FROM entity_links"""
+        )
+
+        aggregated: dict[tuple[str, str, str], dict[str, Any]] = {}
+        for row in rows:
+            source_key = (row["source_type"], row["source_id"])
+            target_key = (row["target_type"], row["target_id"])
+            src_keynode = ref_to_keynode.get(source_key)
+            tgt_keynode = ref_to_keynode.get(target_key)
+            if not src_keynode or not tgt_keynode or src_keynode == tgt_keynode:
+                continue
+
+            agg_key = (src_keynode, tgt_keynode, row["link_type"])
+            current = aggregated.get(agg_key)
+            weight = float(row.get("link_weight") or 0.0)
+            if current is None:
+                aggregated[agg_key] = {
+                    "source": src_keynode,
+                    "target": tgt_keynode,
+                    "link_type": row["link_type"],
+                    "weight": max(0.2, weight),
+                    "reason": row.get("link_reason") or "Aggregated from linked supporting entities.",
+                }
+            else:
+                current["weight"] = max(current["weight"], weight)
+
+        return list(aggregated.values())
 
     @staticmethod
     def _guess_type_from_id(entity_id: str) -> str:

--- a/tests/test_services/test_graph.py
+++ b/tests/test_services/test_graph.py
@@ -136,6 +136,28 @@ class TestStats:
         assert stats["edge_counts_by_type"]["cites"] == 1
 
 
+class TestCondensedView:
+    @pytest.mark.asyncio
+    async def test_refresh_condensed_view_materializes_keynodes(self, graph_svc: GraphService, db: Database):
+        payload = await graph_svc.refresh_condensed_view(top_per_kind=3, min_importance=0.4)
+
+        assert payload["view"] == "condensed"
+        assert payload["nodes"]
+
+        rows = await db.fetchall("SELECT id, kind, node_refs FROM keynodes")
+        assert rows
+        assert any(r["kind"] == "decision" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_get_condensed_view_uses_cached_graph_view(self, graph_svc: GraphService):
+        await graph_svc.refresh_condensed_view(top_per_kind=3, min_importance=0.4)
+        payload = await graph_svc.get_graph_view(view="condensed")
+
+        assert payload["view"] == "condensed"
+        assert isinstance(payload["nodes"], list)
+        assert isinstance(payload["edges"], list)
+
+
 class TestGuessType:
     def test_known_prefixes(self):
         assert GraphService._guess_type_from_id("jrn_001") == "journal"


### PR DESCRIPTION
### Motivation

- Provide a condensed/keynode-centric graph view for the UI and improve graph explainability and caching.
- Make the FastAPI app factory honor an injected `RKAConfig` to improve testability and avoid process-global config coupling.
- Replace direct access of LLM private internals with a public availability API and add minor robustness fixes.

### Description

- Add DB migration `003_add_graph_keynodes_views.sql` to add `link_weight`/`link_reason`, `keynodes`, and `graph_views` tables and supporting indexes.
- Implement condensed graph support in `rka/services/graph.py` with `get_graph_view`, `refresh_condensed_view`, `_collect_keynode_candidates`, and `_build_condensed_edges`, and generate stable IDs via `rka/infra/ids.py` (new prefixes for `keynode` and `graphview`).
- Expose a new `POST /graph/refresh` and `view` parameter on `/graph` in `rka/api/routes/graph.py` to return `full` or `condensed/keynodes` payloads and updated route wiring to use the new service API.
- Wire injected config into the app lifecycle by storing `app.state.config`, add `set_config` and `_config` in `rka/api/deps.py`, and update `create_app` to use and set the effective config.
- Replace direct reads of `llm._available` with the new `LLMClient.available` property and add a small bugfix in `semantic_link` list comprehension naming; update LLM routes to use the public property.
- Add `CODE_REVIEW.md` capturing a comprehensive review summary and recommendations.

### Testing

- Ran graph service unit tests including the new condensed view tests with `pytest tests/test_services/test_graph.py::TestCondensedView -q` and the module tests with `pytest tests/test_services/test_graph.py -q`, and they completed successfully.
- Ran Python compile checks with `python -m compileall -q rka` to validate runtime importability and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b2e232ac948324a86a7ed938203f9b)