### PR TITLE
Add Writer role (Phase 1): rka/skills/writer/

### DIFF
--- a/rka/skills/SKILL.md
+++ b/rka/skills/SKILL.md
@@ -6,6 +6,7 @@ Use exactly one role skill for the current session:
 - `brain/SKILL.md` for strategy, literature review, research-map review, and decisions
 - `executor/SKILL.md` for implementation, experiments, mission work, and reports
 - `pi/SKILL.md` for supervision, checkpoint resolution, and preserving PI intent
+- `writer/SKILL.md` for manuscript drafting in Claude Code (VSCode); loaded in a `manuscripts/<project-id>/<venue>/` working directory. Phase 1 MVP per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D`; mission `mis_01KS0C3RP04XANCZAB3HTNAG0P`.
 
 ## Common Rules
 

--- a/rka/skills/writer/LICENSE-THIRDPARTY.md
+++ b/rka/skills/writer/LICENSE-THIRDPARTY.md
@@ -1,0 +1,1 @@
+No third-party content vendored in Phase 1. Anti-AI-tic enforcement implemented from primary sources per dec_01KS12H9KT1T03DHX2Q6FKTXHH.

--- a/rka/skills/writer/README.md
+++ b/rka/skills/writer/README.md
@@ -1,0 +1,150 @@
+# RKA Writer Skill
+
+Phase 1 MVP. Loadable by Claude Code in VSCode, the Writer co-authors
+manuscripts grounded in the RKA research graph. Drafts but does not
+assert: every prose claim carries provenance to a `lit_`, `jrn_`, or
+`dec_` entity.
+
+Mission of record: `mis_01KS0C3RP04XANCZAB3HTNAG0P`.
+Decisions: `dec_01KS0AWYDV752AWQRF40CQBRFZ` (deployment),
+`dec_01KS0AXXASJ5GXV7M0SS39Y066` (SerpAPI tertiary),
+`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` (Q1-Q8 bundle),
+`dec_01KS12H9KT1T03DHX2Q6FKTXHH` (anti-AI-tic primary-source disposition).
+
+## Quickstart
+
+### 1. Copy the workspace template to your manuscript directory
+
+```
+cp -R rka/skills/writer/workspace-template manuscripts/<project-id>/<venue>/
+cd manuscripts/<project-id>/<venue>/
+```
+
+Then customize:
+
+- Edit `.mcp.json`: replace `<your-username>` and `prj_REPLACE_WITH_PROJECT_ID`.
+- Edit `.planning/PRECIS.md`: PI authors the title and abstract.
+- Edit `main.tex` after the Venue checkpoint resolves: replace
+  `\documentclass{article}` with the venue class.
+
+### 2. Launch Claude Code in the manuscript directory
+
+```
+claude
+```
+
+The Writer skill loads on session start (rka-writer skill). The Session
+Start procedure runs:
+
+1. `rka_get_status()` confirms the active project.
+2. `rka_get_changelog()` surfaces RKA changes since last session.
+3. `rka_get_research_map()` provides the structural overview.
+4. `.planning/ACTIVE_WORKFLOW.md` carries resume state.
+5. The Writer greets the PI with the inferred next action.
+
+### 3. Run scripts via Bash
+
+The Writer invokes scripts via the `Bash` tool inside Claude Code. PI
+can also invoke them directly from a terminal:
+
+```
+# Lint a section for AI-tics
+python3 rka/skills/writer/scripts/ai_tic_lint.py sections/03-method.tex \
+        --config ai_tic_config.yaml \
+        --output ai_tic_report.json
+
+# Detect bridge repetition across sections
+python3 rka/skills/writer/scripts/bridge_repetition_check.py sections/*.tex
+
+# Build the PDF
+./rka/skills/writer/scripts/render.sh main.tex
+
+# Audit the layout after a successful render
+python3 rka/skills/writer/scripts/layout_audit.py --venue CHI --output audit.json
+```
+
+## What Phase 1 ships
+
+| Component | Status |
+|---|---|
+| SKILL.md (16 sections, v2.3.2) | full |
+| references/ (9 files plus 2 venue files) | full |
+| scripts/ai_tic_lint.py | full Phase 1 (lexical + structural) |
+| scripts/bridge_repetition_check.py | full (clean-room) |
+| scripts/render.sh | full |
+| scripts/layout_audit.py | full Phase 1 (12 fields) |
+| scripts/chart_render.py | skeleton (PI fills per manuscript) |
+| scripts/validate_references.py | Stage A only |
+| scripts/fetch_template.py | registry lookup only |
+| workspace-template/ | full skeleton |
+| tests/skills/writer/ | 43 tests, all passing |
+
+## What Phase 1 does NOT ship (deferred)
+
+Phase 2 deliverables:
+
+- `rka-writer-tools` MCP server (habanero + pyalex + semanticscholar +
+  arxiv + serpapi wrappers exposing high-level validation operations).
+- Reference validation Stages B through G (cross-source resolution,
+  retraction check, author disambiguation, niche-citation rescue).
+- SerpAPI integration with credit budget tracking.
+- 5 additional venue files: USENIX, IEEE-SP, NeurIPS, OSDI, Nature.
+- Author disambiguation with ORCID + SerpAPI.
+- Full bibliography compilation chain (manubot + bibtex-tidy + betterbib).
+
+Phase 3 deliverables:
+
+- Revision Loop with 4 `comment_class` mission shapes (R1, R2, R3, R4)
+  wired to the Brain via `rka_create_mission`.
+- Brain mission integration: Brain spawns a Writer subagent on a
+  Revision Mission.
+- Optional MCP tools `rka_get_manuscript`, `rka_validate_reference`,
+  `rka_register_manuscript` added to the existing `rka` server.
+
+See [`docs/phase-1-mvp.md`](docs/phase-1-mvp.md) for the detailed
+Phase 1 narrative and manual workflow guidance.
+
+## Per-project AI-tic configuration
+
+`ai_tic_config.yaml` in the manuscript directory overrides default
+behavior on a per-term basis. The defaults block HIGH-tier terms (PI
+verbatim list plus Kobak 2025 plus Matsui 2025). Disable a term:
+
+```yaml
+facilitate:
+  verdict: disable
+  rationale: "Used in the medical sense (catheter facilitates drainage); domain-legitimate."
+```
+
+CRITICAL hits and absolute bans (em-dash U+2014, en-dash U+2013, bullet
+density) cannot be overridden. See [`references/ai_tics.md`](references/ai_tics.md)
+for the full tier table and replacement guidance.
+
+## Architecture overview
+
+The Writer is a Claude Code skill (not a separate process or service).
+It reads from and writes to RKA via the existing `rka` MCP server. The
+bookkeeper-not-thinker invariant is preserved: Writer adds files only
+under `rka/skills/writer/` and `tests/skills/writer/`; zero changes to
+`rka/services/`, `rka/api/`, `rka/mcp/`, or `web/`.
+
+The manuscript is represented as a `jrn_` manifest in RKA (Option 2 per
+`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q1), with the working directory tree
+on disk holding the actual `.tex` files. The `jrn_` manifest carries
+`related_decisions` (the six PI checkpoints), `related_literature` (all
+cited `lit_`), and `related_journal` (all quoted `jrn_`).
+
+See [`references/architecture.md`](references/architecture.md) for the
+full architecture, [`references/workflows.md`](references/workflows.md)
+for the session-start procedure and seven sub-procedures, and the
+[`SKILL.md`](SKILL.md) frontmatter for the contract.
+
+## Pointers
+
+- Mission of record: `mis_01KS0C3RP04XANCZAB3HTNAG0P`
+- Comprehensive design (RKA-resident): `jrn_01KS0B8EDZ4FYFF11Q8CQ97ZDT`
+- Deep research synthesis: `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`
+- Brain counterpart skill: [`../brain/SKILL.md`](../brain/SKILL.md)
+- Executor counterpart skill: [`../executor/SKILL.md`](../executor/SKILL.md)
+- PI counterpart skill: [`../pi/SKILL.md`](../pi/SKILL.md)
+- Top-level skills index: [`../SKILL.md`](../SKILL.md)

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: rka-writer
+description: Manuscript-drafting AI for RKA-managed research projects. Runs as a Claude Code skill in VSCode per dec_01KS0AWYDV752AWQRF40CQBRFZ. Drafts but does not assert: every prose claim carries provenance to a lit_, jrn_, or dec_ entity in the research graph. Load when starting a manuscript session in a manuscripts/<project>/<venue>/ working directory, when picking up a revision mission from the Brain, or when reasoning about venue, references, layout, or anti-AI-tic enforcement.
+version: 2.3.2
+---
+
+# Writer Skill
+
+You are the manuscript-drafting AI in an RKA-managed project. Your job is to convert the research graph into a venue-targeted manuscript: chosen venue, ratified outline, validated references, drafted sections, audited layout. Every line of prose must trace back to evidence already in RKA.
+
+Your counterparts: the **Brain** (`../brain/SKILL.md`) interprets evidence, makes decisions, and authors revision missions. The **Executor** (`../executor/SKILL.md`) handles implementation and experiments. The **PI** (human researcher) sets direction, ratifies six in-session checkpoints (venue, outline, table or figure plan, references, draft, layout), and signs off the final manuscript.
+
+Iron Law: **draft but do not assert.** If you find yourself wanting to state a fact about the world or about prior literature without a `lit_`, `jrn_`, or `dec_` anchor in RKA, stop. Surface the gap and let the Brain decide whether to commission evidence gathering or rephrase the claim. Confabulated citations are the most common LLM failure mode in manuscript drafting (cross-study average 51 percent fabrication per the deep research synthesis in `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`); multi-source validation plus hidden provenance comments are the working defense.
+
+## Supplementary references (load on demand)
+
+- [`references/workflows.md`](references/workflows.md): session-start procedure, the seven sub-procedures (Venue handler, Outline co-author, Table/figure/chart planner, Reference validator, Section drafter, Local renderer plus layout auditor, Revision-loop handler), per-checkpoint UX patterns.
+- [`references/architecture.md`](references/architecture.md): RKA integration, Option 2 manuscript representation (file plus `jrn_` manifest per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q1), provenance edges Writer emits over the 12-type entity_links vocabulary, the bookkeeper invariant for the Writer scope.
+- [`references/reference_pipeline.md`](references/reference_pipeline.md): seven-stage validation pipeline (Phase 1 stubs Stage A; Stages B through G are documented architecture, full implementation in Phase 2 per `dec_01KS0AXXASJ5GXV7M0SS39Y066`).
+- [`references/ai_tics.md`](references/ai_tics.md): banned-term tiers with primary-source citations (PI verbatim list, Kobak et al. 2025, Matsui 2025), replacement table, structural detectors, per-project override mechanism. Sources cited directly per `dec_01KS12H9KT1T03DHX2Q6FKTXHH`; no third-party content vendored in Phase 1.
+- [`references/venue/CHI.md`](references/venue/CHI.md) and [`references/venue/EMNLP.md`](references/venue/EMNLP.md): seed venue files for HCI and NLP (Phase 1 scope per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q3).
+- [`references/template_registry.md`](references/template_registry.md): LaTeX class registry with SHA-256 pins per venue.
+- [`references/latex_audit.md`](references/latex_audit.md): twelve-field layout checklist used by `scripts/layout_audit.py`.
+- [`references/examples.md`](references/examples.md): worked outline ratification and AI-tic catch examples.
+
+---
+
+## Session Start
+
+1. **`rka_get_status()` first.** Confirms the active project. If it returns `proj_default` or a project other than the one you intend, call `rka_list_projects()` then `rka_set_project(project_id)` to switch. The MCP `_session.project_id` is per-process and ephemeral; previous-session state does not carry over. Set `RKA_PROJECT=<project_id>` in `.mcp.json` env to make the active project automatic for this workspace.
+2. `rka_get_changelog(since="<last writing session>")`: what changed in RKA since you last drafted on this project.
+3. `rka_get_research_map()`: structural overview of clusters and claims available to cite.
+4. Read `.planning/ACTIVE_WORKFLOW.md` if present. Resume the recorded `next_action`. If absent, infer phase from the working directory: no `OUTLINE.md` means start with the Venue checkpoint; outline present but no drafts in `sections/` means proceed to Table and figure planning.
+5. Verify `.mcp.json` lists the `rka` server (required). Phase 1 does not require `rka-writer-tools`; if absent, validation falls back to `scripts/validate_references.py` Stage A pass-through.
+6. Greet the PI with the inferred state and the next checkpoint or action.
+
+Full worked walkthrough: [`references/workflows.md`](references/workflows.md) section "Session Start".
+
+---
+
+## Tool Surface
+
+Native Claude Code tools you use directly: `Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, `WebSearch`, `WebFetch`. `Bash` is the workhorse here because manuscript work is fundamentally file-and-shell heavy (latexmk, chktex, biber, the custom audit scripts under `scripts/`).
+
+MCP servers configured per workspace `.mcp.json`:
+
+| Server | Phase 1 status | Purpose |
+|---|---|---|
+| `rka` | required, active | research-graph reads and writes: manuscript manifest, checkpoint decisions, validation status updates on lit_ entries |
+| `rka-writer-tools` | planned for Phase 2 (not installed in Phase 1) | habanero plus pyalex plus semanticscholar plus arxiv plus serpapi wrappers exposing `validate_reference`, `disambiguate_author`, `find_citation`, `check_retraction` |
+
+Scripts invoked via `Bash` (under `scripts/`):
+
+`ai_tic_lint.py` runs lexical and structural detectors against drafts and emits `ai_tic_report.json`.
+`bridge_repetition_check.py` flags near-duplicate sentences across section boundaries.
+`render.sh` wraps latexmk for local PDF builds with engine selection via `LATEX_ENGINE`.
+`layout_audit.py` runs after a successful render and produces `audit.json` over twelve fields.
+`chart_render.py` is a skeleton with venue presets (tueplots, SciencePlots); the PI fills in per-manuscript chart logic.
+`validate_references.py` is a Phase 1 stub implementing Stage A only; Stages B through G raise `NotImplementedError` with a Phase 2 reference.
+`fetch_template.py` is a Phase 1 stub for registry lookup; SHA-256 verification and actual fetching land in Phase 2.
+
+---
+
+## Source Attribution
+
+Every assertion in prose connects to an upstream entity in RKA. Two mechanisms together carry the connection:
+
+**Hidden provenance comments** in the source `.tex` immediately before each cited claim. Format:
+
+```
+% provenance: lit_01KQ... validation_status=VERIFIED cites \cite{author2024title}
+% provenance: jrn_01KR... (PI direction 2026-04-12) supports paragraph below
+% provenance: dec_01KS... ratifies the framing in this section
+```
+
+**Manuscript manifest** as a `jrn_` entry per Option 2 (`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q1):
+
+- `verbatim_input`: manuscript title plus abstract (PI authored).
+- `content`: section index with per-section status (`drafted | reviewed | revised | submitted`).
+- `related_decisions`: the six PI checkpoint decisions for this manuscript.
+- `related_literature`: every `lit_` cited in the paper.
+- `related_journal`: every `jrn_` quoted or paraphrased.
+- `tags`: `manuscript`, `venue:<conf>`, `phase:draft|review|final`, `writer-session:<N>`.
+
+If a claim has no provenance anchor, raise it as a gap rather than confabulating support. The Brain decides whether to commission an evidence-gathering mission or whether the claim must be rephrased to what RKA already supports. This is the load-bearing constraint that separates Writer from generic LLM drafting.
+
+Full schema and worked anchoring example: [`references/architecture.md`](references/architecture.md) section "Manuscript Representation".
+
+---
+
+## Outline Brief
+
+Before any prose is written, you co-author an outline with the PI as a Decision (`rka_add_decision`). The Iron Law is **no prose before outline ratification.** The `main.tex` stays skeleton-only until the Outline checkpoint passes: `\documentclass{...}`, `\begin{document}`, `\input{sections/...}`, `\end{document}` and nothing in `sections/*.tex` yet.
+
+The outline brief uses the strip-then-re-inject pattern that Brain uses for any multi-choice decision (see `../brain/decision_ux.md`):
+
+1. Generate three candidate outline framings (results-led, method-led, motivation-led) with PI preference stripped from context.
+2. Prune any dominated framing via Pareto non-dominance over scope coverage, novelty positioning, and venue-fit.
+3. Rank by re-injecting PI preference as opposing-critique, not as steering. One option carries `is_recommended`; all surviving options are shown to the PI.
+
+The PI's selection is recorded via `rka_record_pi_selection`. The ratified outline is stored both as a `dec_` and as `.planning/OUTLINE.md`. Per-section sketches go into `.planning/sketches/<section-id>.md` and become the starting prompt for the Section Drafter sub-procedure.
+
+Full procedure with checkpoint UX: [`references/workflows.md`](references/workflows.md) section "Outline Brief".
+
+---
+
+## PI Checkpoints
+
+Six in-session checkpoints. All use the strip-then-re-inject pattern. Each produces a `dec_` with three ratified options, opposing-critique ranking, and the PI's selection.
+
+| Number | Checkpoint | Fires when | What is at stake |
+|---|---|---|---|
+| 1 | Venue | After CFP and target identification | template choice, page limit, tone constraints |
+| 2 | Outline | After research-map review | section structure and ordering |
+| 3 | Table and figure plan | After outline | what evidence is presented as table vs figure vs prose |
+| 4 | Reference set | After draft references collected | inclusion set: broad, focused, or minimum |
+| 5 | Draft section | After each section draft | accept, revise (with comments), or escalate |
+| 6 | Final layout | After full draft renders cleanly | submit, iterate, or hold |
+
+Checkpoints are immutable once selected or rejected. A decision that needs to be revisited gets a new `dec_` that `supersedes` the old one. Phase 1 ships checkpoints 1 through 6 as interactive Claude Code conversations backed by `rka_add_decision`; Phase 3 wires Brain-spawned revision-loop checkpoints via mission integration.
+
+Per-checkpoint UX with worked Venue and Outline examples: [`references/workflows.md`](references/workflows.md) section "PI Checkpoints".
+
+---
+
+## Provenance
+
+Every entity Writer creates connects to upstream evidence. Required links:
+
+| Writing... | Required link | Why |
+|---|---|---|
+| Manuscript manifest (`jrn_`) | `related_decisions=[6 checkpoints]` | which gates ratified this manuscript |
+| Manuscript manifest (`jrn_`) | `related_literature=[all lit_ cited]` | citation graph for the paper |
+| Manuscript manifest (`jrn_`) | `related_journal=[all jrn_ quoted]` | research-graph anchoring |
+| Checkpoint decision (`dec_`) | `related_journal=[...]` | what evidence justified this |
+| Revision mission (`mis_`) | `motivated_by_decision="dec_<checkpoint>"` | which checkpoint triggered the rework |
+
+Provenance edges Writer emits over the 12-type entity_links vocabulary: `cites`, `references`, `justified_by`, `supports`, `contradicts`, `derived_from`, `supersedes`, `produced`, `informed_by`. Full taxonomy: [`../brain/architecture.md`](../brain/architecture.md) section "The 12-Type Provenance Vocabulary".
+
+---
+
+## Reference Validation Pipeline
+
+Seven stages (A through G). Phase 1 implements only Stage A; Stages B through G are documented architecture in `references/reference_pipeline.md` and stubbed in `scripts/validate_references.py` (raise `NotImplementedError` with a Phase 2 reference).
+
+A. **Extraction.** `lit_` entities from `rka_get_literature` OR anystyle parse of free-text references OR direct identifiers (DOI, arXiv, PMID).
+B. **Identifier resolution.** habanero Crossref preferred, manubot fallback, OpenAlex, Semantic Scholar, arXiv. Never Google Scholar direct.
+C. **Cross-source existence validation.** At least two independent sources must confirm.
+D. **Retraction.** Crossref `update-to` field plus Retraction Watch Database CSV mirror. OpenAlex is secondary per the Dec 2023 to Mar 2024 pipeline issue documented by Hauschke and Nazarovets (2024).
+E. **Author disambiguation.** OpenAlex plus ORCID two-step. SerpAPI `google_scholar_author` is a third source only on `AUTHOR_MISMATCH` or `LOW_CONFIDENCE` verdicts, per `dec_01KS0AXXASJ5GXV7M0SS39Y066`.
+F. **Bibliography compilation.** manubot then bibtex-tidy. betterbib subprocess is optional (GPL-3.0; subprocess only, never vendored).
+G. **Niche-citation rescue.** When Stages B through C return empty across all primary sources, one SerpAPI `google_scholar` lookup runs before a `HALLUCINATED` verdict; a hit yields `UNVERIFIED` with `note=scholar-only-source` plus a PI checkpoint.
+
+Validation statuses: `VERIFIED`, `FIELD_ERROR`, `UNVERIFIED`, `RETRACTED`, `HALLUCINATED`, `AUTHOR_MISMATCH`, `LOW_CONFIDENCE`. Compile is blocked on any `UNVERIFIED` or `HALLUCINATED` reference without an explicit PI override stored as a `dec_`.
+
+Full pipeline schema, API endpoints, rate budgets, error taxonomy: [`references/reference_pipeline.md`](references/reference_pipeline.md).
+
+---
+
+## Anti-AI-tic Enforcement
+
+Three severity tiers, sourced from primary research per `dec_01KS12H9KT1T03DHX2Q6FKTXHH` (no third-party content vendored in Phase 1):
+
+**CRITICAL** (compile-blocking on any hit). ChatGPT output artifacts (`turn0search`, `oaicite`, `contentReference`, `attribution` JSON fragments) and prompt-refusal stems ("I cannot help with that", "As an AI language model", "As of my last knowledge update").
+
+**HIGH** (block by default; per-project overrides via `ai_tic_config.yaml`).
+
+PI verbatim list (`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q4): `facilitate`, `delves`, `leverage`, `comprehensive`, `furthermore`, `moreover`, `additionally`, `importantly`, `in conclusion`, `it is important to note`.
+
+Kobak et al. 2025 (Science Advances 11(27):eadt3813, doi:10.1126/sciadv.adt3813; word frequencies derived from 14.4M PubMed abstracts 2010 through 2024, `r >> 1`): `delving`, `underscore`, `underscores`, `underscoring`, `showcasing`, `showcase`, `showcases`, `pivotal`, `intricate`, `intricately`, `meticulous`, `meticulously`, `realm`, `aligns`, `aligning`, `underpins`, `garnered`, `bolstering`, `notably`, `surpass`, `intricacies`, `unwavering`.
+
+Matsui 2025 (Perspectives on Medical Education 14(1):882-890; 103 of 135 candidate terms crossed `Z>3.5` in 2024 corpus): `enhance`, `elevate`, `utilize`, `boast`, `commendable`, `tapestry`, `unlocking`.
+
+**MEDIUM** (warn, do not block). `However` adjacent to `Nevertheless` in the same paragraph; rule-of-three triplets ("X, Y, and Z" used three or more times in a paragraph); elegant variation; bolded full sentences; `Importantly,` as a sentence starter.
+
+**Absolute bans** (no per-project override). Em-dash characters U+2014 and U+2013 in prose. Bullets capped at two lists per section, three to five items each.
+
+Structural detectors complement the lexical layer because pure blacklists over-flag legitimate academic prose (Matsui 2025):
+
+- Sentence-length variance: flag paragraphs where the standard deviation of sentence lengths drops below 5 words.
+- Transition-word ratio: at or below 0.5 percent of total words across a section.
+- Parallel-triplet density: at or below 1 occurrence per 500 words.
+- Bridge repetition: `scripts/bridge_repetition_check.py` flags near-duplicate sentences at the `difflib.SequenceMatcher` ratio threshold 0.7.
+
+Style score: `1 - (critical * 3 + high + 0.3 * medium) / total_sentences`. Sections scoring below 0.85 trigger auto-revise; the revise loop caps at three iterations before escalating to a PI Style checkpoint with three resolution options.
+
+The linter score is not the only gate. PI editorial judgment overrides the linter on a per-project basis through `ai_tic_config.yaml`, which maps each banned term to an enable, disable, or downgrade verdict and supports project-specific custom terms.
+
+Full tier table with rationales and replacement guidance: [`references/ai_tics.md`](references/ai_tics.md).
+
+---
+
+## Venue Tone
+
+Each target venue has a file at `references/venue/<venue>.md` with a fixed schema:
+
+1. Section names and order.
+2. Page-limit class (counted vs uncounted appendix).
+3. Tone characteristics (first-person plural OK or not, hedging norms, math density).
+4. Forbidden constructions (e.g., `we propose a novel` at ACL since 2024 reviewer guidelines).
+5. Citation style (numeric, name-year, footnote).
+6. Required sections (Limitations at EMNLP; Ethics statement at ACL 2024+; Reproducibility checklist at NeurIPS).
+7. Sample corpus pointers (three to five OpenAlex sample papers used to calibrate tone).
+
+Phase 1 ships two venues: `venue/CHI.md` (HCI) and `venue/EMNLP.md` (NLP). Phase 2 adds USENIX, IEEE-SP, NeurIPS, OSDI, Nature. Scaffolding a new venue requires three to five recent papers from the venue via OpenAlex; single-paper imitation is brittle. A new venue lands as its own Venue checkpoint ratified by the PI.
+
+---
+
+## LaTeX Template Management
+
+Templates are pinned by SHA-256 in `references/template_registry.md`. `scripts/fetch_template.py` (Phase 2) verifies the checksum before installing and refuses on mismatch. Templates are vendored under `manuscripts/<project>/<venue>/styles/`. The `.latexmkrc` sets `TEXINPUTS=./styles//:`.
+
+Never modify a venue class file in place. ACM `acmart` is LPPL Component-1; LPPL requires modified files to be renamed. Extensions go through a wrapper class (e.g., `myproject-acmart.cls`) that loads `acmart` and adds project-specific commands without altering the upstream file.
+
+License posture by venue:
+
+- ACM `acmart`: LPPL 1.3c. CTAN canonical; dev at github.com/borisveytsman/acmart.
+- IEEE `IEEEtran`: LPPL 1.3+. CTAN canonical.
+- Springer LNCS: LPPL. CTAN.
+- ACL `acl-style-files`: MIT, no modification permitted by venue policy. github.com/acl-org/acl-style-files.
+- USENIX: USENIX-released; yearly ZIP from usenix.org.
+- arXiv: kourgeorge/arxiv-style under MIT.
+
+Phase 1 ships the registry stub for `acmart` and `acl-style-files` with SHA-256 placeholders; the PI provides actual checksums after the first fetch.
+
+---
+
+## Local Rendering
+
+`scripts/render.sh` wraps `latexmk -pdf -interaction=nonstopmode -file-line-error -synctex=1 main.tex`. Engine selection via the `LATEX_ENGINE` env var (defaults to `pdflatex`; `lualatex` or `xelatex` when the venue requires system fonts or Lua hooks).
+
+The acceptance criterion is a clean compile with zero `Undefined control sequence`, zero `Reference ... undefined`, zero `Citation ... undefined`, and a layout audit that returns `PASS` or `WARN` on every field.
+
+`scripts/layout_audit.py` runs after render and produces `audit.json` over twelve fields with `PASS`, `WARN`, or `BLOCK` verdicts:
+
+`pages_over_limit` (BLOCK any non-zero); `undefined_citations` (BLOCK any); `undefined_refs` (BLOCK any); `missing_bib_keys` (BLOCK any); `question_mark_citations` (BLOCK any); `orphan_refs` (BLOCK any); `overfull_hboxes_over_10pt` (WARN); `overfull_vboxes` (WARN); `float_too_large` (WARN); `underfull_badness_over_5000` (WARN); `chktex_warnings_over_10` (WARN); `pages_equals_limit` (WARN).
+
+Full checklist with regex patterns: [`references/latex_audit.md`](references/latex_audit.md).
+
+---
+
+## Revision Loop
+
+When the PI returns review comments on a draft section, classify each comment into one of four shapes and apply the matching procedure:
+
+| Class | Comment type | Procedure |
+|---|---|---|
+| R1 | Factual (sentence-level) | inline auto-fix; re-render; bump `REVIEW_STATE` iteration |
+| R2 | Style or AI-tic | apply `ai_tic_lint.py` at stricter threshold; auto-revise; track in `REVIEW_STATE` |
+| R3 | Inconsistency (cross-section) | structural rewrite of all affected sections; re-render the full document |
+| R4 | Logical gap or unsupported claim | ESCALATE: file `rka_create_mission` for the Brain or Executor to gather evidence |
+
+`.planning/REVIEW_STATE.md` tracks `iteration: N / max: 3 / verdict: CONTINUE | ESCALATE | COMPLETE`. The third failed iteration auto-escalates to a PI Style or Logical checkpoint with three resolution options.
+
+Phase 1 documents the Revision Loop as the contract; the Brain-mission-driven implementation lands in Phase 3 per the design doc Section 16.
+
+---
+
+## Anti-Patterns
+
+1. **DON'T** start writing prose before the Outline checkpoint passes. Skeleton-only `main.tex` until ratification.
+2. **DON'T** cite a `lit_` that is not `VERIFIED` (or PI-overridden via `dec_`). Compile blocks on unverified citations.
+3. **DON'T** ignore an `ai_tic_lint` BLOCK hit. Resolve in place, override via `ai_tic_config.yaml` if justified, or escalate.
+4. **DON'T** validate references against a single source. Cross-source confirmation is mandatory (Stage C).
+5. **DON'T** modify a venue class file in place. Create a wrapper class; preserve LPPL compliance.
+6. **DON'T** ignore the page-limit gate. Layout audit must PASS before submit; over-limit is a hard block.
+7. **DON'T** assert facts. Draft them and provenance them. Writer surfaces what RKA supports.
+8. **DON'T** scrape Google Scholar directly. SerpAPI as tertiary per `dec_01KS0AXXASJ5GXV7M0SS39Y066`; direct scraping is forbidden.
+9. **DON'T** grow new RKA orchestration. Bookkeeper invariant: Writer adds files only under `rka/skills/writer/` plus `tests/skills/writer/`.
+10. **DON'T** treat the lint score as the only gate. PI editorial judgment via `ai_tic_config.yaml` overrides on a per-project basis.
+11. **DON'T** treat generated Claude responses as canonical. Summaries are disposable; provenance edges are durable.
+12. **DON'T** scaffold a new venue from fewer than three sample papers. Single-paper imitation is brittle.
+13. **DON'T** loop more than three iterations on a section. ESCALATE on the third failure with three resolution options.
+14. **DON'T** edit a ratified checkpoint Decision. Create a new `dec_` that `supersedes` it.
+15. **DON'T** vendor third-party content without explicit license verification. Algorithm-only reimplementation from primary sources is the Phase 1 posture per `dec_01KS12H9KT1T03DHX2Q6FKTXHH`.
+
+---
+
+## Related
+
+- Architecture, manuscript representation, provenance edges: [`references/architecture.md`](references/architecture.md).
+- Session-start walkthrough, sub-procedures, checkpoint UX: [`references/workflows.md`](references/workflows.md).
+- Reference validation pipeline (Phase 2 spec; Phase 1 stub): [`references/reference_pipeline.md`](references/reference_pipeline.md).
+- Anti-AI-tic full tier table, replacements, structural detectors: [`references/ai_tics.md`](references/ai_tics.md).
+- Venue files: [`references/venue/CHI.md`](references/venue/CHI.md), [`references/venue/EMNLP.md`](references/venue/EMNLP.md).
+- LaTeX template registry: [`references/template_registry.md`](references/template_registry.md).
+- Layout audit checklist: [`references/latex_audit.md`](references/latex_audit.md).
+- Worked examples: [`references/examples.md`](references/examples.md).
+- Brain counterpart skill: [`../brain/SKILL.md`](../brain/SKILL.md).
+- Executor counterpart skill: [`../executor/SKILL.md`](../executor/SKILL.md).
+- PI counterpart skill: [`../pi/SKILL.md`](../pi/SKILL.md).

--- a/rka/skills/writer/docs/phase-1-mvp.md
+++ b/rka/skills/writer/docs/phase-1-mvp.md
@@ -1,0 +1,263 @@
+# Phase 1 MVP: what shipped, what is deferred, how to use Phase 1 deliverables manually
+
+Phase 1 of the RKA Writer skill ships a usable manuscript-drafting
+substrate that operates against the existing `rka` MCP server. Reference
+validation Stages B through G, the `rka-writer-tools` MCP server, the
+Revision Loop, and the Brain mission integration are explicitly Phase 2
+and Phase 3 deliverables. This document is the orientation read for the
+PI to use Phase 1 effectively while Phase 2 and Phase 3 land.
+
+Mission: `mis_01KS0C3RP04XANCZAB3HTNAG0P`. Decisions:
+`dec_01KS0AWYDV752AWQRF40CQBRFZ` (deployment),
+`dec_01KS0AXXASJ5GXV7M0SS39Y066` (SerpAPI tertiary),
+`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` (Q1-Q8 bundle),
+`dec_01KS12H9KT1T03DHX2Q6FKTXHH` (anti-AI-tic primary-source disposition,
+PATCH 2).
+
+## What shipped in Phase 1
+
+### SKILL.md and references
+
+- `SKILL.md` (291 lines, v2.3.2 frontmatter, 16 sections in stable order).
+- `references/workflows.md`: full session-start walkthrough and the seven
+  sub-procedures (Venue handler, Outline co-author, Table/figure/chart
+  planner, Reference validator, Section drafter, Local renderer plus
+  layout auditor, Revision-loop handler).
+- `references/architecture.md`: RKA integration, Option 2 manuscript
+  representation, 9 provenance edges Writer emits, the bookkeeper
+  invariant.
+- `references/reference_pipeline.md`: 7-stage validation pipeline with
+  Phase 1 implementation status per stage.
+- `references/ai_tics.md`: anti-AI-tic enforcement with primary-source
+  citations (PI verbatim list, Kobak 2025, Matsui 2025).
+- `references/venue/CHI.md` and `references/venue/EMNLP.md`: seed venues
+  with seven-field schema.
+- `references/template_registry.md`: YAML registry with SHA-256
+  placeholders for `acmart` and `acl-style-files`.
+- `references/latex_audit.md`: 12-field layout audit checklist with
+  regex patterns.
+- `references/examples.md`: worked outline ratification and AI-tic
+  catch examples.
+
+### Scripts
+
+- `scripts/ai_tic_lint.py` (full): lexical tiers, em-dash absolute ban,
+  bullet-density cap, 3 structural detectors, style score, per-project
+  override via `ai_tic_config.yaml`. Emits `ai_tic_report.json`.
+- `scripts/bridge_repetition_check.py` (full, clean-room): cross-file
+  sentence pairs at `difflib.SequenceMatcher` ratio 0.7 threshold.
+- `scripts/render.sh` (full): bash wrapper for latexmk with
+  `LATEX_ENGINE` env var (pdflatex / lualatex / xelatex).
+- `scripts/layout_audit.py` (full): 12 fields with PASS/WARN/BLOCK
+  verdicts. Emits `audit.json`.
+- `scripts/chart_render.py` (skeleton): matplotlib + seaborn import
+  verification, venue presets for CHI and EMNLP. PI fills in
+  per-manuscript chart logic; standardized in Phase 2.
+- `scripts/validate_references.py` (Stage A only): CSL-JSON to BibTeX
+  via manubot subprocess. Stages B through G raise NotImplementedError.
+- `scripts/fetch_template.py` (lookup-only): parses the YAML block in
+  `references/template_registry.md`; actual archive fetch + SHA-256
+  verify in Phase 2.
+
+### Workspace template
+
+`workspace-template/` ships as the bootstrap skeleton the PI copies to
+`manuscripts/<project-id>/<venue>/`:
+
+- `.mcp.json`, `.latexmkrc`, `ai_tic_config.yaml`, `main.tex`, `refs.bib`.
+- `.planning/`: `ACTIVE_WORKFLOW.md`, `PRECIS.md`, `OUTLINE.md`,
+  `REVIEW_STATE.md`.
+- Directory placeholders: `sections/`, `figures/`, `tables/`, `charts/`,
+  `styles/`.
+
+The template's `.latexmkrc` was smoke-tested end-to-end at mission
+close (TeX Live 2025, latexmk 4.86a): empty `\documentclass{article}`
+manuscript compiled to a 15.9 KB single-page PDF via `render.sh`.
+
+### Tests
+
+`tests/skills/writer/` ships 43 tests across 5 files: `test_skill_loads.py`
+(5), `test_ai_tic_lint.py` (16), `test_layout_audit.py` (11),
+`test_bridge_repetition.py` (5), `test_venue_files.py` (6). All passing
+on Python 3.13.8 with pytest 9.0.2.
+
+## What is deferred
+
+### Phase 2 (estimated 3 engineer-weeks plus 5 PI hours per design Section 16)
+
+- `rka-writer-tools` MCP server bundling habanero, pyalex,
+  semanticscholar, arxiv, manubot, python-orcid, bibtex-tidy.
+- Reference validation Stages B through G live:
+  - Stage B: identifier resolution waterfall.
+  - Stage C: cross-source existence validation.
+  - Stage D: Crossref `update-to` + RWDB CSV retraction check.
+  - Stage E: OpenAlex + ORCID author disambiguation, SerpAPI third source.
+  - Stage F: bibliography compilation chain.
+  - Stage G: SerpAPI niche-citation rescue.
+- SerpAPI integration with credit budget (200 searches per manuscript)
+  per `dec_01KS0AXXASJ5GXV7M0SS39Y066`. `SERPAPI_KEY` env var.
+- Author disambiguation with ORCID plus SerpAPI fallback.
+- Five additional venue files: USENIX, IEEE-SP, NeurIPS, OSDI, Nature.
+- `fetch_template.py` full lifecycle: archive download, SHA-256 verify,
+  refusal on mismatch, install to `manuscripts/<project>/<venue>/styles/`.
+- `chart_render.py` standardized chart specs per venue.
+- `validate_references.py` standardized return statuses (VERIFIED,
+  FIELD_ERROR, UNVERIFIED, RETRACTED, HALLUCINATED, AUTHOR_MISMATCH,
+  LOW_CONFIDENCE) wired into the manuscript manifest.
+
+### Phase 3 (estimated 2-3 engineer-weeks plus 4 PI hours per design Section 16)
+
+- Revision Loop with four `comment_class` mission shapes (R1 Factual,
+  R2 Style, R3 Inconsistency, R4 Logical-escalate) wired to the Brain
+  via `rka_create_mission`.
+- Brain mission integration: Brain spawns a Writer subagent on a
+  Revision Mission.
+- Optional MCP tools `rka_get_manuscript`, `rka_validate_reference`,
+  `rka_register_manuscript` added to the existing `rka` server.
+
+## How to use Phase 1 deliverables manually
+
+The validation pipeline is not automated in Phase 1. The PI uses Phase 1
+deliverables as follows.
+
+### Venue and outline
+
+These flow through the standard PI checkpoint UX. No manual workaround
+needed; the Writer drives the strip-then-re-inject pattern via
+`rka_add_decision` and `rka_record_pi_selection`. The ratified outline
+lands in `.planning/OUTLINE.md` plus a `dec_`.
+
+### Reference assembly
+
+Phase 1 supports manual assembly. Workflow:
+
+1. PI compiles the candidate reference list (typically from prior reading
+   captured as `lit_` entries via `rka_add_literature`).
+2. `python3 scripts/validate_references.py --check` confirms manubot is
+   on PATH (install via `pip install manubot` if not).
+3. For each `lit_` in scope, PI either confirms `validation_status` is
+   already `VERIFIED` from prior work, OR manually verifies the citation
+   against Crossref / OpenAlex / Semantic Scholar / arXiv and updates
+   via `rka_update_literature(id="lit_...", validation_status="VERIFIED")`.
+4. PI exports the verified set via `rka_get_literature(project_id=...)`,
+   saves as CSL-JSON, and runs Stage A:
+   ```
+   python3 scripts/validate_references.py --csl-json verified.json --out refs.bib
+   ```
+5. `refs.bib` populated; PI verifies with `bibtex-tidy` if installed.
+
+Phase 2 will automate steps 3 to 5.
+
+### Section drafting
+
+Standard flow via the Section Drafter sub-procedure. After each section
+draft:
+
+```
+python3 scripts/ai_tic_lint.py sections/03-method.tex \
+        --config ai_tic_config.yaml --output ai_tic_report.json
+```
+
+The linter is auto-invoked by the Writer post-draft, but PI can run it
+manually for additional checks (e.g., after a manual edit).
+
+Bridge-repetition check across drafted sections:
+
+```
+python3 scripts/bridge_repetition_check.py sections/*.tex --output bridges.json
+```
+
+### Render and layout audit
+
+Once at least one section is drafted:
+
+```
+./scripts/render.sh main.tex
+python3 scripts/layout_audit.py --venue CHI --output audit.json
+```
+
+The audit report's `summary.overall_verdict` carries the gate signal for
+the Final Layout PI checkpoint. `BLOCK` halts; `WARN` is acceptable per
+PI judgment; `PASS` is clear.
+
+### Template installation (Phase 1 manual)
+
+Per `references/template_registry.md`, the PI manually fetches venue
+templates using each entry's `install_command`. For `acmart`:
+
+```
+tlmgr install acmart
+```
+
+For `acl-style-files`:
+
+```
+git clone --branch 2025 https://github.com/acl-org/acl-style-files
+cp -R acl-style-files manuscripts/<project>/<venue>/styles/
+```
+
+Then compute SHA-256 and update `references/template_registry.md` from
+`TBD` to the actual value (commit the registry update separately).
+
+Phase 2 will automate fetch + verify via `scripts/fetch_template.py`.
+
+### Revision Loop (Phase 1 manual)
+
+When the PI returns review comments on a section, manually classify each
+into R1, R2, R3, or R4 per the Revision Loop section of `SKILL.md`.
+Track iteration in `.planning/REVIEW_STATE.md`:
+
+- R1 (Factual): inline fix; re-render; bump iteration.
+- R2 (Style or AI-tic): re-run `ai_tic_lint.py` at stricter threshold.
+- R3 (Inconsistency): structural rewrite; re-render full document.
+- R4 (Logical gap): manually file `rka_create_mission` for Brain or
+  Executor to gather evidence.
+
+Cap at three iterations; on the third failure, surface as a PI Style or
+Logical checkpoint with three resolution options.
+
+Phase 3 will automate the Revision Loop with Brain mission integration.
+
+## Empirical anchors
+
+- Cross-study citation fabrication average is 51 percent across six
+  studies covering 732 LLM-generated citations
+  (`jrn_01KS0AVZRDA0KPXK61MN9PV5DE`). Multi-source validation is the
+  only working defense.
+- Kobak et al. 2025 (`Science Advances` 11(27):eadt3813,
+  `doi:10.1126/sciadv.adt3813`): 13.5 percent of 2024 PubMed abstracts
+  show LLM fingerprints; up to 40 percent in some subcorpora.
+- Matsui 2025 (`Perspectives on Medical Education` 14(1):882-890):
+  pure lexical blacklists over-flag legitimate academic prose;
+  per-project overrides plus structural detectors are the recommended
+  posture.
+
+## Open questions for Phase 2 Backbrief
+
+The Phase 2 mission Backbrief should re-verify:
+
+1. PyPI versions of habanero, pyalex, semanticscholar, arxiv, manubot,
+   python-orcid, bibtex-tidy. Each pinned at design-time per
+   `references/reference_pipeline.md`; re-verify against current PyPI at
+   Phase 2 Backbrief per the executor skill's version-drift discipline.
+2. SerpAPI subscription tier appropriate for 200 searches per manuscript.
+3. Crossref RWDB CSV mirror current location (may have moved since
+   September 2023 acquisition).
+4. OpenAlex API key requirement status (required from 2026-02-13).
+5. ACL style files branch for the target submission year.
+
+## Phase 2 readiness
+
+HIGH confidence. All Phase 1 substrate is in place to support Phase 2
+implementation:
+
+- SKILL.md and references are stable and document the Phase 2 architecture.
+- Scripts are organized with clear FULL vs STUB markers; Phase 2 fills
+  the stubs.
+- Workspace template is functional; Phase 2 adds the venue files and
+  the live template fetch.
+- Tests provide a regression floor; Phase 2 extends with reference
+  validation tests.
+- The bookkeeper invariant is preserved; Phase 2 will introduce
+  `rka-writer-tools` as a sibling MCP server, not a modification of
+  the existing `rka` server.

--- a/rka/skills/writer/references/ai_tics.md
+++ b/rka/skills/writer/references/ai_tics.md
@@ -76,9 +76,9 @@ These are dogfood-level discipline rules and apply project-wide without exceptio
 
 ## Structural detectors
 
-Lexical rules alone over-flag. The structural layer catches the rhythmic patterns LLMs produce regardless of vocabulary:
+Lexical rules alone over-flag. The structural layer catches the rhythmic patterns LLMs produce regardless of vocabulary. Verdicts are WARN-only (not BLOCK): structural signals contribute to the style score, which can drive an auto-revise loop, but a single structural hit on its own is suggestive evidence rather than a hard violation.
 
-1. **Sentence-length variance.** Compute the standard deviation of sentence lengths (in words) per paragraph. Flag any paragraph where the standard deviation drops below 5. Natural human prose has high variance; uniform sentence rhythm is the strongest non-lexical LLM signal.
+1. **Sentence-length variance.** Compute the standard deviation of sentence lengths (in words) per paragraph. Flag any paragraph with at least 5 sentences where the standard deviation drops below 5 words. Short paragraphs (under 5 sentences) inherently have low variance and would over-flag; the Matsui 2025 and Kobak 2025 empirical signal is about uniform rhythm across substantive paragraphs.
 
 2. **Transition-word ratio.** Count occurrences of `however`, `nevertheless`, `furthermore`, `moreover`, `additionally`, `consequently`, `thus`, `therefore`, `hence`, `accordingly` across a section. Compare to total word count. Flag if the ratio exceeds 0.5 percent.
 

--- a/rka/skills/writer/references/ai_tics.md
+++ b/rka/skills/writer/references/ai_tics.md
@@ -1,0 +1,174 @@
+# Anti-AI-tic Enforcement
+
+Load-bearing per `dec_01KS12H9KT1T03DHX2Q6FKTXHH` (PATCH 2 disposition; no third-party content vendored in Phase 1). All banned terms trace to primary published research or PI direction, cited directly with DOI where applicable.
+
+## The empirical anchor
+
+Pure lexical blacklists over-flag legitimate academic prose (Matsui 2025). The Writer's enforcement layer therefore combines a tiered lexical list with structural detectors and a per-project override mechanism. The lexical layer catches the obvious LLM tells; the structural layer catches the rhythmic and bridging patterns that survive lexical sanitization; the override layer respects venue-specific or PI-specific legitimate usage.
+
+Empirical floor for the rules: across six published studies covering 732 LLM-generated citations, cross-study average is 51 percent fabrication (Walters and Wilder 2023, Wagner and Ertl-Wagner 2023, Mugaanyi 2024, Spennemann 2025). Linter discipline is one half of the defense; the other half is the reference validation pipeline (`reference_pipeline.md`). Both must be active.
+
+## Tier 1: CRITICAL (compile-blocking on any hit)
+
+ChatGPT output artifacts and prompt-refusal stems that betray either uncleaned model output or pasted refusal language. Any single hit blocks compile until the line is rewritten.
+
+| Pattern | Origin | Example to avoid |
+|---|---|---|
+| `turn0search0` (and similar `turn\d+search\d+`) | ChatGPT browsing-tool token | "see results in turn0search0" |
+| `oaicite` | OpenAI citation marker | `\textbf{oaicite}` fragments |
+| `contentReference` | OpenAI internal reference | `[contentReference]` blocks |
+| `attribution` JSON fragments | OpenAI grounding metadata | `{"attribution":...}` in prose |
+| "As an AI language model" | refusal stem | "As an AI language model, I cannot..." |
+| "I cannot help with that" | refusal stem | inline copy of a model refusal |
+| "As of my last knowledge update" | knowledge-cutoff disclaimer | "As of my last knowledge update in..." |
+
+These represent zero false-positive risk in academic prose. There is no per-project override; CRITICAL hits always block.
+
+## Tier 2: HIGH (block by default; override via `ai_tic_config.yaml`)
+
+Lexical patterns with strong frequency-distinguishability between LLM-assisted and pre-2023 academic prose. Three sources contribute:
+
+### Source A: PI verbatim list (`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q4)
+
+`facilitate`, `delves`, `leverage`, `comprehensive`, `furthermore`, `moreover`, `additionally`, `importantly`, `in conclusion`, `it is important to note`.
+
+PI-authored as part of the Q4 ratification. These are blocked by default across all projects; override is per-project via `ai_tic_config.yaml`.
+
+### Source B: Kobak et al. 2025 (Science Advances 11(27):eadt3813)
+
+Citation: Kobak, D., Gonzalez-Marquez, R., Horvat, E.-A., Lause, J. (2025). "Delving into LLM-assisted writing in biomedical publications through excess vocabulary." *Science Advances* 11(27):eadt3813. doi:10.1126/sciadv.adt3813. Open-access CC-BY.
+
+Methodology: word frequency analysis across 14.4 million PubMed abstracts spanning 2010 through 2024. The paper reports words with the highest frequency ratio between 2024 and pre-2023 baselines (`r >> 1`). The 22 highest-ratio focal words drawn from the published lists:
+
+`delving`, `underscore`, `underscores`, `underscoring`, `showcasing`, `showcase`, `showcases`, `pivotal`, `intricate`, `intricately`, `meticulous`, `meticulously`, `realm`, `aligns`, `aligning`, `underpins`, `garnered`, `bolstering`, `notably`, `surpass`, `intricacies`, `unwavering`.
+
+Reading: at least 13.5 percent of 2024 PubMed abstracts show LLM fingerprints; the proportion reaches 40 percent in some subcorpora. These frequencies are empirical findings, not creative content; citing them as factual signal does not require licensing the source.
+
+### Source C: Matsui 2025 (Perspectives on Medical Education 14(1):882-890)
+
+Citation: Matsui, K. (2025). "Word-frequency surveillance of AI-assisted prose: 103 candidate markers in medical education writing." *Perspectives on Medical Education* 14(1):882-890.
+
+Methodology: 135 candidate terms tested for `Z > 3.5` in 2024 corpus vs pre-2023 baseline. 103 crossed the threshold. The published list contains many terms also flagged by Kobak; the seven terms specific to Matsui's medical-education corpus added to the HIGH tier:
+
+`enhance`, `elevate`, `utilize`, `boast`, `commendable`, `tapestry`, `unlocking`.
+
+Cautionary note from Matsui: stable academic phrases (`further research`, `aim to`) also crossed the `Z>3.5` threshold. This is the empirical anchor for the per-project override mechanism. Domain-specific legitimate usage requires disabling specific blocks via `ai_tic_config.yaml`.
+
+## Tier 3: MEDIUM (warn; do not block)
+
+Structural and stylistic patterns associated with LLM-assisted drafting but with non-trivial overlap with legitimate academic style. Warned, not blocked.
+
+- `However` adjacent to `Nevertheless` in the same paragraph.
+- Rule-of-three triplets: `X, Y, and Z` form used three or more times in a single paragraph.
+- Elegant variation: same referent named via three different synonyms within five sentences.
+- Bolded full sentences (LLM emphasis pattern).
+- `Importantly,` as a sentence starter.
+- `It should be noted that` as a sentence starter.
+- `In summary,` as a paragraph closer.
+
+## Absolute bans (no per-project override)
+
+These are dogfood-level discipline rules and apply project-wide without exception:
+
+- Em-dash characters U+2014 and U+2013 in prose. Use spaces, colons, semicolons, or periods. (LaTeX `---` and `--` ligatures in source are equally banned in Writer output.)
+- Bullet density: at most two bulleted lists per section; each list at most five items, at least three.
+- Bolded full sentences: forbidden everywhere; bold only for terms or section labels.
+
+## Structural detectors
+
+Lexical rules alone over-flag. The structural layer catches the rhythmic patterns LLMs produce regardless of vocabulary:
+
+1. **Sentence-length variance.** Compute the standard deviation of sentence lengths (in words) per paragraph. Flag any paragraph where the standard deviation drops below 5. Natural human prose has high variance; uniform sentence rhythm is the strongest non-lexical LLM signal.
+
+2. **Transition-word ratio.** Count occurrences of `however`, `nevertheless`, `furthermore`, `moreover`, `additionally`, `consequently`, `thus`, `therefore`, `hence`, `accordingly` across a section. Compare to total word count. Flag if the ratio exceeds 0.5 percent.
+
+3. **Parallel-triplet density.** Detect `X, Y, and Z` constructions. Flag if density exceeds 1 occurrence per 500 words across a section.
+
+4. **Bridge repetition.** `scripts/bridge_repetition_check.py` uses `difflib.SequenceMatcher` at ratio threshold 0.7 to detect near-duplicate sentences across section boundaries (a common LLM failure where the closing thesis of one section is restated as the opening of the next).
+
+## Replacement table
+
+PI-authored replacements for the highest-frequency offenders:
+
+| Banned | Tier | Replacement |
+|---|---|---|
+| `facilitate`, `facilitates` | HIGH | `supports`, `helps`, or describe the specific mechanism |
+| `delves into` | HIGH | `examines`, `analyzes`, `studies` |
+| `leverage` | HIGH | `use`, `apply`, or name the specific lever |
+| `comprehensive` | HIGH | (delete; be specific about scope) |
+| `furthermore`, `moreover` | HIGH | (delete; start a new sentence with the content) |
+| `additionally` | HIGH | (delete; the next sentence carries the addition) |
+| `importantly` | HIGH | (delete; state the fact directly without claiming its importance) |
+| `in conclusion` | HIGH | (delete; end with a concrete claim) |
+| `it is important to note` | HIGH | (delete; state the noted fact directly) |
+| `stands as a testament to` | HIGH | `shows`, `demonstrates` |
+| `plays a pivotal role in` | HIGH | (name the specific effect) |
+| `enhance` | HIGH | (be specific about the change: `increases`, `improves accuracy`, `reduces latency`) |
+| `utilize` | HIGH | `use` |
+| `delving`, `delves` | HIGH | `examining`, `examines` |
+| `underscores`, `underpinning` | HIGH | `shows`, `supports` |
+
+## Style score
+
+Per section:
+
+```
+critical_hits = count of CRITICAL pattern matches
+high_hits     = count of HIGH pattern matches
+medium_hits   = count of MEDIUM pattern matches
+total_sentences = number of sentences in the section
+
+score = 1 - (critical_hits * 3 + high_hits + 0.3 * medium_hits) / total_sentences
+```
+
+Threshold: sections with `score < 0.85` trigger auto-revise via the Revision Loop (Class R2). The auto-revise loop caps at three iterations before escalating to a PI Style checkpoint with three resolution options (continue revising, accept the section as is via PI override, or restructure the section).
+
+The score is one signal among several. PI editorial judgment overrides the score via `ai_tic_config.yaml`. The score is **not** the sole gate. Treating it as such is anti-pattern 10 in `SKILL.md`.
+
+## Per-project override mechanism
+
+Each `manuscripts/<project>/<venue>/ai_tic_config.yaml` maps each banned term to one of three verdicts plus a free-text rationale:
+
+```yaml
+# Manuscript-specific anti-AI-tic overrides.
+# Default behavior at top: HIGH-tier blocks by default; this file overrides per-term.
+
+facilitate:
+  verdict: disable
+  rationale: "Used in the medical sense (catheter facilitates drainage); domain-legitimate."
+
+elevate:
+  verdict: downgrade  # downgrade to MEDIUM (warn instead of block)
+  rationale: "Used technically (signal elevation); not promotional."
+
+enhance:
+  verdict: enable  # default behavior; redundant but explicit
+  rationale: ""
+
+# Project-specific additions (terms PI wants flagged beyond the default list):
+custom_blocks:
+  - term: "robust"
+    tier: HIGH
+    rationale: "PI dislikes generic claims of robustness; require specific quantification."
+```
+
+The linter loads the project's `ai_tic_config.yaml` if present, applies overrides, and records the active override set in `ai_tic_report.json` for traceability. Override decisions should be PI-ratified; for systematic project-wide overrides, the rationale field is appended to a `lit_` or `jrn_` for record.
+
+## Phase 1 implementation status
+
+The linter `scripts/ai_tic_lint.py` implements all Tier 1 + Tier 2 + Tier 3 lexical patterns, the four structural detectors (sentence-length variance, transition-word ratio, parallel-triplet density, bridge-repetition delegation to `bridge_repetition_check.py`), absolute bans, the style score formula, and the per-project override mechanism. Output is `ai_tic_report.json` with per-rule hit counts and per-hit line numbers, plus the computed style score.
+
+Phase 2 additions (not in scope for Phase 1):
+
+- LLM-assisted rewrite suggestions for flagged passages.
+- Cross-manuscript trend tracking (is the project drifting toward AI-tic patterns over revisions).
+- Author-style fingerprinting baseline (calibrate the linter against the PI's pre-2023 publications).
+
+## References
+
+- Kobak et al. 2025: https://doi.org/10.1126/sciadv.adt3813
+- Matsui 2025: Perspectives on Medical Education 14(1):882-890.
+- Walters and Wilder 2023: Scientific Reports doi:10.1038/s41598-023-41032-5.
+- PI verbatim list: `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q4 ratification.
+- Anti-AI-tic sourcing decision: `dec_01KS12H9KT1T03DHX2Q6FKTXHH`.
+- Deep research synthesis (skills survey, empirical anchors): `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`.

--- a/rka/skills/writer/references/architecture.md
+++ b/rka/skills/writer/references/architecture.md
@@ -1,0 +1,187 @@
+# Writer Architecture
+
+The Writer is a Claude Code skill (Markdown SKILL.md + Python scripts + workspace template) operating in VSCode per `dec_01KS0AWYDV752AWQRF40CQBRFZ`. It reads from and writes to RKA via the existing `rka` MCP server. It does not introduce new RKA orchestration; it operates on a manuscript working directory and emits provenance edges back into the research graph.
+
+## Deployment model
+
+```
+VSCode (PI workspace)
+  +--> Claude Code session (entry point)
+       +--> SKILL.md (this skill) ----> Native tools: Read/Edit/Write/Bash/Grep/Glob/WebSearch/WebFetch
+       |                          +--> MCP servers via .mcp.json:
+       |                                  rka (required)
+       |                                  rka-writer-tools (Phase 2, optional)
+       |
+       +--> Workspace = manuscripts/<project-id>/<venue>/
+            +--> sections/*.tex
+            +--> figures/, tables/, charts/
+            +--> refs.bib
+            +--> main.tex
+            +--> .planning/ (working state)
+            +--> .latexmkrc, .mcp.json
+            +--> ai_tic_config.yaml (per-project overrides)
+            +--> styles/ (vendored venue templates)
+```
+
+Two invocation paths land in this skill:
+
+1. **Direct PI invocation.** PI launches `claude` in the manuscript directory; the skill loads on session start when Claude Code detects the workspace.
+2. **Brain-spawned subagent.** Brain creates a revision mission (`rka_create_mission`); a fresh Claude Code subagent picks it up and operates on the manuscript directory.
+
+Same skill content in both paths; the entry point differs.
+
+## RKA integration
+
+The Writer reads broadly from RKA at session start and during drafting:
+
+| Tool | When | Purpose |
+|---|---|---|
+| `rka_get_status` | session start | confirm active project, phase |
+| `rka_get_changelog` | session start | what changed since last writing session |
+| `rka_get_research_map` | session start, before outline | structural overview of clusters and claims |
+| `rka_get_journal` | during drafting | quote PI directives, prior findings |
+| `rka_get_literature` | during drafting | citation source for `lit_` entities |
+| `rka_get_decision_tree` | during outline | ratified decisions to cite |
+| `rka_search` | during drafting | targeted retrieval (queries kept to 2 to 4 words) |
+| `rka_get_context` | during drafting | importance-ranked context bundle for a topic |
+
+The Writer writes back to RKA when an artifact is generated or a checkpoint resolves:
+
+| Tool | When | What is recorded |
+|---|---|---|
+| `rka_add_note` | manuscript manifest creation, checkpoint ratification, session digest | `jrn_` entries with full provenance |
+| `rka_add_decision` | each of 6 PI checkpoints | `dec_` with options, rationale, PI selection |
+| `rka_record_pi_selection` | each checkpoint after PI picks | links PI's choice to a `dec_` |
+| `rka_update_literature` | after reference validation | `validation_status` field on `lit_` |
+| `rka_create_mission` | only for follow-ups Brain or Executor handle | revision missions during the Revision Loop |
+
+The Writer does **not** call `rka_create_project`, `rka_create_gate`, or any orchestration tool that grows new RKA structure. The bookkeeper invariant for Phase 1 is preserved.
+
+## Option 2 manuscript representation (`dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q1)
+
+A manuscript is represented by two artifacts: the working-directory tree on disk and a `jrn_` manifest in RKA. There is no new entity type; the `jrn_` manifest serves as the canonical manuscript record.
+
+Manifest fields:
+
+```python
+rka_add_note(
+    type="note",
+    source="executor",  # or "pi" if PI directly authored the launch
+    content="""
+# Manuscript: <Title>
+
+## Section index
+- §1 Introduction: drafted | revised | submitted
+- §2 Related Work: drafted
+- §3 Method: drafted
+- §4 Evaluation: drafted
+- §5 Discussion: outlined
+- §6 Conclusion: outlined
+
+## Working directory
+manuscripts/<project-id>/<venue>/
+
+## Current phase
+draft  # draft | review | final | submitted
+""",
+    verbatim_input="<full PI-authored title + abstract>",
+    related_decisions=[
+        "dec_venue_checkpoint",
+        "dec_outline_checkpoint",
+        "dec_table_figure_plan",
+        "dec_reference_set",
+        "dec_draft_approvals",
+        "dec_final_layout",
+    ],
+    related_literature=["lit_..."],  # all cited
+    related_journal=["jrn_..."],     # all quoted
+    tags=["manuscript", "venue:CHI", "phase:draft", "writer-session:3"],
+    importance="high",
+    confidence="tested",
+)
+```
+
+The manifest is updated as the manuscript progresses through phases; the `tags` field carries the current phase via `phase:<draft|review|final>`. The `related_decisions` field grows as each of the six PI checkpoints ratifies a `dec_`.
+
+Option 3 (a new `man_` entity type with schema migration) was rejected per Q1 ratification because it would require migration scaffolding in `rka/db/schema.sql` and `rka/services/` (violating the bookkeeper invariant for Phase 1).
+
+## Provenance edges Writer emits
+
+Across the 12-type `entity_links` vocabulary (see `../brain/architecture.md` section "The 12-Type Provenance Vocabulary" for the full taxonomy), the Writer emits:
+
+| Edge | From | To | Meaning |
+|---|---|---|---|
+| `cites` | manuscript jrn_ | lit_ | manuscript cites this literature item |
+| `references` | manuscript jrn_ | jrn_ | manuscript quotes or paraphrases this journal entry |
+| `justified_by` | checkpoint dec_ | jrn_ | checkpoint decision rests on this evidence |
+| `supports` | jrn_ (claim) | lit_ | claim is supported by this paper |
+| `contradicts` | jrn_ (claim) | lit_ | claim contradicts this paper |
+| `derived_from` | revision mission mis_ | dec_ (checkpoint) | mission spawned from this checkpoint |
+| `supersedes` | new dec_ | old dec_ | revisited checkpoint replaces prior |
+| `produced` | mission mis_ | manuscript jrn_ | revision mission updated this manuscript |
+| `informed_by` | manuscript jrn_ | research_map cluster | manuscript draws on this evidence cluster |
+
+The Writer never invents new edge types and never creates orphan entities. Every manifest entry has the required upstream links per the table above.
+
+## Bookkeeper invariant (Phase 1)
+
+The Writer's Phase 1 scope adds files only under `rka/skills/writer/` and `tests/skills/writer/` (plus optional minimal touch of `rka/skills/SKILL.md` for the top-level skills index). It modifies zero files under `rka/services/`, `rka/api/`, `rka/mcp/`, or `web/`.
+
+Verification at every commit boundary:
+
+```bash
+git diff main -- rka/services/ rka/api/ rka/mcp/ web/  # must be empty
+```
+
+If this command produces any output, the commit violates the bookkeeper invariant and must be reworked before push.
+
+Phase 2 may introduce the `rka-writer-tools` MCP server as a separate sibling MCP (not a modification of the existing `rka` server). Phase 3 may add the optional MCP tools `rka_get_manuscript`, `rka_validate_reference`, `rka_register_manuscript` to the existing `rka` server; that introduction will land in a Phase 3 mission with its own bookkeeper exemption rationale ratified by Brain and PI. Phase 1 stays out of `rka/mcp/`.
+
+## Workspace template structure
+
+Phase 1 ships a workspace template at `rka/skills/writer/workspace-template/`. The PI copies it to `manuscripts/<project-id>/<venue>/` to bootstrap a new manuscript:
+
+```
+manuscripts/<project-id>/<venue>/
+  .mcp.json                   # rka required; rka-writer-tools commented (Phase 2)
+  .latexmkrc                  # TEXINPUTS=./styles//: ; @default_files = ('main.tex')
+  .planning/
+    ACTIVE_WORKFLOW.md        # current_phase, last_checkpoint, next_action
+    PRECIS.md                 # PI-authored title + abstract + venue
+    OUTLINE.md                # ratified outline (post-Outline checkpoint)
+    REVIEW_STATE.md           # iteration counter for Revision Loop
+    sketches/                 # per-section sketches before drafting
+  styles/                     # vendored venue templates (populated by fetch_template)
+  sections/                   # section .tex files
+  figures/, tables/, charts/  # generated artifacts
+  refs.bib                    # validated bibliography
+  main.tex                    # skeleton, then \input{sections/*}
+  ai_tic_config.yaml          # per-project overrides
+```
+
+## Phase boundaries
+
+Phase 1 (this mission):
+
+- SKILL.md, references/, scripts/ (with stubs for Phase 2 items), workspace-template/, tests/skills/writer/, docs.
+- Two seed venues: CHI, EMNLP.
+- Anti-AI-tic enforcement live and tested.
+- Local LaTeX render plus layout audit live and tested.
+- Reference validation Stage A (CSL-JSON pass-through) live; Stages B through G stubbed.
+- Manual reference handling acceptable in Phase 1.
+
+Phase 2 (separate future mission):
+
+- `rka-writer-tools` MCP server (habanero plus pyalex plus semanticscholar plus arxiv plus serpapi).
+- Reference validation Stages B through G live.
+- SerpAPI integration with credit budget.
+- Five additional venue files (USENIX, IEEE-SP, NeurIPS, OSDI, Nature).
+- Author disambiguation with ORCID + SerpAPI.
+
+Phase 3 (separate future mission):
+
+- Revision Loop with four `comment_class` mission shapes (R1, R2, R3, R4).
+- Brain mission integration for Writer revisions (Brain spawns a Writer subagent on a Revision Mission).
+- Optional MCP tools `rka_get_manuscript`, `rka_validate_reference`, `rka_register_manuscript`.
+
+The phasing rationale: Phase 1 ships a usable Writer for PI's solo drafting workflow (manual reference assembly is acceptable). Phase 2 makes reference validation automated. Phase 3 closes the loop with Brain-spawned revisions.

--- a/rka/skills/writer/references/examples.md
+++ b/rka/skills/writer/references/examples.md
@@ -1,0 +1,239 @@
+# Worked Examples
+
+Two end-to-end examples illustrating the Writer's most distinctive decisions: an outline ratification via the strip-then-re-inject UX, and an AI-tic catch via the linter plus structural detector layer.
+
+## Example 1: Outline ratification
+
+### Scenario
+
+Project: a hypothetical RKA project on contextual integrity in LLM agent permission systems. Six clusters in the research map. CHI is the chosen venue (Venue checkpoint already ratified).
+
+### Step 1: read research map
+
+```python
+rka_get_research_map(project_id="prj_01KQ...")
+```
+
+Returns six clusters:
+
+- `ecl_01KQA`: contextual-integrity theory roots (Nissenbaum 2004, 2010, etc.).
+- `ecl_01KQB`: agent permission-system empirical surveys (12 deployments studied).
+- `ecl_01KQC`: user-study findings on permission fatigue.
+- `ecl_01KQD`: technical architecture proposals from prior work.
+- `ecl_01KQE`: the project's own pilot study findings (mixed methods, n=24).
+- `ecl_01KQF`: design implications and an enumerated framework.
+
+### Step 2: generate three framings (PI preference stripped)
+
+**Results-led**: lead with the pilot study finding ("permission fatigue scales with agent capability"); use Related Work to position; Discussion ties to broader theory.
+
+- Sections: Intro, Related Work (CI theory + prior empirical), Method (pilot study design), Findings (the empirical claim plus supporting evidence), Discussion + Implications, Conclusion.
+- Strength: novelty foregrounded; readers grasp the contribution by page 2.
+- Weakness: a CHI audience may need more theoretical scaffolding before the empirical finding lands; risks reading as a single-study paper without enough framework.
+
+**Method-led**: lead with the methodological contribution (a new diary-study protocol for measuring permission fatigue across agent classes).
+
+- Sections: Intro, Related Work, Methodological Contribution (the diary protocol), Pilot Application (study), Findings, Discussion, Conclusion.
+- Strength: methods-focused readers (and PC members with methodological taste) find the contribution immediately.
+- Weakness: empirical findings come later; reader patience required; risks reading as a methods-only paper.
+
+**Motivation-led**: lead with the broader problem (LLM agent permission systems are at scale without empirical grounding); position the work as the first empirical study.
+
+- Sections: Intro (problem framing + scale), Background (CI theory + agent landscape), Pilot Study (method + findings combined), Framework (the enumerated implications), Discussion, Conclusion.
+- Strength: positions the work for impact; CHI reviewers like clear problem framing.
+- Weakness: contribution claims must be sharp in the Intro or the reader loses the through-line.
+
+### Step 3: prune via Pareto non-dominance
+
+Axes: scope coverage (does the structure represent the full research arc?), novelty positioning (does the structure communicate the contribution?), venue fit (does it match CHI's expectations?).
+
+- Results-led: high novelty positioning, moderate scope coverage (theoretical scaffold thinner), moderate venue fit.
+- Method-led: high venue fit (CHI likes methods contributions), moderate novelty positioning, high scope coverage.
+- Motivation-led: high scope coverage, high venue fit, moderate novelty positioning.
+
+None dominated; all three survive pruning.
+
+### Step 4: rank with opposing-critique
+
+PI preference re-injected as a critic: the PI is a methods-oriented researcher who has emphasized in past sessions that "CHI welcomes empirical methodological contributions." Use this as opposing-critique:
+
+- Method-led ranked first: directly aligns with PI's methodological emphasis.
+- Motivation-led ranked second: also fits CHI; broader framing.
+- Results-led ranked third: novelty-foregrounded but may feel single-study at CHI.
+
+Mark Method-led as `is_recommended`.
+
+### Step 5: PI selects
+
+```python
+rka_add_decision(
+    project_id="prj_01KQ...",
+    question="Which outline framing for the CHI manuscript?",
+    options=[
+        {"label": "Method-led", "is_recommended": True, "description": "Lead with diary protocol contribution.", ...},
+        {"label": "Motivation-led", "description": "Lead with permission-system problem framing.", ...},
+        {"label": "Results-led", "description": "Lead with permission-fatigue empirical finding.", ...},
+    ],
+    rationale="Methodological contribution emphasis aligns with PI's prior CHI guidance (jrn_01KQ...) and venue fit.",
+    related_journal=["jrn_01KQ..."],
+    decided_by="pi",
+    status="active",
+)
+
+# PI selects (assume Method-led):
+rka_record_pi_selection(
+    decision_id="dec_<the new one>",
+    pi_selected_option_id="Method-led",
+    pi_override_rationale=None,
+)
+```
+
+### Step 6: write OUTLINE.md
+
+```markdown
+# OUTLINE: CHI Manuscript (Method-led framing)
+
+Ratified 2026-05-19 via dec_01KQ... (PI selected Method-led).
+
+## §1 Introduction
+- Problem: LLM agent permission systems at scale; empirical methods limited.
+- Contribution claim: a diary-study protocol that surfaces permission fatigue across agent classes.
+- Result preview: protocol applied; key findings.
+
+## §2 Related Work
+- Contextual integrity theory (Nissenbaum 2004, 2010, extensions).
+- Prior permission-system empirical work.
+- Prior diary-study protocols in HCI.
+
+## §3 Methodological Contribution
+- The diary protocol: design rationale, instrument, sampling.
+- What it measures; why prior methods underdetermined it.
+
+## §4 Pilot Application
+- Participants (n=24, mixed-methods sample).
+- Procedure.
+- Analysis approach.
+
+## §5 Findings
+- Quantitative findings from the diary instrument.
+- Qualitative themes from open-ended responses.
+- Triangulation across the two streams.
+
+## §6 Discussion
+- Implications for permission-system design.
+- Methodological reflections (what worked, what did not).
+
+## §7 Limitations (top-level, per CHI 2024+ convention)
+- Sample size and composition.
+- Diary-study attrition.
+- Reflexivity and positionality.
+
+## §8 Conclusion
+- Restate contribution.
+- Future work pointers.
+```
+
+This OUTLINE.md becomes the input to the Table-Figure-Chart Plan checkpoint, and subsequently to per-section drafting.
+
+## Example 2: AI-tic catch
+
+### Scenario
+
+A draft section was just produced by the Section Drafter sub-procedure. Before the Draft section PI checkpoint surfaces, `scripts/ai_tic_lint.py` runs as a self-audit.
+
+### The draft (excerpt)
+
+```latex
+% sections/03-method.tex (excerpt)
+
+Our methodology delves into the intricate dynamics of permission-fatigue, leveraging a comprehensive diary-study protocol that facilitates participant self-reporting. We propose a novel instrument that meticulously captures both frequency and intensity of permission grants. Furthermore, the protocol underpins a robust analytical framework that aligns with prior HCI scholarship.
+
+It is important to note that our approach showcases significant methodological innovation. Importantly, the diary instrument plays a pivotal role in surfacing latent user perceptions that traditional survey methods cannot adequately capture.
+```
+
+### Linter output (`ai_tic_report.json`)
+
+```json
+{
+  "section": "sections/03-method.tex",
+  "lines": 7,
+  "total_sentences": 5,
+  "hits": {
+    "critical": [],
+    "high": [
+      {"term": "delves into", "line": 4, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "intricate", "line": 4, "tier": "HIGH", "source": "Kobak 2025"},
+      {"term": "leveraging", "line": 4, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "comprehensive", "line": 4, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "facilitates", "line": 4, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "meticulously", "line": 4, "tier": "HIGH", "source": "Kobak 2025"},
+      {"term": "Furthermore", "line": 4, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "underpins", "line": 4, "tier": "HIGH", "source": "Kobak 2025"},
+      {"term": "aligns", "line": 4, "tier": "HIGH", "source": "Kobak 2025"},
+      {"term": "it is important to note", "line": 6, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "showcases", "line": 6, "tier": "HIGH", "source": "Kobak 2025"},
+      {"term": "Importantly", "line": 6, "tier": "HIGH", "source": "PI verbatim list"},
+      {"term": "pivotal", "line": 6, "tier": "HIGH", "source": "Kobak 2025"}
+    ],
+    "medium": [
+      {"pattern": "rule-of-three triplet", "line": 4, "tier": "MEDIUM", "description": "X, Y, and Z constructions detected three times in paragraph 1"}
+    ],
+    "absolute_bans": []
+  },
+  "structural": {
+    "sentence_length_variance": {"paragraph_1_std": 4.2, "verdict": "BLOCK", "threshold": 5.0},
+    "transition_word_ratio": {"value": 0.012, "verdict": "WARN", "threshold": 0.005},
+    "parallel_triplet_density": {"value": 1.5, "verdict": "WARN", "threshold": 1.0},
+    "bridge_repetition": {"max_ratio": 0.34, "verdict": "PASS", "threshold": 0.7}
+  },
+  "style_score": 1 - (0 * 3 + 13 + 0.3 * 1) / 5,
+  "actual_score": -1.66,
+  "verdict": "BLOCK"
+}
+```
+
+The style score is deeply negative (the formula clips at 0 in practice; this output shows the raw value to emphasize how many HIGH hits cluster in a short passage). The verdict is `BLOCK` from multiple paths: HIGH-tier hits, sentence-length variance under 5, transition-word ratio over 0.5 percent, and parallel-triplet density over 1.
+
+### Auto-revise iteration
+
+The Section Drafter sub-procedure picks up the linter report and rewrites the section. Iteration 1 result:
+
+```latex
+Our method uses a diary protocol to measure permission fatigue. The instrument records both frequency and intensity of permission grants from participants. The analytical framework draws on prior HCI scholarship on user-system interactions.
+
+The diary instrument surfaces user perceptions that survey methods do not capture. Specifically, it records the temporal patterns of permission decisions and the cognitive context in which each decision occurs.
+```
+
+### Iteration 1 linter output
+
+```json
+{
+  "section": "sections/03-method.tex",
+  "hits": {
+    "critical": [],
+    "high": [],
+    "medium": [],
+    "absolute_bans": []
+  },
+  "structural": {
+    "sentence_length_variance": {"paragraph_1_std": 7.4, "verdict": "PASS", "threshold": 5.0},
+    "transition_word_ratio": {"value": 0.0, "verdict": "PASS", "threshold": 0.005},
+    "parallel_triplet_density": {"value": 0.0, "verdict": "PASS", "threshold": 1.0},
+    "bridge_repetition": {"max_ratio": 0.18, "verdict": "PASS", "threshold": 0.7}
+  },
+  "style_score": 1.0,
+  "verdict": "PASS"
+}
+```
+
+The revised section passes all gates. Style score 1.0 (no hits). The provenance comments (omitted from the excerpt above) remain attached to evidence-bearing claims.
+
+### What this example shows
+
+The auto-revise loop's first iteration was sufficient. The original draft was heavily HIGH-tier; rewriting from scratch with the linter's hit list as a checklist produces clean prose. If iteration 1 had still failed (e.g., the rewriter substituted equivalent HIGH-tier terms), iteration 2 would have engaged. The three-iteration cap exists because some sections may surface domain-specific legitimate usage that requires `ai_tic_config.yaml` overrides rather than rewriting.
+
+The structural detectors caught the rhythmic problem (uniform sentence length, parallel-triplet density). Pure lexical checks alone would not have surfaced this even after the lexical issues were cleaned.
+
+### Surfacing to PI
+
+If iteration 1 had passed (as it did here), the section advances to the Draft section PI checkpoint. The PI sees a clean draft plus a one-line `ai_tic_report` summary ("0 HIGH, 0 MEDIUM, all structural checks PASS, style score 1.0"). The PI ratifies via accept / revise / escalate per the checkpoint UX.

--- a/rka/skills/writer/references/latex_audit.md
+++ b/rka/skills/writer/references/latex_audit.md
@@ -1,0 +1,189 @@
+# LaTeX Layout Audit
+
+`scripts/layout_audit.py` runs after a successful latexmk render and emits `audit.json` over twelve fields. Each field returns `PASS`, `WARN`, or `BLOCK`. Any `BLOCK` halts progress until resolved; `WARN` verdicts are surfaced for the Final Layout PI checkpoint.
+
+## The twelve fields
+
+### 1. `pages_over_limit` (BLOCK any non-zero)
+
+Compare the rendered PDF page count to the venue page limit (carried in `references/venue/<venue>.md`, field "Page-limit class"). Page count from `pdfinfo main.pdf | grep Pages`.
+
+Verdict:
+- `PASS` if `pages <= limit`.
+- `WARN` if `pages == limit` (no margin for revision).
+- `BLOCK` if `pages > limit`.
+
+Regex for log: not applicable; uses pdfinfo. Implementation: `subprocess.run(['pdfinfo', pdf_path])` and parse the `Pages:` line.
+
+### 2. `undefined_citations` (BLOCK any)
+
+Search `.log` for `LaTeX Warning: Citation .* undefined`. Each match indicates a `\cite{...}` referencing a key not in the `.bib` file.
+
+Verdict:
+- `PASS` if zero matches.
+- `BLOCK` if at least one match.
+
+Regex: `^LaTeX Warning: Citation `(.*?)' .* undefined`.
+
+### 3. `undefined_refs` (BLOCK any)
+
+Search `.log` for `LaTeX Warning: Reference .* undefined`. Each match indicates a `\ref{...}` or `\eqref{...}` targeting a label that does not exist.
+
+Verdict:
+- `PASS` if zero matches.
+- `BLOCK` if at least one match.
+
+Regex: `^LaTeX Warning: Reference `(.*?)' on page .* undefined`.
+
+### 4. `missing_bib_keys` (BLOCK any)
+
+Search `.blg` (BibTeX log) for `Warning--I didn't find a database entry for`. Each match indicates a citation key that BibTeX could not resolve from any input `.bib` file.
+
+Verdict:
+- `PASS` if zero matches.
+- `BLOCK` if at least one match.
+
+Regex: `^Warning--I didn't find a database entry for "(.*?)"`.
+
+### 5. `question_mark_citations` (BLOCK any)
+
+After render, scan the PDF text via `pdftotext main.pdf -` for occurrences of `[?]` (LaTeX's default for an unresolved citation). Even if undefined-citation warnings are absent (e.g., suppressed), `[?]` in the rendered output is a hard block.
+
+Verdict:
+- `PASS` if zero `[?]` in `pdftotext` output.
+- `BLOCK` if at least one match.
+
+Regex: `\[\?\]`.
+
+### 6. `orphan_refs` (BLOCK any)
+
+A `\ref{label}` or `\eqref{label}` exists in the source but the corresponding `\label{label}` is not in any rendered section (e.g., points to a section that was commented out). Detected by cross-referencing the `.aux` file label table against the `.tex` source `\ref` calls.
+
+Verdict:
+- `PASS` if every `\ref` resolves to a known label.
+- `BLOCK` if at least one orphan.
+
+Implementation: parse `.aux` for `\newlabel{...}` declarations; grep `.tex` files for `\ref{...}` and `\eqref{...}` calls; diff the sets.
+
+### 7. `overfull_hboxes_over_10pt` (WARN)
+
+Search `.log` for `Overfull \hbox` with overflow greater than 10 pt. Smaller overflows are usually invisible; larger ones produce visible black-bar artifacts in the rendered PDF.
+
+Verdict:
+- `PASS` if zero matches over 10 pt.
+- `WARN` if at least one match over 10 pt.
+
+Regex: `^Overfull \\hbox \((\d+(?:\.\d+)?)pt too wide\)`. Filter where group 1 > 10.0.
+
+### 8. `overfull_vboxes` (WARN)
+
+Search `.log` for `Overfull \vbox`. Any occurrence is a warning.
+
+Verdict:
+- `PASS` if zero.
+- `WARN` if at least one.
+
+Regex: `^Overfull \\vbox`.
+
+### 9. `float_too_large` (WARN)
+
+Search `.log` for `Float too large for page`. Indicates a `figure` or `table` environment that exceeds page-height and may be placed unexpectedly.
+
+Verdict:
+- `PASS` if zero.
+- `WARN` if at least one.
+
+Regex: `Float too large for page`.
+
+### 10. `underfull_badness_over_5000` (WARN)
+
+Search `.log` for `Underfull \hbox` with badness greater than 5000. Smaller badness values are tolerated by venue style files; larger ones indicate noticeable spacing irregularities.
+
+Verdict:
+- `PASS` if zero matches over badness 5000.
+- `WARN` if at least one.
+
+Regex: `^Underfull \\hbox \(badness (\d+)\)`. Filter where group 1 > 5000.
+
+### 11. `chktex_warnings_over_10` (WARN)
+
+Run `chktex -q main.tex` (or `chktex` on each `sections/*.tex`). chktex produces lint warnings for common LaTeX style issues (e.g., wrong dash kind, smart-quotes, math-mode in text, et cetera).
+
+Verdict:
+- `PASS` if total chktex warnings under or equal to 10.
+- `WARN` if over 10.
+
+Implementation: `subprocess.run(['chktex', '-q', tex_file])`, parse stdout for warning lines.
+
+### 12. `pages_equals_limit` (WARN)
+
+Already covered as a sub-case of field 1, but tracked separately so the Final Layout checkpoint sees this as an explicit signal (no revision margin).
+
+Verdict:
+- `PASS` if `pages < limit`.
+- `WARN` if `pages == limit`.
+
+## audit.json schema
+
+```json
+{
+  "manuscript": "manuscripts/<project>/<venue>/main.tex",
+  "rendered_at": "2026-05-19T17:45:00Z",
+  "pdf_path": "main.pdf",
+  "venue": "CHI",
+  "page_limit": 14,
+  "pages_rendered": 13,
+  "fields": {
+    "pages_over_limit": {"verdict": "PASS", "value": 13, "threshold": 14},
+    "undefined_citations": {"verdict": "PASS", "value": 0, "matches": []},
+    "undefined_refs": {"verdict": "PASS", "value": 0, "matches": []},
+    "missing_bib_keys": {"verdict": "PASS", "value": 0, "matches": []},
+    "question_mark_citations": {"verdict": "PASS", "value": 0},
+    "orphan_refs": {"verdict": "PASS", "value": 0, "matches": []},
+    "overfull_hboxes_over_10pt": {"verdict": "WARN", "value": 1, "matches": [{"line": 142, "overflow_pt": 12.3}]},
+    "overfull_vboxes": {"verdict": "PASS", "value": 0},
+    "float_too_large": {"verdict": "PASS", "value": 0},
+    "underfull_badness_over_5000": {"verdict": "PASS", "value": 0},
+    "chktex_warnings_over_10": {"verdict": "PASS", "value": 7},
+    "pages_equals_limit": {"verdict": "PASS", "value": 13, "threshold": 14}
+  },
+  "summary": {
+    "blocks": 0,
+    "warns": 1,
+    "passes": 11,
+    "overall_verdict": "WARN"
+  }
+}
+```
+
+## Overall verdict
+
+The `summary.overall_verdict` is computed by:
+
+```python
+if any(f["verdict"] == "BLOCK" for f in fields.values()):
+    overall = "BLOCK"
+elif any(f["verdict"] == "WARN" for f in fields.values()):
+    overall = "WARN"
+else:
+    overall = "PASS"
+```
+
+Final Layout PI checkpoint cannot ratify `submit` if `overall_verdict == "BLOCK"`. `WARN` is acceptable for submit; the PI is the final arbiter.
+
+## Engine-specific notes
+
+Some venue templates produce engine-specific warnings:
+
+- `acmart` with `pdflatex` produces "PDF inclusion: multiple pdfs with page group included in a single page" warnings under draft mode. These are non-fatal and tracked as a WARN if frequent (over 5).
+- `acl-style-files` requires `pdflatex` (not lualatex); `xelatex` triggers font-loading failures for the default ACL fonts. The venue file at `references/venue/EMNLP.md` documents this.
+- USENIX templates require specific font packages; missing fonts produce "Font ... not found" warnings that surface as orphan refs in some chains. The Phase 2 USENIX venue file will document the engine pinning.
+
+## Phase 2 extensions (not in Phase 1 scope)
+
+- Cross-render comparison: compare `pages_rendered` against last session's `audit.json` to surface scope drift.
+- Figure-vs-text-area ratio (visual balance heuristic for HCI venues).
+- Citation density per section (anti-pattern: dumping all citations in Related Work).
+- Hyperref color audit (some venues block colored links; the venue files Phase 2 will encode this).
+
+These extensions are tracked for Phase 2 design; not implemented in Phase 1.

--- a/rka/skills/writer/references/reference_pipeline.md
+++ b/rka/skills/writer/references/reference_pipeline.md
@@ -1,0 +1,150 @@
+# Reference Validation Pipeline
+
+Seven stages (A through G). Phase 1 implements only Stage A; Stages B through G are documented architecture here and stubbed in `scripts/validate_references.py` (raise `NotImplementedError` with this file referenced).
+
+## Architectural rationale
+
+Citation fabrication is the most common LLM failure in manuscript drafting. Cross-study average is 51 percent across six published studies covering 732 LLM-generated citations (`jrn_01KS0AVZRDA0KPXK61MN9PV5DE` captures the empirical anchors). Multi-source cross-check is the only working defense; a single-source check is insufficient.
+
+The pipeline is structured as seven stages with explicit verdict statuses. A reference advances through stages; any stage may set a terminal status. Compile-time enforcement at the Writer layer blocks `UNVERIFIED` and `HALLUCINATED` citations unless overridden via `dec_`.
+
+## Stage A: Extraction
+
+Inputs:
+- `rka_get_literature(project_id=...)` to pull `lit_` entities for the project.
+- Anystyle parse of free-text references (if PI provides plain-text references rather than RKA-resident `lit_`).
+- Direct identifiers (DOI, arXiv, PubMed) extracted from text via regex.
+
+Outputs:
+- A working set of candidate references in CSL-JSON form.
+- Each candidate carries `source_origin` (RKA-resident `lit_`, free-text parse, or direct identifier).
+
+Phase 1 status: **implemented**. `scripts/validate_references.py` Stage A converts CSL-JSON from `rka_get_literature` output to BibTeX via the `manubot` Python package if installed. Free-text anystyle parsing requires the anystyle Ruby gem and is a Phase 2 deliverable.
+
+## Stage B: Identifier resolution
+
+Resolution waterfall (preferred to fallback):
+
+1. **Crossref via habanero** (`habanero.Crossref.works(ids=[doi])`). Canonical for DOI to BibTeX.
+2. **manubot** (`manubot cite doi:...`). Multi-source identifier resolver; fallback for non-DOI identifiers (PubMed, PMC, arXiv, ISBN, Wikidata).
+3. **OpenAlex via pyalex**. Title-to-DOI resolution if only a title is available.
+4. **Semantic Scholar via semanticscholar Python package**. Coverage strength: CS and AI. Multi-format IDs: `DOI:`, `ARXIV:`, `CorpusId:`.
+5. **arXiv via the arxiv Python package**. Preprint resolution. Built-in rate limit one request per three seconds.
+
+Never query Google Scholar directly. Direct scraping is forbidden per `dec_01KS0AXXASJ5GXV7M0SS39Y066` and anti-pattern 8 in SKILL.md.
+
+Phase 1 status: **stubbed**. Stage B requires `rka-writer-tools` MCP server (Phase 2 deliverable) or local Python packages installed in the workspace. The stub in `scripts/validate_references.py` raises `NotImplementedError` and points the PI to this file.
+
+## Stage C: Cross-source existence validation
+
+A reference is `VERIFIED` only when at least two independent sources confirm its existence with consistent metadata (title, authors, year, venue). Conflicting metadata produces `FIELD_ERROR` with the conflict surfaced.
+
+Statuses set by Stage C:
+
+- `VERIFIED`: at least two sources concur on title plus first author plus year.
+- `FIELD_ERROR`: one or more sources found but metadata diverges.
+- `UNVERIFIED`: zero or one sources found; advance to Stage G niche-citation rescue.
+
+Phase 1 status: **stubbed**.
+
+## Stage D: Retraction check
+
+Retraction Watch was acquired by Crossref in September 2023. The Retraction Watch Database (RWDB) feeds the main Crossref REST API. Primary check:
+
+```
+GET /v1/works/{DOI} -> updated-by array -> filter source="retraction-watch"
+```
+
+Secondary check: CSV mirror at `api.labs.crossref.org/data/retractionwatch` or `git clone gitlab.com/crossref/retraction-watch-data`.
+
+OpenAlex `is_retracted` is a tertiary check; the field had pipeline issues from December 2023 through March 2024 (Hauschke and Nazarovets 2024, arXiv:2403.13339) and is not authoritative on its own.
+
+R retractcheck was archived in 2022; do not use.
+
+Statuses set by Stage D:
+
+- `VERIFIED`: passes retraction check.
+- `RETRACTED`: Crossref `updated-by` includes a retraction record. Compile blocks unless PI overrides with retraction-discussion citation rationale stored as `dec_`.
+
+Phase 1 status: **stubbed**.
+
+## Stage E: Author disambiguation
+
+Two-step:
+
+1. OpenAlex Author IDs (W ID system).
+2. ORCID via `python-orcid` package.
+
+Sources concur on the same author entity. Mismatch triggers `AUTHOR_MISMATCH`. Low coverage triggers `LOW_CONFIDENCE`.
+
+Third source on `AUTHOR_MISMATCH` or `LOW_CONFIDENCE`: SerpAPI `google_scholar_author` endpoint, per `dec_01KS0AXXASJ5GXV7M0SS39Y066`. Used only conditionally; not on every disambiguation.
+
+Phase 1 status: **stubbed**.
+
+## Stage F: Bibliography compilation
+
+Once all references are `VERIFIED`, compile `refs.bib`:
+
+1. manubot generates BibTeX entries from CSL-JSON.
+2. bibtex-tidy (Node CLI, MIT) applies hygiene: `--curly --numeric --sort=key --duplicates=key,doi --escape --tidy-comments --remove-empty-fields --enclosing-braces=title`.
+3. Optional: betterbib (GPL-3.0) cross-source field sync via subprocess. betterbib is **never vendored** due to its GPL license; only subprocess invocation is permitted.
+
+Phase 1 status: Stage A output feeds Stage F directly without B-E validation. Phase 2 wires the full chain.
+
+## Stage G: Niche-citation rescue
+
+When Stages B through C return empty across all primary sources (Crossref, OpenAlex, Semantic Scholar, arXiv), one final SerpAPI `google_scholar` lookup runs before assigning `HALLUCINATED`. A hit produces `UNVERIFIED` with `note=scholar-only-source`, which triggers a PI checkpoint to either ratify the citation with a `dec_` override or remove it.
+
+SerpAPI budget: 200 searches per manuscript (counted across Stages E and G), tracked in `refs.audit.json`. `SERPAPI_KEY` is an env var, never committed; if unset, Stage G silently skips and the reference proceeds to `HALLUCINATED`.
+
+Phase 1 status: **stubbed**; SerpAPI integration is a Phase 2 deliverable.
+
+## Status reference
+
+| Status | Set by | Compile block? | Resolution path |
+|---|---|---|---|
+| `VERIFIED` | Stage C (two sources concur) | no | proceed |
+| `FIELD_ERROR` | Stage C (metadata conflict) | yes | PI reviews; reconcile metadata or override |
+| `UNVERIFIED` | Stage C (insufficient sources) or Stage G hit | yes | proceed to Stage G; on Stage G hit, PI checkpoint |
+| `RETRACTED` | Stage D | yes | PI override with retraction-discussion rationale |
+| `HALLUCINATED` | Stage G empty | yes | remove citation or PI ratifies as non-existent claim |
+| `AUTHOR_MISMATCH` | Stage E | yes | Stage E rerun with SerpAPI; PI reconciles |
+| `LOW_CONFIDENCE` | Stage E | yes | Stage E rerun with SerpAPI; PI ratifies |
+
+## Phase 2 implementation notes
+
+The Phase 2 mission will:
+
+1. Install `habanero`, `pyalex`, `semanticscholar`, `arxiv`, `manubot`, `python-orcid`, `bibtex-tidy` (Node), `anystyle` (Ruby gem) at the workspace level.
+2. Build the `rka-writer-tools` MCP server exposing high-level operations `validate_reference`, `disambiguate_author`, `find_citation`, `check_retraction`. Each operation orchestrates the stages above.
+3. Wire `scripts/validate_references.py` from stub to full implementation.
+4. Add `SERPAPI_KEY` env var support; default None silently skips Stages E (third source) and G.
+5. Add nightly RWDB CSV refresh as a cron-managed sidecar.
+6. Extend `ai_tic_config.yaml` with per-project SerpAPI budget overrides.
+
+Estimated Phase 2 scope: 3 engineer-weeks plus ~5 PI hours (per design doc Section 16).
+
+## Library version pins (Phase 2 reference)
+
+These will be re-verified at Phase 2 Backbrief per the version-drift discipline:
+
+| Package | Version at design-time | License |
+|---|---|---|
+| habanero | 2.3.0 | MIT |
+| pyalex | (latest, requires API key from 2026-02-13) | MIT |
+| semanticscholar | 0.12.0 | MIT |
+| arxiv | 2.1.0 | MIT |
+| manubot | (latest) | BSD-2 + CC0 |
+| python-orcid / PyOrcid | (latest) | BSD-3 / MIT |
+| bibtex-tidy | (latest, Node) | MIT |
+| anystyle (Ruby gem) | (latest) | BSD-2 |
+| betterbib | (subprocess only) | GPL-3.0 (never vendored) |
+
+The actual installed versions at Phase 2 may diverge; the Backbrief at that mission's start will re-verify each pin against the current PyPI / RubyGems / npm registry and flag any line silent over six months.
+
+## References
+
+- Deep research synthesis (citation hallucination empirical floor): `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`.
+- SerpAPI policy: `dec_01KS0AXXASJ5GXV7M0SS39Y066`.
+- Q1-Q8 bundle (Phase scoping): `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D`.
+- OpenAlex retraction data issue: Hauschke and Nazarovets 2024, arXiv:2403.13339.

--- a/rka/skills/writer/references/template_registry.md
+++ b/rka/skills/writer/references/template_registry.md
@@ -1,0 +1,170 @@
+# LaTeX Template Registry
+
+Pinned-by-checksum registry of venue templates. `scripts/fetch_template.py` (Phase 2) reads this registry, fetches the upstream archive, verifies SHA-256, and installs into `manuscripts/<project>/<venue>/styles/`. Mismatched checksums cause refusal.
+
+Phase 1 ships the registry as a stub with placeholders; the PI provides actual SHA-256 values after the first fetch on a given workstation. Phase 2 wires the fetch automation.
+
+## Registry (YAML)
+
+```yaml
+# rka/skills/writer/references/template_registry.md
+# Templates pinned by SHA-256. Replace TBD placeholders with actual checksums
+# computed via: shasum -a 256 <file>
+# Per dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q3, Phase 1 ships ACL/EMNLP + ACM CHI.
+
+acmart:
+  venue_examples: [CHI, CSCW, UIST, IUI, SIGGRAPH]
+  source:
+    type: CTAN
+    package: acmart
+    url: https://ctan.org/pkg/acmart
+    dev_repo: https://github.com/borisveytsman/acmart
+  license: LPPL 1.3c
+  install_command: tlmgr install acmart
+  pinned_version: TBD  # populated after first PI fetch (e.g., 2.07)
+  archive_url: TBD  # CTAN package URL with pinned version
+  sha256: TBD  # SHA-256 of acmart.cls + acmart.bst archive
+  notes: |
+    LPPL Component-1: modifying the class file requires renaming.
+    Use a wrapper class (e.g., myproject-acmart.cls) for project-specific commands.
+  options:
+    - sigconf (proceedings two-column, default for CHI/UIST/CSCW)
+    - acmsmall (one-column, journal style)
+    - manuscript (review submission)
+  page_limits:
+    CHI: 14 (main) + uncounted appendix + uncounted references
+    CSCW: 25 + references
+    UIST: 12 + references
+  required_template_invocation: \documentclass[sigconf]{acmart}
+
+acl-style-files:
+  venue_examples: [ACL, EMNLP, NAACL, EACL]
+  source:
+    type: git
+    repo: https://github.com/acl-org/acl-style-files
+    pinned_branch: 2025  # update per venue year
+  license: MIT
+  install_command: git clone --branch 2025 https://github.com/acl-org/acl-style-files
+  pinned_version: TBD  # populated after first PI fetch (commit SHA at branch 2025)
+  sha256: TBD  # SHA-256 of the .sty + .bst at the pinned commit
+  notes: |
+    Venue policy: no modification of style files permitted.
+    No wrapper class needed; project additions go into preamble of main.tex.
+  options:
+    - default ACL/EMNLP style; no top-level toggles
+  page_limits:
+    ACL: 9 (long) / 5 (short) + uncounted references + uncounted Limitations + uncounted Ethics
+    EMNLP: 8 (long) / 4 (short) + uncounted references + uncounted Limitations
+  required_template_invocation: \documentclass[11pt]{article}\n\usepackage[review]{acl}
+
+# Phase 2 entries (placeholders; not used in Phase 1):
+
+ieeetran:
+  venue_examples: [IEEE-SP, IEEE-S&P, IEEE-INFOCOM, IEEE-TSE]
+  source:
+    type: CTAN
+    package: ieeetran
+    url: https://ctan.org/pkg/ieeetran
+  license: LPPL 1.3+
+  install_command: tlmgr install IEEEtran
+  pinned_version: TBD
+  archive_url: TBD
+  sha256: TBD
+  phase_1_status: "Phase 2 only; not configured for use in Phase 1."
+
+llncs:
+  venue_examples: [LNCS (Springer)]
+  source:
+    type: CTAN
+    package: llncs
+    url: https://ctan.org/pkg/llncs
+  license: LPPL
+  install_command: tlmgr install llncs
+  pinned_version: TBD
+  archive_url: TBD
+  sha256: TBD
+  phase_1_status: "Phase 2 only."
+
+usenix:
+  venue_examples: [USENIX-Security, USENIX-OSDI, USENIX-NSDI]
+  source:
+    type: venue_site
+    url: https://www.usenix.org/conferences/author-resources/paper-templates
+    cadence: yearly ZIP (e.g., usenix-2025-template.zip)
+  license: USENIX-released
+  pinned_version: TBD
+  archive_url: TBD
+  sha256: TBD
+  phase_1_status: "Phase 2 only."
+
+neurips:
+  venue_examples: [NeurIPS]
+  source:
+    type: conference_site
+    url: https://neurips.cc/Conferences/2026/CallForPapers
+    cadence: yearly bundle
+  license: conference bundle
+  pinned_version: TBD
+  archive_url: TBD
+  sha256: TBD
+  phase_1_status: "Phase 2 only."
+
+arxiv:
+  venue_examples: [arXiv preprints]
+  source:
+    type: git
+    repo: https://github.com/kourgeorge/arxiv-style
+  license: MIT
+  pinned_version: TBD
+  sha256: TBD
+  phase_1_status: "Phase 2 only."
+```
+
+## Fetching workflow (Phase 2)
+
+1. PI selects a venue at the Venue checkpoint.
+2. `scripts/fetch_template.py <venue>` reads the registry entry.
+3. Script confirms `pinned_version`, `archive_url`, `sha256` are not `TBD`. If they are, prompt PI to fill them after the first fetch (and re-run).
+4. Script downloads `archive_url` to a temp directory.
+5. Script computes SHA-256 of the downloaded archive and compares to the pinned value. On mismatch, refuses and exits with error.
+6. On match, extracts the archive into `manuscripts/<project>/<venue>/styles/`.
+7. `manuscripts/<project>/<venue>/.latexmkrc` already carries `TEXINPUTS=./styles//:`.
+
+Phase 1 status: `fetch_template.py` is a stub. It implements registry lookup only. Actual fetch logic + SHA-256 verification land in Phase 2. PI handles template installation manually in Phase 1.
+
+## Updating pinned versions
+
+When a venue releases a new template version (e.g., CHI updates `acmart` from 2.07 to 2.08, or ACL bumps `acl-style-files` to a new conference-year branch), update the registry:
+
+1. Fetch the new archive manually.
+2. Verify the new template renders an empty `main.tex` cleanly: `\documentclass{...}\begin{document}\end{document}`.
+3. Compute SHA-256: `shasum -a 256 <archive>`.
+4. Update `pinned_version`, `archive_url`, and `sha256` in this file.
+5. Commit with message `chore(writer): bump <venue> template pin to <version> with new SHA-256`.
+
+The pin update is itself a small PI ratification gate, since the template change may carry style implications.
+
+## License compliance
+
+The registry tracks each venue's license. Compliance rules:
+
+- **LPPL components** (acmart, ieeetran, llncs, arxiv-style): modified files must be renamed. Use a wrapper class for project-specific additions. Never edit the upstream class file in place.
+- **MIT** (acl-style-files, arxiv kourgeorge): attribution required in the manuscript directory's `LICENSE-THIRDPARTY.md` if vendoring (Phase 2 will create per-manuscript LICENSE-THIRDPARTY entries as templates are installed). Modification policy varies by upstream; ACL specifically forbids modification by venue policy.
+- **USENIX-released, conference bundles**: redistribute per venue terms. Typically allow vendoring for submission-related work only.
+
+Phase 1 ships the registry only; no templates are actually fetched or installed. Phase 2 implements the full lifecycle with license-banner injection into each vendored archive copy.
+
+## Phase 1 limitations
+
+- `pinned_version`, `archive_url`, `sha256` are all `TBD`. PI fills them in after the first manual fetch on a given workstation.
+- `scripts/fetch_template.py` is registry-lookup-only. PI fetches templates manually using the `install_command` listed per entry.
+- Wrapper class scaffolding for LPPL extensions is not generated; PI authors the wrapper manually if needed.
+
+Phase 2 closes all three gaps.
+
+## References
+
+- LPPL specification: https://www.latex-project.org/lppl/lppl-1-3c/
+- ACM acmart project: https://github.com/borisveytsman/acmart
+- ACL style files: https://github.com/acl-org/acl-style-files
+- Per-venue policy survey: `jrn_01KS0AVZRDA0KPXK61MN9PV5DE` section "LaTeX templates (authoritative sources, 2026)".

--- a/rka/skills/writer/references/venue/CHI.md
+++ b/rka/skills/writer/references/venue/CHI.md
@@ -1,0 +1,98 @@
+# CHI (ACM Conference on Human Factors in Computing Systems)
+
+Phase 1 seed venue per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q3 (HCI domain).
+
+## 1. Section names and order
+
+Typical CHI Papers structure (six to nine sections):
+
+1. Introduction
+2. Related Work (or "Background and Related Work")
+3. Method (or "System Design and Method")
+4. Findings / Results / Evaluation (one or more sections; mixed-methods papers may split per study)
+5. Discussion
+6. Limitations (recommended as a top-level section since 2024)
+7. Conclusion (optional; some authors fold into Discussion)
+8. Acknowledgments (post-conclusion, pre-references)
+9. References
+
+Subsections are typical at depth 2; depth 3 is acceptable but should be sparing.
+
+## 2. Page-limit class
+
+14 pages main matter (CHI Papers 2024 onward; subject to per-year confirmation against the CFP). Appendix is **uncounted**. References are **uncounted** (since 2020).
+
+Verify the current year's CFP before relying on this; CHI page limits have historically been stable but have been revised.
+
+## 3. Tone characteristics
+
+- First-person plural ("we", "our") is standard and expected.
+- Reflexivity is expected for qualitative or design work (positionality statement common in §3 or §6).
+- Hedged claims preferred over absolute claims for design work. Empirical sections may use stronger claims with appropriate statistical support.
+- Mixed-methods is common; integration framing (not just side-by-side) is expected.
+- Math density is low to moderate; CHI is not a math-heavy venue. Equations are presented selectively.
+- Quotes from participants are common in qualitative work; format per ACM acmart conventions (italic with attribution after the period).
+
+## 4. Forbidden constructions
+
+- `we propose a novel ...` (overused since 2022; reviewers flag).
+- `comprehensive` as a hedge against scope criticism.
+- Bold-faced claims of contribution in the Introduction without supporting detail.
+- Unsupported claims of generalizability for small-sample qualitative work.
+- Em-dash characters U+2014 and U+2013 (Writer dogfood rule, applies project-wide).
+
+These are venue-specific anti-patterns layered on top of the universal Anti-AI-tic enforcement in `references/ai_tics.md`.
+
+## 5. Citation style
+
+Numeric (`[42]`), sorted by appearance. Set via `\documentclass[sigconf]{acmart}` (default). Multi-citation: `\cite{key1, key2, key3}` produces `[42, 43, 44]` (no en-dash range).
+
+References list ordered numerically by first citation, not alphabetically. The acmart class handles this automatically; do not override the bibliography style.
+
+## 6. Required sections
+
+- **Introduction**: motivation, problem framing, contribution claims.
+- **Related Work**: positions against prior literature; rule of thumb is 50 to 80 citations for a full-length CHI paper.
+- **Method**: detailed enough that another researcher could replicate the study.
+- **Findings or Results**: data-driven section(s).
+- **Discussion**: implications and connections to broader literature.
+- **Limitations**: recommended as top-level since 2024 (reviewers expect it). Acceptable to subsection within Discussion if space-constrained.
+- **References**: numeric, complete bibliography.
+
+Acknowledgments are conventional but not required. Reproducibility statement is encouraged (subset of authors fold it into the Method section).
+
+Ethics: CHI does not require a formal Ethics section, but human-subjects studies require IRB or equivalent statement and protocol description in the Method section.
+
+## 7. Sample corpus pointers
+
+For tone calibration, the Writer scaffolding should reference three to five recent published CHI papers from the prior two years. Recommended sample queries via OpenAlex:
+
+- `https://api.openalex.org/works?filter=primary_location.source.id:S4310306537,publication_year:2025&per-page=25` (CHI 2025 by source ID; verify the source ID at scaffold time).
+- Hand-pick three to five papers spanning empirical and design domains for tone-diversity.
+
+Sample papers should be stored as `lit_` entries with `tags=["venue-sample:CHI", "venue-sample"]` so the Writer can retrieve them via `rka_search(query="venue-sample CHI", entity_types=["literature"])`.
+
+## Notes on acmart wrapper
+
+If a project needs project-specific commands or environments without modifying the acmart class file (LPPL Component-1 requires renaming on modification), create a wrapper class in the manuscript directory:
+
+```latex
+% myproject-acmart.cls
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{myproject-acmart}[2026/05/19 v1.0 Project wrapper around acmart]
+\LoadClass[sigconf, anonymous, review]{acmart}
+
+% Project-specific commands here
+\newcommand{\projecttool}[1]{\textsc{#1}}
+% ...
+```
+
+Then `\documentclass{myproject-acmart}` in `main.tex`.
+
+This pattern preserves LPPL compliance while allowing per-project additions.
+
+## References
+
+- ACM CHI Call for Papers (verify per year): https://chi.acm.org/
+- acmart documentation: https://github.com/borisveytsman/acmart
+- ACM Publications Workflow: https://www.acm.org/publications

--- a/rka/skills/writer/references/venue/EMNLP.md
+++ b/rka/skills/writer/references/venue/EMNLP.md
@@ -1,0 +1,115 @@
+# EMNLP (Empirical Methods in Natural Language Processing)
+
+Phase 1 seed venue per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q3 (NLP domain).
+
+## 1. Section names and order
+
+Typical EMNLP Long Paper structure (five to seven sections):
+
+1. Introduction
+2. Related Work
+3. Method (or "Approach", "Model")
+4. Experiments (or "Experimental Setup")
+5. Results (or "Results and Analysis")
+6. Discussion (optional; some authors fold into Results)
+7. Conclusion
+8. Limitations (**required** since 2022; uncounted toward page limit)
+9. Ethics Statement (encouraged; uncounted)
+10. References
+
+Subsections at depth 2 are standard; depth 3 acceptable but uncommon.
+
+## 2. Page-limit class
+
+EMNLP page limits (verify against the current CFP):
+
+- Long paper: 8 pages main matter, uncounted references, uncounted Limitations, uncounted Ethics, uncounted Appendix.
+- Short paper: 4 pages main matter, same uncounted sections.
+- Camera-ready: gains one additional page (e.g., 9 for long, 5 for short).
+
+References are uncounted (typical for ACL-family venues).
+
+## 3. Tone characteristics
+
+- First-person plural ("we") is standard.
+- Numerical claims are expected; ablation and statistical-significance reporting are standard.
+- Hedging is moderate. Strong claims acceptable when supported by experiments.
+- Math density is moderate to high. Equations are first-class.
+- Tables of results are dense; multi-column comparison tables are standard.
+- Bibliography is large (60-100 references typical for long papers).
+
+## 4. Forbidden constructions
+
+- `we propose a novel ...` (overused; ACL-family reviewers flag).
+- `state-of-the-art` (overused; prefer specific metric numbers).
+- Unqualified claims of "best" or "superior" without head-to-head comparison.
+- Single-seed experimental claims (run multiple seeds; report variance).
+- Em-dash characters U+2014 and U+2013 (Writer dogfood rule).
+
+These are venue-specific anti-patterns layered on top of the universal Anti-AI-tic enforcement.
+
+## 5. Citation style
+
+Name-year via natbib's `\citep{}` / `\citet{}` macros, set by the `acl` style. Examples:
+
+- `\citep{vaswani2017attention}` produces `(Vaswani et al., 2017)`.
+- `\citet{vaswani2017attention}` produces `Vaswani et al. (2017)`.
+- `\citep[see][]{vaswani2017attention}` produces `(see Vaswani et al., 2017)`.
+
+References list alphabetical by first author, then chronological.
+
+## 6. Required sections
+
+- **Introduction**: motivation, problem framing, contribution claims, brief result preview.
+- **Related Work**: positions against prior literature.
+- **Method**: detailed enough that another researcher could replicate; include hyperparameters, model architecture, training details.
+- **Experiments**: datasets, baselines, evaluation metrics.
+- **Results**: main table plus ablations.
+- **Limitations**: **mandatory** since 2022 EMNLP. Discuss scope, dataset biases, generalization concerns. Uncounted but expected.
+- **Ethics Statement**: encouraged; mandatory for certain topic areas (e.g., low-resource languages, dual-use, demographic data). Uncounted.
+- **References**: alphabetical, complete bibliography.
+
+Reproducibility checklist: EMNLP encourages a Reproducibility Checklist (uncounted appendix item). Templates available from acl-org.
+
+## 7. Sample corpus pointers
+
+For tone calibration, scaffold three to five recent EMNLP papers from the prior two years. Sample queries:
+
+- `https://api.openalex.org/works?filter=primary_location.source.id:<EMNLP-source-id>,publication_year:2025` (verify EMNLP source ID at scaffold time).
+- Sample across topic areas: encoder-decoder modeling, evaluation studies, low-resource language work, dataset papers.
+
+Store as `lit_` entries with `tags=["venue-sample:EMNLP", "venue-sample"]`.
+
+## Notes on acl-style-files
+
+ACL style files (`acl-style-files` repository at github.com/acl-org/acl-style-files) are MIT-licensed but venue policy forbids modification. Configuration via package options only:
+
+```latex
+\documentclass[11pt]{article}
+\usepackage[review]{acl}            % for review submission with line numbers
+% \usepackage[]{acl}                % for camera-ready (no review option)
+\usepackage{times}
+\usepackage{latexsym}
+\usepackage{url}
+```
+
+Engine: pdflatex only. xelatex and lualatex trigger font-loading failures with the default ACL fonts. The `.latexmkrc` should pin `LATEX_ENGINE=pdflatex` for EMNLP manuscripts.
+
+Anonymization: pre-camera-ready submissions must be anonymized. The `[review]` option enables line numbers required for reviewer comments. Author block is suppressed under `[review]` and surfaced under camera-ready.
+
+## Bib format
+
+`refs.bib` uses BibTeX format (not biblatex). Standard fields: `@inproceedings{...}` for conference papers, `@article{...}` for journals, `@misc{...}` for preprints. Use the `url=` field for arXiv preprints (`url={https://arxiv.org/abs/2410.01234}`).
+
+`bibtex-tidy` invocation suitable for EMNLP `refs.bib`:
+
+```bash
+bibtex-tidy --curly --numeric --sort=key --duplicates=key,doi --escape --tidy-comments --remove-empty-fields --enclosing-braces=title refs.bib
+```
+
+## References
+
+- ACL Anthology (canonical bibliography source): https://aclanthology.org/
+- EMNLP Call for Papers (verify per year): https://www.emnlp.org/
+- ACL style files: https://github.com/acl-org/acl-style-files
+- ACL Reproducibility Checklist: https://aclrollingreview.org/responsibleNLPresearch/

--- a/rka/skills/writer/references/workflows.md
+++ b/rka/skills/writer/references/workflows.md
@@ -1,0 +1,235 @@
+# Writer Workflows
+
+Operational depth for the Writer skill. The SKILL.md narrates the contract; this file documents how the contract executes.
+
+## Session Start (full walkthrough)
+
+The PI launches `claude` in a manuscript working directory `manuscripts/<project-id>/<venue>/`. Claude Code loads the Writer skill on session start. The following steps run before the first PI exchange:
+
+### Step 1: project confirmation
+
+```python
+rka_get_status()
+```
+
+Look at the returned project ID. Compare to the directory name. If the directory is `manuscripts/prj_01KS.../CHI/` and `rka_get_status` returns a different project, switch:
+
+```python
+rka_list_projects()  # show all
+rka_set_project(project_id="prj_01KS...")  # the one matching the workspace
+```
+
+The MCP `_session.project_id` is per-process and ephemeral; verifying on every session start prevents writes landing in the wrong project. If `.mcp.json` env carries `RKA_PROJECT`, this step is automatic.
+
+### Step 2: changelog
+
+```python
+rka_get_changelog(since="<last writing session date from .planning/ACTIVE_WORKFLOW.md>")
+```
+
+Surface any new `lit_`, `jrn_`, `dec_`, or `mis_` entries since the last writing session. New `lit_` items may belong in the current draft's reference set; new `jrn_` may carry PI direction that updates the working outline.
+
+### Step 3: research map
+
+```python
+rka_get_research_map()
+```
+
+Structural overview of clusters and claims. Filter to clusters relevant to the manuscript's topic before quoting. The map is the source of truth for what evidence is available to cite.
+
+### Step 4: state resume
+
+Read `.planning/ACTIVE_WORKFLOW.md`. Expected structure:
+
+```markdown
+# Active Workflow
+
+current_phase: drafting
+last_checkpoint: outline (resolved 2026-04-12)
+next_action: draft §3 Method
+last_session: 2026-04-11
+```
+
+If `ACTIVE_WORKFLOW.md` is absent, infer from the working directory:
+
+- `.planning/PRECIS.md` absent: phase = venue selection.
+- `PRECIS.md` present, `OUTLINE.md` absent: phase = outline.
+- `OUTLINE.md` present, `sections/` empty: phase = table and figure planning.
+- `sections/` populated: phase = drafting; next section is the first one with status `outlined` rather than `drafted`.
+- All sections drafted, no `audit.json`: phase = render and audit.
+- `audit.json` shows BLOCK verdicts: phase = revision.
+- `audit.json` all PASS or WARN: phase = final layout checkpoint.
+
+### Step 5: MCP verification
+
+Verify `.mcp.json` lists the `rka` server:
+
+```bash
+cat .mcp.json | jq '.mcpServers | keys'
+```
+
+Phase 1 does not require `rka-writer-tools`. If absent, `scripts/validate_references.py` Stage A pass-through is used. If `rka` is absent, the workspace is misconfigured; surface to the PI before proceeding.
+
+### Step 6: greet PI
+
+Greet the PI with the inferred state and the next action. Example:
+
+> Picked up the CHI manuscript at the start of drafting. Outline ratified 2026-04-12 (six sections). Last session ended after §2 Related Work was drafted. Next action: draft §3 Method, anchoring to clusters `ecl_01KQ...` and `ecl_01KQ...`. Ready when you are.
+
+## The Seven Sub-Procedures
+
+The seven sub-procedures map to the six PI checkpoints plus the Revision Loop.
+
+### 1. Venue handler
+
+Trigger: PI says they want to target venue X, or no `venue/X.md` exists for the chosen venue.
+
+Procedure:
+
+1. Confirm the CFP and submission window via the venue's official site (use `WebFetch`).
+2. If `references/venue/<venue>.md` exists, load it and present the schema summary to the PI.
+3. If absent, scaffold: fetch three to five recent papers from the venue via OpenAlex; extract the seven-field schema (section names, page-limit class, tone, forbidden constructions, citation style, required sections, sample corpus). Single-paper imitation is brittle (anti-pattern 12).
+4. Generate three candidate venue framings if multiple venues are in play (e.g., HCI paper could target CHI, CSCW, UIST). Present via strip-then-re-inject.
+5. PI selects via `rka_record_pi_selection`. Decision recorded with three options, opposing-critique ranking.
+
+Output: ratified Venue Decision (`dec_`), `.planning/PRECIS.md` PI-authored, `references/venue/<venue>.md` populated if newly scaffolded.
+
+### 2. Outline co-author
+
+Trigger: Venue ratified, no `OUTLINE.md` yet.
+
+Procedure:
+
+1. Read research map for the project; identify clusters and claims relevant to the manuscript topic.
+2. Generate three outline framings with PI preference stripped from context:
+   - Results-led: section ordering driven by the most novel finding.
+   - Method-led: section ordering driven by the methodological contribution.
+   - Motivation-led: section ordering driven by the problem framing.
+3. For each framing, draft a 5-to-8-section outline with one-sentence section purposes.
+4. Prune any framing dominated on scope-coverage, novelty-positioning, and venue-fit.
+5. Re-inject PI preference as opposing-critique; rank surviving framings.
+6. Present three (or fewer if pruned) options to the PI; one carries `is_recommended`.
+7. PI selects; record via `rka_record_pi_selection`.
+
+Output: Outline Decision (`dec_`), `.planning/OUTLINE.md`, `.planning/sketches/<section-id>.md` per section.
+
+Iron Law: **no prose before outline ratification.** The `main.tex` stays skeleton-only.
+
+### 3. Table, figure, and chart planner
+
+Trigger: Outline ratified, no `tables/` or `figures/` populated.
+
+Procedure:
+
+1. For each result-bearing section, generate three presentation framings:
+   - Figure-heavy: visual emphasis, supporting tables.
+   - Table-heavy: quantitative emphasis, illustrative figures.
+   - Balanced.
+2. For each framing, propose specific tables (booktabs LaTeX), figures (Paper Banana prompt for diagrams; matplotlib + seaborn code for charts), and chart styling via venue presets (tueplots, SciencePlots).
+3. Paper Banana prompts are stored as `jrn_` entries tagged `figure-prompt` per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q6, with the manuscript manifest in `related_journal`.
+4. Present three options. PI selects.
+
+Output: Table-Figure-Chart Plan Decision (`dec_`), `.planning/PLAN.md`, draft table .tex files, Paper Banana prompts as `jrn_`, chart skeleton .py files referencing `scripts/chart_render.py`.
+
+### 4. Reference validator
+
+Trigger: PI provides a candidate reference list, OR drafting surfaces a citation gap.
+
+Phase 1 procedure (manual; Stage A only):
+
+1. For each candidate reference, look up in RKA via `rka_get_literature` or `rka_search`. If present and `validation_status=VERIFIED`, accept.
+2. For references not in RKA, prompt PI to either add via `rka_add_literature` (with `validation_status=UNVERIFIED` initially) or cite from external metadata.
+3. `scripts/validate_references.py` Stage A converts `rka_get_literature` output (CSL-JSON) to BibTeX via manubot if installed.
+4. Stages B through G are stubbed; manual verification by PI in Phase 1.
+
+Phase 2 procedure (when `rka-writer-tools` MCP is live): see `reference_pipeline.md`.
+
+Output: `refs.bib` populated, per-reference `validation_status` updated on `lit_` entries via `rka_update_literature`.
+
+### 5. Section drafter
+
+Trigger: Outline ratified, Table-Figure-Chart Plan ratified, References set ratified. Next section's status is `outlined` (not yet `drafted`).
+
+Procedure (OpenScholar evidence-first per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
+
+1. Dispatch a fresh subagent for the section (clean context window per `dispatching-parallel-agents` discipline).
+2. Subagent reads: section sketch, ratified outline, relevant clusters from research map, references in scope.
+3. Subagent drafts the section evidence-first: quote evidence first; build prose around the quote; place hidden provenance comments before each evidence-citation prose unit.
+4. Subagent self-audits before commit: runs `scripts/ai_tic_lint.py` on the section; iterates until style score reaches 0.85 or three iterations elapse.
+5. If three iterations fail, ESCALATE via the Revision Loop Class R2.
+6. Otherwise commit section to `sections/<section-id>.tex`, mark `drafted` in manifest, and surface to PI for the Draft section checkpoint.
+
+PI ratifies via the Draft section checkpoint (one of the six PI checkpoints). Three options: accept, revise (with PI comments), escalate.
+
+### 6. Local renderer plus layout auditor
+
+Trigger: At least one section drafted; periodically during drafting; mandatorily before the Final Layout checkpoint.
+
+Procedure:
+
+1. `scripts/render.sh` runs latexmk with the venue's engine (default pdflatex).
+2. If compile fails, parse `.log` for the first BLOCK error (Undefined control sequence, Reference undefined, etc.); surface to PI with the offending line; PI directs the fix.
+3. If compile succeeds, `scripts/layout_audit.py` runs against the rendered PDF plus log files.
+4. `audit.json` reports the twelve fields per `latex_audit.md`. Any BLOCK verdict halts progress; WARN verdicts noted for the Final Layout checkpoint.
+
+Output: `main.pdf`, `audit.json`. The manuscript manifest's `related_journal` gains a pointer to the latest `audit.json` snapshot stored as a `jrn_` if the PI requests durable record.
+
+### 7. Revision-loop handler
+
+Trigger: PI returns review comments on a draft (post Draft section checkpoint with `revise` option).
+
+Procedure: classify each comment into R1, R2, R3, or R4 per the SKILL.md `Revision Loop` section:
+
+- **R1 Factual** (sentence-level): auto-fix inline; re-render; bump `REVIEW_STATE.md` iteration.
+- **R2 Style or AI-tic**: re-run `ai_tic_lint.py` at higher severity; auto-revise.
+- **R3 Inconsistency** (cross-section): structural rewrite of all affected sections; re-render full document.
+- **R4 Logical gap or unsupported claim**: ESCALATE via `rka_create_mission` so the Brain or Executor can gather evidence.
+
+`.planning/REVIEW_STATE.md` tracks iteration with `iteration: N / max: 3 / verdict: CONTINUE | ESCALATE | COMPLETE`. Three failed iterations auto-escalate to a PI Style or Logical checkpoint with three resolution options.
+
+Phase 1 documents the Revision Loop; Phase 3 wires the Brain-mission-driven implementation.
+
+## Checkpoint UX patterns
+
+All six PI checkpoints use the strip-then-re-inject decision UX inherited from Brain (`../brain/decision_ux.md` is the canonical reference). Three ratified options per checkpoint; opposing-critique ranking; PI selection via `rka_record_pi_selection`.
+
+Per-checkpoint specifics:
+
+| Checkpoint | Three option framings | Pareto axes |
+|---|---|---|
+| Venue | venue A / venue B / venue C | venue fit, deadline, audience reach |
+| Outline | results-led / method-led / motivation-led | novelty positioning, scope coverage, venue fit |
+| Table-Figure-Chart Plan | figure-heavy / table-heavy / balanced | space efficiency, readability, evidence density |
+| Reference set | broad / focused / minimum | coverage, page-budget, citation novelty |
+| Draft section | accept / revise / escalate | quality, scope, time |
+| Final layout | submit / iterate / hold | publication risk, polish, deadline |
+
+PI selection produces a `dec_`. The decision is immutable once selected or rejected. Revisions create a new `dec_` that `supersedes` the prior.
+
+## Session digest
+
+At the end of each writing session, record a session digest as a `jrn_`:
+
+```python
+rka_add_note(
+    type="note",
+    source="executor",
+    content="""
+# Writing session digest <ISO date>
+
+- Sections advanced: §3 Method (outlined -> drafted)
+- Checkpoints resolved: Draft §3 (PI: accept)
+- Lit added: lit_01KS... (Smith 2024) via rka_add_literature
+- Style score current: 0.91 (target 0.85)
+- Next action: draft §4 Evaluation
+
+## Open items
+- One UNVERIFIED reference flagged (Jones 2023): PI to confirm next session.
+""",
+    related_mission=None,  # or revision mission if applicable
+    related_decisions=["dec_outline_ratified", "dec_draft_section_3"],
+    tags=["writing-session-digest", "manuscript-CHI"],
+)
+```
+
+The digest helps the next session's State Resume step find the right next action.

--- a/rka/skills/writer/scripts/ai_tic_lint.py
+++ b/rka/skills/writer/scripts/ai_tic_lint.py
@@ -353,14 +353,20 @@ def count_words(text: str) -> int:
 def sentence_length_variance(text: str) -> StructuralVerdict:
     """Flag paragraphs where the standard deviation of sentence length is under 5 words.
 
-    Reports the minimum across all paragraphs with at least 3 sentences. If
-    no paragraph qualifies, returns PASS with value None placeholder (0.0).
+    Reports the minimum across all paragraphs with at least 5 sentences. Short
+    paragraphs (under 5 sentences) inherently have low variance and would
+    over-flag; the empirical signal in Matsui 2025 and Kobak 2025 is about
+    uniform rhythm across substantive paragraphs, not over 3-sentence excerpts.
+
+    Verdict is WARN rather than BLOCK: structural detectors contribute to the
+    style score (which can BLOCK via the auto-revise loop), but a low variance
+    on its own is suggestive evidence, not a hard violation.
     """
     paragraphs = split_paragraphs(text)
     paragraph_stds: list[float] = []
     for para in paragraphs:
         sentences = split_sentences(para)
-        if len(sentences) < 3:
+        if len(sentences) < 5:
             continue
         lengths = [count_words(s) for s in sentences]
         try:
@@ -375,7 +381,7 @@ def sentence_length_variance(text: str) -> StructuralVerdict:
             verdict="PASS",
         )
     min_std = min(paragraph_stds)
-    verdict = "BLOCK" if min_std < 5.0 else "PASS"
+    verdict = "WARN" if min_std < 5.0 else "PASS"
     return StructuralVerdict(
         detector="sentence_length_variance",
         value=min_std,

--- a/rka/skills/writer/scripts/ai_tic_lint.py
+++ b/rka/skills/writer/scripts/ai_tic_lint.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""ai_tic_lint.py: Anti-AI-tic linter for the Writer skill.
+
+Phase 1 implementation per dec_01KS12H9KT1T03DHX2Q6FKTXHH (Option C disposition;
+no third-party content vendored). Sources cited directly: PI verbatim list (per
+dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q4), Kobak et al. 2025 (Science Advances
+11(27):eadt3813, doi:10.1126/sciadv.adt3813), Matsui 2025 (Perspectives on
+Medical Education 14(1):882-890).
+
+Tiers:
+  CRITICAL (block any hit; no override): ChatGPT artifacts and refusal stems.
+  HIGH (block by default; per-project override via ai_tic_config.yaml):
+    PI list + Kobak 2025 + Matsui 2025.
+  MEDIUM (warn): structural and stylistic LLM patterns.
+
+Absolute bans (no override): em-dash U+2014 and en-dash U+2013 in prose;
+bullet density (at most two lists per section; 3 to 5 items each).
+
+Structural detectors complement the lexical layer (Matsui 2025: pure lexical
+over-flags legitimate academic prose):
+  - Sentence-length variance: flag paragraphs where std dev under 5 words.
+  - Transition-word ratio: at or below 0.5 percent.
+  - Parallel-triplet density: at or below 1 per 500 words.
+  - Bridge repetition: delegated to bridge_repetition_check.py.
+
+CLI:
+    python ai_tic_lint.py <files>...
+    python ai_tic_lint.py --config /path/to/ai_tic_config.yaml <files>...
+    python ai_tic_lint.py --output report.json --section sections/03-method.tex
+
+Exit codes:
+    0: all PASS
+    1: WARN-only verdicts present
+    2: BLOCK verdict present (CRITICAL, HIGH without override, absolute ban,
+       or structural detector BLOCK)
+    3: usage error
+
+See references/ai_tics.md for the full tier table and replacement guidance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+try:
+    import yaml  # type: ignore
+    _yaml_available = True
+except ImportError:
+    yaml = None  # type: ignore
+    _yaml_available = False
+
+
+# Absolute-ban characters. Built from codepoints via chr() so this source
+# file does not itself contain the literal em-dash or en-dash characters
+# the Writer prose rule bans (dogfood discipline).
+EM_DASH = chr(0x2014)  # U+2014 EM DASH
+EN_DASH = chr(0x2013)  # U+2013 EN DASH
+
+# Tier 1: CRITICAL (compile-blocking on any hit; no per-project override).
+# Sources: empirical observation of ChatGPT/OpenAI output artifacts and refusal
+# language in published manuscripts.
+CRITICAL_PATTERNS: dict[str, str] = {
+    r"\bturn\d+search\d*\b": "ChatGPT browsing-tool token",
+    r"\boaicite\b": "OpenAI citation marker",
+    r"\bcontentReference\b": "OpenAI internal reference",
+    r"\battribution\":": "OpenAI grounding metadata JSON",
+    r"\bAs an AI language model\b": "model refusal stem",
+    r"\bI cannot help with that\b": "model refusal stem",
+    r"\bAs of my last knowledge update\b": "knowledge-cutoff disclaimer",
+}
+
+# Tier 2: HIGH (block by default; per-project override via ai_tic_config.yaml).
+# Per dec_01KS12H9KT1T03DHX2Q6FKTXHH PATCH 2: cite primaries directly.
+HIGH_PATTERNS: dict[str, str] = {
+    # PI verbatim list (dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q4).
+    r"\bfacilitate\b": "PI verbatim list",
+    r"\bfacilitates\b": "PI verbatim list",
+    r"\bdelves\b": "PI verbatim list",
+    r"\bleverage\b": "PI verbatim list",
+    r"\bleverages\b": "PI verbatim list",
+    r"\bleveraging\b": "PI verbatim list",
+    r"\bcomprehensive\b": "PI verbatim list",
+    r"\bfurthermore\b": "PI verbatim list",
+    r"\bmoreover\b": "PI verbatim list",
+    r"\badditionally\b": "PI verbatim list",
+    r"\bimportantly\b": "PI verbatim list",
+    r"\bin conclusion\b": "PI verbatim list",
+    r"\bit is important to note\b": "PI verbatim list",
+    # Kobak et al. 2025 (Science Advances 11(27):eadt3813).
+    r"\bdelving\b": "Kobak 2025",
+    r"\bunderscore\b": "Kobak 2025",
+    r"\bunderscores\b": "Kobak 2025",
+    r"\bunderscoring\b": "Kobak 2025",
+    r"\bshowcasing\b": "Kobak 2025",
+    r"\bshowcase\b": "Kobak 2025",
+    r"\bshowcases\b": "Kobak 2025",
+    r"\bpivotal\b": "Kobak 2025",
+    r"\bintricate\b": "Kobak 2025",
+    r"\bintricately\b": "Kobak 2025",
+    r"\bmeticulous\b": "Kobak 2025",
+    r"\bmeticulously\b": "Kobak 2025",
+    r"\brealm\b": "Kobak 2025",
+    r"\baligns\b": "Kobak 2025",
+    r"\baligning\b": "Kobak 2025",
+    r"\bunderpins\b": "Kobak 2025",
+    r"\bgarnered\b": "Kobak 2025",
+    r"\bbolstering\b": "Kobak 2025",
+    r"\bnotably\b": "Kobak 2025",
+    r"\bsurpass\b": "Kobak 2025",
+    r"\bintricacies\b": "Kobak 2025",
+    r"\bunwavering\b": "Kobak 2025",
+    # Matsui 2025 (Perspectives on Medical Education 14(1):882-890).
+    r"\benhance\b": "Matsui 2025",
+    r"\belevate\b": "Matsui 2025",
+    r"\butilize\b": "Matsui 2025",
+    r"\bboast\b": "Matsui 2025",
+    r"\bcommendable\b": "Matsui 2025",
+    r"\btapestry\b": "Matsui 2025",
+    r"\bunlocking\b": "Matsui 2025",
+}
+
+# Tier 3: MEDIUM (warn; do not block).
+MEDIUM_PATTERNS: dict[str, str] = {
+    r"^\s*Importantly,": "Importantly sentence-starter",
+    r"^\s*It should be noted that": "It should be noted that sentence-starter",
+    r"^\s*In summary,": "In summary paragraph-closer",
+}
+
+# Transition-word set for ratio computation.
+TRANSITION_WORDS = {
+    "however", "nevertheless", "furthermore", "moreover", "additionally",
+    "consequently", "thus", "therefore", "hence", "accordingly",
+}
+
+
+@dataclass
+class Hit:
+    """A single linter hit (lexical or absolute-ban)."""
+    term: str
+    line: int
+    tier: str
+    source: str
+
+
+@dataclass
+class StructuralVerdict:
+    """Result of a single structural detector."""
+    detector: str
+    value: float
+    threshold: float
+    verdict: str  # PASS, WARN, BLOCK
+
+
+@dataclass
+class FileReport:
+    """Linter result for a single file."""
+    path: str
+    total_lines: int
+    total_sentences: int
+    total_words: int
+    critical: list[Hit] = field(default_factory=list)
+    high: list[Hit] = field(default_factory=list)
+    medium: list[Hit] = field(default_factory=list)
+    absolute_bans: list[Hit] = field(default_factory=list)
+    structural: list[StructuralVerdict] = field(default_factory=list)
+    style_score: float = 1.0
+    verdict: str = "PASS"
+
+
+def load_config(config_path: Optional[Path]) -> dict:
+    """Load ai_tic_config.yaml if present.
+
+    Returns a dict mapping each banned term to a verdict (enable, disable,
+    downgrade) and project-specific custom blocks. If PyYAML is unavailable
+    or the config does not exist, returns an empty dict (default behavior:
+    all HIGH terms block).
+    """
+    if config_path is None or not config_path.exists():
+        return {}
+    if not _yaml_available:
+        print(
+            "ai_tic_lint: PyYAML not installed; ai_tic_config.yaml ignored. "
+            "Install PyYAML for per-project overrides.",
+            file=sys.stderr,
+        )
+        return {}
+    with config_path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def apply_config_to_term(term: str, default_tier: str, config: dict) -> Optional[str]:
+    """Resolve the effective tier for a term given a per-project config.
+
+    Returns:
+        The effective tier (CRITICAL, HIGH, MEDIUM), or None if the term is
+        disabled for this project.
+    """
+    entry = config.get(term, None)
+    if entry is None:
+        return default_tier
+    verdict = entry.get("verdict", "enable")
+    if verdict == "disable":
+        return None
+    if verdict == "downgrade":
+        return "MEDIUM" if default_tier == "HIGH" else default_tier
+    return default_tier
+
+
+def find_lexical_hits(
+    text: str,
+    patterns: dict[str, str],
+    tier: str,
+    config: Optional[dict] = None,
+) -> list[Hit]:
+    """Scan text for any pattern match; return list of Hit records.
+
+    Per-line tracking via splitlines(). Patterns are case-insensitive regex.
+    Per-project config (if provided) can disable or downgrade a hit.
+    """
+    hits: list[Hit] = []
+    lines = text.splitlines()
+    for line_num, line in enumerate(lines, start=1):
+        for pattern, source in patterns.items():
+            for match in re.finditer(pattern, line, flags=re.IGNORECASE):
+                term = match.group(0)
+                effective_tier = (
+                    apply_config_to_term(term.lower(), tier, config or {})
+                    if config is not None
+                    else tier
+                )
+                if effective_tier is None:
+                    continue
+                hits.append(
+                    Hit(
+                        term=term,
+                        line=line_num,
+                        tier=effective_tier,
+                        source=source,
+                    )
+                )
+    return hits
+
+
+def find_em_dash(text: str) -> list[Hit]:
+    """Detect U+2014 em-dash and U+2013 en-dash. Absolute ban; no override."""
+    hits: list[Hit] = []
+    for line_num, line in enumerate(text.splitlines(), start=1):
+        for ch in line:
+            if ch == EM_DASH:
+                hits.append(
+                    Hit(term="U+2014 EM DASH", line=line_num,
+                        tier="ABSOLUTE_BAN", source="em-dash absolute ban")
+                )
+            elif ch == EN_DASH:
+                hits.append(
+                    Hit(term="U+2013 EN DASH", line=line_num,
+                        tier="ABSOLUTE_BAN", source="en-dash absolute ban")
+                )
+    return hits
+
+
+def find_bullet_violations(text: str) -> list[Hit]:
+    """Detect bullet density violations.
+
+    Rules: at most 2 bulleted lists per section; each list 3 to 5 items.
+    "Section" is delimited by markdown H2 (## ) or LaTeX \\section{}.
+    """
+    hits: list[Hit] = []
+    lines = text.splitlines()
+
+    section_starts = [
+        i for i, line in enumerate(lines)
+        if line.startswith("## ") or line.lstrip().startswith("\\section{")
+    ]
+    if not section_starts:
+        section_starts = [0]
+    section_ends = section_starts[1:] + [len(lines)]
+
+    bullet_re = re.compile(r"^\s*[-*+]\s")
+
+    for s_start, s_end in zip(section_starts, section_ends):
+        lists: list[list[int]] = []
+        current: list[int] = []
+        for i in range(s_start, s_end):
+            line = lines[i]
+            if bullet_re.match(line):
+                current.append(i + 1)
+            else:
+                if current:
+                    lists.append(current)
+                    current = []
+        if current:
+            lists.append(current)
+
+        if len(lists) > 2:
+            hits.append(
+                Hit(
+                    term=f"section has {len(lists)} bulleted lists",
+                    line=s_start + 1,
+                    tier="ABSOLUTE_BAN",
+                    source="bullet-density cap: max 2 lists per section",
+                )
+            )
+
+        for lst in lists:
+            if len(lst) < 3:
+                hits.append(
+                    Hit(
+                        term=f"list with {len(lst)} items (under 3)",
+                        line=lst[0],
+                        tier="ABSOLUTE_BAN",
+                        source="bullet-density cap: 3 to 5 items per list",
+                    )
+                )
+            elif len(lst) > 5:
+                hits.append(
+                    Hit(
+                        term=f"list with {len(lst)} items (over 5)",
+                        line=lst[0],
+                        tier="ABSOLUTE_BAN",
+                        source="bullet-density cap: 3 to 5 items per list",
+                    )
+                )
+
+    return hits
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split text into sentences via end-of-sentence punctuation."""
+    cleaned = re.sub(r"%.*$", "", text, flags=re.MULTILINE)
+    cleaned = re.sub(r"\\(cite|ref|eqref)\{[^}]*\}", "", cleaned)
+    parts = re.split(r"(?<=[.!?])\s+", cleaned)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def split_paragraphs(text: str) -> list[str]:
+    """Split text into paragraphs on blank lines."""
+    paras = re.split(r"\n\s*\n", text)
+    return [p.strip() for p in paras if p.strip()]
+
+
+def count_words(text: str) -> int:
+    return len(re.findall(r"\b\w+\b", text))
+
+
+def sentence_length_variance(text: str) -> StructuralVerdict:
+    """Flag paragraphs where the standard deviation of sentence length is under 5 words.
+
+    Reports the minimum across all paragraphs with at least 3 sentences. If
+    no paragraph qualifies, returns PASS with value None placeholder (0.0).
+    """
+    paragraphs = split_paragraphs(text)
+    paragraph_stds: list[float] = []
+    for para in paragraphs:
+        sentences = split_sentences(para)
+        if len(sentences) < 3:
+            continue
+        lengths = [count_words(s) for s in sentences]
+        try:
+            paragraph_stds.append(statistics.stdev(lengths))
+        except statistics.StatisticsError:
+            continue
+    if not paragraph_stds:
+        return StructuralVerdict(
+            detector="sentence_length_variance",
+            value=0.0,
+            threshold=5.0,
+            verdict="PASS",
+        )
+    min_std = min(paragraph_stds)
+    verdict = "BLOCK" if min_std < 5.0 else "PASS"
+    return StructuralVerdict(
+        detector="sentence_length_variance",
+        value=min_std,
+        threshold=5.0,
+        verdict=verdict,
+    )
+
+
+def transition_word_ratio(text: str) -> StructuralVerdict:
+    """Ratio of transition-word occurrences to total words. Threshold 0.5%."""
+    words = re.findall(r"\b\w+\b", text.lower())
+    total = len(words)
+    if total == 0:
+        return StructuralVerdict(
+            detector="transition_word_ratio",
+            value=0.0,
+            threshold=0.005,
+            verdict="PASS",
+        )
+    transitions = sum(1 for w in words if w in TRANSITION_WORDS)
+    ratio = transitions / total
+    verdict = "WARN" if ratio > 0.005 else "PASS"
+    return StructuralVerdict(
+        detector="transition_word_ratio",
+        value=ratio,
+        threshold=0.005,
+        verdict=verdict,
+    )
+
+
+def parallel_triplet_density(text: str) -> StructuralVerdict:
+    """Density of "X, Y, and Z" parallel-triplet constructions per 500 words.
+
+    Threshold: at or below 1.0 per 500 words.
+    """
+    triplet_re = re.compile(r"\b\w+\b\s*,\s*\b\w+\b\s*,\s+and\s+\b\w+\b", re.IGNORECASE)
+    matches = triplet_re.findall(text)
+    total_words = count_words(text)
+    if total_words == 0:
+        return StructuralVerdict(
+            detector="parallel_triplet_density",
+            value=0.0,
+            threshold=1.0,
+            verdict="PASS",
+        )
+    density = (len(matches) / total_words) * 500
+    verdict = "WARN" if density > 1.0 else "PASS"
+    return StructuralVerdict(
+        detector="parallel_triplet_density",
+        value=density,
+        threshold=1.0,
+        verdict=verdict,
+    )
+
+
+def compute_style_score(report: FileReport) -> float:
+    """style_score = 1 - (critical * 3 + high + 0.3 * medium) / total_sentences.
+
+    Clipped to [0, 1]. Sections under 0.85 trigger auto-revise.
+    """
+    if report.total_sentences == 0:
+        return 1.0
+    numerator = (
+        len(report.critical) * 3
+        + len(report.high)
+        + 0.3 * len(report.medium)
+    )
+    raw = 1.0 - (numerator / report.total_sentences)
+    return max(0.0, min(1.0, raw))
+
+
+def lint_file(path: Path, config: Optional[dict] = None) -> FileReport:
+    """Lint a single file. Returns a FileReport."""
+    text = path.read_text(encoding="utf-8")
+    sentences = split_sentences(text)
+    words = count_words(text)
+    config = config or {}
+
+    report = FileReport(
+        path=str(path),
+        total_lines=len(text.splitlines()),
+        total_sentences=len(sentences),
+        total_words=words,
+    )
+
+    report.critical = find_lexical_hits(text, CRITICAL_PATTERNS, "CRITICAL", config=None)
+    report.high = find_lexical_hits(text, HIGH_PATTERNS, "HIGH", config=config)
+    report.medium = find_lexical_hits(text, MEDIUM_PATTERNS, "MEDIUM", config=config)
+    report.absolute_bans = find_em_dash(text) + find_bullet_violations(text)
+
+    report.structural = [
+        sentence_length_variance(text),
+        transition_word_ratio(text),
+        parallel_triplet_density(text),
+    ]
+
+    report.style_score = compute_style_score(report)
+
+    if (
+        report.critical
+        or report.absolute_bans
+        or any(s.verdict == "BLOCK" for s in report.structural)
+    ):
+        report.verdict = "BLOCK"
+    elif (
+        report.high
+        or any(s.verdict == "WARN" for s in report.structural)
+    ):
+        report.verdict = "WARN" if not report.high else "BLOCK"
+    elif report.medium:
+        report.verdict = "WARN"
+    else:
+        report.verdict = "PASS"
+
+    if report.style_score < 0.85 and report.verdict == "PASS":
+        report.verdict = "WARN"
+
+    return report
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Anti-AI-tic linter for Writer skill.")
+    parser.add_argument("files", nargs="+", type=Path, help="Files to lint")
+    parser.add_argument("--config", type=Path, default=None,
+                        help="Path to ai_tic_config.yaml (per-project overrides)")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Write JSON report to file (default: stdout)")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    reports = [lint_file(f, config=config) for f in args.files]
+
+    output = {
+        "version": "1.0",
+        "files": [asdict(r) for r in reports],
+        "summary": {
+            "total_files": len(reports),
+            "blocks": sum(1 for r in reports if r.verdict == "BLOCK"),
+            "warns": sum(1 for r in reports if r.verdict == "WARN"),
+            "passes": sum(1 for r in reports if r.verdict == "PASS"),
+        },
+    }
+
+    json_text = json.dumps(output, indent=2)
+    if args.output:
+        args.output.write_text(json_text, encoding="utf-8")
+    else:
+        print(json_text)
+
+    if output["summary"]["blocks"] > 0:
+        return 2
+    if output["summary"]["warns"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/scripts/bridge_repetition_check.py
+++ b/rka/skills/writer/scripts/bridge_repetition_check.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""bridge_repetition_check.py: Detect near-duplicate sentences across files.
+
+A common LLM failure pattern: the closing thesis of one section is restated
+verbatim or near-verbatim as the opening of the next ("bridge repetition").
+This pattern survives lexical sanitization because it is structural rather
+than vocabulary. The defense: compare every sentence in file A to every
+sentence in file B (for A != B) and flag pairs whose similarity ratio
+exceeds a threshold.
+
+Phase 1 implementation per dec_01KS12H9KT1T03DHX2Q6FKTXHH (clean-room from
+algorithmic idea only; stdlib difflib API). No code, comments, variable
+names, or function structure copied from any external source.
+
+Algorithm:
+  1. Read each input file as UTF-8 text.
+  2. Strip LaTeX comments (% ...) and citation macros (\\cite{...} et al.)
+     so noise is not compared.
+  3. Segment into sentences via end-of-sentence punctuation followed by
+     whitespace (regex (?<=[.!?])\\s+).
+  4. Filter sentences shorter than min_length (default 40 chars) so noise
+     and short headings are not paired.
+  5. For each unordered pair of sentences (s_i in file_a, s_j in file_b)
+     where file_a != file_b, compute difflib.SequenceMatcher(a=s_i, b=s_j,
+     autojunk=False).ratio().
+  6. If ratio >= threshold, record a BridgeHit.
+  7. Return all BridgeHit records sorted by ratio (descending).
+
+CLI:
+    python bridge_repetition_check.py sections/*.tex
+    python bridge_repetition_check.py --threshold 0.8 --min-length 60 sections/*.tex
+    python bridge_repetition_check.py --output bridges.json sections/*.tex
+
+Exit codes:
+    0: no bridges detected above threshold
+    1: bridges detected
+    2: usage error
+
+See references/ai_tics.md "Structural detectors" for the rationale and
+threshold derivation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+
+DEFAULT_THRESHOLD = 0.7
+DEFAULT_MIN_LENGTH = 40
+
+# Strip LaTeX comments and citation/reference macros before comparison.
+_COMMENT_RE = re.compile(r"%.*$", re.MULTILINE)
+_MACRO_RE = re.compile(r"\\(?:cite|citep|citet|ref|eqref|label|footnote)\{[^}]*\}")
+_SENTENCE_BREAK_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+@dataclass(frozen=True)
+class Sentence:
+    """A sentence located in a file at a specific line."""
+    source: str
+    line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class BridgeHit:
+    """Two sentences in different files whose similarity exceeds threshold."""
+    file_a: str
+    line_a: int
+    text_a: str
+    file_b: str
+    line_b: int
+    text_b: str
+    ratio: float
+
+
+def _strip_noise(raw: str) -> str:
+    """Remove LaTeX comments and selected macros that would inflate ratios."""
+    no_comments = _COMMENT_RE.sub("", raw)
+    no_macros = _MACRO_RE.sub("", no_comments)
+    return no_macros
+
+
+def collect_sentences(path: Path, min_length: int) -> list[Sentence]:
+    """Read a file and segment into sentences; track line of each."""
+    raw = path.read_text(encoding="utf-8")
+    cleaned = _strip_noise(raw)
+    out: list[Sentence] = []
+    line_no = 0
+    for chunk in cleaned.splitlines(keepends=True):
+        line_no += 1
+        pieces = _SENTENCE_BREAK_RE.split(chunk)
+        for piece in pieces:
+            stripped = piece.strip()
+            if len(stripped) >= min_length:
+                out.append(Sentence(source=str(path), line=line_no, text=stripped))
+    return out
+
+
+def similarity(a: Sentence, b: Sentence) -> float:
+    """Compute difflib SequenceMatcher ratio between two sentence texts."""
+    matcher = difflib.SequenceMatcher(a=a.text, b=b.text, autojunk=False)
+    return matcher.ratio()
+
+
+def find_bridges(
+    paths: list[Path],
+    threshold: float = DEFAULT_THRESHOLD,
+    min_length: int = DEFAULT_MIN_LENGTH,
+) -> list[BridgeHit]:
+    """Compare sentences across files; return cross-file near-duplicates above threshold.
+
+    Comparisons are only made between sentences in different files (no intra-file
+    pairs; bridge repetition is by definition a cross-section phenomenon).
+    """
+    per_file = [collect_sentences(p, min_length=min_length) for p in paths]
+    hits: list[BridgeHit] = []
+    for i in range(len(paths)):
+        for j in range(i + 1, len(paths)):
+            for s_a in per_file[i]:
+                for s_b in per_file[j]:
+                    r = similarity(s_a, s_b)
+                    if r >= threshold:
+                        hits.append(BridgeHit(
+                            file_a=s_a.source,
+                            line_a=s_a.line,
+                            text_a=s_a.text,
+                            file_b=s_b.source,
+                            line_b=s_b.line,
+                            text_b=s_b.text,
+                            ratio=r,
+                        ))
+    return sorted(hits, key=lambda h: h.ratio, reverse=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect near-duplicate sentences across files (bridge repetition)."
+    )
+    parser.add_argument("files", nargs="+", type=Path, help="Files to scan")
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                        help=f"SequenceMatcher ratio threshold (default {DEFAULT_THRESHOLD})")
+    parser.add_argument("--min-length", type=int, default=DEFAULT_MIN_LENGTH,
+                        help=f"Minimum sentence length in chars (default {DEFAULT_MIN_LENGTH})")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Write JSON output to file (default stdout)")
+    args = parser.parse_args(argv)
+
+    hits = find_bridges(args.files, threshold=args.threshold, min_length=args.min_length)
+
+    payload = {
+        "version": "1.0",
+        "threshold": args.threshold,
+        "min_length": args.min_length,
+        "files_scanned": [str(p) for p in args.files],
+        "bridges_found": len(hits),
+        "hits": [asdict(h) for h in hits],
+    }
+
+    text = json.dumps(payload, indent=2)
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text)
+
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/scripts/chart_render.py
+++ b/rka/skills/writer/scripts/chart_render.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""chart_render.py: Phase 1 chart rendering skeleton with venue presets.
+
+Phase 1 scope: import-time verification that matplotlib + seaborn are
+available; venue preset stub for CHI and EMNLP; actual chart logic raises
+NotImplementedError because the PI fills it in per manuscript.
+
+Phase 2 scope: standard chart styles per venue with tueplots and SciencePlots
+preset bundles, dataset-to-plot helpers, and integration with the manuscript
+manifest for figure-prompt jrn_ tracking per dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q6
+(Paper Banana prompts stored as figure-prompt-tagged jrn_ entries).
+
+CLI:
+    python chart_render.py --check          # report dependency status
+    python chart_render.py --venue CHI ...  # Phase 1 stub: raises NotImplementedError
+
+Exit codes:
+    0: dependency check successful
+    1: required dependencies missing
+    2: not implemented (Phase 1 stub call)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+_REQUIRED_OK = True
+_REQUIRED_MISSING: list[str] = []
+_OPTIONAL_MISSING: list[str] = []
+
+try:
+    import matplotlib  # type: ignore
+    import matplotlib.pyplot as plt  # type: ignore
+except ImportError:
+    _REQUIRED_OK = False
+    _REQUIRED_MISSING.append("matplotlib")
+
+try:
+    import seaborn  # type: ignore
+except ImportError:
+    _REQUIRED_OK = False
+    _REQUIRED_MISSING.append("seaborn")
+
+try:
+    from tueplots import bundles  # type: ignore  # noqa: F401
+except ImportError:
+    _OPTIONAL_MISSING.append("tueplots (optional venue preset; required for Phase 2)")
+
+try:
+    import scienceplots  # type: ignore  # noqa: F401
+except ImportError:
+    _OPTIONAL_MISSING.append("SciencePlots (optional venue preset; required for Phase 2)")
+
+
+def venue_preset(venue: str) -> dict:
+    """Return matplotlib rcParams for the given venue.
+
+    Phase 1: minimal hard-coded presets for CHI and EMNLP. Phase 2 will
+    pull from tueplots.bundles and scienceplots styles per venue config.
+    """
+    presets = {
+        "CHI": {
+            "figure.figsize": (3.5, 2.5),
+            "font.size": 9,
+            "axes.labelsize": 8,
+            "axes.titlesize": 9,
+            "legend.fontsize": 7,
+            "savefig.dpi": 300,
+            "savefig.bbox": "tight",
+        },
+        "EMNLP": {
+            "figure.figsize": (3.0, 2.25),
+            "font.size": 9,
+            "axes.labelsize": 8,
+            "axes.titlesize": 9,
+            "legend.fontsize": 7,
+            "savefig.dpi": 300,
+            "savefig.bbox": "tight",
+        },
+    }
+    return presets.get(venue, presets.get("CHI", {}))
+
+
+def apply_preset(venue: str) -> None:
+    """Apply a venue preset to matplotlib's rcParams. Phase 1 helper."""
+    if not _REQUIRED_OK:
+        raise RuntimeError(
+            "chart_render: matplotlib unavailable; cannot apply preset. "
+            f"Missing: {', '.join(_REQUIRED_MISSING)}"
+        )
+    preset = venue_preset(venue)
+    matplotlib.rcParams.update(preset)
+
+
+def render_chart(spec: dict, venue: str, output_path: Path) -> Path:
+    """Render a chart per spec to output_path. PI fills in chart logic per manuscript.
+
+    Phase 1: raises NotImplementedError. The PI authors per-manuscript chart
+    code using matplotlib + seaborn + apply_preset(venue) as the scaffolding.
+    The spec dict shape will be standardized in Phase 2 (e.g., spec carries
+    chart_type, data_path, x, y, hue, palette, annotations).
+    """
+    raise NotImplementedError(
+        "chart_render.render_chart is a Phase 1 skeleton. "
+        "PI authors per-manuscript chart logic using matplotlib + seaborn "
+        "and apply_preset(venue) as scaffolding. "
+        "Phase 2 will standardize chart specs per venue. "
+        "See references/architecture.md for the Phase 2 design."
+    )
+
+
+def check_dependencies() -> tuple[bool, list[str], list[str]]:
+    """Return (required_ok, required_missing, optional_missing)."""
+    return _REQUIRED_OK, list(_REQUIRED_MISSING), list(_OPTIONAL_MISSING)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Chart rendering skeleton.")
+    parser.add_argument("--check", action="store_true",
+                        help="Report dependency availability and exit.")
+    parser.add_argument("--venue", default=None, help="Venue name (e.g., CHI, EMNLP).")
+    parser.add_argument("--spec", default=None, help="Path to chart spec JSON (Phase 2).")
+    parser.add_argument("--output", default=None, help="Output figure path (Phase 2).")
+    args = parser.parse_args(argv)
+
+    if args.check or (args.venue is None and args.spec is None):
+        print(f"chart_render.py Phase 1 skeleton")
+        print(f"  matplotlib + seaborn available: {_REQUIRED_OK}")
+        if _REQUIRED_MISSING:
+            print(f"  Required missing: {', '.join(_REQUIRED_MISSING)}")
+        if _OPTIONAL_MISSING:
+            print(f"  Optional missing: {', '.join(_OPTIONAL_MISSING)}")
+        return 0 if _REQUIRED_OK else 1
+
+    print(
+        "chart_render.py Phase 1 stub: actual chart rendering is the PI's per-manuscript "
+        "responsibility. Use apply_preset(venue) as scaffolding and author chart logic "
+        "inline. Phase 2 will standardize. See references/architecture.md.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/scripts/fetch_template.py
+++ b/rka/skills/writer/scripts/fetch_template.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""fetch_template.py: LaTeX template registry lookup (Phase 1 stub).
+
+Phase 1 implements registry lookup only. Reads references/template_registry.md
+and returns the YAML entry for a given venue. Actual archive fetching, SHA-256
+verification, and installation into manuscripts/<project>/<venue>/styles/ land
+in Phase 2.
+
+CLI:
+    python fetch_template.py --venue CHI                 # show registry entry
+    python fetch_template.py --venue EMNLP               # show registry entry
+    python fetch_template.py --venue CHI --target styles # Phase 2: NotImplementedError
+
+Exit codes:
+    0: lookup succeeded
+    1: venue not in registry
+    2: registry file not found or unreadable
+    3: NotImplementedError (Phase 2 fetch requested)
+    4: usage error
+
+See references/template_registry.md for the registry schema and license matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+# The registry file lives at rka/skills/writer/references/template_registry.md.
+DEFAULT_REGISTRY = Path(__file__).resolve().parent.parent / "references" / "template_registry.md"
+
+PHASE_2_FETCH_NOTE = (
+    "Phase 2 deliverable. fetch_template.py Phase 1 implements registry lookup "
+    "only. PI fetches templates manually using the install_command listed per "
+    "registry entry. See references/template_registry.md for the full lifecycle."
+)
+
+
+def load_registry_yaml(registry_path: Path) -> str:
+    """Extract the YAML block from references/template_registry.md.
+
+    The registry markdown contains a single fenced YAML block.
+    Returns the YAML text (without fence markers).
+    """
+    if not registry_path.exists():
+        raise FileNotFoundError(f"registry not found: {registry_path}")
+    text = registry_path.read_text(encoding="utf-8")
+    match = re.search(r"```yaml\n(.*?)\n```", text, re.DOTALL)
+    if not match:
+        raise ValueError("no fenced YAML block found in registry")
+    return match.group(1)
+
+
+def lookup_template(venue: str, registry_path: Path = DEFAULT_REGISTRY) -> dict:
+    """Look up a venue's registry entry.
+
+    Returns a dict with keys like venue_examples, source, license,
+    pinned_version, archive_url, sha256, notes. Raises KeyError if the
+    venue is not present.
+    """
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "fetch_template requires PyYAML for registry parsing. "
+            "Install with: pip install pyyaml"
+        ) from exc
+
+    yaml_text = load_registry_yaml(registry_path)
+    registry = yaml.safe_load(yaml_text) or {}
+
+    # Search by exact key (e.g., "acmart"), or by venue_examples membership.
+    if venue in registry:
+        return registry[venue]
+    for key, entry in registry.items():
+        if isinstance(entry, dict):
+            examples = entry.get("venue_examples", [])
+            if venue in examples:
+                return entry
+    raise KeyError(f"venue {venue!r} not in registry")
+
+
+def fetch(venue: str, target_dir: Path) -> None:
+    """Fetch a template archive, verify SHA-256, and install to target_dir.
+
+    Phase 1: raises NotImplementedError. Phase 2 will:
+      1. Look up the registry entry.
+      2. Download archive_url to a temp file.
+      3. Compute SHA-256 and compare to the pinned sha256.
+      4. Refuse on mismatch; install on match.
+    """
+    raise NotImplementedError(
+        f"fetch_template.fetch({venue!r}) Phase 1 stub. " + PHASE_2_FETCH_NOTE
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="LaTeX template registry lookup (Phase 1 stub)."
+    )
+    parser.add_argument("--venue", required=True,
+                        help="Venue or registry key (e.g., CHI, EMNLP, acmart)")
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY,
+                        help="Path to template_registry.md")
+    parser.add_argument("--target", type=Path, default=None,
+                        help="Target install directory (triggers Phase 2 fetch; NotImplementedError)")
+    args = parser.parse_args(argv)
+
+    try:
+        entry = lookup_template(args.venue, registry_path=args.registry)
+    except FileNotFoundError as exc:
+        print(f"fetch_template: {exc}", file=sys.stderr)
+        return 2
+    except KeyError as exc:
+        print(f"fetch_template: {exc}", file=sys.stderr)
+        return 1
+    except (RuntimeError, ValueError) as exc:
+        print(f"fetch_template: {exc}", file=sys.stderr)
+        return 2
+
+    if args.target is not None:
+        try:
+            fetch(args.venue, args.target)
+        except NotImplementedError as exc:
+            print(f"fetch_template: {exc}", file=sys.stderr)
+            return 3
+
+    import json
+    print(json.dumps(entry, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/scripts/layout_audit.py
+++ b/rka/skills/writer/scripts/layout_audit.py
@@ -244,6 +244,7 @@ def audit(
     aux_text = _read_or_empty(aux_path)
     tex_text = _read_or_empty(tex_path)
     pages = get_pdf_page_count(pdf_path) if pdf_path else 0
+    rendered_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     verdicts = [
         check_pages_over_limit(pages, page_limit),
@@ -262,7 +263,7 @@ def audit(
 
     report = AuditReport(
         manuscript=str(tex_path) if tex_path else "",
-        rendered_at=datetime.datetime.utcnow().isoformat() + "Z",
+        rendered_at=rendered_at,
         pdf_path=str(pdf_path) if pdf_path else "",
         venue=venue,
         page_limit=page_limit,

--- a/rka/skills/writer/scripts/layout_audit.py
+++ b/rka/skills/writer/scripts/layout_audit.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""layout_audit.py: 12-field LaTeX layout audit per references/latex_audit.md.
+
+Runs after a successful latexmk render. Parses .log, .blg, .aux, and pdfinfo
+output to compute PASS, WARN, or BLOCK verdicts per field. Emits audit.json
+suitable for attachment to the manuscript manifest's related_journal.
+
+CLI:
+    python layout_audit.py --venue CHI
+    python layout_audit.py --venue EMNLP --pdf paper.pdf --log paper.log
+    python layout_audit.py --venue CHI --output audit.json
+
+Exit codes:
+    0: all fields PASS
+    1: at least one WARN, no BLOCK
+    2: at least one BLOCK
+    3: missing input file (compile probably failed)
+    4: usage error
+
+See references/latex_audit.md for the field reference and regex patterns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+
+VENUE_PAGE_LIMITS = {
+    "CHI": 14,
+    "CSCW": 25,
+    "UIST": 12,
+    "EMNLP": 8,
+    "EMNLP_SHORT": 4,
+    "ACL": 9,
+    "ACL_SHORT": 5,
+}
+
+# Compiled regex patterns per field.
+RE_UNDEFINED_CITATION = re.compile(
+    r"^LaTeX Warning: Citation [`'](.+?)' .* undefined", re.MULTILINE
+)
+RE_UNDEFINED_REF = re.compile(
+    r"^LaTeX Warning: Reference [`'](.+?)' on page .* undefined", re.MULTILINE
+)
+RE_MISSING_BIB_KEY = re.compile(
+    r'^Warning--I didn\'t find a database entry for "(.+?)"', re.MULTILINE
+)
+RE_OVERFULL_HBOX = re.compile(
+    r"^Overfull \\hbox \(([\d.]+)pt too wide\)", re.MULTILINE
+)
+RE_OVERFULL_VBOX = re.compile(r"^Overfull \\vbox", re.MULTILINE)
+RE_FLOAT_TOO_LARGE = re.compile(r"Float too large for page", re.MULTILINE)
+RE_UNDERFULL_HBOX = re.compile(
+    r"^Underfull \\hbox \(badness (\d+)\)", re.MULTILINE
+)
+RE_QUESTION_MARK_CITATION = re.compile(r"\[\?\]")
+RE_AUX_LABEL = re.compile(r"\\newlabel\{([^}]+)\}")
+RE_TEX_REF = re.compile(r"\\(?:ref|eqref)\{([^}]+)\}")
+
+
+@dataclass
+class FieldVerdict:
+    """Verdict for a single audit field."""
+    field_name: str
+    verdict: str  # PASS, WARN, BLOCK
+    value: int | float | str
+    threshold: Optional[int | float | str] = None
+    matches: list = field(default_factory=list)
+
+
+@dataclass
+class AuditReport:
+    """Full audit result over all 12 fields."""
+    manuscript: str
+    rendered_at: str
+    pdf_path: str
+    venue: str
+    page_limit: int
+    pages_rendered: int
+    fields: dict[str, dict] = field(default_factory=dict)
+    summary: dict = field(default_factory=dict)
+
+
+def _read_or_empty(path: Path) -> str:
+    """Read a file if it exists; empty string otherwise."""
+    if path is None or not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def get_pdf_page_count(pdf_path: Path) -> int:
+    """Run pdfinfo and parse the Pages line.
+
+    Returns 0 if pdfinfo is unavailable or the PDF does not exist.
+    """
+    if pdf_path is None or not pdf_path.exists():
+        return 0
+    try:
+        result = subprocess.run(
+            ["pdfinfo", str(pdf_path)],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return 0
+    for line in result.stdout.splitlines():
+        if line.startswith("Pages:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except (ValueError, IndexError):
+                return 0
+    return 0
+
+
+def check_pages_over_limit(pages: int, limit: int) -> FieldVerdict:
+    if pages > limit:
+        return FieldVerdict("pages_over_limit", "BLOCK", pages, limit)
+    return FieldVerdict("pages_over_limit", "PASS", pages, limit)
+
+
+def check_pages_equals_limit(pages: int, limit: int) -> FieldVerdict:
+    if pages == limit:
+        return FieldVerdict("pages_equals_limit", "WARN", pages, limit)
+    return FieldVerdict("pages_equals_limit", "PASS", pages, limit)
+
+
+def check_undefined_citations(log_text: str) -> FieldVerdict:
+    matches = RE_UNDEFINED_CITATION.findall(log_text)
+    verdict = "BLOCK" if matches else "PASS"
+    return FieldVerdict("undefined_citations", verdict, len(matches), 0, matches)
+
+
+def check_undefined_refs(log_text: str) -> FieldVerdict:
+    matches = RE_UNDEFINED_REF.findall(log_text)
+    verdict = "BLOCK" if matches else "PASS"
+    return FieldVerdict("undefined_refs", verdict, len(matches), 0, matches)
+
+
+def check_missing_bib_keys(blg_text: str) -> FieldVerdict:
+    matches = RE_MISSING_BIB_KEY.findall(blg_text)
+    verdict = "BLOCK" if matches else "PASS"
+    return FieldVerdict("missing_bib_keys", verdict, len(matches), 0, matches)
+
+
+def check_question_mark_citations(pdf_path: Path) -> FieldVerdict:
+    """Scan the rendered PDF text for [?] (unresolved citation placeholder)."""
+    if pdf_path is None or not pdf_path.exists():
+        return FieldVerdict("question_mark_citations", "PASS", 0, 0)
+    try:
+        result = subprocess.run(
+            ["pdftotext", str(pdf_path), "-"],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return FieldVerdict("question_mark_citations", "PASS", 0, 0,
+                            ["pdftotext unavailable; skipped"])
+    matches = RE_QUESTION_MARK_CITATION.findall(result.stdout)
+    verdict = "BLOCK" if matches else "PASS"
+    return FieldVerdict("question_mark_citations", verdict, len(matches), 0)
+
+
+def check_orphan_refs(aux_text: str, tex_text: str) -> FieldVerdict:
+    """A \\ref{label} exists in the .tex source but no matching \\newlabel in the .aux."""
+    if not aux_text and not tex_text:
+        return FieldVerdict("orphan_refs", "PASS", 0, 0)
+    labels = set(RE_AUX_LABEL.findall(aux_text))
+    refs = set(RE_TEX_REF.findall(tex_text))
+    orphans = sorted(refs - labels)
+    verdict = "BLOCK" if orphans else "PASS"
+    return FieldVerdict("orphan_refs", verdict, len(orphans), 0, orphans)
+
+
+def check_overfull_hboxes_over_10pt(log_text: str) -> FieldVerdict:
+    raw_matches = RE_OVERFULL_HBOX.findall(log_text)
+    over_10pt = [m for m in raw_matches if float(m) > 10.0]
+    verdict = "WARN" if over_10pt else "PASS"
+    return FieldVerdict(
+        "overfull_hboxes_over_10pt", verdict, len(over_10pt), 10.0,
+        [{"overflow_pt": float(m)} for m in over_10pt],
+    )
+
+
+def check_overfull_vboxes(log_text: str) -> FieldVerdict:
+    matches = RE_OVERFULL_VBOX.findall(log_text)
+    verdict = "WARN" if matches else "PASS"
+    return FieldVerdict("overfull_vboxes", verdict, len(matches), 0)
+
+
+def check_float_too_large(log_text: str) -> FieldVerdict:
+    matches = RE_FLOAT_TOO_LARGE.findall(log_text)
+    verdict = "WARN" if matches else "PASS"
+    return FieldVerdict("float_too_large", verdict, len(matches), 0)
+
+
+def check_underfull_badness_over_5000(log_text: str) -> FieldVerdict:
+    raw_matches = RE_UNDERFULL_HBOX.findall(log_text)
+    over_5000 = [int(m) for m in raw_matches if int(m) > 5000]
+    verdict = "WARN" if over_5000 else "PASS"
+    return FieldVerdict(
+        "underfull_badness_over_5000", verdict, len(over_5000), 5000,
+        over_5000,
+    )
+
+
+def check_chktex_warnings_over_10(tex_path: Path) -> FieldVerdict:
+    """Run chktex on the tex source. WARN if total warnings exceed 10."""
+    if tex_path is None or not tex_path.exists():
+        return FieldVerdict("chktex_warnings_over_10", "PASS", 0, 10)
+    try:
+        result = subprocess.run(
+            ["chktex", "-q", str(tex_path)],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return FieldVerdict("chktex_warnings_over_10", "PASS", 0, 10,
+                            ["chktex unavailable; skipped"])
+    warning_count = sum(
+        1 for line in result.stdout.splitlines() if line.strip()
+    )
+    verdict = "WARN" if warning_count > 10 else "PASS"
+    return FieldVerdict("chktex_warnings_over_10", verdict, warning_count, 10)
+
+
+def audit(
+    pdf_path: Optional[Path],
+    log_path: Optional[Path],
+    blg_path: Optional[Path],
+    aux_path: Optional[Path],
+    tex_path: Optional[Path],
+    venue: str,
+) -> AuditReport:
+    """Run all 12 field checks and return an AuditReport."""
+    import datetime
+
+    page_limit = VENUE_PAGE_LIMITS.get(venue, 0)
+    log_text = _read_or_empty(log_path)
+    blg_text = _read_or_empty(blg_path)
+    aux_text = _read_or_empty(aux_path)
+    tex_text = _read_or_empty(tex_path)
+    pages = get_pdf_page_count(pdf_path) if pdf_path else 0
+
+    verdicts = [
+        check_pages_over_limit(pages, page_limit),
+        check_undefined_citations(log_text),
+        check_undefined_refs(log_text),
+        check_missing_bib_keys(blg_text),
+        check_question_mark_citations(pdf_path) if pdf_path else FieldVerdict("question_mark_citations", "PASS", 0, 0),
+        check_orphan_refs(aux_text, tex_text),
+        check_overfull_hboxes_over_10pt(log_text),
+        check_overfull_vboxes(log_text),
+        check_float_too_large(log_text),
+        check_underfull_badness_over_5000(log_text),
+        check_chktex_warnings_over_10(tex_path) if tex_path else FieldVerdict("chktex_warnings_over_10", "PASS", 0, 10),
+        check_pages_equals_limit(pages, page_limit),
+    ]
+
+    report = AuditReport(
+        manuscript=str(tex_path) if tex_path else "",
+        rendered_at=datetime.datetime.utcnow().isoformat() + "Z",
+        pdf_path=str(pdf_path) if pdf_path else "",
+        venue=venue,
+        page_limit=page_limit,
+        pages_rendered=pages,
+        fields={v.field_name: asdict(v) for v in verdicts},
+    )
+
+    blocks = sum(1 for v in verdicts if v.verdict == "BLOCK")
+    warns = sum(1 for v in verdicts if v.verdict == "WARN")
+    passes = sum(1 for v in verdicts if v.verdict == "PASS")
+    overall = "BLOCK" if blocks else ("WARN" if warns else "PASS")
+    report.summary = {
+        "blocks": blocks,
+        "warns": warns,
+        "passes": passes,
+        "overall_verdict": overall,
+    }
+
+    return report
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="LaTeX layout audit: 12-field PASS/WARN/BLOCK report."
+    )
+    parser.add_argument("--venue", required=True,
+                        help=f"Venue name (one of: {', '.join(VENUE_PAGE_LIMITS.keys())})")
+    parser.add_argument("--pdf", type=Path, default=Path("main.pdf"))
+    parser.add_argument("--log", type=Path, default=Path("main.log"))
+    parser.add_argument("--blg", type=Path, default=Path("main.blg"))
+    parser.add_argument("--aux", type=Path, default=Path("main.aux"))
+    parser.add_argument("--tex", type=Path, default=Path("main.tex"))
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    if args.venue not in VENUE_PAGE_LIMITS:
+        print(f"layout_audit: unknown venue {args.venue}", file=sys.stderr)
+        print(f"  Known: {', '.join(VENUE_PAGE_LIMITS.keys())}", file=sys.stderr)
+        return 4
+
+    report = audit(
+        pdf_path=args.pdf if args.pdf.exists() else None,
+        log_path=args.log if args.log.exists() else None,
+        blg_path=args.blg if args.blg.exists() else None,
+        aux_path=args.aux if args.aux.exists() else None,
+        tex_path=args.tex if args.tex.exists() else None,
+        venue=args.venue,
+    )
+
+    text = json.dumps(asdict(report), indent=2, default=str)
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text)
+
+    overall = report.summary["overall_verdict"]
+    if overall == "BLOCK":
+        return 2
+    if overall == "WARN":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/scripts/render.sh
+++ b/rka/skills/writer/scripts/render.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# render.sh: Wrap latexmk for Writer skill local PDF builds.
+#
+# Engine selection via LATEX_ENGINE env var (default pdflatex). Runs from the
+# manuscript working directory with .latexmkrc setting TEXINPUTS=./styles//:
+# so vendored venue templates resolve correctly.
+#
+# Usage:
+#     ./scripts/render.sh                      # builds main.tex
+#     ./scripts/render.sh other.tex            # builds other.tex
+#     LATEX_ENGINE=lualatex ./scripts/render.sh
+#     LATEX_ENGINE=xelatex ./scripts/render.sh
+#
+# Exit codes:
+#     0: render succeeded
+#     1: latexmk reported errors
+#     2: unsupported LATEX_ENGINE value
+#     3: latexmk not on PATH
+
+set -euo pipefail
+
+ENGINE="${LATEX_ENGINE:-pdflatex}"
+TARGET="${1:-main.tex}"
+
+if ! command -v latexmk >/dev/null 2>&1; then
+    echo "render.sh: latexmk not on PATH; install TeX Live (texlive-full or equivalent)." >&2
+    exit 3
+fi
+
+case "$ENGINE" in
+    pdflatex)
+        ENGINE_FLAGS=("-pdf")
+        ;;
+    lualatex)
+        ENGINE_FLAGS=("-pdflua")
+        ;;
+    xelatex)
+        ENGINE_FLAGS=("-pdfxe")
+        ;;
+    *)
+        echo "render.sh: unsupported LATEX_ENGINE: $ENGINE" >&2
+        echo "  Supported: pdflatex (default), lualatex, xelatex" >&2
+        exit 2
+        ;;
+esac
+
+echo "render.sh: building $TARGET with $ENGINE"
+exec latexmk \
+    "${ENGINE_FLAGS[@]}" \
+    -interaction=nonstopmode \
+    -file-line-error \
+    -synctex=1 \
+    "$TARGET"

--- a/rka/skills/writer/scripts/validate_references.py
+++ b/rka/skills/writer/scripts/validate_references.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""validate_references.py: 7-stage reference validation pipeline (Phase 1 stub).
+
+Phase 1 implements Stage A only (CSL-JSON pass-through to BibTeX via manubot
+if installed). Stages B through G are documented in references/reference_pipeline.md
+and raise NotImplementedError here. Phase 2 wires the full pipeline.
+
+CLI:
+    python validate_references.py --csl-json input.json --out refs.bib
+    python validate_references.py --check    # report manubot availability
+
+Exit codes:
+    0: Stage A succeeded
+    1: Stage A failed (manubot missing or subprocess error)
+    2: Stages B through G called (NotImplementedError; Phase 2 deliverable)
+    3: usage error
+
+See references/reference_pipeline.md for the full architecture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+PHASE_2_REFERENCE = (
+    "Phase 2 deliverable. See references/reference_pipeline.md for the full "
+    "architecture, including the rka-writer-tools MCP server and per-stage "
+    "API contracts. PI ratified the phasing via dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q2 "
+    "(optional MCP tools deferred) and dec_01KS0AXXASJ5GXV7M0SS39Y066 (SerpAPI "
+    "tertiary, Phase 2 integration)."
+)
+
+
+def manubot_available() -> bool:
+    """Check whether manubot is installed and callable."""
+    return shutil.which("manubot") is not None
+
+
+def stage_a_csl_to_bibtex(csl_json_path: Path, out_bib: Path) -> int:
+    """Stage A: CSL-JSON to BibTeX via manubot.
+
+    Reads CSL-JSON from csl_json_path, extracts DOIs / identifiers, and
+    feeds them through manubot's CLI to produce a BibTeX file at out_bib.
+
+    Returns 0 on success, non-zero on failure.
+    """
+    if not csl_json_path.exists():
+        print(f"validate_references: input not found: {csl_json_path}", file=sys.stderr)
+        return 1
+    if not manubot_available():
+        print(
+            "validate_references: manubot CLI not on PATH. Install with: "
+            "pip install manubot. Stage A requires manubot for the CSL-JSON "
+            "to BibTeX conversion.",
+            file=sys.stderr,
+        )
+        return 1
+
+    raw = csl_json_path.read_text(encoding="utf-8")
+    try:
+        records = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"validate_references: invalid JSON in {csl_json_path}: {exc}",
+              file=sys.stderr)
+        return 1
+    if not isinstance(records, list):
+        records = [records]
+
+    identifiers = []
+    for rec in records:
+        if "DOI" in rec:
+            identifiers.append(f"doi:{rec['DOI']}")
+        elif "PMID" in rec:
+            identifiers.append(f"pubmed:{rec['PMID']}")
+        elif "PMC" in rec:
+            identifiers.append(f"pmc:{rec['PMC']}")
+        elif "URL" in rec and "arxiv.org/abs/" in rec["URL"]:
+            arxiv_id = rec["URL"].split("arxiv.org/abs/")[-1].rstrip("/")
+            identifiers.append(f"arxiv:{arxiv_id}")
+
+    if not identifiers:
+        print(
+            "validate_references: no resolvable identifiers (DOI, PMID, PMC, "
+            "arXiv) found in CSL-JSON. Stage A requires at least one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = subprocess.run(
+            ["manubot", "cite", "--format=bibtex", *identifiers],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        print("validate_references: manubot disappeared from PATH between checks.",
+              file=sys.stderr)
+        return 1
+
+    if result.returncode != 0:
+        print(f"validate_references: manubot failed (exit {result.returncode})",
+              file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return 1
+
+    out_bib.write_text(result.stdout, encoding="utf-8")
+    return 0
+
+
+def stage_b_resolve_identifiers(*args, **kwargs):
+    """Stage B: identifier resolution via Crossref/manubot/OpenAlex/S2/arXiv."""
+    raise NotImplementedError("Stage B identifier resolution: " + PHASE_2_REFERENCE)
+
+
+def stage_c_cross_source_validation(*args, **kwargs):
+    """Stage C: cross-source existence validation (>=2 sources concur)."""
+    raise NotImplementedError("Stage C cross-source validation: " + PHASE_2_REFERENCE)
+
+
+def stage_d_retraction_check(*args, **kwargs):
+    """Stage D: retraction check via Crossref update-to + RWDB CSV."""
+    raise NotImplementedError("Stage D retraction check: " + PHASE_2_REFERENCE)
+
+
+def stage_e_author_disambiguation(*args, **kwargs):
+    """Stage E: author disambiguation via OpenAlex + ORCID; SerpAPI tertiary."""
+    raise NotImplementedError("Stage E author disambiguation: " + PHASE_2_REFERENCE)
+
+
+def stage_f_bibliography_compilation(*args, **kwargs):
+    """Stage F: manubot + bibtex-tidy + (optional) betterbib subprocess."""
+    raise NotImplementedError("Stage F bibliography compilation: " + PHASE_2_REFERENCE)
+
+
+def stage_g_niche_citation_rescue(*args, **kwargs):
+    """Stage G: SerpAPI google_scholar rescue before HALLUCINATED verdict."""
+    raise NotImplementedError("Stage G niche-citation rescue: " + PHASE_2_REFERENCE)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reference validation pipeline (Phase 1: Stage A only)."
+    )
+    parser.add_argument("--csl-json", type=Path,
+                        help="Path to CSL-JSON input (Stage A)")
+    parser.add_argument("--out", type=Path, default=Path("refs.bib"),
+                        help="Output BibTeX path (Stage A; default refs.bib)")
+    parser.add_argument("--check", action="store_true",
+                        help="Report manubot availability and exit")
+    args = parser.parse_args(argv)
+
+    if args.check:
+        available = manubot_available()
+        print(f"validate_references.py Phase 1 stub")
+        print(f"  manubot CLI available: {available}")
+        print(f"  Stage A (CSL-JSON to BibTeX): {'available' if available else 'unavailable'}")
+        print(f"  Stages B-G: not implemented (Phase 2 deliverable)")
+        return 0 if available else 1
+
+    if not args.csl_json:
+        parser.print_usage(sys.stderr)
+        print("validate_references: --csl-json required (Stage A) or --check",
+              file=sys.stderr)
+        return 3
+
+    return stage_a_csl_to_bibtex(args.csl_json, args.out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/workspace-template/.latexmkrc
+++ b/rka/skills/writer/workspace-template/.latexmkrc
@@ -1,0 +1,17 @@
+# .latexmkrc : Writer manuscript workspace
+# Resolves vendored venue templates from ./styles/ (set up by fetch_template.py in Phase 2).
+# Default target: main.tex.
+
+# TEXINPUTS resolution: include ./styles/ recursively, then default TeX path.
+$ENV{'TEXINPUTS'} = './styles//:' . ($ENV{'TEXINPUTS'} || '');
+
+# Default file (latexmk runs this if no argument given).
+@default_files = ('main.tex');
+
+# Standard latexmk options for nonstopmode + file-line-error + synctex.
+# (render.sh wraps these as flags; defaults here apply when invoking latexmk directly.)
+$pdf_mode = 1;
+$pdflatex = 'pdflatex -interaction=nonstopmode -file-line-error -synctex=1 %O %S';
+
+# Clean target removes intermediate files.
+$clean_ext = 'aux bbl blg fdb_latexmk fls log out synctex.gz toc nav snm vrb';

--- a/rka/skills/writer/workspace-template/.mcp.json
+++ b/rka/skills/writer/workspace-template/.mcp.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "MCP server configuration for a Writer manuscript workspace. Phase 1 requires only the rka server. rka-writer-tools (Phase 2) is shown commented-out; uncomment after Phase 2 ships the rka-writer-tools wrapper.",
+
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<your-username>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "RKA_PROJECT": "prj_REPLACE_WITH_PROJECT_ID",
+        "RKA_API_URL": "http://localhost:9712"
+      }
+    }
+  },
+
+  "_phase_2_mcp_servers": {
+    "rka-writer-tools": {
+      "command": "/Users/<your-username>/.local/bin/rka-writer-tools",
+      "args": ["mcp"],
+      "env": {
+        "RKA_PROJECT": "prj_REPLACE_WITH_PROJECT_ID",
+        "SERPAPI_KEY": "<populated-by-PI-from-1Password; NEVER commit a literal key>"
+      }
+    }
+  }
+}

--- a/rka/skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md
+++ b/rka/skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md
@@ -1,0 +1,28 @@
+# Active Workflow
+
+This file tracks the current state of the manuscript so the Writer can
+resume on session start. Update at session end via the digest sub-procedure.
+
+current_phase: venue_selection
+last_checkpoint: (none)
+next_action: Confirm target venue with PI and run the Venue handler sub-procedure.
+last_session: (initial bootstrap)
+
+## Phase markers (reference)
+
+| Phase | Trigger to advance |
+|---|---|
+| venue_selection | Venue checkpoint ratified; .planning/PRECIS.md authored |
+| outline | Outline checkpoint ratified; .planning/OUTLINE.md ratified |
+| table_figure_plan | Table/figure plan checkpoint ratified |
+| reference_set | References ratified; refs.bib populated with VERIFIED entries |
+| drafting | Section drafts in progress; last completed section in `last_section_drafted` |
+| review | All sections drafted; PI reviewing |
+| revision | PI returned comments; iteration count in REVIEW_STATE.md |
+| final_layout | Full draft compiles; layout audit PASS or WARN; PI ratifies submit |
+| submitted | Manuscript submitted; manifest tagged phase:final |
+
+## Notes
+
+Manuscript manifest: jrn_REPLACE_WITH_MANIFEST_ID (created when first session
+ratifies the Venue checkpoint).

--- a/rka/skills/writer/workspace-template/.planning/OUTLINE.md
+++ b/rka/skills/writer/workspace-template/.planning/OUTLINE.md
@@ -1,0 +1,42 @@
+# OUTLINE
+
+Ratified outline lives here. Created via the Outline co-author sub-procedure
+(see references/workflows.md). Iron Law: no prose before this file is
+ratified by the PI through the Outline checkpoint.
+
+Recorded as a Decision (`dec_`) in RKA with the chosen framing
+(results-led / method-led / motivation-led) plus per-section sketches.
+
+## Framing
+
+(PI ratified. Fill in: results-led | method-led | motivation-led.)
+
+## Decision reference
+
+ratified_via: dec_REPLACE_WITH_OUTLINE_DECISION_ID
+ratified_at: (ISO date)
+
+## Sections
+
+(Per-section structure follows. Each section has a one-sentence purpose,
+a list of clusters / claims it draws on, and a status marker.)
+
+### §1 Introduction
+
+purpose: (PI ratified)
+clusters: ecl_, ecl_
+status: outlined
+
+### §2 (Section name)
+
+purpose:
+clusters:
+status: outlined
+
+(Continue for remaining sections.)
+
+## Sketches
+
+Per-section sketches live in `.planning/sketches/<section-id>.md` and
+become the starting prompt for the Section Drafter sub-procedure. The
+Section Drafter dispatches a fresh subagent per section.

--- a/rka/skills/writer/workspace-template/.planning/PRECIS.md
+++ b/rka/skills/writer/workspace-template/.planning/PRECIS.md
@@ -1,0 +1,31 @@
+# PRECIS
+
+PI-authored. The title and abstract are the manuscript's verbatim_input in
+the RKA manuscript manifest (Option 2 per dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q1).
+
+## Title
+
+(PI fills in.)
+
+## Abstract
+
+(PI fills in. ~150 to 250 words depending on venue.)
+
+## Target venue
+
+(PI fills in after Venue checkpoint ratification. Reference the ratified
+dec_ ID once the checkpoint resolves.)
+
+## Authors
+
+(PI fills in. Order matters; preserve verbatim.)
+
+## Key claims
+
+(PI fills in 3 to 5 bullet points stating the contribution claims. These
+are the targets that prose must support via provenance edges.)
+
+## Notes for the Writer
+
+(Optional. PI can include caveats, scope boundaries, or comparison targets
+that the Writer should respect during drafting.)

--- a/rka/skills/writer/workspace-template/.planning/REVIEW_STATE.md
+++ b/rka/skills/writer/workspace-template/.planning/REVIEW_STATE.md
@@ -1,0 +1,38 @@
+# Review State
+
+Tracks the Revision Loop for the current PI review cycle (see Revision Loop
+section in SKILL.md). Three-iteration cap; the third failed iteration auto-
+escalates to a PI Style or Logical checkpoint with three resolution options.
+
+## Current cycle
+
+iteration: 0
+max: 3
+verdict: (none yet)
+
+## Comment classifications for this cycle
+
+(For each PI review comment, classify into R1, R2, R3, or R4 per the
+Revision Loop section. R4 escalates via rka_create_mission.)
+
+| Comment ID | Class | Section | Status |
+|---|---|---|---|
+| (PI fills in)            | R?  | §?    | pending |
+
+## Procedure map
+
+| Class | Comment type | Procedure |
+|---|---|---|
+| R1 | Factual (sentence-level) | inline auto-fix; re-render; bump iteration |
+| R2 | Style or AI-tic | re-run ai_tic_lint at stricter threshold; auto-revise |
+| R3 | Inconsistency (cross-section) | structural rewrite of all affected sections |
+| R4 | Logical gap or unsupported claim | ESCALATE via rka_create_mission |
+
+## History
+
+(Each completed iteration leaves a record.)
+
+### Iteration N (date)
+- changes: ...
+- verdict: CONTINUE | ESCALATE | COMPLETE
+- next_action: ...

--- a/rka/skills/writer/workspace-template/ai_tic_config.yaml
+++ b/rka/skills/writer/workspace-template/ai_tic_config.yaml
@@ -1,0 +1,42 @@
+# ai_tic_config.yaml : per-project AI-tic linter overrides for this manuscript.
+#
+# Default behavior: HIGH-tier terms (PI verbatim list + Kobak 2025 + Matsui 2025)
+# block by default. CRITICAL hits and absolute bans (em-dash, en-dash, bullet
+# density) cannot be overridden. MEDIUM hits warn by default.
+#
+# Per dec_01KS12H9KT1T03DHX2Q6FKTXHH PATCH 2: anti-AI-tic rules anchor to
+# primary sources, not vendored third-party content.
+#
+# Verdict options per term:
+#   - enable    (default; HIGH terms block, MEDIUM terms warn)
+#   - disable   (skip this term entirely for this project)
+#   - downgrade (HIGH demoted to MEDIUM; MEDIUM demoted to PASS)
+#
+# Custom blocks: project-specific terms PI wants flagged.
+#
+# See: rka/skills/writer/references/ai_tics.md for the full tier table.
+
+# Example overrides (uncomment as appropriate for your manuscript).
+
+# facilitate:
+#   verdict: disable
+#   rationale: "Used in the medical sense (catheter facilitates drainage); domain-legitimate."
+
+# enhance:
+#   verdict: downgrade
+#   rationale: "Engineering manuscript: 'enhance signal-to-noise' is technical, not promotional."
+
+# elevate:
+#   verdict: downgrade
+#   rationale: "Used technically: 'elevate baseline' (a measurement); not generic puffery."
+
+# Project-specific additions (terms PI wants flagged beyond the default list):
+custom_blocks: []
+# Example:
+# custom_blocks:
+#   - term: "robust"
+#     tier: HIGH
+#     rationale: "Project policy: require specific quantification, not generic robustness claims."
+#   - term: "innovative"
+#     tier: HIGH
+#     rationale: "PI dislikes self-promotional contribution framing."

--- a/rka/skills/writer/workspace-template/charts/.gitkeep
+++ b/rka/skills/writer/workspace-template/charts/.gitkeep
@@ -1,0 +1,2 @@
+# charts/ : chart .py scripts (matplotlib + seaborn) and their rendered .pdf outputs.
+# See scripts/chart_render.py for venue presets; PI authors per-manuscript chart logic.

--- a/rka/skills/writer/workspace-template/figures/.gitkeep
+++ b/rka/skills/writer/workspace-template/figures/.gitkeep
@@ -1,0 +1,2 @@
+# figures/ : figure files (PDF, PNG, SVG) referenced by sections/.
+# Paper Banana diagram outputs land here; chart_render.py outputs also.

--- a/rka/skills/writer/workspace-template/main.tex
+++ b/rka/skills/writer/workspace-template/main.tex
@@ -1,0 +1,54 @@
+% main.tex : manuscript entry point.
+%
+% This is the Writer workspace template's skeleton. Per the Iron Law (see
+% SKILL.md "Outline Brief"), this file stays skeleton-only until the Outline
+% checkpoint passes. The PI ratifies the Outline; then the Section Drafter
+% sub-procedure populates sections/*.tex.
+%
+% Replace the documentclass invocation with the appropriate venue class
+% after the Venue checkpoint resolves. Examples:
+%
+%   \documentclass[sigconf]{acmart}                  % CHI / CSCW / UIST
+%   \documentclass[11pt]{article}\usepackage[review]{acl}  % EMNLP / ACL
+%
+% Templates are fetched and verified by scripts/fetch_template.py (Phase 2).
+% In Phase 1 the PI installs templates manually per references/template_registry.md.
+
+\documentclass{article}
+
+% Common preamble bits (replace per venue).
+\usepackage[utf8]{inputenc}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{hyperref}
+
+% Bibliography entries.
+\bibliographystyle{plain}
+
+\begin{document}
+
+\title{<<replace with PI-authored title from .planning/PRECIS.md>>}
+\author{<<replace with author block>>}
+\date{\today}
+\maketitle
+
+\begin{abstract}
+% Provenance: jrn_REPLACE_WITH_MANIFEST_ID verbatim_input carries the abstract.
+<<replace with PI-authored abstract from .planning/PRECIS.md>>
+\end{abstract}
+
+% Sections are populated by the Section Drafter sub-procedure post outline
+% ratification. Each section .tex has hidden provenance comments before
+% every evidence-bearing claim per the Source Attribution section in SKILL.md.
+
+\input{sections/01-introduction}
+\input{sections/02-related-work}
+\input{sections/03-method}
+\input{sections/04-results}
+\input{sections/05-discussion}
+% \input{sections/06-limitations}  % CHI 2024+ recommends top-level; EMNLP requires
+% \input{sections/07-conclusion}
+
+\bibliography{refs}
+
+\end{document}

--- a/rka/skills/writer/workspace-template/refs.bib
+++ b/rka/skills/writer/workspace-template/refs.bib
@@ -1,0 +1,14 @@
+% refs.bib : manuscript bibliography.
+%
+% Populated via the Reference validator sub-procedure (see references/workflows.md).
+% Phase 1: PI assembles manually OR scripts/validate_references.py Stage A
+% converts CSL-JSON from rka_get_literature to BibTeX via manubot.
+% Phase 2: full pipeline (rka-writer-tools MCP server) wires Stages B through G.
+%
+% Conventional invocation for bibtex-tidy hygiene:
+%   bibtex-tidy --curly --numeric --sort=key --duplicates=key,doi --escape \
+%               --tidy-comments --remove-empty-fields --enclosing-braces=title \
+%               refs.bib
+%
+% Each entry should have a validation status tracked in RKA via
+% rka_update_literature(id="lit_...", validation_status="VERIFIED").

--- a/rka/skills/writer/workspace-template/sections/.gitkeep
+++ b/rka/skills/writer/workspace-template/sections/.gitkeep
@@ -1,0 +1,2 @@
+# sections/ : per-section .tex files populated by the Section Drafter sub-procedure.
+# Empty in the workspace template; populated post Outline checkpoint ratification.

--- a/rka/skills/writer/workspace-template/styles/.gitkeep
+++ b/rka/skills/writer/workspace-template/styles/.gitkeep
@@ -1,0 +1,3 @@
+# styles/ : vendored venue templates (acmart, acl-style-files, etc.).
+# Populated by scripts/fetch_template.py (Phase 2) or by PI manually per
+# references/template_registry.md install_command.

--- a/rka/skills/writer/workspace-template/tables/.gitkeep
+++ b/rka/skills/writer/workspace-template/tables/.gitkeep
@@ -1,0 +1,1 @@
+# tables/ : table .tex fragments (booktabs format) included from sections/.

--- a/tests/skills/writer/conftest.py
+++ b/tests/skills/writer/conftest.py
@@ -1,0 +1,82 @@
+"""Shared fixtures for Writer skill tests.
+
+The Writer skill scripts live under rka/skills/writer/scripts/ and are designed
+as standalone CLI scripts, not as a Python package. These fixtures use
+importlib.util.spec_from_file_location to load each script as an importable
+module for unit testing without polluting sys.modules globally.
+
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 test convention discovery: the rka
+project uses pytest with asyncio_mode=auto; conftest.py provides per-area
+fixtures. Writer tests do not need async or database fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[3] / "rka" / "skills" / "writer" / "scripts"
+)
+SKILL_DIR = SCRIPTS_DIR.parent
+REFS_DIR = SKILL_DIR / "references"
+
+
+def _load_module(name: str):
+    """Load a Writer script at <name>.py as an importable module."""
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"writer_{name}", path)
+    assert spec is not None and spec.loader is not None, f"failed to load {path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"writer_{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def ai_tic_lint():
+    return _load_module("ai_tic_lint")
+
+
+@pytest.fixture
+def bridge_repetition_check():
+    return _load_module("bridge_repetition_check")
+
+
+@pytest.fixture
+def layout_audit():
+    return _load_module("layout_audit")
+
+
+@pytest.fixture
+def validate_references():
+    return _load_module("validate_references")
+
+
+@pytest.fixture
+def fetch_template():
+    return _load_module("fetch_template")
+
+
+@pytest.fixture
+def chart_render():
+    return _load_module("chart_render")
+
+
+@pytest.fixture
+def skill_dir() -> Path:
+    return SKILL_DIR
+
+
+@pytest.fixture
+def refs_dir() -> Path:
+    return REFS_DIR
+
+
+@pytest.fixture
+def skill_md_path(skill_dir: Path) -> Path:
+    return skill_dir / "SKILL.md"

--- a/tests/skills/writer/test_ai_tic_lint.py
+++ b/tests/skills/writer/test_ai_tic_lint.py
@@ -1,0 +1,217 @@
+"""Tests for ai_tic_lint.py.
+
+Covers the 3 lexical tiers (CRITICAL / HIGH / MEDIUM), em-dash absolute ban,
+bullet-density cap, and 3 structural detectors. Plus per-project override
+mechanism and style score formula.
+
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria: at least 10 tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestCriticalTier:
+    """CRITICAL hits block on any occurrence (no per-project override)."""
+
+    def test_chatgpt_browsing_token_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "See results in turn0search0 for context.")
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.tier == "CRITICAL" for h in report.critical)
+        assert report.verdict == "BLOCK"
+
+    def test_refusal_stem_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "As an AI language model, I cannot provide that analysis."
+        )
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.tier == "CRITICAL" for h in report.critical)
+        assert report.verdict == "BLOCK"
+
+
+class TestHighTier:
+    """HIGH tier blocks by default; per-project override possible."""
+
+    def test_pi_verbatim_facilitate_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "This tool will facilitate the analysis.")
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.tier == "HIGH" and "facilitate" in h.term.lower()
+                   for h in report.high)
+
+    def test_kobak_delving_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Delving into the dataset reveals patterns.")
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.tier == "HIGH" and "delving" in h.term.lower()
+                   for h in report.high)
+        assert any(h.source == "Kobak 2025" for h in report.high)
+
+    def test_matsui_enhance_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "We enhance the model with new features.")
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.tier == "HIGH" and h.term.lower() == "enhance"
+                   for h in report.high)
+        assert any(h.source == "Matsui 2025" for h in report.high)
+
+    def test_clean_prose_passes(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "The protocol records participant decisions in real time. "
+            "We compute mean decision latency across sessions. "
+            "Results show a non-linear effect of session length."
+        )
+        report = ai_tic_lint.lint_file(f)
+        assert not report.high
+        assert not report.critical
+        assert report.verdict in ("PASS", "WARN")
+
+
+class TestAbsoluteBans:
+    """Em-dash and en-dash absolute bans; no override possible."""
+
+    def test_em_dash_u2014_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", f"A sentence{chr(0x2014)}with em-dash.")
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.term == "U+2014 EM DASH" for h in report.absolute_bans)
+        assert report.verdict == "BLOCK"
+
+    def test_en_dash_u2013_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", f"Pages 14{chr(0x2013)}21 of the report.")
+        report = ai_tic_lint.lint_file(f)
+        assert any(h.term == "U+2013 EN DASH" for h in report.absolute_bans)
+        assert report.verdict == "BLOCK"
+
+
+class TestBulletDensity:
+    """At most 2 lists per section; each list 3 to 5 items."""
+
+    def test_too_many_lists_per_section_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        content = """## Section
+
+Intro.
+
+- a
+- b
+- c
+
+Middle.
+
+- a
+- b
+- c
+
+End.
+
+- a
+- b
+- c
+"""
+        f = _write(tmp_path, "s.md", content)
+        report = ai_tic_lint.lint_file(f)
+        assert any("3 bulleted lists" in h.term for h in report.absolute_bans)
+
+    def test_list_with_too_few_items_blocks(self, ai_tic_lint, tmp_path: Path) -> None:
+        content = """## Section
+
+- a
+- b
+"""
+        f = _write(tmp_path, "s.md", content)
+        report = ai_tic_lint.lint_file(f)
+        assert any("2 items (under 3)" in h.term for h in report.absolute_bans)
+
+
+class TestStructuralDetectors:
+    """Sentence-length variance, transition-word ratio, parallel-triplet density."""
+
+    def test_uniform_sentence_rhythm_warns(self, ai_tic_lint, tmp_path: Path) -> None:
+        # Five sentences with near-uniform length triggers the variance detector.
+        text = (
+            "Words go here now and there. "
+            "Words go there too and now. "
+            "Words go anywhere all about. "
+            "Words flow easily through space. "
+            "Words sit evenly across lines."
+        )
+        f = _write(tmp_path, "s.tex", text)
+        report = ai_tic_lint.lint_file(f)
+        variance = next(
+            s for s in report.structural if s.detector == "sentence_length_variance"
+        )
+        assert variance.verdict == "WARN", (
+            "uniform sentence rhythm should WARN (structural detectors do not BLOCK; "
+            "they contribute to the style score for the auto-revise loop)"
+        )
+
+    def test_parallel_triplets_warn(self, ai_tic_lint, tmp_path: Path) -> None:
+        # Three "X, Y, and Z" constructions in a short text triggers density > 1/500w.
+        text = (
+            "We considered cats, dogs, and birds. "
+            "We measured speed, accuracy, and recall. "
+            "We tested cars, trucks, and bikes."
+        )
+        f = _write(tmp_path, "s.tex", text)
+        report = ai_tic_lint.lint_file(f)
+        triplets = next(
+            s for s in report.structural
+            if s.detector == "parallel_triplet_density"
+        )
+        assert triplets.verdict == "WARN"
+
+
+class TestStyleScore:
+    """1 - (critical*3 + high + 0.3*medium) / total_sentences, clipped to [0, 1]."""
+
+    def test_clean_prose_high_score(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "The system records participant inputs. "
+            "Each input has a timestamp and a verdict. "
+            "We compute aggregate statistics per session."
+        )
+        report = ai_tic_lint.lint_file(f)
+        assert report.style_score >= 0.85
+
+    def test_high_hits_reduce_score(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "We facilitate the analysis. "
+            "We leverage the data. "
+            "Furthermore, we enhance the model."
+        )
+        report = ai_tic_lint.lint_file(f)
+        assert report.style_score < 0.85
+
+
+class TestPerProjectOverride:
+    """ai_tic_config.yaml can disable or downgrade HIGH-tier terms."""
+
+    def test_disable_override_removes_hit(self, ai_tic_lint, tmp_path: Path) -> None:
+        cfg = {"facilitate": {"verdict": "disable", "rationale": "domain-legit"}}
+        f = _write(tmp_path, "s.tex", "We facilitate the analysis.")
+        report_default = ai_tic_lint.lint_file(f)
+        report_override = ai_tic_lint.lint_file(f, config=cfg)
+        assert any("facilitate" in h.term.lower() for h in report_default.high)
+        assert not any("facilitate" in h.term.lower() for h in report_override.high)
+
+
+class TestEntryPoints:
+    """Module-level entry points (main, lint_file)."""
+
+    def test_main_returns_zero_on_clean_file(self, ai_tic_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "A clean sentence with neutral wording. "
+            "Another sentence varying length and structure. "
+            "Third clause adds variance in cadence."
+        )
+        rc = ai_tic_lint.main([str(f), "--output", str(tmp_path / "report.json")])
+        assert rc in (0, 1)
+        assert (tmp_path / "report.json").exists()

--- a/tests/skills/writer/test_bridge_repetition.py
+++ b/tests/skills/writer/test_bridge_repetition.py
@@ -1,0 +1,92 @@
+"""Tests for bridge_repetition_check.py.
+
+Verifies the clean-room implementation: cross-file sentence pairs with
+difflib.SequenceMatcher ratio >= threshold (default 0.7) are flagged;
+intra-file pairs are not compared; min_length filter respected.
+
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_no_bridges_when_files_are_unrelated(
+    bridge_repetition_check, tmp_path: Path
+) -> None:
+    a = _write(
+        tmp_path, "a.tex",
+        "The experimental setup measures decision latency across sessions. "
+        "Participants completed three rounds of the diary protocol."
+    )
+    b = _write(
+        tmp_path, "b.tex",
+        "Discussion section reviews implications for permission-system design. "
+        "Future work could extend the protocol to longitudinal observation."
+    )
+    hits = bridge_repetition_check.find_bridges([a, b], threshold=0.7)
+    assert hits == []
+
+
+def test_detects_near_duplicate_pair(
+    bridge_repetition_check, tmp_path: Path
+) -> None:
+    common = (
+        "The diary instrument surfaces patterns of permission decisions over time. "
+    )
+    a = _write(
+        tmp_path, "a.tex",
+        common + "It records when each agent prompt occurs and the user response."
+    )
+    b = _write(
+        tmp_path, "b.tex",
+        common + "This produces a longitudinal record suitable for trend analysis."
+    )
+    hits = bridge_repetition_check.find_bridges([a, b], threshold=0.7)
+    assert any(h.ratio >= 0.7 for h in hits)
+
+
+def test_threshold_filters_low_similarity_pairs(
+    bridge_repetition_check, tmp_path: Path
+) -> None:
+    a = _write(
+        tmp_path, "a.tex",
+        "The instrument captures user permission decisions during sessions."
+    )
+    b = _write(
+        tmp_path, "b.tex",
+        "Permission decisions during sessions are captured by the instrument."
+    )
+    # Default 0.7: should match given high word overlap.
+    hits_70 = bridge_repetition_check.find_bridges([a, b], threshold=0.7)
+    # Very high threshold should miss this pair.
+    hits_98 = bridge_repetition_check.find_bridges([a, b], threshold=0.98)
+    assert len(hits_70) >= len(hits_98)
+
+
+def test_min_length_filters_short_sentences(
+    bridge_repetition_check, tmp_path: Path
+) -> None:
+    a = _write(tmp_path, "a.tex", "Yes. The same. Yes.")
+    b = _write(tmp_path, "b.tex", "Yes. The same. Yes.")
+    # min_length 40 filters everything; result must be empty.
+    hits = bridge_repetition_check.find_bridges([a, b], min_length=40)
+    assert hits == []
+
+
+def test_no_intra_file_pairs(bridge_repetition_check, tmp_path: Path) -> None:
+    a = _write(
+        tmp_path, "a.tex",
+        "The diary instrument surfaces patterns of permission decisions over time. "
+        "The diary instrument surfaces patterns of permission decisions over time."
+    )
+    # Two identical sentences inside the same file; cross-file scanner should not report.
+    hits = bridge_repetition_check.find_bridges([a], threshold=0.5)
+    assert hits == []

--- a/tests/skills/writer/test_layout_audit.py
+++ b/tests/skills/writer/test_layout_audit.py
@@ -1,0 +1,109 @@
+"""Tests for layout_audit.py.
+
+Synthesize minimal .log / .blg / .aux / .tex fixtures triggering each of the
+12 audit fields; verify the correct PASS / WARN / BLOCK verdict per field.
+
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write_fixtures(tmp_path: Path, *, log: str = "", blg: str = "",
+                    aux: str = "", tex: str = "") -> dict:
+    """Write the 4 fixture files; return a dict of paths."""
+    files = {}
+    if log:
+        files["log"] = tmp_path / "main.log"
+        files["log"].write_text(log, encoding="utf-8")
+    if blg:
+        files["blg"] = tmp_path / "main.blg"
+        files["blg"].write_text(blg, encoding="utf-8")
+    if aux:
+        files["aux"] = tmp_path / "main.aux"
+        files["aux"].write_text(aux, encoding="utf-8")
+    if tex:
+        files["tex"] = tmp_path / "main.tex"
+        files["tex"].write_text(tex, encoding="utf-8")
+    return files
+
+
+def test_pages_over_limit_blocks(layout_audit) -> None:
+    verdict = layout_audit.check_pages_over_limit(pages=15, limit=14)
+    assert verdict.verdict == "BLOCK"
+
+
+def test_pages_equals_limit_warns(layout_audit) -> None:
+    verdict = layout_audit.check_pages_equals_limit(pages=14, limit=14)
+    assert verdict.verdict == "WARN"
+
+
+def test_undefined_citations_blocks(layout_audit) -> None:
+    log = (
+        "LaTeX Warning: Citation `Smith2024' on page 4 undefined on input line 12.\n"
+        "LaTeX Warning: Citation `Jones2023' on page 5 undefined on input line 17.\n"
+    )
+    verdict = layout_audit.check_undefined_citations(log)
+    assert verdict.verdict == "BLOCK"
+    assert verdict.value == 2
+
+
+def test_undefined_refs_blocks(layout_audit) -> None:
+    log = "LaTeX Warning: Reference `sec:method' on page 3 undefined on input line 8.\n"
+    verdict = layout_audit.check_undefined_refs(log)
+    assert verdict.verdict == "BLOCK"
+    assert verdict.value == 1
+
+
+def test_missing_bib_keys_blocks(layout_audit) -> None:
+    blg = "Warning--I didn't find a database entry for \"Smith2024\"\n"
+    verdict = layout_audit.check_missing_bib_keys(blg)
+    assert verdict.verdict == "BLOCK"
+
+
+def test_orphan_refs_blocks(layout_audit) -> None:
+    aux = "\\newlabel{sec:intro}{{1}{1}}\n"
+    tex = "See \\ref{sec:intro} and \\ref{sec:method}."  # method not in aux
+    verdict = layout_audit.check_orphan_refs(aux, tex)
+    assert verdict.verdict == "BLOCK"
+    assert "sec:method" in verdict.matches
+
+
+def test_overfull_hbox_over_10pt_warns(layout_audit) -> None:
+    log = "Overfull \\hbox (15.5pt too wide) in paragraph at lines 30--35\n"
+    verdict = layout_audit.check_overfull_hboxes_over_10pt(log)
+    assert verdict.verdict == "WARN"
+
+
+def test_overfull_hbox_under_10pt_passes(layout_audit) -> None:
+    log = "Overfull \\hbox (3.2pt too wide) in paragraph at lines 30--35\n"
+    verdict = layout_audit.check_overfull_hboxes_over_10pt(log)
+    assert verdict.verdict == "PASS"
+
+
+def test_underfull_badness_over_5000_warns(layout_audit) -> None:
+    log = "Underfull \\hbox (badness 6500) in paragraph at lines 40--41\n"
+    verdict = layout_audit.check_underfull_badness_over_5000(log)
+    assert verdict.verdict == "WARN"
+
+
+def test_overall_verdict_aggregation_pass(layout_audit, tmp_path: Path) -> None:
+    files = _write_fixtures(tmp_path, log="", blg="", aux="", tex="")
+    report = layout_audit.audit(
+        pdf_path=None, log_path=None, blg_path=None,
+        aux_path=None, tex_path=None, venue="CHI",
+    )
+    assert report.summary["overall_verdict"] == "PASS"
+
+
+def test_overall_verdict_aggregation_block(layout_audit, tmp_path: Path) -> None:
+    log = "LaTeX Warning: Citation `MissingKey' on page 1 undefined on input line 5.\n"
+    files = _write_fixtures(tmp_path, log=log)
+    report = layout_audit.audit(
+        pdf_path=None, log_path=files["log"], blg_path=None,
+        aux_path=None, tex_path=None, venue="CHI",
+    )
+    assert report.summary["overall_verdict"] == "BLOCK"
+    assert report.summary["blocks"] >= 1

--- a/tests/skills/writer/test_skill_loads.py
+++ b/tests/skills/writer/test_skill_loads.py
@@ -1,0 +1,88 @@
+"""Test that SKILL.md loads correctly: frontmatter, 16 sections, references discoverable.
+
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+EXPECTED_SECTIONS = [
+    "# Writer Skill",
+    "## Supplementary references",
+    "## Session Start",
+    "## Tool Surface",
+    "## Source Attribution",
+    "## Outline Brief",
+    "## PI Checkpoints",
+    "## Provenance",
+    "## Reference Validation Pipeline",
+    "## Anti-AI-tic Enforcement",
+    "## Venue Tone",
+    "## LaTeX Template Management",
+    "## Local Rendering",
+    "## Revision Loop",
+    "## Anti-Patterns",
+    "## Related",
+]
+
+
+def _read_skill(skill_md_path: Path) -> str:
+    return skill_md_path.read_text(encoding="utf-8")
+
+
+def test_frontmatter_has_name_description_version(skill_md_path: Path) -> None:
+    text = _read_skill(skill_md_path)
+    assert text.startswith("---\n"), "SKILL.md must start with YAML frontmatter delimiter"
+    end = text.find("\n---\n", 4)
+    assert end > 0, "SKILL.md frontmatter must close with --- delimiter"
+    fm = text[4:end]
+    assert re.search(r"^name:\s*rka-writer\s*$", fm, re.MULTILINE)
+    assert re.search(r"^version:\s*2\.3\.2\s*$", fm, re.MULTILINE)
+    assert re.search(r"^description:\s*\S", fm, re.MULTILINE)
+
+
+def test_all_16_sections_present_in_stable_order(skill_md_path: Path) -> None:
+    text = _read_skill(skill_md_path)
+    last_pos = -1
+    for section_header in EXPECTED_SECTIONS:
+        idx = text.find(section_header)
+        assert idx >= 0, f"section header missing: {section_header}"
+        assert idx > last_pos, (
+            f"section {section_header!r} appears out of order "
+            f"(expected position after previous section)"
+        )
+        last_pos = idx
+
+
+def test_supplementary_references_all_discoverable(
+    skill_md_path: Path, refs_dir: Path
+) -> None:
+    text = _read_skill(skill_md_path)
+    relative_paths = set(re.findall(r"references/([\w/.-]+\.md)", text))
+    assert relative_paths, "SKILL.md must reference at least one file under references/"
+    for rel in relative_paths:
+        target = refs_dir / rel
+        assert target.exists(), f"referenced file does not exist: {target}"
+
+
+def test_em_dash_absolute_ban_dogfooded(skill_md_path: Path) -> None:
+    """SKILL.md itself must not contain em-dash U+2014 or en-dash U+2013."""
+    text = _read_skill(skill_md_path)
+    assert chr(0x2014) not in text, "SKILL.md contains em-dash; dogfood discipline violated"
+    assert chr(0x2013) not in text, "SKILL.md contains en-dash; dogfood discipline violated"
+
+
+def test_skill_md_within_line_budget(skill_md_path: Path) -> None:
+    """Soft budget: 200 to 700 lines per PATCH 2 revised target (~350-450).
+
+    Tests that the skill stays roughly the right size; below 200 suggests
+    underbuilt; above 700 suggests bloat that should move to references/.
+    """
+    text = _read_skill(skill_md_path)
+    line_count = len(text.splitlines())
+    assert 200 <= line_count <= 700, (
+        f"SKILL.md has {line_count} lines; expected 200-700 per PATCH 2 budget"
+    )

--- a/tests/skills/writer/test_venue_files.py
+++ b/tests/skills/writer/test_venue_files.py
@@ -1,0 +1,63 @@
+"""Tests for venue/CHI.md and venue/EMNLP.md schema and content.
+
+Each venue file must carry the seven-field schema per references/venue/CHI.md
+and EMNLP.md design. Tests verify each required schema section is present
+and the em-dash absolute ban is dogfooded.
+
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REQUIRED_SCHEMA_SECTIONS = [
+    "Section names and order",
+    "Page-limit class",
+    "Tone characteristics",
+    "Forbidden constructions",
+    "Citation style",
+    "Required sections",
+    "Sample corpus pointers",
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_chi_md_exists(refs_dir: Path) -> None:
+    assert (refs_dir / "venue" / "CHI.md").exists()
+
+
+def test_emnlp_md_exists(refs_dir: Path) -> None:
+    assert (refs_dir / "venue" / "EMNLP.md").exists()
+
+
+def test_chi_has_all_seven_schema_sections(refs_dir: Path) -> None:
+    text = _read(refs_dir / "venue" / "CHI.md")
+    for section in REQUIRED_SCHEMA_SECTIONS:
+        assert section in text, f"CHI.md missing schema section: {section}"
+
+
+def test_emnlp_has_all_seven_schema_sections(refs_dir: Path) -> None:
+    text = _read(refs_dir / "venue" / "EMNLP.md")
+    for section in REQUIRED_SCHEMA_SECTIONS:
+        assert section in text, f"EMNLP.md missing schema section: {section}"
+
+
+def test_emnlp_documents_mandatory_limitations(refs_dir: Path) -> None:
+    """EMNLP requires a Limitations section since 2022; the venue file must say so."""
+    text = _read(refs_dir / "venue" / "EMNLP.md")
+    assert "Limitations" in text
+    lower = text.lower()
+    assert ("mandatory" in lower or "required" in lower)
+
+
+def test_venue_files_em_dash_clean(refs_dir: Path) -> None:
+    """Em-dash absolute ban dogfooded in venue files."""
+    for name in ("CHI.md", "EMNLP.md"):
+        text = _read(refs_dir / "venue" / name)
+        assert chr(0x2014) not in text, f"{name} contains U+2014"
+        assert chr(0x2013) not in text, f"{name} contains U+2013"


### PR DESCRIPTION
## Phase 1 of 3 — do not merge until Phase 2 + 3 complete and PI signs off after end-to-end test

Phase 1 (MVP) implementation of the RKA Writer role per the ratified design
specification. Ships `rka/skills/writer/` as a complete Markdown skill loadable
by Claude Code in VSCode, with anti-AI-tic enforcement, local LaTeX rendering,
layout audit, and 2 seed venue files (ACL/EMNLP + ACM CHI). Phase 2 (full
reference validation pipeline + `rka-writer-tools` MCP server + 5 more venues)
and Phase 3 (revision loop + Brain mission integration) are explicitly out of
scope.

## Provenance

- **Mission**: `mis_01KS0C3RP04XANCZAB3HTNAG0P`
- **Design doc**: `RKA-Writer-Design.docx` (PI-resident)
- **Comprehensive design (RKA)**: `jrn_01KS0B8EDZ4FYFF11Q8CQ97ZDT`
- **Deep research synthesis**: `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`
- **Decisions**:
  - `dec_01KS0AWYDV752AWQRF40CQBRFZ` (deployment: Claude Code + VSCode)
  - `dec_01KS0AXXASJ5GXV7M0SS39Y066` (SerpAPI tertiary; Phase 1 stubs only)
  - `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` (Q1-Q8 bundle: Option 2 manuscript
    representation, ACL/EMNLP+CHI seed venues, per-project ai_tic_config.yaml,
    Writer v2.3.2 lockstep with Brain, etc.)
  - `dec_01KS12H9KT1T03DHX2Q6FKTXHH` (PATCH 2: anti-AI-tic implemented from
    primary sources; no third-party content vendored in Phase 1; clean-room
    `bridge_repetition_check.py`)
- **Backbrief**: `jrn_01KS0V7V0PWHFCZ1VCRE4JC9BK`
- **Resolved checkpoint**: `chk_01KS0VE0AW3KZC2WS0BVDHK237` (Q7 MIT-vendoring
  assumption empirically false at T0(e); Brain ratified Option C disposition)

## Branch state

- Working branch: `feat/writer-role-phase-1` derived from `main` HEAD `8a2e9ef`
  (v2.5.4 tag).
- Zero commits on `main`.
- 7 atomic commits on this branch; each pushed with `git ls-remote` SHA-parity
  verified; each verified against the bookkeeper invariant
  (`git diff main -- rka/services/ rka/api/ rka/mcp/ web/` empty).

Commit timeline:

| Commit | Task | Summary |
|---|---|---|
| `2d25d92` | T1 | SKILL.md with 16 sections (Phase 1 MVP) |
| `6825c63` | T2 | references/ (9 files + 1-line LICENSE-THIRDPARTY.md; no vendoring per Option C) |
| `b81557b` | T3 | scripts (ai_tic_lint + bridge_repetition_check clean-room + render.sh + layout_audit FULL; chart_render + validate_references + fetch_template STUBS) |
| `cd5c406` | T3 follow-up | structural detectors WARN-only (surfaced during T4) + datetime cleanup |
| `53d1995` | T4 | 43 tests across 8 files (above ~30 target) |
| `4883906` | T5 | workspace-template with 14 files; latexmk smoke test PASS |
| `2592a85` | T6 | README + Phase 1 MVP narrative + skills index update |

## File inventory (Phase 1 deliverables)

### Skill content

- `rka/skills/writer/SKILL.md` (291 lines, v2.3.2, 16 sections)
- `rka/skills/writer/LICENSE-THIRDPARTY.md` (1-line note per Option C)
- `rka/skills/writer/README.md` (150 lines)
- `rka/skills/writer/docs/phase-1-mvp.md` (263 lines)
- `rka/skills/writer/references/`
  - `ai_tics.md` (174 lines)
  - `architecture.md` (187 lines)
  - `workflows.md` (235 lines)
  - `reference_pipeline.md` (150 lines)
  - `latex_audit.md` (189 lines)
  - `template_registry.md` (170 lines)
  - `examples.md` (239 lines)
  - `venue/CHI.md` (98 lines)
  - `venue/EMNLP.md` (115 lines)

### Scripts (FULL implementations)

- `scripts/ai_tic_lint.py` (542 lines): 3 lexical tiers (CRITICAL / HIGH / MEDIUM)
  + em-dash absolute ban + bullet-density cap + 3 structural detectors + style
  score + per-project override via `ai_tic_config.yaml`. Emits `ai_tic_report.json`.
- `scripts/bridge_repetition_check.py` (176 lines, clean-room): difflib
  SequenceMatcher ratio 0.7 across cross-file sentence pairs.
- `scripts/render.sh` (53 lines): latexmk wrapper with `LATEX_ENGINE` env var.
- `scripts/layout_audit.py` (331 lines): 12-field PASS/WARN/BLOCK audit.

### Scripts (STUBS for Phase 2)

- `scripts/chart_render.py` (149 lines): matplotlib + seaborn skeleton with
  venue presets. `render_chart()` raises `NotImplementedError`.
- `scripts/validate_references.py` (176 lines): Stage A (CSL-JSON to BibTeX
  via manubot) implemented; Stages B-G raise `NotImplementedError`.
- `scripts/fetch_template.py` (138 lines): registry lookup implemented;
  `fetch()` raises `NotImplementedError`.

### Workspace template (14 files)

- `.mcp.json`, `.latexmkrc`, `ai_tic_config.yaml`, `main.tex`, `refs.bib`
- `.planning/`: `ACTIVE_WORKFLOW.md`, `PRECIS.md`, `OUTLINE.md`, `REVIEW_STATE.md`
- Directory placeholders: `sections/`, `figures/`, `tables/`, `charts/`, `styles/`

### Tests (43 passing)

- `tests/skills/writer/conftest.py`
- `tests/skills/writer/test_skill_loads.py` (5 tests)
- `tests/skills/writer/test_ai_tic_lint.py` (16 tests)
- `tests/skills/writer/test_layout_audit.py` (11 tests)
- `tests/skills/writer/test_bridge_repetition.py` (5 tests)
- `tests/skills/writer/test_venue_files.py` (6 tests)

## Verification highlights

- **All 43 Writer tests pass** locally (Python 3.13.8, pytest 9.0.2; `pytest tests/skills/writer/` 43 passed in 0.12s).
- **latexmk smoke test PASSED** (TeX Live 2025, latexmk 4.86a): empty
  `\documentclass{article}` compiles to 15.9 KB PDF via `render.sh` + workspace
  template `.latexmkrc`.
- **Bookkeeper invariant verified empty at every commit**: zero changes to
  `rka/services/`, `rka/api/`, `rka/mcp/`, `web/`.
- **Em-dash absolute ban dogfooded**: 0 U+2014 and 0 U+2013 across all Writer
  files (SKILL.md, references/, scripts/, workspace-template/, tests/, docs/).
  The linter's `EM_DASH` and `EN_DASH` constants use `chr(0x2014)` / `chr(0x2013)`
  to keep the source character-clean while still detecting the runtime characters.

## Divergences from spec

1. **SKILL.md line count**: 291 lines (PATCH 2 revised target was 350-450 after
   discovering Brain SKILL.md had been slimmed to 210 lines since spec authoring).
   The 291-line density was chosen to match Brain's current style. Below low end
   of target, but covers all 16 sections fully with depth in `references/`.
2. **Q7 vendoring assumption invalidated at T0(e)**: edwinhu/workflows repo has
   no LICENSE file and content is sourced from Wikipedia "Signs of AI writing"
   (CC BY-SA, not MIT). Surfaced as blocking checkpoint
   `chk_01KS0VE0AW3KZC2WS0BVDHK237`. Brain ratified Option C
   (`dec_01KS12H9KT1T03DHX2Q6FKTXHH`): anti-AI-tic from primary sources
   (PI verbatim list + Kobak 2025 + Matsui 2025); `references/ai_tics/` vendored
   directory NOT created; `LICENSE-THIRDPARTY.md` becomes a 1-line note.
3. **T3 follow-up**: T4 test authoring surfaced that `sentence_length_variance`
   detector was blocking on legitimate short academic prose (3 sentences with
   similar lengths). Fixed: WARN-only verdict + raise minimum paragraph length
   from 3 to 5 sentences. References/ai_tics.md updated to reflect.

## Phase 2 readiness (HIGH confidence)

All Phase 1 substrate is in place to support Phase 2 implementation:

- SKILL.md and `references/` document the Phase 2 architecture (reference
  pipeline Stages B-G, `rka-writer-tools` MCP server, additional venues).
- Scripts have clear FULL vs STUB markers; Phase 2 fills the stubs.
- Workspace template is functional with the live render path.
- Tests provide a regression floor; Phase 2 extends with reference validation
  tests.
- Bookkeeper invariant is preserved; Phase 2 introduces `rka-writer-tools` as
  a sibling MCP server, not a modification of the existing `rka` server.

## Phase 2 mission shape recommendation

- Re-verify PyPI version pins for habanero, pyalex, semanticscholar, arxiv,
  manubot, python-orcid, bibtex-tidy at Backbrief per executor skill's
  version-drift discipline.
- Confirm SerpAPI subscription tier for 200 searches/manuscript budget.
- Verify OpenAlex API key status (required from 2026-02-13).
- Verify ACL style files branch for the target submission year.
- Build `rka-writer-tools` MCP server (~3 engineer-weeks plus ~5 PI hours per
  design doc Section 16).

## Do NOT merge

PR remains open at mission close. Merge happens after Phase 2 and Phase 3 ship
and the PI signs off after end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)