### PR TITLE
ci: Phase 0 pytest workflow verification (throwaway)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,42 @@
+name: pytest
+
+# CI runs pytest outside Docker against a fresh venv, per v2.2 Phase 0 design
+# (dec_01KPE5V4EXMWR9MGGPKA1R2VGH). The runtime Dockerfile installs only
+# .[llm,academic,workspace] — keeping production images slim. GitHub Actions
+# installs .[llm,academic,workspace,dev] directly into the runner, so each CI
+# job gets a fresh in-memory/migrated test DB via pytest's tmp_path fixtures.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pytest-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install project with runtime + dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[llm,academic,workspace,dev]"
+
+      - name: Run pytest
+        run: python -m pytest -q --tb=short

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Research Knowledge Agent (RKA)
 
+[![pytest](https://github.com/infinitywings/rka/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/infinitywings/rka/actions/workflows/pytest.yml)
+
 **Persistent research memory for AI-assisted investigations.**
 
 RKA gives your research project a brain that doesn't forget between sessions. It stores every finding, decision, hypothesis, and literature reference in a structured knowledge base with full provenance chains. The Brain (Claude) handles all knowledge enrichment — no local LLM required.
@@ -149,6 +151,14 @@ rka_get_context(topic="...")   → Token-budgeted context package
 | **Multi-project** | Isolated project databases with MCP tools for switching |
 | **Web dashboard** | 12-page React UI: research map with filterable stats, decision tree, knowledge graph, markdown-rendered journal, expandable missions |
 | **Onboarding** | `rka_generate_claude_md` auto-generates project-specific CLAUDE.md from live DB state |
+| **Skills plugin** | Role-specific SKILL.md guides packaged as MCP prompts (Brain, Executor, PI) with worked examples and anti-patterns |
+| **Knowledge freshness** | Staleness detection and propagation through the dependency graph; contradiction detection via vector similarity |
+| **Validation gates** | Structured go/no-go checkpoints (Gate 0–3) with Go/Kill/Hold/Recycle verdicts and assumption tracking |
+| **Cluster management** | Split large clusters, merge thin ones — claim provenance preserved automatically |
+| **Literature workflow** | `rka_process_paper` captures reading annotations as structured claims in one call |
+| **RQ lifecycle** | Track research questions from open → partially_answered → answered → reframed → closed |
+| **Evidence assembly** | `rka_assemble_evidence` produces lit reviews, progress reports, and proposal sections from existing knowledge |
+| **Data integrity** | Categorized table registry prevents silent data loss during export; `rka_check_integrity` verifies the knowledge graph |
 
 ---
 
@@ -158,6 +168,7 @@ rka_get_context(topic="...")   → Token-budgeted context package
 - [Key Concepts](#key-concepts)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [Skills Plugin](#skills-plugin--role-specific-workflow-guidance)
 - [Multi-Project Support](#multi-project-support)
 - [CLI Reference](#cli-reference)
 - [Configuration](#configuration)
@@ -187,7 +198,7 @@ graph TD
     end
 
     subgraph "RKA Server"
-        MCP["MCP Server — 50+ tools"]
+        MCP["MCP Server — 80+ tools"]
         API["REST API — FastAPI"]
         SVC["Service Layer — shared logic"]
         DB["SQLite + FTS5 + sqlite-vec"]
@@ -357,13 +368,17 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 
 **Optional LLM:** If you want `rka_ask` and `rka_generate_summary` features, configure a cloud LLM API (or local LM Studio/Ollama) from the web UI Settings page (`http://localhost:9712/settings`). This is optional — core functionality works without any LLM.
 
-**Connect Claude Code (MCP via pipx):**
+**Connect Claude Code (MCP via uv tool):**
 
 Install the MCP binary outside Docker so Claude Code can launch it directly:
 
 ```bash
-pipx install . --force
+UV_CACHE_DIR=/tmp/uv-cache uv tool install --force .
 ```
+
+The binary includes role-specific skill prompts (`brain_skill`, `executor_skill`, `pi_skill`) that Claude can load for full workflow guidance.
+
+Add to your Claude Code MCP config (`.claude/mcp.json` or VS Code settings):
 
 ```json
 {
@@ -377,6 +392,16 @@ pipx install . --force
 ```
 
 The MCP binary is stateless — it proxies all calls to the Docker container's REST API at `RKA_API_URL`.
+
+**After code changes**, always reinstall the MCP binary:
+
+```bash
+uv tool uninstall rka
+rm -rf /tmp/uv-cache
+UV_CACHE_DIR=/tmp/uv-cache uv tool install --force --reinstall .
+```
+
+Plain `uv tool install --force .` uses cached wheels and may NOT pick up changes.
 
 ### Option B: From Source (Development)
 
@@ -404,8 +429,8 @@ rka serve
 **Connect Claude Desktop/Code (MCP):**
 
 ```bash
-# Install the MCP binary via pipx (avoids macOS sandbox issues)
-pipx install . --force
+# Install the MCP binary via uv tool (avoids macOS sandbox issues)
+UV_CACHE_DIR=/tmp/uv-cache uv tool install --force .
 ```
 
 ```json
@@ -470,6 +495,42 @@ After import, switch to the project in the sidebar and explore the Decision Tree
 Use the web UI for browsing and Q&A, or use Claude Desktop/Code with MCP tools for the full Brain/Executor workflow. The dashboard lets you select the active project, browse the Research Map, manage the review queue, and export the active project as a knowledge pack.
 
 For end-to-end task walkthroughs, see [USAGE_GUIDE.md](USAGE_GUIDE.md) or the [Wiki](https://github.com/infinitywings/rka/wiki).
+
+---
+
+## Skills Plugin — Role-Specific Workflow Guidance
+
+RKA ships with role-specific skill guides that teach Claude how to use the tools effectively. These are packaged with the MCP binary and available as MCP prompts.
+
+### Available Skills
+
+| Skill | Target | Content |
+|-------|--------|---------|
+| `brain_skill` | Claude Desktop | Session start protocol, PI attribution, provenance discipline, claim extraction, multi-task parsing, Research Map workflow, confirmation briefs, knowledge freshness, validation gates, anti-patterns |
+| `executor_skill` | Claude Code | Mission pickup protocol, backbrief procedure, recording standards, escalation triggers, report submission, MCP binary reinstall, cross-role awareness |
+| `pi_skill` | Human researcher | Quick reference for checking status, reading the research map, reviewing decisions, finding what changed |
+
+### How Skills Are Loaded
+
+The MCP server instructions tell Claude to load the appropriate skill prompt at session start. Claude Desktop loads `brain_skill`; Claude Code loads `executor_skill`. The PI can read `skills/pi/SKILL.md` directly.
+
+### Key Workflows
+
+**Brain session start:**
+1. `rka_set_project()` → `rka_get_changelog(since="yesterday")` → `rka_get_research_map()`
+2. Process up to 10 maintenance items silently
+3. Greet the user
+
+**Executor mission pickup:**
+1. `rka_get_mission()` → read `motivated_by_decision` → read context links
+2. Present a Backbrief (plan summary, assumptions, risks)
+3. Wait for Brain approval before starting
+
+**Validation gates (go/no-go checkpoints):**
+1. `rka_create_gate(mission_id, gate_type, deliverables, pass_criteria)`
+2. Work proceeds → deliverables created
+3. `rka_evaluate_gate(gate_id, verdict, notes, assumption_status)`
+4. If assumptions invalidated → staleness cascades through the knowledge graph
 
 ---
 
@@ -724,6 +785,14 @@ All tools are prefixed with `rka_` and available through the MCP stdio interface
 | `rka_supersede_decision` | Mark a decision as superseded by a new decision, with optional re-distillation of affected claims |
 | `rka_trace_provenance` | Trace the full provenance chain for an entity — all upstream sources and downstream derivatives |
 
+### Cluster Management (v2.1)
+
+| Tool | Purpose |
+|------|---------|
+| `rka_list_clusters` | List evidence clusters with claim counts, confidence, and synthesis |
+| `rka_split_cluster` | Split a cluster into multiple new clusters by reassigning its claims |
+| `rka_merge_clusters` | Merge multiple clusters into one new cluster |
+
 ### Review Queue (v2.0)
 
 | Tool | Purpose |
@@ -732,6 +801,31 @@ All tools are prefixed with `rka_` and available through the MCP stdio interface
 | `rka_review_cluster` | Review and approve or revise an evidence cluster's synthesized summary |
 | `rka_review_claims` | Review a set of claims — accept, reject, merge, or flag for further investigation |
 | `rka_resolve_contradiction` | Resolve a contradiction between two claims with a rationale and disposition |
+
+### Knowledge Freshness (v2.1)
+
+| Tool | Purpose |
+|------|---------|
+| `rka_flag_stale` | Flag a claim, cluster, or decision as stale (yellow/red) with optional propagation through the dependency graph |
+| `rka_check_freshness` | Scan for potentially stale knowledge: aging claims, superseded sources, stale clusters and decisions |
+| `rka_detect_contradictions` | Find claims that may contradict a given claim using vector similarity or FTS fallback |
+
+### Validation Gates (v2.1)
+
+| Tool | Purpose |
+|------|---------|
+| `rka_create_gate` | Create a validation gate checkpoint (problem_framing, plan_validation, evidence_review, synthesis_validation) |
+| `rka_evaluate_gate` | Evaluate a gate with Go/Kill/Hold/Recycle verdict; invalidated assumptions auto-cascade staleness |
+
+### Researcher Experience (v2.1)
+
+| Tool | Purpose |
+|------|---------|
+| `rka_get_changelog` | Cross-entity temporal view — what changed since a given date across all entity types |
+| `rka_assemble_evidence` | Assemble evidence under a research question into structured markdown (lit_review, progress_report, proposal_section) |
+| `rka_process_paper` | Literature reading workflow — create reading notes + extract claims from annotations in one call |
+| `rka_advance_rq` | Advance a research question's lifecycle (open → partially_answered → answered → reframed → closed) |
+| `rka_check_integrity` | Verify knowledge base integrity — orphaned edges, missing references, count mismatches |
 
 ### Search and Context
 
@@ -787,12 +881,6 @@ All tools are prefixed with `rka_` and available through the MCP stdio interface
 |------|---------|
 | `rka_export` | Export research data as markdown, JSON, or Mermaid diagram (scopes: state, decisions, literature, full) |
 | `rka_export_mermaid` | Export the decision tree as a Mermaid flowchart with status-based styling |
-
-### Enrichment
-
-| Tool | Purpose |
-|------|---------|
-| `rka_enrich` | Trigger or check background enrichment jobs for one or more entities |
 
 ---
 
@@ -896,6 +984,26 @@ Most entity endpoints are project-scoped. Pass `X-RKA-Project: <project_id>` to 
 | `GET` | `/review-queue` | List review-queue items (filters: status, reason, since) |
 | `POST` | `/review-queue` | Add an item to the review queue manually |
 | `PUT` | `/review-queue/{id}/resolve` | Resolve a review-queue item with a disposition |
+
+### Researcher Tools (v2.1)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/changelog` | Cross-entity temporal view (query: `since`, `limit`) |
+| `GET` | `/assemble-evidence` | Assemble evidence as markdown (query: `research_question_id`, `format`) |
+| `POST` | `/clusters/split` | Split a cluster into multiple new clusters |
+| `POST` | `/clusters/merge` | Merge multiple clusters into one |
+| `POST` | `/literature/process-paper` | Process paper annotations into claims |
+| `POST` | `/research-questions/advance` | Advance an RQ lifecycle status |
+
+### Knowledge Freshness (v2.1)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/freshness/flag-stale` | Flag an entity as stale with optional propagation |
+| `GET` | `/freshness/check` | Scan for potentially stale items |
+| `POST` | `/freshness/detect-contradictions` | Find contradiction candidates via vector similarity or FTS |
+| `GET` | `/integrity` | Run knowledge base integrity check |
 
 ### Search and Context
 
@@ -1196,6 +1304,11 @@ The test suite covers database schema, CRUD operations, FTS5 search, context eng
 
 ```
 rka/
++-- skills/                     # MCP skill prompts (packaged with binary)
+|   +-- SKILL.md                # Router: detects role, directs to sub-skill
+|   +-- brain/SKILL.md          # Brain workflow guide (~450 lines)
+|   +-- executor/SKILL.md       # Executor workflow guide (~150 lines)
+|   +-- pi/SKILL.md             # PI quick reference
 +-- rka/                        # Python package
 |   +-- cli.py                  # Click CLI (init, serve, mcp, status, backup, migrate, bootstrap)
 |   +-- config.py               # Pydantic settings (RKAConfig)
@@ -1221,7 +1334,8 @@ rka/
 |   |   +-- audit.py            # Audit log queries and counts
 |   |   +-- academic.py         # BibTeX import, DOI enrichment, Mermaid export
 |   |   +-- artifacts.py        # Artifact registration + figure extraction
-|   |   +-- knowledge_pack.py   # Project export/import packs
+|   |   +-- knowledge_pack.py   # Project export/import packs (categorized table registry)
+|   |   +-- researcher_tools.py # Changelog, evidence assembly, cluster split/merge, paper processing, RQ lifecycle
 |   |   +-- workspace.py        # Workspace bootstrap (scan, classify, ingest)
 |   |   +-- jobs.py             # Job queue primitives
 |   |   +-- summary.py          # Q&A + summary generation
@@ -1256,7 +1370,7 @@ rka/
 |           +-- project.py
 |           +-- llm.py
 |           +-- summary.py
-|           +-- enrich.py
+|           +-- researcher_tools.py  # Changelog, evidence assembly, split/merge, process paper, advance RQ, integrity
 |           +-- events.py
 |           +-- tags.py
 +-- web/                        # React dashboard (Vite + TypeScript)
@@ -1301,6 +1415,7 @@ rka/
 | **Phase 7** | Notebook + LLM Config — Q&A chat, summary generation, runtime LLM configuration, context window auto-detection, knowledge graph, Docker deployment | Complete |
 | **Phase 8** | Multi-Project + Knowledge Packs — project isolation, dashboard project management, portable project export/import, artifact-safe import remapping, MCP multi-project tools | Complete |
 | **Phase 9** | v2.0 — Progressive distillation pipeline (entries -> claims -> clusters -> research map), three-level Research Map page, Brain-augmented enrichment via review queue, decision superseding with re-distillation, provenance chains, typed cross-references (link_), hierarchical topic taxonomy, background worker process, onboarding tools (rka_generate_claude_md), simplified journal entry types (note/log/directive) | Complete |
+| **Phase 10** | v2.1 — Skills plugin (role-specific SKILL.md as MCP prompts), interactive Research Map with cluster detail panels, researcher experience tools (changelog, evidence assembly, cluster split/merge, literature processing, RQ lifecycle), three-layer defense-in-depth (actor alignment protocol, knowledge freshness with staleness propagation, validation gates), knowledge pack redesign with table registry and integrity checks, `rka_check_integrity` tool | Complete |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rka"
-version = "2.1.0"
+version = "2.2.0-dev"
 description = "Research Knowledge Agent — MCP server + REST API for AI-assisted research orchestration"
 requires-python = ">=3.11"
 dependencies = [

--- a/rka/__init__.py
+++ b/rka/__init__.py
@@ -1,3 +1,3 @@
 """Research Knowledge Agent — MCP server + REST API for AI-assisted research."""
 
-__version__ = "2.1.0"
+__version__ = "2.2.0-dev"

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -2657,9 +2657,7 @@ async def rka_trace_provenance(
         max_depth: Maximum hops to traverse (default 4)
     """
     async with _client() as c:
-        r = await c.get("/api/graph/ego", params={
-            "entity_id": entity_id, "depth": max_depth,
-        })
+        r = await c.get(f"/api/graph/ego/{entity_id}", params={"depth": max_depth})
         _raise_with_detail(r)
     data = r.json()
     nodes = {n["id"]: n for n in data.get("nodes", [])}

--- a/rka/services/graph.py
+++ b/rka/services/graph.py
@@ -249,11 +249,27 @@ class GraphService:
             if not frontier:
                 break
             placeholders = ",".join("?" for _ in frontier)
+            frontier_list = list(frontier)
             rows = await self.db.fetchall(
                 f"SELECT source_type, source_id, link_type, target_type, target_id, created_at "
                 f"FROM entity_links "
                 f"WHERE {self._project_clause()} AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
-                [project_id] + list(frontier) + list(frontier),
+                [project_id] + frontier_list + frontier_list,
+            )
+            # Also expand via claim_edges (cluster membership + claim-to-claim relations).
+            # Returns no rows when the frontier contains no clm_/ecl_ IDs, so this is safe
+            # for non-claim entities.
+            # Edge direction: member_of points claim -> cluster (source_claim_id -> cluster_id,
+            # target_claim_id is NULL). Other relations (supports/contradicts/qualifies/supersedes)
+            # point source_claim_id -> target_claim_id.
+            ce_rows = await self.db.fetchall(
+                f"SELECT source_claim_id, target_claim_id, cluster_id, relation, created_at "
+                f"FROM claim_edges "
+                f"WHERE {self._project_clause()} AND ("
+                f"source_claim_id IN ({placeholders}) OR "
+                f"target_claim_id IN ({placeholders}) OR "
+                f"cluster_id IN ({placeholders}))",
+                [project_id] + frontier_list + frontier_list + frontier_list,
             )
             visited |= frontier
             next_frontier: set[str] = set()
@@ -265,6 +281,22 @@ class GraphService:
                     "created_at": row["created_at"],
                 })
                 for eid in (row["source_id"], row["target_id"]):
+                    if eid not in visited:
+                        next_frontier.add(eid)
+            for row in ce_rows:
+                src = row["source_claim_id"]
+                # member_of edges point claim -> cluster (target_claim_id is NULL).
+                # All other relations point claim -> claim.
+                tgt = row["cluster_id"] if row["relation"] == "member_of" else row["target_claim_id"]
+                if not src or not tgt:
+                    continue
+                all_edges.append({
+                    "source": src,
+                    "target": tgt,
+                    "link_type": row["relation"],
+                    "created_at": row["created_at"],
+                })
+                for eid in (src, tgt):
                     if eid not in visited:
                         next_frontier.add(eid)
             frontier = next_frontier

--- a/tests/test_api/test_app_lifespan.py
+++ b/tests/test_api/test_app_lifespan.py
@@ -18,8 +18,12 @@ from rka.infra.llm import LLMClient
 
 @pytest.mark.asyncio
 async def test_lifespan_does_not_block_on_llm_startup_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Probe sleeps 1.0s; lifespan must return well before the probe completes.
+    # Earlier threshold of 0.15s was flaky on slower/shared CI runners — a 0.5s
+    # threshold still catches a blocking regression (would be >=1.0s) while
+    # tolerating CI scheduling noise.
     async def fake_is_available(self: LLMClient) -> bool:
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(1.0)
         self._available = False
         return False
 
@@ -44,7 +48,7 @@ async def test_lifespan_does_not_block_on_llm_startup_probe(tmp_path: Path, monk
     elapsed = time.perf_counter() - start
 
     try:
-        assert elapsed < 0.15
+        assert elapsed < 0.5
     finally:
         await lifespan.__aexit__(None, None, None)
 

--- a/tests/test_db/test_v2_migration.py
+++ b/tests/test_db/test_v2_migration.py
@@ -74,6 +74,11 @@ async def test_decisions_have_v2_columns(db: Database):
 @pytest.mark.asyncio
 async def test_missions_have_v2_columns(db: Database):
     """Missions table has iteration, parent_mission_id, motivated_by_decision."""
+    # motivated_by_decision is a FK to decisions(id); seed the referenced row first.
+    await db.execute(
+        """INSERT INTO decisions (id, phase, question, decided_by, status, project_id)
+           VALUES ('dec_x', 'p1', 'test?', 'brain', 'active', 'proj_default')""",
+    )
     await db.execute(
         """INSERT INTO missions (id, phase, objective, status, iteration, motivated_by_decision, project_id)
            VALUES ('msn_test', 'p1', 'test', 'pending', 2, 'dec_x', 'proj_default')""",
@@ -87,6 +92,11 @@ async def test_missions_have_v2_columns(db: Database):
 @pytest.mark.asyncio
 async def test_claims_table_exists(db: Database):
     """Claims table is created by migration."""
+    # claims.source_entry_id FKs to journal(id); seed it first.
+    await db.execute(
+        """INSERT INTO journal (id, type, content, source, confidence, importance, status, pinned, project_id)
+           VALUES ('jrn_1', 'note', 'src', 'brain', 'hypothesis', 'normal', 'active', 0, 'proj_default')""",
+    )
     await db.execute(
         """INSERT INTO claims (id, source_entry_id, claim_type, content, project_id)
            VALUES ('clm_test', 'jrn_1', 'hypothesis', 'test claim', 'proj_default')""",
@@ -117,7 +127,12 @@ async def test_evidence_clusters_table_exists(db: Database):
 @pytest.mark.asyncio
 async def test_claim_edges_table_exists(db: Database):
     """Claim edges table is created by migration."""
-    # First create a claim to reference
+    # claims.source_entry_id FKs to journal(id); claim_edges.source_claim_id FKs to claims(id).
+    # Seed the full chain before the claim_edges insert.
+    await db.execute(
+        """INSERT INTO journal (id, type, content, source, confidence, importance, status, pinned, project_id)
+           VALUES ('jrn_1', 'note', 'src', 'brain', 'hypothesis', 'normal', 'active', 0, 'proj_default')""",
+    )
     await db.execute(
         """INSERT INTO claims (id, source_entry_id, claim_type, content, project_id)
            VALUES ('clm_e1', 'jrn_1', 'evidence', 'test', 'proj_default')""",

--- a/tests/test_services/test_decision_literature_worker.py
+++ b/tests/test_services/test_decision_literature_worker.py
@@ -79,13 +79,13 @@ class TestDecisionQueue:
         fts_rows = await db.fetchall("SELECT * FROM fts_decisions WHERE id = ?", [dec.id])
         assert len(fts_rows) == 1
 
-        # 2 jobs enqueued
+        # Only embed job enqueued; LLM-dependent auto_tag removed when local LLM
+        # was deprecated — those responsibilities moved to the Brain.
         jobs = await db.fetchall(
             "SELECT job_type, status FROM jobs WHERE entity_type = 'decision' AND entity_id = ? ORDER BY job_type",
             [dec.id],
         )
         assert jobs == [
-            {"job_type": "decision_auto_tag", "status": "pending"},
             {"job_type": "decision_embed", "status": "pending"},
         ]
 
@@ -127,7 +127,7 @@ class TestDecisionQueue:
         )
 
         worker = EnrichmentWorker(
-            db=db, llm=llm, embeddings=embeddings,
+            db=db, embeddings=embeddings,
             poll_interval=0.01, lease_seconds=60, max_attempts=3,
         )
 
@@ -135,11 +135,12 @@ class TestDecisionQueue:
         while await worker.run_once():
             handled += 1
 
-        assert handled == 2
+        # Only the embed job is processed; auto_tag is no longer enqueued.
+        assert handled == 1
         refreshed = await svc.get(dec.id)
         assert refreshed.enrichment_status == "ready"
-        assert sorted(refreshed.tags) == ["architecture", "database"]
-        assert llm.calls == 1
+        assert refreshed.tags == []
+        assert llm.calls == 0
         assert embeddings.calls == 1
 
 
@@ -172,7 +173,6 @@ class TestLiteratureQueue:
             [lit.id],
         )
         assert jobs == [
-            {"job_type": "literature_auto_tag", "status": "pending"},
             {"job_type": "literature_embed", "status": "pending"},
         ]
 
@@ -212,7 +212,7 @@ class TestLiteratureQueue:
         )
 
         worker = EnrichmentWorker(
-            db=db, llm=llm, embeddings=embeddings,
+            db=db, embeddings=embeddings,
             poll_interval=0.01, lease_seconds=60, max_attempts=3,
         )
 
@@ -220,11 +220,11 @@ class TestLiteratureQueue:
         while await worker.run_once():
             handled += 1
 
-        assert handled == 2
+        assert handled == 1
         refreshed = await svc.get(lit.id)
         assert refreshed.enrichment_status == "ready"
-        assert sorted(refreshed.tags) == ["attention", "transformers"]
-        assert llm.calls == 1
+        assert refreshed.tags == []
+        assert llm.calls == 0
         assert embeddings.calls == 1
 
     @pytest.mark.asyncio

--- a/tests/test_services/test_graph.py
+++ b/tests/test_services/test_graph.py
@@ -126,6 +126,49 @@ class TestEgoGraph:
         assert len(result["edges"]) == 0
 
 
+class TestEgoGraphClaimEdges:
+    @pytest_asyncio.fixture
+    async def cluster_svc(self, db: Database) -> GraphService:
+        """GraphService seeded with a cluster and two member claims via claim_edges."""
+        await db.execute(
+            "INSERT INTO journal (id, type, content, source, confidence, phase, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ["jrn_src", "finding", "Source entry for test claims", "brain", "hypothesis", "phase_1", "proj_default"],
+        )
+        await db.execute(
+            "INSERT INTO evidence_clusters (id, label, project_id) VALUES (?, ?, ?)",
+            ["ecl_test", "Test cluster", "proj_default"],
+        )
+        await db.execute(
+            "INSERT INTO claims (id, source_entry_id, claim_type, content, project_id) VALUES (?, ?, ?, ?, ?)",
+            ["clm_a", "jrn_src", "evidence", "Claim A", "proj_default"],
+        )
+        await db.execute(
+            "INSERT INTO claims (id, source_entry_id, claim_type, content, project_id) VALUES (?, ?, ?, ?, ?)",
+            ["clm_b", "jrn_src", "evidence", "Claim B", "proj_default"],
+        )
+        await db.execute(
+            "INSERT INTO claim_edges (id, source_claim_id, cluster_id, relation, project_id) VALUES (?, ?, ?, ?, ?)",
+            ["ced_a", "clm_a", "ecl_test", "member_of", "proj_default"],
+        )
+        await db.execute(
+            "INSERT INTO claim_edges (id, source_claim_id, cluster_id, relation, project_id) VALUES (?, ?, ?, ?, ?)",
+            ["ced_b", "clm_b", "ecl_test", "member_of", "proj_default"],
+        )
+        await db.commit()
+        return GraphService(db=db)
+
+    @pytest.mark.asyncio
+    async def test_cluster_ego_includes_member_claims(self, cluster_svc: GraphService):
+        result = await cluster_svc.get_ego_graph("ecl_test", depth=1)
+        node_ids = {n["id"] for n in result["nodes"]}
+        assert node_ids == {"ecl_test", "clm_a", "clm_b"}
+        edge_types = [e["link_type"] for e in result["edges"]]
+        assert edge_types.count("member_of") == 2
+        for edge in result["edges"]:
+            assert edge["target"] == "ecl_test"
+            assert edge["source"] in {"clm_a", "clm_b"}
+
+
 class TestDecisionTree:
     @pytest.mark.asyncio
     async def test_returns_decision_with_linked_entities(self, graph_svc: GraphService):

--- a/tests/test_services/test_mission_worker.py
+++ b/tests/test_services/test_mission_worker.py
@@ -89,8 +89,8 @@ class TestMissionQueue:
                ORDER BY job_type""",
             ["proj_alpha", mission.id],
         )
+        # LLM-dependent mission_auto_tag is no longer enqueued — only embed.
         assert jobs == [
-            {"job_type": "mission_auto_tag", "status": "pending"},
             {"job_type": "mission_embed", "status": "pending"},
         ]
 
@@ -120,7 +120,6 @@ class TestMissionQueue:
 
         worker = EnrichmentWorker(
             db=db,
-            llm=llm,
             embeddings=embeddings,
             poll_interval=0.01,
             lease_seconds=60,
@@ -132,11 +131,11 @@ class TestMissionQueue:
             handled += 1
 
         refreshed = await svc.get(mission.id)
-        assert handled == 2
+        assert handled == 1
         assert refreshed is not None
         assert refreshed.enrichment_status == "ready"
-        assert refreshed.tags == ["evaluation", "baseline"]
-        assert llm.calls == 1
+        assert refreshed.tags == []
+        assert llm.calls == 0
         assert embeddings.calls == 1
 
         metadata = await db.fetchall(
@@ -151,7 +150,7 @@ class TestMissionQueue:
             "SELECT status FROM jobs WHERE entity_id = ? ORDER BY job_type",
             [mission.id],
         )
-        assert [job["status"] for job in jobs] == ["completed", "completed"]
+        assert [job["status"] for job in jobs] == ["completed"]
 
     @pytest.mark.asyncio
     async def test_job_queue_dedupes_pending_jobs(self, db: Database):
@@ -180,6 +179,7 @@ class TestMissionQueue:
 
     @pytest.mark.asyncio
     async def test_worker_marks_job_failed_after_max_attempts(self, db: Database):
+        """Exceptions raised during job processing mark the job failed after max_attempts."""
         await _ensure_project(db, "proj_alpha", "Alpha")
         await db.execute(
             "INSERT INTO missions (id, phase, objective, status, project_id) VALUES (?, ?, ?, ?, ?)",
@@ -187,20 +187,23 @@ class TestMissionQueue:
         )
         await db.commit()
 
+        class FailingEmbeddings(DummyEmbeddings):
+            async def embed_document(self, text: str) -> list[float]:
+                raise RuntimeError("Embedding service unavailable")
+
         queue = JobQueue(db, default_max_attempts=1)
         await queue.enqueue(
-            "mission_auto_tag",
+            "mission_embed",
             project_id="proj_alpha",
             entity_type="mission",
             entity_id="mis_fail",
             max_attempts=1,
-            dedupe_key="proj_alpha:mission:mis_fail:auto_tag",
+            dedupe_key="proj_alpha:mission:mis_fail:embed",
         )
 
         worker = EnrichmentWorker(
             db=db,
-            llm=DummyLLM(raises=True),
-            embeddings=None,
+            embeddings=FailingEmbeddings(db),
             poll_interval=0.01,
             lease_seconds=60,
             max_attempts=1,
@@ -214,4 +217,4 @@ class TestMissionQueue:
         assert row is not None
         assert row["status"] == "failed"
         assert row["attempts"] == 1
-        assert "LLM unavailable" in row["last_error"]
+        assert "Embedding service unavailable" in row["last_error"]

--- a/tests/test_services/test_note_worker.py
+++ b/tests/test_services/test_note_worker.py
@@ -81,7 +81,7 @@ class DummyEmbeddings(EmbeddingService):
 class TestNoteQueue:
     @pytest.mark.asyncio
     async def test_create_note_returns_immediately(self, db: Database):
-        """Note creation should not call LLM inline; enrichment is queued."""
+        """Note creation should not call LLM inline; only embed enrichment is queued."""
         await _ensure_project(db, "proj_notes", "Notes")
         llm = DummyLLM()
         embeddings = DummyEmbeddings(db)
@@ -96,11 +96,12 @@ class TestNoteQueue:
             actor="executor",
         )
 
-        # No LLM calls during create
+        # No LLM calls during create (auto_tag/auto_link/auto_summarize were removed
+        # when local-LLM enrichment was deprecated — those moved to the Brain).
         assert llm.calls == {"auto_tag": 0, "semantic_link": 0, "summarize": 0}
         assert embeddings.calls == 0
 
-        # Enrichment is pending
+        # Embed is queued, note reports pending until the worker processes it.
         assert note.enrichment_status == "pending"
         assert note.tags == []
         assert note.summary is None
@@ -109,7 +110,7 @@ class TestNoteQueue:
         fts_rows = await db.fetchall("SELECT * FROM fts_journal WHERE id = ?", [note.id])
         assert len(fts_rows) == 1
 
-        # 4 jobs enqueued: auto_tag, auto_link, auto_summarize, embed
+        # Only note_embed is enqueued.
         jobs = await db.fetchall(
             """SELECT job_type, status, priority
                FROM jobs
@@ -117,73 +118,13 @@ class TestNoteQueue:
                ORDER BY job_type""",
             ["proj_notes", note.id],
         )
-        assert len(jobs) == 4
-        job_types = [j["job_type"] for j in jobs]
-        assert "note_auto_tag" in job_types
-        assert "note_auto_link" in job_types
-        assert "note_auto_summarize" in job_types
-        assert "note_embed" in job_types
-
-    @pytest.mark.asyncio
-    async def test_create_note_with_user_tags_skips_auto_tag_job(self, db: Database):
-        """When user provides tags, auto_tag job is not enqueued."""
-        await _ensure_project(db, "proj_notes", "Notes")
-        llm = DummyLLM()
-        svc = NoteService(db, llm=llm, embeddings=None, project_id="proj_notes")
-
-        note = await svc.create(
-            JournalEntryCreate(
-                content="Manual observation.",
-                type="observation",
-                source="pi",
-                tags=["manual", "curated"],
-            ),
-        )
-
-        assert sorted(note.tags) == ["curated", "manual"]
-
-        jobs = await db.fetchall(
-            "SELECT job_type FROM jobs WHERE entity_id = ? ORDER BY job_type",
-            [note.id],
-        )
-        job_types = [j["job_type"] for j in jobs]
-        assert "note_auto_tag" not in job_types
-        assert "note_auto_link" in job_types
-        assert "note_auto_summarize" in job_types
-
-    @pytest.mark.asyncio
-    async def test_create_note_with_user_links_skips_auto_link_job(self, db: Database):
-        """When user provides related entities, auto_link job is not enqueued."""
-        await _ensure_project(db, "proj_notes", "Notes")
-        llm = DummyLLM()
-        svc = NoteService(db, llm=llm, embeddings=None, project_id="proj_notes")
-
-        note = await svc.create(
-            JournalEntryCreate(
-                content="This finding relates to mission X.",
-                type="finding",
-                source="executor",
-                related_mission="mis_test001",
-            ),
-        )
-
-        jobs = await db.fetchall(
-            "SELECT job_type FROM jobs WHERE entity_id = ? ORDER BY job_type",
-            [note.id],
-        )
-        job_types = [j["job_type"] for j in jobs]
-        assert "note_auto_link" not in job_types
-        assert "note_auto_tag" in job_types
-        assert "note_auto_summarize" in job_types
+        assert [j["job_type"] for j in jobs] == ["note_embed"]
 
     @pytest.mark.asyncio
     async def test_worker_processes_note_jobs(self, db: Database):
-        """Worker should process all note jobs and populate tags/summary/embedding."""
+        """Worker processes note_embed; no LLM-dependent jobs enqueued post-deprecation."""
         await _ensure_project(db, "proj_notes", "Notes")
-        llm = DummyLLM(
-            tags=["precision", "fine-tuning"],
-            summary="15% precision improvement after fine-tuning.",
-        )
+        llm = DummyLLM()  # unused by worker; kept for NoteService construction parity
         embeddings = DummyEmbeddings(db)
         svc = NoteService(db, llm=llm, embeddings=embeddings, project_id="proj_notes")
 
@@ -198,7 +139,6 @@ class TestNoteQueue:
 
         worker = EnrichmentWorker(
             db=db,
-            llm=llm,
             embeddings=embeddings,
             poll_interval=0.01,
             lease_seconds=60,
@@ -209,16 +149,14 @@ class TestNoteQueue:
         while await worker.run_once():
             handled += 1
 
-        assert handled == 4
+        assert handled == 1
 
         refreshed = await svc.get(note.id)
         assert refreshed is not None
         assert refreshed.enrichment_status == "ready"
-        assert sorted(refreshed.tags) == ["fine-tuning", "precision"]
-        assert refreshed.summary == "15% precision improvement after fine-tuning."
-        assert llm.calls["auto_tag"] == 1
-        assert llm.calls["summarize"] == 1
-        assert llm.calls["semantic_link"] == 1
+        assert refreshed.tags == []
+        assert refreshed.summary is None
+        assert llm.calls == {"auto_tag": 0, "semantic_link": 0, "summarize": 0}
         assert embeddings.calls == 1
 
     @pytest.mark.asyncio
@@ -250,9 +188,13 @@ class TestNoteQueue:
 
     @pytest.mark.asyncio
     async def test_worker_handles_note_job_failure(self, db: Database):
-        """Failed LLM calls should mark jobs as failed after max attempts."""
+        """Exceptions during embed processing mark the job failed after max attempts."""
         await _ensure_project(db, "proj_notes", "Notes")
-        # Create note without LLM so no jobs are enqueued
+
+        class FailingEmbeddings(DummyEmbeddings):
+            async def embed_document(self, text: str) -> list[float]:
+                raise RuntimeError("Embedding service unavailable")
+
         svc_no_llm = NoteService(db, llm=None, embeddings=None, project_id="proj_notes")
         note = await svc_no_llm.create(
             JournalEntryCreate(
@@ -262,21 +204,19 @@ class TestNoteQueue:
             ),
         )
 
-        # Manually enqueue a job that will fail
         queue = JobQueue(db, default_max_attempts=1)
         await queue.enqueue(
-            "note_auto_tag",
+            "note_embed",
             project_id="proj_notes",
             entity_type="journal",
             entity_id=note.id,
             max_attempts=1,
-            dedupe_key=f"proj_notes:journal:{note.id}:auto_tag",
+            dedupe_key=f"proj_notes:journal:{note.id}:embed",
         )
 
         worker = EnrichmentWorker(
             db=db,
-            llm=DummyLLM(raises=True),
-            embeddings=None,
+            embeddings=FailingEmbeddings(db),
             poll_interval=0.01,
             lease_seconds=60,
             max_attempts=1,
@@ -290,7 +230,7 @@ class TestNoteQueue:
         assert row is not None
         assert row["status"] == "failed"
         assert row["attempts"] == 1
-        assert "LLM unavailable" in row["last_error"]
+        assert "Embedding service unavailable" in row["last_error"]
 
         # Note should show failed enrichment status
         refreshed = await svc_no_llm.get(note.id)

--- a/tests/test_services/test_workspace.py
+++ b/tests/test_services/test_workspace.py
@@ -445,10 +445,10 @@ class TestIngest:
         assert result.total_errors == 0
         assert result.total_created == 1
 
-        # Verify the entry exists and has methodology type
+        # Migration 009 mapped legacy 'methodology' -> 'log' for the v2 type vocabulary.
         rows = await db.fetchall("SELECT * FROM journal")
         assert len(rows) == 1
-        assert rows[0]["type"] == "methodology"
+        assert rows[0]["type"] == "log"
         assert "analysis.py" in rows[0]["content"]
 
     @pytest.mark.asyncio
@@ -464,9 +464,10 @@ class TestIngest:
         assert result.total_errors == 0
         assert result.total_created == 1
 
+        # Migration 009 mapped legacy 'observation' -> 'note' for the v2 type vocabulary.
         rows = await db.fetchall("SELECT * FROM journal")
         assert len(rows) == 1
-        assert rows[0]["type"] == "observation"
+        assert rows[0]["type"] == "note"
 
     @pytest.mark.asyncio
     async def test_ingest_skips_unknown(


### PR DESCRIPTION
## Summary

Throwaway PR to verify the new pytest CI workflow runs green before Mission 0.4 makes the real commits to the v2.2 branch.

Bundles four Phase 0 mission outputs:
- **Mission 0.1** URL fix at `rka/mcp/server.py:2660`
- **Mission 0.2** version bumps (`pyproject.toml` + `rka/__init__.py` → `2.2.0-dev`)
- **Mission 0.5** `get_ego_graph` extension + `TestEgoGraphClaimEdges`
- **Mission 0.3** (this mission) `.github/workflows/pytest.yml` + 17 stale test fixes + README badge

## Test plan

- [ ] CI workflow runs
- [ ] All 227 tests pass
- [ ] Workflow takes less than 5 minutes (mission checkpoint trigger threshold)

**Do not merge** — Mission 0.4 creates the clean commits on the v2.2 branch.