### PR TITLE
Add multi-project foundations, project-scoped graph views, and config/LLM hardening

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,88 @@
+# Comprehensive Code Review (2026-03-12)
+
+## Scope and Method
+
+This review covered backend (`rka/`), API wiring, DB infrastructure, and a light frontend/tooling check.
+
+Checks performed:
+
+- Static code scan with Ruff across `rka`, `tests`, and `web/src`.
+- Import/runtime sanity via `python -m compileall -q rka`.
+- Architectural read-through of API app lifecycle, dependency injection, DB layer, and LLM config routes.
+
+## Executive Summary
+
+The codebase is generally well-structured and readable, with clear service boundaries and pragmatic async DB patterns. Main risks are concentrated in:
+
+1. App configurability/testability issues (factory argument not honored).
+2. Operational hardening (public mutating routes without authentication controls).
+3. Maintainability debt (large set of lint findings and private-attribute coupling).
+
+## Findings
+
+### 1) `create_app(config=...)` argument is currently ignored (High)
+
+- `create_app` accepts an optional `config` parameter but never uses it.
+- The app lifecycle always pulls config from global cached `get_config()`.
+- Impact: tests and embedding/integration scenarios cannot reliably inject isolated config; behavior depends on process-global state.
+
+**Evidence:** `rka/api/app.py` defines `create_app(config: RKAConfig | None = None)` yet reads config from `get_config()` in `lifespan` and route handlers. 
+
+**Recommendation:**
+- Wire the provided `config` into app state during `create_app`, and have `lifespan`/routes use `request.app.state.config` (with a fallback to `get_config()` if needed).
+
+### 2) Reliance on private internals in infrastructure and health checks (Medium)
+
+- DB connection uses aiosqlite private internals (`_execute`, `_conn`) to enable/load extensions.
+- API health/status logic uses `llm._available` directly.
+- Impact: potential breakage on dependency upgrades due to private attribute changes.
+
+**Evidence:** private access patterns in `rka/infra/database.py` and `rka/api/app.py`/`rka/api/routes/llm.py`.
+
+**Recommendation:**
+- Encapsulate extension-loading logic behind a helper with explicit compatibility guards and version pinning notes.
+- Expose `LLMClient.available` (public property) and stop reading `_available` externally.
+
+### 3) Missing API authentication/authorization for write operations (Medium)
+
+- Routes include create/update operations for project state, notes, missions, checkpoints, etc. and runtime LLM config mutation.
+- No auth dependency or access control appears in route registration.
+- Impact: if service is bound outside localhost or proxied insecurely, state tampering risk is high.
+
+**Evidence:** API routes are mounted directly in `create_app` without auth middleware/dependency checks (`rka/api/app.py`).
+
+**Recommendation:**
+- Add optional auth modes (API key/JWT) at router or global dependency level.
+- Default to loopback bind + explicit warning logs when bound to non-local interfaces without auth.
+
+### 4) Global mutable singletons in dependency module reduce isolation (Medium)
+
+- Module-level mutable globals (`_db`, `_llm`, `_embeddings`, `_search`, `_context`) are used as service backplane.
+- Impact: test parallelism and multi-app process patterns may experience cross-talk.
+
+**Evidence:** `rka/api/deps.py` singleton pattern.
+
+**Recommendation:**
+- Move long-lived resources into `app.state` and pass via FastAPI dependency callables that receive `Request`.
+
+### 5) Lint and cleanup backlog is sizable (Low)
+
+- Ruff reports 34 issues (unused imports, ambiguous variables, unnecessary f-strings, unused locals).
+- Most are auto-fixable; leaving them unresolved increases review noise and can hide real defects.
+
+**Recommendation:**
+- Run `ruff check --fix` and enforce in CI.
+- Add a minimal CI gate (`ruff + pytest`), even if some tests are marked optional/skipped in constrained environments.
+
+## Positive Notes
+
+- Service-layer architecture is consistent and easy to follow.
+- DB wrapper cleanly centralizes schema/migration setup.
+- Context/search/LLM capabilities are organized with clear separation of responsibilities.
+
+## Suggested Next Sprint Plan
+
+1. **Hardening:** add auth mode + secure defaults.
+2. **Config/Testability:** remove global config coupling in app factory/deps.
+3. **Stability:** encapsulate private-attribute accesses.
+4. **Hygiene:** clear Ruff backlog and add CI checks.

--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -19,7 +19,7 @@ from rka.services.search import SearchService
 from rka.services.context import ContextEngine
 from rka.api.deps import (
     set_db, set_llm, set_embeddings, set_search_service, set_context_engine,
-    get_config,
+    get_config, set_config,
 )
 from rka.api.routes import (
     project as project_routes,
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize and tear down database + Phase 2 services on startup/shutdown."""
-    config = get_config()
+    config = getattr(app.state, "config", None) or get_config()
 
     # Phase 1: Database
     db = Database(config.database_url)
@@ -82,13 +82,13 @@ async def lifespan(app: FastAPI):
             logger.warning(
                 "LLM health check FAILED — Q&A, summaries, and classification "
                 "will error until the LLM backend is reachable. Ensure your "
-                "LM Studio / Ollama instance is running."
+                "configured LLM backend is running."
             )
     else:
         logger.warning(
             "LLM is DISABLED (RKA_LLM_ENABLED=false). Q&A, summaries, "
             "and classification features will not work. Set RKA_LLM_ENABLED=true "
-            "and configure RKA_LLM_API_BASE to your LM Studio / Ollama endpoint."
+            "and configure model/backend settings from the Settings page or environment."
         )
     set_llm(llm)
 
@@ -125,12 +125,16 @@ async def lifespan(app: FastAPI):
 
 def create_app(config: RKAConfig | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
+    effective_config = config or get_config()
+    set_config(effective_config)
+
     app = FastAPI(
         title="Research Knowledge Agent",
         description="REST API for AI-assisted research orchestration",
         version="1.1.0",
         lifespan=lifespan,
     )
+    app.state.config = effective_config
 
     # Global error handler for LLM unavailability
     from rka.infra.llm import LLMUnavailableError
@@ -142,8 +146,7 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
             content={
                 "detail": str(exc),
                 "error": "llm_unavailable",
-                "hint": "Ensure your LM Studio / Ollama instance is running and "
-                        "RKA_LLM_ENABLED=true with RKA_LLM_API_BASE set correctly.",
+                "hint": "Ensure LLM is enabled and model/backend settings are configured correctly.",
             },
         )
 
@@ -186,7 +189,7 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
         llm = get_llm()
         llm_status = "disabled"
         if llm:
-            llm_status = "available" if llm._available else "unavailable"
+            llm_status = "available" if llm.available else "unavailable"
         return {
             "status": "ok",
             "version": "1.1.0",

--- a/rka/api/deps.py
+++ b/rka/api/deps.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 
+from fastapi import Depends, Header, HTTPException, Query
+
 from rka.config import RKAConfig
 from rka.infra.database import Database
 from rka.infra.llm import LLMClient
@@ -30,15 +32,42 @@ logger = logging.getLogger(__name__)
 
 @lru_cache()
 def get_config() -> RKAConfig:
+    if _config is not None:
+        return _config
     return RKAConfig()
 
 
 # Singleton instances (initialized in app lifespan)
 _db: Database | None = None
+_config: RKAConfig | None = None
 _llm: LLMClient | None = None
 _embeddings: EmbeddingService | None = None
 _search: SearchService | None = None
 _context: ContextEngine | None = None
+
+DEFAULT_PROJECT_ID = "proj_default"
+
+
+def set_config(config: RKAConfig) -> None:
+    global _config
+    _config = config
+
+
+def get_project_id(
+    x_rka_project: str | None = Header(default=None, alias="X-RKA-Project"),
+    project_id: str | None = Query(default=None),
+) -> str:
+    """Resolve project id from header/query with legacy-compatible default."""
+    return (x_rka_project or project_id or DEFAULT_PROJECT_ID).strip()
+
+
+async def require_project(project_id: str = Depends(get_project_id)) -> str:
+    """Validate project exists before executing project-scoped operations."""
+    db = get_db()
+    row = await db.fetchone("SELECT id FROM projects WHERE id = ?", [project_id])
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    return project_id
 
 
 def get_db() -> Database:

--- a/rka/api/routes/graph.py
+++ b/rka/api/routes/graph.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, Query
 
-from rka.api.deps import get_graph_service
+from rka.api.deps import get_graph_service, require_project
 from rka.services.graph import GraphService
 
 router = APIRouter()
@@ -12,33 +14,60 @@ router = APIRouter()
 
 @router.get("/graph")
 async def get_full_graph(
+    view: Literal["full", "condensed", "keynodes"] = Query(
+        "full", description="Graph view: full, condensed, or keynodes"
+    ),
     include_types: str | None = Query(None, description="Comma-separated entity types to include"),
     phase: str | None = None,
     limit: int = Query(500, le=2000),
+    project_id: str = Depends(require_project),
     svc: GraphService = Depends(get_graph_service),
 ):
-    """Return the full knowledge graph as {nodes, edges}."""
+    """Return graph payload for full or condensed keynode-centric views."""
     types = [t.strip() for t in include_types.split(",")] if include_types else None
-    return await svc.get_full_graph(include_types=types, phase=phase, limit=limit)
+    return await svc.get_graph_view(
+        project_id=project_id,
+        view=view,
+        include_types=types,
+        phase=phase,
+        limit=limit,
+    )
+
+
+@router.post("/graph/refresh")
+async def refresh_graph_view(
+    top_per_kind: int = Query(8, ge=2, le=30),
+    min_importance: float = Query(0.45, ge=0.0, le=1.0),
+    project_id: str = Depends(require_project),
+    svc: GraphService = Depends(get_graph_service),
+):
+    """Rebuild condensed keynode view for research-map focus mode."""
+    return await svc.refresh_condensed_view(
+        project_id=project_id,
+        top_per_kind=top_per_kind,
+        min_importance=min_importance,
+    )
 
 
 @router.get("/graph/ego/{entity_id}")
 async def get_ego_graph(
     entity_id: str,
     depth: int = Query(1, ge=1, le=3),
+    project_id: str = Depends(require_project),
     svc: GraphService = Depends(get_graph_service),
 ):
     """Return subgraph centered on an entity up to `depth` hops."""
-    return await svc.get_ego_graph(entity_id, depth=depth)
+    return await svc.get_ego_graph(entity_id, depth=depth, project_id=project_id)
 
 
 @router.get("/graph/decision-tree")
 async def get_decision_tree(
     root_id: str | None = None,
+    project_id: str = Depends(require_project),
     svc: GraphService = Depends(get_graph_service),
 ):
     """Return decisions as a tree with linked entities."""
-    return await svc.get_decision_tree(root_id=root_id)
+    return await svc.get_decision_tree(root_id=root_id, project_id=project_id)
 
 
 @router.get("/graph/timeline")
@@ -46,15 +75,17 @@ async def get_timeline(
     phase: str | None = None,
     since: str | None = None,
     limit: int = Query(100, le=1000),
+    project_id: str = Depends(require_project),
     svc: GraphService = Depends(get_graph_service),
 ):
     """Return chronological event timeline."""
-    return await svc.get_timeline(phase=phase, since=since, limit=limit)
+    return await svc.get_timeline(project_id=project_id, phase=phase, since=since, limit=limit)
 
 
 @router.get("/graph/stats")
 async def get_graph_stats(
+    project_id: str = Depends(require_project),
     svc: GraphService = Depends(get_graph_service),
 ):
     """Return graph statistics: node/edge counts by type."""
-    return await svc.get_stats()
+    return await svc.get_stats(project_id=project_id)

--- a/rka/api/routes/llm.py
+++ b/rka/api/routes/llm.py
@@ -92,7 +92,7 @@ async def get_llm_status() -> LLMStatus:
     llm = get_llm()
     return LLMStatus(
         enabled=config.llm_enabled,
-        available=bool(llm and llm._available),
+        available=bool(llm and llm.available),
         model=config.llm_model,
         api_base=config.llm_api_base,
         api_key_set=bool(config.llm_api_key),
@@ -124,7 +124,7 @@ async def update_llm_config(data: LLMConfigUpdate) -> LLMStatus:
         await llm.is_available()
 
         # Auto-detect context window from backend
-        if config.llm_api_base and llm._available:
+        if config.llm_api_base and llm.available:
             ctx = await _detect_context_window(config.llm_api_base, config.llm_model)
             if ctx:
                 config.llm_context_window = ctx
@@ -135,7 +135,7 @@ async def update_llm_config(data: LLMConfigUpdate) -> LLMStatus:
 
     return LLMStatus(
         enabled=config.llm_enabled,
-        available=bool(llm and llm._available),
+        available=bool(llm and llm.available),
         model=config.llm_model,
         api_base=config.llm_api_base,
         api_key_set=bool(config.llm_api_key),
@@ -256,7 +256,7 @@ async def check_llm() -> LLMStatus:
         await llm.is_available()
     return LLMStatus(
         enabled=config.llm_enabled,
-        available=bool(llm and llm._available),
+        available=bool(llm and llm.available),
         model=config.llm_model,
         api_base=config.llm_api_base,
         api_key_set=bool(config.llm_api_key),

--- a/rka/api/routes/project.py
+++ b/rka/api/routes/project.py
@@ -4,16 +4,33 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from rka.models.project import ProjectState, ProjectStateUpdate
+from rka.api.deps import get_project_service, require_project
+from rka.models.project import ProjectCreate, ProjectInfo, ProjectState, ProjectStateUpdate
 from rka.services.project import ProjectService
-from rka.api.deps import get_project_service
 
 router = APIRouter()
 
 
+@router.get("/projects", response_model=list[ProjectInfo])
+async def list_projects(svc: ProjectService = Depends(get_project_service)):
+    return await svc.list_projects()
+
+
+@router.post("/projects", response_model=ProjectInfo)
+async def create_project(
+    data: ProjectCreate,
+    actor: str = "web_ui",
+    svc: ProjectService = Depends(get_project_service),
+):
+    return await svc.create_project(data, actor=actor)
+
+
 @router.get("/status", response_model=ProjectState)
-async def get_status(svc: ProjectService = Depends(get_project_service)):
-    state = await svc.get()
+async def get_status(
+    project_id: str = Depends(require_project),
+    svc: ProjectService = Depends(get_project_service),
+):
+    state = await svc.get(project_id=project_id)
     if state is None:
         raise HTTPException(404, "Project not initialized. Run `rka init` first.")
     return state
@@ -23,6 +40,7 @@ async def get_status(svc: ProjectService = Depends(get_project_service)):
 async def update_status(
     data: ProjectStateUpdate,
     actor: str = "web_ui",
+    project_id: str = Depends(require_project),
     svc: ProjectService = Depends(get_project_service),
 ):
-    return await svc.update(data, actor=actor)
+    return await svc.update(data, actor=actor, project_id=project_id)

--- a/rka/cli.py
+++ b/rka/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from pathlib import Path
 
 import click
@@ -22,7 +21,6 @@ def main():
 @click.option("--dir", "directory", default=".", help="Project directory")
 def init(name: str, description: str | None, directory: str):
     """Initialize a new RKA project."""
-    from rka.config import RKAConfig
     from rka.infra.database import Database
     from rka.services.project import ProjectService
 
@@ -43,7 +41,7 @@ def init(name: str, description: str | None, directory: str):
     click.echo(f"✅ Initialized RKA project: {state.project_name}")
     click.echo(f"   Database: {db_path}")
     click.echo(f"   Phase: {state.current_phase}")
-    click.echo(f"\nRun 'rka serve' to start the API server.")
+    click.echo("\nRun 'rka serve' to start the API server.")
 
     # Create .env file if it doesn't exist
     env_path = project_dir / ".env"
@@ -56,11 +54,12 @@ def init(name: str, description: str | None, directory: str):
             f"RKA_PORT=9712\n"
             f"\n"
             f"# LLM (Phase 2 — uncomment when ready)\n"
-            f"# RKA_LLM_MODEL=ollama/qwen3:32b\n"
+            f"# RKA_LLM_MODEL=<provider/model>\n"
+            f"# RKA_LLM_API_BASE=<your_openai_compatible_endpoint>\n"
             f"# RKA_LLM_ENABLED=true\n"
             f"# RKA_EMBEDDINGS_ENABLED=true\n"
         )
-        click.echo(f"   Created .env file")
+        click.echo("   Created .env file")
 
 
 @main.command()
@@ -280,7 +279,7 @@ def bootstrap_scan(folder: str, ignore: tuple, no_llm: bool, json_output: bool):
         click.echo(f"  {f.relative_path} [{f.category.value}→{f.proposed_type}]{dup}{llm_tag}")
 
     if manifest.warnings:
-        click.echo(f"\n⚠️  Warnings:")
+        click.echo("\n⚠️  Warnings:")
         for w in manifest.warnings:
             click.echo(f"  - {w}")
 

--- a/rka/config.py
+++ b/rka/config.py
@@ -26,19 +26,18 @@ class RKAConfig(BaseSettings):
     host: str = Field(default="127.0.0.1", description="API server host")
     port: int = Field(default=9712, description="API server port")
 
-    # LLM — required for Q&A, summaries, classification
-    # Default: LM Studio on localhost:1234 (OpenAI-compatible)
-    llm_model: str = Field(default="openai/qwen3-32b", description="LiteLLM model identifier (openai/* for LM Studio, ollama/* for Ollama)")
-    llm_api_base: str | None = Field(default="http://localhost:1234/v1", description="LLM API base URL (LM Studio default: http://localhost:1234/v1)")
-    llm_api_key: str | None = Field(default=None, description="API key (not needed for local LM Studio / Ollama)")
-    llm_enabled: bool = Field(default=True, description="Enable LLM (required for Q&A, summaries, classification)")
+    # LLM — configured at runtime from Settings page or env vars.
+    llm_model: str = Field(default="", description="LiteLLM model identifier")
+    llm_api_base: str | None = Field(default=None, description="LLM API base URL")
+    llm_api_key: str | None = Field(default=None, description="Optional API key")
+    llm_enabled: bool = Field(default=False, description="Enable LLM features")
     llm_think: bool = Field(
         default=False,
         description="Enable thinking mode for reasoning models (disable for structured extraction)",
     )
 
     # LLM context window — auto-detected from backend, or set manually
-    llm_context_window: int = Field(default=4096, description="Model context window in tokens (auto-detected from LM Studio)")
+    llm_context_window: int = Field(default=0, description="Model context window in tokens (0 = unknown/auto)")
 
     # Embeddings (Phase 2)
     embedding_model: str = Field(

--- a/rka/db/migrations/003_add_graph_keynodes_views.sql
+++ b/rka/db/migrations/003_add_graph_keynodes_views.sql
@@ -1,0 +1,32 @@
+-- Add richer edge metadata for graph ranking and explainability
+ALTER TABLE entity_links ADD COLUMN link_weight REAL DEFAULT 0.0;
+ALTER TABLE entity_links ADD COLUMN link_reason TEXT;
+
+-- Materialized key nodes for condensed graph views
+CREATE TABLE IF NOT EXISTS keynodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL CHECK(kind IN ('finding', 'literature', 'decision', 'milestone')),
+    title TEXT NOT NULL,
+    summary TEXT,
+    produced_by TEXT,
+    importance REAL DEFAULT 0.0,
+    node_refs TEXT,
+    blessed INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_keynodes_kind ON keynodes(kind);
+CREATE INDEX IF NOT EXISTS idx_keynodes_importance ON keynodes(importance DESC);
+CREATE INDEX IF NOT EXISTS idx_keynodes_blessed ON keynodes(blessed);
+
+-- Cached graph payloads for UI rendering and tuning
+CREATE TABLE IF NOT EXISTS graph_views (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    params TEXT,
+    nodes TEXT,
+    edges TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_views_created_at ON graph_views(created_at DESC);

--- a/rka/db/migrations/004_add_multi_project_foundation.sql
+++ b/rka/db/migrations/004_add_multi_project_foundation.sql
@@ -1,0 +1,98 @@
+-- Multi-project foundation (shared DB, project-scoped data)
+
+-- Canonical projects registry
+CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+-- Per-project state (replacement for singleton project_state id=1 model)
+CREATE TABLE IF NOT EXISTS project_states (
+    project_id TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+    project_name TEXT NOT NULL,
+    project_description TEXT,
+    current_phase TEXT,
+    phases_config TEXT,
+    summary TEXT,
+    blockers TEXT,
+    metrics TEXT,
+    created_at TEXT,
+    updated_at TEXT
+);
+
+-- Ensure the default legacy-compatible project exists
+INSERT OR IGNORE INTO projects (id, name, description, created_by)
+VALUES ('proj_default', 'Default Project', 'Migrated legacy singleton project', 'system');
+
+-- Seed project_states from singleton project_state if present
+INSERT OR IGNORE INTO project_states (
+    project_id,
+    project_name,
+    project_description,
+    current_phase,
+    phases_config,
+    summary,
+    blockers,
+    metrics,
+    created_at,
+    updated_at
+)
+SELECT
+    'proj_default',
+    project_name,
+    project_description,
+    current_phase,
+    phases_config,
+    summary,
+    blockers,
+    metrics,
+    created_at,
+    updated_at
+FROM project_state
+WHERE id = 1;
+
+-- Project scoping columns (nullable for backward compatibility during rollout)
+ALTER TABLE decisions ADD COLUMN project_id TEXT;
+ALTER TABLE missions ADD COLUMN project_id TEXT;
+ALTER TABLE literature ADD COLUMN project_id TEXT;
+ALTER TABLE journal ADD COLUMN project_id TEXT;
+ALTER TABLE checkpoints ADD COLUMN project_id TEXT;
+ALTER TABLE events ADD COLUMN project_id TEXT;
+ALTER TABLE audit_log ADD COLUMN project_id TEXT;
+ALTER TABLE tags ADD COLUMN project_id TEXT;
+ALTER TABLE bootstrap_log ADD COLUMN project_id TEXT;
+ALTER TABLE entity_links ADD COLUMN project_id TEXT;
+ALTER TABLE keynodes ADD COLUMN project_id TEXT;
+ALTER TABLE graph_views ADD COLUMN project_id TEXT;
+
+-- Backfill existing rows into default project scope
+UPDATE decisions SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE missions SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE literature SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE journal SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE checkpoints SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE events SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE audit_log SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE tags SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE bootstrap_log SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE entity_links SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE keynodes SET project_id = 'proj_default' WHERE project_id IS NULL;
+UPDATE graph_views SET project_id = 'proj_default' WHERE project_id IS NULL;
+
+-- Indexes for project-scoped queries
+CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project_id);
+CREATE INDEX IF NOT EXISTS idx_missions_project ON missions(project_id);
+CREATE INDEX IF NOT EXISTS idx_literature_project ON literature(project_id);
+CREATE INDEX IF NOT EXISTS idx_journal_project ON journal(project_id);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_project ON checkpoints(project_id);
+CREATE INDEX IF NOT EXISTS idx_events_project ON events(project_id);
+CREATE INDEX IF NOT EXISTS idx_audit_project ON audit_log(project_id);
+CREATE INDEX IF NOT EXISTS idx_tags_project ON tags(project_id);
+CREATE INDEX IF NOT EXISTS idx_bootstrap_project ON bootstrap_log(project_id);
+CREATE INDEX IF NOT EXISTS idx_entity_links_project ON entity_links(project_id);
+CREATE INDEX IF NOT EXISTS idx_keynodes_project ON keynodes(project_id);
+CREATE INDEX IF NOT EXISTS idx_graph_views_project ON graph_views(project_id);

--- a/rka/infra/ids.py
+++ b/rka/infra/ids.py
@@ -12,6 +12,7 @@ _PREFIXES = {
     "mission": "mis",
     "checkpoint": "chk",
     "event": "evt",
+    "project": "prj",
     "scan": "scn",
     "link": "lnk",
     "artifact": "art",
@@ -19,6 +20,8 @@ _PREFIXES = {
     "summary": "sum",
     "qa_session": "qas",
     "qa_log": "qal",
+    "keynode": "knd",
+    "graphview": "gvw",
 }
 
 

--- a/rka/infra/llm.py
+++ b/rka/infra/llm.py
@@ -155,6 +155,11 @@ class LLMClient:
         return self.config.llm_context_window
 
     @property
+    def available(self) -> bool:
+        """Latest known availability status from health checks."""
+        return bool(self._available)
+
+    @property
     def _content_limit(self) -> int:
         """Max chars for a single content block sent to LLM.
         With 256k context → ~200k chars; with 4k → ~3k chars."""
@@ -220,6 +225,10 @@ class LLMClient:
         """Health check — can we reach the LLM?"""
         if not self.config.llm_enabled:
             return False
+        if not self.model:
+            self._available = False
+            logger.debug("LLM health check skipped: no model configured")
+            return False
         try:
             import litellm
             kwargs: dict = dict(
@@ -250,7 +259,11 @@ class LLMClient:
         if not self.config.llm_enabled:
             raise LLMUnavailableError(
                 "LLM is not enabled. Configure it in Settings or set "
-                "RKA_LLM_ENABLED=true with RKA_LLM_API_BASE pointing to your LM Studio / Ollama."
+                "RKA_LLM_ENABLED=true and provide model/backend settings."
+            )
+        if not self.model:
+            raise LLMUnavailableError(
+                "LLM model is not configured. Set a model in Settings before using LLM features."
             )
         try:
             client = self._get_instructor()
@@ -275,7 +288,7 @@ class LLMClient:
             self._available = False
             raise LLMUnavailableError(
                 f"LLM call failed: {exc}. "
-                f"Ensure your LM Studio / Ollama is running and the model is loaded."
+                f"Ensure your configured LLM backend is reachable and the selected model is available."
             ) from exc
 
     async def auto_tag(
@@ -399,7 +412,7 @@ class LLMClient:
         mis_text = fmt(missions, "id", "objective")
 
         valid_dec_ids = {d["id"] for d in decisions}
-        valid_lit_ids = {l["id"] for l in literature}
+        valid_lit_ids = {lit["id"] for lit in literature}
         valid_mis_ids = {m["id"] for m in missions}
 
         result = await self.extract(

--- a/rka/models/project.py
+++ b/rka/models/project.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -35,3 +34,23 @@ class ProjectStateUpdate(BaseModel):
     summary: str | None = None
     blockers: str | None = None
     metrics: dict[str, Any] | None = None
+
+
+class ProjectInfo(BaseModel):
+    """Project metadata."""
+
+    id: str
+    name: str
+    description: str | None = None
+    created_by: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class ProjectCreate(BaseModel):
+    """Create a new project container."""
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    phases_config: list[str] | None = None

--- a/rka/services/context.py
+++ b/rka/services/context.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from rka.infra.database import Database
 from rka.infra.llm import LLMClient
-from rka.models.context import ContextPackage, ContextRequest
+from rka.models.context import ContextPackage
 from rka.services.search import SearchService
 
 logger = logging.getLogger(__name__)
@@ -270,9 +270,14 @@ class ContextEngine:
 
         return candidates
 
-    async def _get_current_phase(self) -> str | None:
+    async def _get_current_phase(self, project_id: str = "proj_default") -> str | None:
         """Get the current project phase."""
-        row = await self.db.fetchone("SELECT current_phase FROM project_state LIMIT 1")
+        row = await self.db.fetchone(
+            "SELECT current_phase FROM project_states WHERE project_id = ?",
+            [project_id],
+        )
+        if row is None and project_id == "proj_default":
+            row = await self.db.fetchone("SELECT current_phase FROM project_state LIMIT 1")
         return row["current_phase"] if row else None
 
     def _render_entry(self, entry: dict, max_len: int | None = None) -> str:

--- a/rka/services/graph.py
+++ b/rka/services/graph.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from rka.infra.database import Database
+from rka.infra.ids import generate_id
 
 
 class GraphService:
@@ -15,6 +16,11 @@ class GraphService:
     def __init__(self, db: Database):
         self.db = db
 
+    @staticmethod
+    def _project_clause(alias: str = "") -> str:
+        prefix = f"{alias}." if alias else ""
+        return f"({prefix}project_id = ? OR {prefix}project_id IS NULL)"
+
     # ------------------------------------------------------------------
     # Full graph (all entity_links + nodes)
     # ------------------------------------------------------------------
@@ -22,6 +28,7 @@ class GraphService:
     async def get_full_graph(
         self,
         *,
+        project_id: str = "proj_default",
         include_types: list[str] | None = None,
         phase: str | None = None,
         limit: int = 500,
@@ -37,8 +44,8 @@ class GraphService:
         # Fetch all entity links
         link_rows = await self.db.fetchall(
             "SELECT source_type, source_id, link_type, target_type, target_id, created_at "
-            "FROM entity_links ORDER BY created_at DESC LIMIT ?",
-            [limit],
+            f"FROM entity_links WHERE {self._project_clause()} ORDER BY created_at DESC LIMIT ?",
+            [project_id, limit],
         )
 
         # Collect unique entity IDs we need to look up
@@ -66,7 +73,8 @@ class GraphService:
             if include_types and etype not in include_types:
                 continue
             conditions = []
-            params: list = []
+            params: list = [project_id]
+            conditions.append(self._project_clause())
             if phase and has_phase:
                 conditions.append("phase = ?")
                 params.append(phase)
@@ -92,7 +100,7 @@ class GraphService:
                 entity_ids.setdefault(etype, set()).add(nid)
 
         # Fill in any linked nodes that weren't fetched as orphans
-        await self._fill_missing_nodes(nodes, entity_ids)
+        await self._fill_missing_nodes(nodes, entity_ids, project_id=project_id)
 
         # Filter by type if requested
         if include_types:
@@ -102,11 +110,134 @@ class GraphService:
 
         return {"nodes": list(nodes.values()), "edges": edges}
 
+    async def get_graph_view(
+        self,
+        *,
+        project_id: str = "proj_default",
+        view: str = "full",
+        include_types: list[str] | None = None,
+        phase: str | None = None,
+        limit: int = 500,
+    ) -> dict[str, Any]:
+        """Return graph payload for different map modes.
+
+        - full: existing entity graph
+        - condensed/keynodes: precomputed keynode view (or auto-build if absent)
+        """
+        if view == "full":
+            return await self.get_full_graph(
+                project_id=project_id,
+                include_types=include_types,
+                phase=phase,
+                limit=limit,
+            )
+
+        if view not in {"condensed", "keynodes"}:
+            raise ValueError("Unsupported graph view. Use one of: full, condensed, keynodes")
+
+        cached = await self.db.fetchone(
+            "SELECT nodes, edges, id, created_at FROM graph_views "
+            f"WHERE name = ? AND {self._project_clause()} ORDER BY created_at DESC LIMIT 1",
+            ["condensed", project_id],
+        )
+        if not cached:
+            await self.refresh_condensed_view(project_id=project_id)
+            cached = await self.db.fetchone(
+                "SELECT nodes, edges, id, created_at FROM graph_views "
+                f"WHERE name = ? AND {self._project_clause()} ORDER BY created_at DESC LIMIT 1",
+                ["condensed", project_id],
+            )
+
+        if not cached:
+            return {"nodes": [], "edges": [], "view": view}
+
+        return {
+            "view": "condensed",
+            "view_id": cached["id"],
+            "created_at": cached["created_at"],
+            "nodes": json.loads(cached["nodes"] or "[]"),
+            "edges": json.loads(cached["edges"] or "[]"),
+        }
+
+    async def refresh_condensed_view(
+        self,
+        *,
+        project_id: str = "proj_default",
+        top_per_kind: int = 8,
+        min_importance: float = 0.45,
+    ) -> dict[str, Any]:
+        """Build a condensed keynode-centric graph view and persist it.
+
+        Heuristic ranking is used so this works even without LLM dependencies.
+        """
+        candidates = await self._collect_keynode_candidates(project_id=project_id, top_per_kind=top_per_kind)
+        selected = [c for c in candidates if c["importance"] >= min_importance]
+
+        await self.db.execute(
+            f"DELETE FROM keynodes WHERE blessed = 0 AND {self._project_clause()}",
+            [project_id],
+        )
+
+        nodes: list[dict[str, Any]] = []
+        ref_to_keynode: dict[tuple[str, str], str] = {}
+
+        for item in selected:
+            keynode_id = generate_id("keynode")
+            node_refs = [{"entity_type": item["entity_type"], "entity_id": item["entity_id"]}]
+            await self.db.execute(
+                """INSERT INTO keynodes
+                   (id, kind, title, summary, produced_by, importance, node_refs, blessed, project_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)""",
+                [
+                    keynode_id,
+                    item["kind"],
+                    item["title"],
+                    item.get("summary"),
+                    "system",
+                    item["importance"],
+                    json.dumps(node_refs),
+                    project_id,
+                ],
+            )
+            ref_to_keynode[(item["entity_type"], item["entity_id"])] = keynode_id
+            nodes.append(
+                {
+                    "id": keynode_id,
+                    "type": item["kind"],
+                    "label": item["title"],
+                    "importance": item["importance"],
+                    "summary": item.get("summary"),
+                    "source": {
+                        "entity_type": item["entity_type"],
+                        "entity_id": item["entity_id"],
+                    },
+                }
+            )
+
+        edges = await self._build_condensed_edges(project_id=project_id, ref_to_keynode=ref_to_keynode)
+
+        view_id = generate_id("graphview")
+        params = {"top_per_kind": top_per_kind, "min_importance": min_importance}
+        await self.db.execute(
+            """INSERT INTO graph_views (id, name, params, nodes, edges, project_id)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            [view_id, "condensed", json.dumps(params), json.dumps(nodes), json.dumps(edges), project_id],
+        )
+        await self.db.commit()
+
+        return {
+            "view": "condensed",
+            "view_id": view_id,
+            "params": params,
+            "nodes": nodes,
+            "edges": edges,
+        }
+
     # ------------------------------------------------------------------
     # Ego graph (neighborhood of a single entity)
     # ------------------------------------------------------------------
 
-    async def get_ego_graph(self, entity_id: str, depth: int = 1) -> dict[str, Any]:
+    async def get_ego_graph(self, entity_id: str, depth: int = 1, project_id: str = "proj_default") -> dict[str, Any]:
         """Return the subgraph centered on entity_id up to `depth` hops."""
         visited: set[str] = set()
         frontier: set[str] = {entity_id}
@@ -119,8 +250,8 @@ class GraphService:
             rows = await self.db.fetchall(
                 f"SELECT source_type, source_id, link_type, target_type, target_id, created_at "
                 f"FROM entity_links "
-                f"WHERE source_id IN ({placeholders}) OR target_id IN ({placeholders})",
-                list(frontier) + list(frontier),
+                f"WHERE {self._project_clause()} AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
+                [project_id] + list(frontier) + list(frontier),
             )
             visited |= frontier
             next_frontier: set[str] = set()
@@ -157,7 +288,7 @@ class GraphService:
             entity_ids.setdefault(etype, set()).add(nid)
 
         nodes: dict[str, dict] = {}
-        await self._fill_missing_nodes(nodes, entity_ids)
+        await self._fill_missing_nodes(nodes, entity_ids, project_id=project_id)
 
         return {"nodes": list(nodes.values()), "edges": unique_edges}
 
@@ -165,7 +296,7 @@ class GraphService:
     # Decision tree (hierarchical)
     # ------------------------------------------------------------------
 
-    async def get_decision_tree(self, root_id: str | None = None) -> list[dict]:
+    async def get_decision_tree(self, root_id: str | None = None, project_id: str = "proj_default") -> list[dict]:
         """Return decisions as a tree structure.
 
         If root_id is given, return only that subtree.
@@ -174,7 +305,8 @@ class GraphService:
         rows = await self.db.fetchall(
             "SELECT id, parent_id, question, chosen, status, phase, rationale, "
             "related_missions, related_literature, created_at "
-            "FROM decisions ORDER BY created_at"
+            f"FROM decisions WHERE {self._project_clause()} ORDER BY created_at",
+            [project_id],
         )
 
         # Build lookup
@@ -200,8 +332,8 @@ class GraphService:
             links = await self.db.fetchall(
                 f"SELECT source_type, source_id, link_type, target_type, target_id "
                 f"FROM entity_links "
-                f"WHERE source_id IN ({placeholders}) OR target_id IN ({placeholders})",
-                dec_ids + dec_ids,
+                f"WHERE {self._project_clause()} AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
+                [project_id] + dec_ids + dec_ids,
             )
             for link in links:
                 for dec_id in dec_ids:
@@ -234,13 +366,14 @@ class GraphService:
 
     async def get_timeline(
         self,
+        project_id: str = "proj_default",
         phase: str | None = None,
         since: str | None = None,
         limit: int = 100,
     ) -> list[dict]:
         """Return a chronological timeline of events with linked context."""
-        conditions = []
-        params: list = []
+        conditions = [self._project_clause()]
+        params: list = [project_id]
         if phase:
             conditions.append("phase = ?")
             params.append(phase)
@@ -262,7 +395,7 @@ class GraphService:
     # Stats
     # ------------------------------------------------------------------
 
-    async def get_stats(self) -> dict[str, Any]:
+    async def get_stats(self, project_id: str = "proj_default") -> dict[str, Any]:
         """Return graph statistics: node/edge counts by type."""
         node_counts = {}
         for etype, table in [
@@ -272,14 +405,21 @@ class GraphService:
             ("literature", "literature"),
             ("checkpoint", "checkpoints"),
         ]:
-            row = await self.db.fetchone(f"SELECT COUNT(*) as cnt FROM {table}")
+            row = await self.db.fetchone(
+                f"SELECT COUNT(*) as cnt FROM {table} WHERE {self._project_clause()}",
+                [project_id],
+            )
             node_counts[etype] = row["cnt"] if row else 0
 
-        edge_row = await self.db.fetchone("SELECT COUNT(*) as cnt FROM entity_links")
+        edge_row = await self.db.fetchone(
+            f"SELECT COUNT(*) as cnt FROM entity_links WHERE {self._project_clause()}",
+            [project_id],
+        )
         total_edges = edge_row["cnt"] if edge_row else 0
 
         edge_type_rows = await self.db.fetchall(
-            "SELECT link_type, COUNT(*) as cnt FROM entity_links GROUP BY link_type"
+            f"SELECT link_type, COUNT(*) as cnt FROM entity_links WHERE {self._project_clause()} GROUP BY link_type",
+            [project_id],
         )
         edge_counts = {r["link_type"]: r["cnt"] for r in edge_type_rows}
 
@@ -295,7 +435,10 @@ class GraphService:
     # ------------------------------------------------------------------
 
     async def _fill_missing_nodes(
-        self, nodes: dict[str, dict], entity_ids: dict[str, set[str]]
+        self,
+        nodes: dict[str, dict],
+        entity_ids: dict[str, set[str]],
+        project_id: str = "proj_default",
     ) -> None:
         """Look up entity metadata for IDs not already in the nodes dict."""
         table_map: dict[str, tuple[str, str, str, bool]] = {
@@ -320,8 +463,8 @@ class GraphService:
             rows = await self.db.fetchall(
                 f"SELECT id, {label_col}, {status_col}, "
                 f"{phase_col}, created_at "
-                f"FROM {table} WHERE id IN ({placeholders})",
-                missing,
+                f"FROM {table} WHERE {self._project_clause()} AND id IN ({placeholders})",
+                [project_id] + missing,
             )
             for r in rows:
                 label_text = r[label_col] or ""
@@ -338,6 +481,160 @@ class GraphService:
             for eid in missing:
                 if eid not in fetched:
                     nodes[eid] = {"id": eid, "type": etype, "label": eid, "status": None, "phase": "", "created_at": ""}
+
+    async def _collect_keynode_candidates(
+        self,
+        *,
+        project_id: str = "proj_default",
+        top_per_kind: int,
+    ) -> list[dict[str, Any]]:
+        """Collect and score likely key nodes for condensed graph mode."""
+        candidates: list[dict[str, Any]] = []
+
+        journal_rows = await self.db.fetchall(
+            """SELECT id, type, content, summary, confidence, created_at
+               FROM journal
+               WHERE (project_id = ? OR project_id IS NULL)
+                 AND type IN ('finding', 'insight', 'hypothesis', 'methodology', 'summary')
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            [project_id, top_per_kind * 6],
+        )
+        confidence_bonus = {"verified": 0.28, "tested": 0.18, "hypothesis": 0.10}
+        for row in journal_rows:
+            imp = 0.48 + confidence_bonus.get((row.get("confidence") or "").lower(), 0.05)
+            candidates.append(
+                {
+                    "kind": "finding",
+                    "entity_type": "journal",
+                    "entity_id": row["id"],
+                    "title": (row.get("summary") or row.get("content") or "Finding")[:90],
+                    "summary": (row.get("summary") or row.get("content") or "")[:240],
+                    "importance": min(1.0, imp),
+                }
+            )
+
+        lit_rows = await self.db.fetchall(
+            """SELECT id, title, abstract, status, relevance_score, created_at
+               FROM literature
+               WHERE (project_id = ? OR project_id IS NULL)
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            [project_id, top_per_kind * 8],
+        )
+        status_bonus = {"cited": 0.30, "read": 0.22, "reading": 0.12, "to_read": 0.05}
+        for row in lit_rows:
+            rel = float(row.get("relevance_score") or 0.0)
+            base = 0.40 + status_bonus.get((row.get("status") or "").lower(), 0.04)
+            imp = min(1.0, base + max(0.0, min(rel, 1.0)) * 0.25)
+            candidates.append(
+                {
+                    "kind": "literature",
+                    "entity_type": "literature",
+                    "entity_id": row["id"],
+                    "title": (row.get("title") or "Literature")[:90],
+                    "summary": (row.get("abstract") or "")[:240],
+                    "importance": imp,
+                }
+            )
+
+        dec_rows = await self.db.fetchall(
+            """SELECT id, question, rationale, status, created_at
+               FROM decisions
+               WHERE (project_id = ? OR project_id IS NULL)
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            [project_id, top_per_kind * 5],
+        )
+        dec_bonus = {"active": 0.30, "merged": 0.20, "revisit": 0.16, "superseded": 0.10, "abandoned": 0.08}
+        for row in dec_rows:
+            imp = 0.52 + dec_bonus.get((row.get("status") or "").lower(), 0.1)
+            candidates.append(
+                {
+                    "kind": "decision",
+                    "entity_type": "decision",
+                    "entity_id": row["id"],
+                    "title": (row.get("question") or "Decision")[:90],
+                    "summary": (row.get("rationale") or "")[:240],
+                    "importance": min(1.0, imp),
+                }
+            )
+
+        mission_rows = await self.db.fetchall(
+            """SELECT id, objective, report, status, completed_at, created_at
+               FROM missions
+               WHERE (project_id = ? OR project_id IS NULL)
+                 AND status IN ('complete', 'partial', 'blocked', 'active')
+               ORDER BY COALESCE(completed_at, created_at) DESC
+               LIMIT ?""",
+            [project_id, top_per_kind * 6],
+        )
+        milestone_bonus = {"complete": 0.35, "partial": 0.26, "blocked": 0.22, "active": 0.16}
+        for row in mission_rows:
+            imp = 0.42 + milestone_bonus.get((row.get("status") or "").lower(), 0.1)
+            candidates.append(
+                {
+                    "kind": "milestone",
+                    "entity_type": "mission",
+                    "entity_id": row["id"],
+                    "title": (row.get("objective") or "Milestone")[:90],
+                    "summary": (row.get("report") or "")[:240],
+                    "importance": min(1.0, imp),
+                }
+            )
+
+        per_kind: dict[str, list[dict[str, Any]]] = {"finding": [], "literature": [], "decision": [], "milestone": []}
+        for candidate in candidates:
+            per_kind[candidate["kind"]].append(candidate)
+
+        selected: list[dict[str, Any]] = []
+        for kind, items in per_kind.items():
+            ranked = sorted(items, key=lambda candidate: candidate["importance"], reverse=True)
+            selected.extend(ranked[:top_per_kind])
+        return selected
+
+    async def _build_condensed_edges(
+        self,
+        project_id: str,
+        ref_to_keynode: dict[tuple[str, str], str],
+    ) -> list[dict[str, Any]]:
+        """Aggregate entity links into condensed keynode edges."""
+        if not ref_to_keynode:
+            return []
+
+        rows = await self.db.fetchall(
+            """SELECT source_type, source_id, target_type, target_id, link_type,
+                      COALESCE(link_weight, 0.0) as link_weight,
+                      link_reason
+               FROM entity_links
+               WHERE (project_id = ? OR project_id IS NULL)""",
+            [project_id],
+        )
+
+        aggregated: dict[tuple[str, str, str], dict[str, Any]] = {}
+        for row in rows:
+            source_key = (row["source_type"], row["source_id"])
+            target_key = (row["target_type"], row["target_id"])
+            src_keynode = ref_to_keynode.get(source_key)
+            tgt_keynode = ref_to_keynode.get(target_key)
+            if not src_keynode or not tgt_keynode or src_keynode == tgt_keynode:
+                continue
+
+            agg_key = (src_keynode, tgt_keynode, row["link_type"])
+            current = aggregated.get(agg_key)
+            weight = float(row.get("link_weight") or 0.0)
+            if current is None:
+                aggregated[agg_key] = {
+                    "source": src_keynode,
+                    "target": tgt_keynode,
+                    "link_type": row["link_type"],
+                    "weight": max(0.2, weight),
+                    "reason": row.get("link_reason") or "Aggregated from linked supporting entities.",
+                }
+            else:
+                current["weight"] = max(current["weight"], weight)
+
+        return list(aggregated.values())
 
     @staticmethod
     def _guess_type_from_id(entity_id: str) -> str:

--- a/rka/services/project.py
+++ b/rka/services/project.py
@@ -4,39 +4,94 @@ from __future__ import annotations
 
 import json
 
-from rka.models.project import ProjectState, ProjectStateUpdate
+from rka.infra.ids import generate_id
+from rka.models.project import ProjectCreate, ProjectInfo, ProjectState, ProjectStateUpdate
 from rka.services.base import BaseService, _now
 
 
 class ProjectService(BaseService):
-    """Manages the singleton project state."""
+    """Manages projects and per-project state."""
 
-    async def get(self) -> ProjectState | None:
-        """Get current project state."""
-        row = await self.db.fetchone("SELECT * FROM project_state WHERE id = 1")
+    DEFAULT_PROJECT_ID = "proj_default"
+
+    async def list_projects(self) -> list[ProjectInfo]:
+        rows = await self.db.fetchall(
+            "SELECT id, name, description, created_by, created_at, updated_at "
+            "FROM projects ORDER BY created_at"
+        )
+        return [ProjectInfo(**dict(row)) for row in rows]
+
+    async def create_project(self, data: ProjectCreate, actor: str = "system") -> ProjectInfo:
+        project_id = (data.id or generate_id("project")).strip()
+        now = _now()
+        await self.db.execute(
+            """INSERT INTO projects (id, name, description, created_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            [project_id, data.name, data.description, actor, now, now],
+        )
+
+        phases = data.phases_config or [
+            "literature", "planning", "data_collection", "implementation", "evaluation", "paper_writing",
+        ]
+        await self.db.execute(
+            """INSERT OR IGNORE INTO project_states
+               (project_id, project_name, project_description, current_phase, phases_config, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            [project_id, data.name, data.description, phases[0], json.dumps(phases), now, now],
+        )
+        await self.db.commit()
+        await self.audit("create", "project", project_id, actor, {"name": data.name})
+        row = await self.db.fetchone("SELECT * FROM projects WHERE id = ?", [project_id])
+        return ProjectInfo(**dict(row))
+
+    async def get(self, project_id: str = DEFAULT_PROJECT_ID) -> ProjectState | None:
+        """Get state for a project."""
+        row = await self.db.fetchone(
+            "SELECT * FROM project_states WHERE project_id = ?",
+            [project_id],
+        )
+        if row is None and project_id == self.DEFAULT_PROJECT_ID:
+            # Legacy fallback for pre-migration DBs
+            row = await self.db.fetchone("SELECT * FROM project_state WHERE id = 1")
         if row is None:
             return None
         return self._row_to_model(row)
 
-    async def initialize(self, name: str, description: str | None = None, phases: list[str] | None = None) -> ProjectState:
+    async def initialize(
+        self,
+        name: str,
+        description: str | None = None,
+        phases: list[str] | None = None,
+        project_id: str = DEFAULT_PROJECT_ID,
+    ) -> ProjectState:
         """Initialize project state (called by `rka init`)."""
         default_phases = phases or [
             "literature", "planning", "data_collection",
             "implementation", "evaluation", "paper_writing",
         ]
         await self.db.execute(
-            """INSERT OR REPLACE INTO project_state
-               (id, project_name, project_description, current_phase, phases_config)
-               VALUES (1, ?, ?, ?, ?)""",
-            [name, description, default_phases[0], json.dumps(default_phases)],
+            """INSERT OR IGNORE INTO projects (id, name, description, created_by)
+               VALUES (?, ?, ?, 'system')""",
+            [project_id, name, description],
+        )
+        await self.db.execute(
+            """INSERT OR REPLACE INTO project_states
+               (project_id, project_name, project_description, current_phase, phases_config, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, COALESCE((SELECT created_at FROM project_states WHERE project_id = ?), ?), ?)""",
+            [project_id, name, description, default_phases[0], json.dumps(default_phases), project_id, _now(), _now()],
         )
         await self.db.commit()
-        await self.audit("create", "project", "1", "system", {"name": name})
-        return await self.get()
+        await self.audit("create", "project", project_id, "system", {"name": name})
+        return await self.get(project_id=project_id)
 
-    async def update(self, data: ProjectStateUpdate, actor: str = "system") -> ProjectState:
+    async def update(
+        self,
+        data: ProjectStateUpdate,
+        actor: str = "system",
+        project_id: str = DEFAULT_PROJECT_ID,
+    ) -> ProjectState:
         """Update project state with partial data."""
-        current = await self.get()
+        current = await self.get(project_id=project_id)
         if current is None:
             raise ValueError("Project not initialized. Run `rka init` first.")
 
@@ -57,8 +112,8 @@ class ProjectService(BaseService):
         values = list(updates.values())
 
         await self.db.execute(
-            f"UPDATE project_state SET {set_clause} WHERE id = 1",
-            values,
+            f"UPDATE project_states SET {set_clause} WHERE project_id = ?",
+            values + [project_id],
         )
         await self.db.commit()
 
@@ -67,14 +122,14 @@ class ProjectService(BaseService):
             await self.emit_event(
                 event_type="phase_changed",
                 entity_type="project",
-                entity_id="1",
+                entity_id=project_id,
                 actor=actor,
                 summary=f"Phase changed: {current.current_phase} → {data.current_phase}",
                 phase=data.current_phase,
             )
 
-        await self.audit("update", "project", "1", actor, {"fields": list(updates.keys())})
-        return await self.get()
+        await self.audit("update", "project", project_id, actor, {"fields": list(updates.keys())})
+        return await self.get(project_id=project_id)
 
     def _row_to_model(self, row: dict) -> ProjectState:
         return ProjectState(

--- a/tests/test_db/test_multi_project_foundation.py
+++ b/tests/test_db/test_multi_project_foundation.py
@@ -1,0 +1,37 @@
+"""Tests for multi-project foundation migration."""
+
+from __future__ import annotations
+
+import pytest
+
+from rka.infra.database import Database
+
+
+@pytest.mark.asyncio
+async def test_default_project_seeded(db: Database):
+    row = await db.fetchone("SELECT id, name FROM projects WHERE id = 'proj_default'")
+    assert row is not None
+    assert row["name"] == "Default Project"
+
+
+@pytest.mark.asyncio
+async def test_core_tables_have_project_id_columns(db: Database):
+    tables = [
+        "decisions",
+        "missions",
+        "literature",
+        "journal",
+        "checkpoints",
+        "events",
+        "audit_log",
+        "tags",
+        "bootstrap_log",
+        "entity_links",
+        "keynodes",
+        "graph_views",
+    ]
+
+    for table in tables:
+        cols = await db.fetchall(f"PRAGMA table_info({table})")
+        col_names = {c["name"] for c in cols}
+        assert "project_id" in col_names

--- a/tests/test_services/test_graph.py
+++ b/tests/test_services/test_graph.py
@@ -14,38 +14,44 @@ async def graph_svc(db: Database) -> GraphService:
     """GraphService with seed data: journal, decision, mission, literature, entity_links."""
     # Seed entities
     await db.execute(
-        "INSERT INTO journal (id, type, content, source, confidence, phase) VALUES (?, ?, ?, ?, ?, ?)",
-        ["jrn_001", "finding", "Side-channel observation on IoT", "pi", "hypothesis", "phase_1"],
+        "INSERT INTO journal (id, type, content, source, confidence, phase, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ["jrn_001", "finding", "Side-channel observation on IoT", "pi", "hypothesis", "phase_1", "proj_default"],
     )
     await db.execute(
-        "INSERT INTO journal (id, type, content, source, confidence, phase) VALUES (?, ?, ?, ?, ?, ?)",
-        ["jrn_002", "insight", "Amplification factor is sqrt(n)", "brain", "tested", "phase_1"],
+        "INSERT INTO journal (id, type, content, source, confidence, phase, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ["jrn_002", "insight", "Amplification factor is sqrt(n)", "brain", "tested", "phase_1", "proj_default"],
     )
     await db.execute(
-        "INSERT INTO decisions (id, question, rationale, decided_by, status, phase) VALUES (?, ?, ?, ?, ?, ?)",
-        ["dec_001", "Statistical vs ML approach", "Balance accuracy", "brain", "active", "phase_1"],
+        "INSERT INTO decisions (id, question, rationale, decided_by, status, phase, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ["dec_001", "Statistical vs ML approach", "Balance accuracy", "brain", "active", "phase_1", "proj_default"],
     )
     await db.execute(
-        "INSERT INTO missions (id, objective, phase, status) VALUES (?, ?, ?, ?)",
-        ["mis_001", "Survey timing methodologies", "phase_1", "active"],
+        "INSERT INTO missions (id, objective, phase, status, project_id) VALUES (?, ?, ?, ?, ?)",
+        ["mis_001", "Survey timing methodologies", "phase_1", "active", "proj_default"],
     )
     await db.execute(
-        "INSERT INTO literature (id, title, status) VALUES (?, ?, ?)",
-        ["lit_001", "Remote Timing Attacks", "reading"],
+        "INSERT INTO literature (id, title, status, project_id) VALUES (?, ?, ?, ?)",
+        ["lit_001", "Remote Timing Attacks", "reading", "proj_default"],
     )
 
     # Seed entity_links
     await db.execute(
-        "INSERT INTO entity_links (id, source_type, source_id, link_type, target_type, target_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ["lnk_001", "journal", "jrn_001", "references", "decision", "dec_001", "brain"],
+        "INSERT INTO entity_links (id, source_type, source_id, link_type, target_type, target_id, created_by, project_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ["lnk_001", "journal", "jrn_001", "references", "decision", "dec_001", "brain", "proj_default"],
     )
     await db.execute(
-        "INSERT INTO entity_links (id, source_type, source_id, link_type, target_type, target_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ["lnk_002", "journal", "jrn_001", "cites", "literature", "lit_001", "brain"],
+        "INSERT INTO entity_links (id, source_type, source_id, link_type, target_type, target_id, created_by, project_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ["lnk_002", "journal", "jrn_001", "cites", "literature", "lit_001", "brain", "proj_default"],
     )
     await db.execute(
-        "INSERT INTO entity_links (id, source_type, source_id, link_type, target_type, target_id, created_by) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ["lnk_003", "decision", "dec_001", "triggered", "mission", "mis_001", "brain"],
+        "INSERT INTO entity_links (id, source_type, source_id, link_type, target_type, target_id, created_by, project_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ["lnk_003", "decision", "dec_001", "triggered", "mission", "mis_001", "brain", "proj_default"],
+    )
+
+    # Different project data for isolation checks
+    await db.execute(
+        "INSERT INTO decisions (id, question, rationale, decided_by, status, phase, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ["dec_999", "Other project only", "N/A", "brain", "active", "phase_x", "proj_other"],
     )
     await db.commit()
 
@@ -86,6 +92,12 @@ class TestFullGraph:
         assert "references" in link_types
         assert "cites" in link_types
         assert "triggered" in link_types
+
+    @pytest.mark.asyncio
+    async def test_scopes_rows_by_project_id(self, graph_svc: GraphService):
+        result = await graph_svc.get_full_graph(project_id="proj_default")
+        node_ids = {n["id"] for n in result["nodes"]}
+        assert "dec_999" not in node_ids
 
 
 class TestEgoGraph:
@@ -134,6 +146,28 @@ class TestStats:
         assert stats["total_edges"] == 3
         assert stats["node_counts"]["journal"] == 2
         assert stats["edge_counts_by_type"]["cites"] == 1
+
+
+class TestCondensedView:
+    @pytest.mark.asyncio
+    async def test_refresh_condensed_view_materializes_keynodes(self, graph_svc: GraphService, db: Database):
+        payload = await graph_svc.refresh_condensed_view(top_per_kind=3, min_importance=0.4)
+
+        assert payload["view"] == "condensed"
+        assert payload["nodes"]
+
+        rows = await db.fetchall("SELECT id, kind, node_refs FROM keynodes")
+        assert rows
+        assert any(r["kind"] == "decision" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_get_condensed_view_uses_cached_graph_view(self, graph_svc: GraphService):
+        await graph_svc.refresh_condensed_view(top_per_kind=3, min_importance=0.4)
+        payload = await graph_svc.get_graph_view(view="condensed")
+
+        assert payload["view"] == "condensed"
+        assert isinstance(payload["nodes"], list)
+        assert isinstance(payload["edges"], list)
 
 
 class TestGuessType:


### PR DESCRIPTION
### Motivation

- Introduce multi-project support so the application can host multiple project containers in a single DB and scope queries by `project_id`.
- Provide condensed/keynode graph views for the research map to improve UI performance and explainability.
- Improve app configurability and LLM handling by honoring injected `config` in the app factory and avoiding reliance on private LLM internals.

### Description

- Wire `create_app(config)` to use the provided `RKAConfig` via `app.state.config` and `set_config`, and update health/error handlers to read the injected config.
- Add dependency helpers in `rka.api.deps`: `set_config`, `get_project_id`, and `require_project`, plus a default `DEFAULT_PROJECT_ID` fallback; update DI singletons accordingly.
- Add multi-project DB migrations: `003_add_graph_keynodes_views.sql` (keynodes, graph_views, edge metadata) and `004_add_multi_project_foundation.sql` (projects, project_states, add `project_id` columns, seed `proj_default`).
- Rewrite `GraphService` to be project-aware (query scoping), add `get_graph_view`, `refresh_condensed_view`, keynode candidate collection, condensed edge aggregation, and helper methods; update routes in `rka/api/routes/graph.py` to accept `project_id` and new view/refresh endpoints.
- Expand `ProjectService` to manage multiple projects with `list_projects`, `create_project`, project-scoped `get`, `initialize`, and `update` flows and emit project-scoped events/audit entries.
- Make `LLMClient` safer and public-facing by adding `available` property, handling empty-model cases, improving error hints, and replacing private `_available` checks across the API and routes.
- Update models, IDs, CLI templates, and various route handlers to use `project_id` (including adding `ProjectInfo`/`ProjectCreate` models), and add ID prefixes for `project`, `keynode`, and `graphview` in `rka/infra/ids.py`.
- Add `CODE_REVIEW.md` summary and introduce/adjust tests for the new multi-project foundation and graph service behavior.

### Testing

- Ran `pytest tests/test_db/test_multi_project_foundation.py` which verifies the `proj_default` seed and presence of `project_id` columns and the test passed.
- Ran `pytest tests/test_services/test_graph.py` which exercises project-scoped graph behavior, ego/full/condensed views, and stats, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b2e232ac948324a86a7ed938203f9b)