### PR TITLE
feat(embeddings): v2.5.5 — dim-flex generalization across all 6 entity types (3 coupled bug fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,170 @@
 All notable changes to RKA are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) + semver.
 
+## [2.5.5] — 2026-05-20 (patch release; embedding-dim-flex generalization across all 6 entity types — coupled 3-bug fix)
+
+**Mission**: `mis_01KS1RFNM2T1HTB077G507T1FR`
+**Motivating decision**: `dec_01KS1RAAN8RNAAEYP2TEQPPAA9` (Option A bundled fix)
+**Surfaced by**: PI on a peer machine 2026-05-19; another Brain session worked
+around the bug via direct DB operations + a manually-triggered PUT.
+**Sequencing note**: `mis_01KS0QEW21N2NG4EJTKJ3JTWTE` (Eval-v2 corpus refresh)
+**slides from v2.5.5 to v2.5.6** because corpus refresh needs corrected
+embeddings to compute against. v2.5.5 takes the corpus refresh's
+originally-planned tag; corpus refresh ships next.
+
+### Honest framing — three coupled bugs
+
+After PI switched the embedding backend from `nomic-embed-text-v1.5` (768-dim)
+to `text-embedding-qwen3-embedding-8b` (4096-dim) on 2026-05-15, semantic
+search across journals — which dominates user retrieval — kept returning
+vectors from the retired nomic model, permanently. Triage surfaced three
+defects that compound:
+
+- **Bug 1** — Only `vec_claims` had dim-flex reshape (migration 022 + v2.4
+  `rka/services/embedding_reshape.py`). The other five vec_* tables
+  (`vec_journal`, `vec_decisions`, `vec_literature`, `vec_missions`,
+  `vec_artifacts`) were defined with hardcoded `float[768]` in
+  `rka/db/schema_phase2.sql` and migration 002; no reshape mechanism
+  existed. PUT `/api/config/embedding` propagated the new dim to
+  `vec_claims` only.
+- **Bug 2** — `rka/infra/embeddings.py:needs_reembed` compared only
+  `content_hash`; never `model_name` or `dimensions`. So a model swap left
+  every unchanged entity flagged "not stale" even though its stored vector
+  belonged to a retired backend. The metadata row's `model_name` field said
+  "nomic" forever.
+- **Bug 3** — `rka/services/embedding_backfill.py:BackfillService.run_backfill`
+  iterated `claims WHERE embedding_pending = 1` only; never touched
+  journal/decisions/literature/missions/artifacts. Even if Bug 1 were
+  patched, those five tables would stay empty after reshape.
+
+### Fixed (this release)
+
+- **`reshape_vec_table` generalization** (`rka/services/embedding_reshape.py`).
+  Added `current_vec_table_dim(db, table_name)`, `reshape_vec_table(db,
+  table_name, *, dim)`, and `reshape_all_vec_tables_if_needed(db, *, dim)`.
+  A `_TABLE_TO_ENTITY` map covers all six vec_* tables. The v2.4 surface
+  (`reshape_vec_claims`, `reshape_vec_claims_if_needed`,
+  `current_vec_claims_dim`) is preserved as thin wrappers; existing 11-test
+  reshape suite stays green.
+- **Per-entity-type pending signal**. `vec_claims` keeps the v2.4
+  `claims.embedding_pending` flag (the BackfillService cursor + existing
+  tests depend on it). The other five entity types use
+  `embedding_metadata`-absence: reshape DELETEs metadata rows for the
+  affected `entity_type`, and v2.5.5's 3-tuple `needs_reembed` (below)
+  returns True until backfill repopulates them.
+- **Startup hook + PUT handler now reshape every vec_* table**
+  (`rka/api/app.py`, `rka/api/routes/config.py`). The PUT handler's 202
+  response body now carries a `reshape` key with per-table outcome
+  alongside `job_id` + `status_url`.
+- **3-tuple `needs_reembed`** (`rka/infra/embeddings.py`). The query widens
+  to `SELECT content_hash, model_name, dimensions`. Returns True on ANY
+  mismatch OR metadata absence. Defensive `dim == 0` early-return forces
+  re-embed when the backend hasn't reported a dim yet.
+- **`BackfillService` iterates all six entity types**
+  (`rka/services/embedding_backfill.py`). New signature parameter
+  `entity_types: Sequence[str] | None = None` defaults to the full set
+  (claim, journal, decision, literature, mission, artifact). Per-entity-type
+  cursor + write loop is parameterized by `_ENTITY_BACKFILL_CONFIGS` keyed on
+  entity_type. Content composition matches the v2.4 entity write-path
+  callers (e.g. journal = `content + " " + summary`; decision = `question +
+  " " + rationale`; literature = `title + " " + abstract`; mission =
+  `objective + " " + context`; artifact = `build_artifact_text(filename,
+  filetype, mime, metadata)`). Per-type embed-batch failures are isolated:
+  one type's failure does not stop the others; the final state is "failed"
+  iff any type errored. v2.4 single-type-failure error format preserved
+  when only one type fails.
+- **Atomic metadata write in backfill loop**. The v2.4 backfill wrote only
+  to `vec_claims` and skipped the metadata update; v2.5.5 always writes the
+  matching `embedding_metadata` row with the active `content_hash +
+  model_name + dimensions` so the 3-tuple gate's invariant holds.
+- **Migration 024** (`024_dim_flex_all_vec_tables.sql`). Documentation-only
+  no-op SQL file mirroring the migration 022 pattern; reshape itself is a
+  runtime operation because the dim is config-driven (lives in
+  `/data/embedding_config.json`).
+- **Version-string drift fix**: `rka/__init__.py:__version__` had drifted
+  to "2.5.3" while `pyproject.toml` was at "2.5.4". Both bumped to "2.5.5"
+  together in this release.
+
+### Tests (+21 across 3 files; suite 732 → 753 passing)
+
+- `tests/test_services/test_embedding_reshape.py` (+9): 5 parametrized
+  cases for each new vec_* table; metadata-DELETE behavior on non-claims
+  reshape; claim metadata survives (uses flag); `reshape_all_vec_tables_if_needed`
+  iterates every table; idempotent second-call no-op; rejects unknown
+  table name.
+- `tests/test_services/test_embedding_backfill.py` (+6): default
+  iterates all six types; restricts to named entity_types; per-entity-type
+  failure isolation; rejects unknown entity_type; end-to-end reshape →
+  invalidate → backfill repopulates; idle (nothing pending) completes
+  immediately.
+- `tests/test_infra/test_embeddings_needs_reembed.py` (NEW, +6): full
+  3-tuple match → False; content_hash mismatch → True; model_name
+  mismatch → True (the Bug-2 trigger); dimensions mismatch → True;
+  metadata absent → True; defensive `dim == 0` → True.
+
+Existing v2.4 backfill tests preserved by passing `entity_types=("claim",)`
+explicitly so they continue to test the claims-specific path under the
+new all-types default.
+
+### Live verification (2026-05-20 against the production container)
+
+Before `docker compose up -d --build`:
+```
+vec_claims:     dim=4096  (already reshaped via prior manual op)
+vec_journal:    dim=768   ← Bug 1
+vec_decisions:  dim=768   ← Bug 1
+vec_literature: dim=768   ← Bug 1
+vec_missions:   dim=768   ← Bug 1
+vec_artifacts:  dim=768   ← Bug 1
+embedding_metadata: claim/decision/journal/mission all at dim=768
+                    model=nomic-ai/nomic-embed-text-v1.5 (Bug 2)
+```
+
+After rebuild + restart (T2 startup hook fires automatically):
+```
+vec_claims:     dim=4096
+vec_journal:    dim=4096  ✓
+vec_decisions:  dim=4096  ✓
+vec_literature: dim=4096  ✓
+vec_missions:   dim=4096  ✓
+vec_artifacts:  dim=4096  ✓
+embedding_metadata: journal/decision/mission rows DELETEd by startup hook
+                    (entries will be re-embedded via 3-tuple
+                    needs_reembed on next embed_and_store call OR via a
+                    PUT-triggered backfill)
+```
+
+Backfill kick-off requires an explicit PUT (background task fires only
+on PUT, not on startup). The operational note below describes the path.
+
+### Operational user note
+
+Users who switched the embedding backend before upgrading to v2.5.5 and
+whose `embedding_metadata` rows still carry an outdated `model_name` or
+`dimensions` tuple should re-PUT `/api/config/embedding` after upgrade to
+trigger the full all-entity reshape + backfill. The PUT body must have a
+different `(backend, model, dim)` signature than the current saved config
+for the handler to fire backfill — if your goal is just to refresh stale
+metadata under the same backend, the alternative is to let the 3-tuple
+`needs_reembed` gate refresh each entity individually as it is touched
+(read/write paths trigger embed-on-stale).
+
+The startup hook brings vec_* table dims into parity automatically on
+container restart without invoking the backfill loop.
+
+### Surfaced-by-empirical-state evidence
+
+PI's peer machine ran a manual reshape via direct DB SQL + PUT trigger as
+a workaround; this established the bug class, the empirical state we
+verify against, and the operational path for users on existing
+deployments.
+
+### Brain post-mortem reference
+
+- `jrn_01KS1S2QMVQPMXS8KHK1JS6HS1`: Executor Backbrief filed pre-implementation
+  with full empirical baseline of the 6 vec_* tables + embedding_metadata
+  aggregate + per-entity content-composition audit.
+
 ## [2.5.4] — 2026-05-19 (patch release; D4 bundle-narrowing + attribution metric — Phase-3 PARTIAL close)
 
 **Mission**: `mis_01KS0C8BKTHCA8GB38BGDR1PTQ`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rka"
-version = "2.5.4"
+version = "2.5.5"
 description = "Research Knowledge Agent — MCP server + REST API for AI-assisted research orchestration"
 requires-python = ">=3.11"
 dependencies = [

--- a/rka/__init__.py
+++ b/rka/__init__.py
@@ -1,3 +1,3 @@
 """Research Knowledge Agent — MCP server + REST API for AI-assisted research."""
 
-__version__ = "2.5.3"
+__version__ = "2.5.5"

--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -134,7 +134,7 @@ async def lifespan(app: FastAPI):
             EmbeddingConfigError,
             EmbeddingConfigService,
         )
-        from rka.services.embedding_reshape import reshape_vec_claims_if_needed
+        from rka.services.embedding_reshape import reshape_all_vec_tables_if_needed
 
         cfg_svc = EmbeddingConfigService(config_dir=config.data_dir)
         try:
@@ -165,15 +165,23 @@ async def lifespan(app: FastAPI):
                 embeddings.dim,
             )
 
-            # Mission D T4 startup-hook: reshape vec_claims if its dim no
-            # longer matches the configured embedding dim.
+            # v2.5.5 startup-hook (mis_01KS1RFNM2T1HTB077G507T1FR): reshape
+            # every vec_* table whose dim no longer matches the configured
+            # embedding dim. The v2.4 path covered vec_claims only; the
+            # other five hardcoded float[768] tables were stuck at the old
+            # dim and their embedding_metadata kept the stale model_name.
             target_dim = int(embedding_cfg.config.get("dim") or embeddings.dim or 768)
-            did_reshape, pending = await reshape_vec_claims_if_needed(db, dim=target_dim)
-            if did_reshape:
+            reshape_results = await reshape_all_vec_tables_if_needed(
+                db, dim=target_dim
+            )
+            reshaped = [
+                (t, p) for t, (did, p) in reshape_results.items() if did
+            ]
+            if reshaped:
                 logger.info(
-                    "vec_claims reshaped at startup (dim=%d); %d claims now pending re-embed",
+                    "vec tables reshaped at startup (dim=%d): %s",
                     target_dim,
-                    pending,
+                    ", ".join(f"{t} pending={p}" for t, p in reshaped),
                 )
         except EmbeddingConfigError as exc:
             # Corrupt config OR unwritable data_dir: fall back to legacy

--- a/rka/api/routes/config.py
+++ b/rka/api/routes/config.py
@@ -39,6 +39,7 @@ from rka.services.embedding_config import (
     EmbeddingConfig,
     EmbeddingConfigService,
 )
+from rka.services.embedding_reshape import reshape_all_vec_tables_if_needed
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,19 @@ async def put_embedding_config(
     # Swap the app-level embeddings handle so subsequent requests use it.
     request.app.state.embeddings = new_embeddings
 
+    # v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR): reshape EVERY vec_* table
+    # before backfill starts. The v2.4 path reshaped vec_claims only;
+    # this version covers vec_journal/decisions/literature/missions/
+    # artifacts too, plus invalidates their stale metadata so backfill
+    # picks them up.
+    target_dim = int(
+        (saved.config or {}).get("dim")
+        or test_result.detected_dim
+        or new_embeddings.dim
+        or 768
+    )
+    reshape_results = await reshape_all_vec_tables_if_needed(db, dim=target_dim)
+
     status_obj = register_job()
     backfill_svc = BackfillService(db=db, embeddings=new_embeddings)
     background_tasks.add_task(_run_backfill_safely, backfill_svc, status_obj)
@@ -163,6 +177,10 @@ async def put_embedding_config(
             **_redact(saved),
             "job_id": status_obj.job_id,
             "status_url": f"/api/config/embedding/backfill/status?job_id={status_obj.job_id}",
+            "reshape": {
+                table: {"did_reshape": did, "pending": pending}
+                for table, (did, pending) in reshape_results.items()
+            },
         },
     )
 

--- a/rka/db/migrations/024_dim_flex_all_vec_tables.sql
+++ b/rka/db/migrations/024_dim_flex_all_vec_tables.sql
@@ -1,0 +1,40 @@
+-- Mission v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR): generalize the
+-- vec_claims dim-flex pattern from migration 022 to ALL six vec_*
+-- tables (vec_journal, vec_decisions, vec_literature, vec_missions,
+-- vec_artifacts in addition to vec_claims). Documents the runtime
+-- generalization performed by rka/services/embedding_reshape.py; this
+-- file is intentionally a no-op (no DDL) so application of migration
+-- 024 is idempotent and safe to re-run.
+--
+-- Why no DDL here:
+--   - Reshape requires reading /data/embedding_config.json to discover
+--     the configured dim, which pure SQL cannot do.
+--   - Pending-signal differs per entity type:
+--       * vec_claims: keeps the v2.4 `claims.embedding_pending` column
+--         (added in migration 022) — the BackfillService cursor reads
+--         it directly.
+--       * vec_journal, vec_decisions, vec_literature, vec_missions,
+--         vec_artifacts: use `embedding_metadata` absence as the
+--         pending signal. Reshape DELETEs metadata rows for the
+--         affected entity_type; the v2.5.5 3-tuple `needs_reembed`
+--         (model_name + dimensions + content_hash) returns True until
+--         backfill repopulates them.
+--   - No new columns added to journal / decisions / literature /
+--     missions / artifacts: smaller migration footprint, no rewrite of
+--     each entity table's storage.
+--
+-- After this migration is recorded, the runtime hook in
+-- `rka/api/app.py` startup calls `reshape_all_vec_tables_if_needed`
+-- which inspects each vec_* table's current dim and drops+recreates
+-- any whose dim no longer matches the configured embedding dim. The
+-- PUT /api/config/embedding handler does the same prior to kicking
+-- off the BackfillService background task.
+--
+-- Operational note for users upgrading across this migration:
+--   If your embedding_metadata rows still show an outdated model_name
+--   or dimensions tuple (e.g. you ran a manual reshape earlier and
+--   metadata was never invalidated), re-PUT /api/config/embedding
+--   with the same body to trigger the all-tables reshape + backfill.
+
+-- Intentionally no DDL.
+SELECT 1 WHERE 0;

--- a/rka/infra/embeddings.py
+++ b/rka/infra/embeddings.py
@@ -109,18 +109,37 @@ class EmbeddingService:
         text: str,
         project_id: str = "proj_default",
     ) -> bool:
-        """Check if stored embedding is stale (content changed)."""
+        """Check if the stored embedding is stale.
+
+        v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR Bug 2): we now check the
+        full identity tuple (content_hash, model_name, dimensions). The
+        v2.4 implementation only compared content_hash, so a backend
+        swap (e.g. nomic-768 → qwen3-4096) left every unchanged entity
+        flagged "not stale" even though its stored vector belonged to a
+        retired model + dim.
+        """
         if self.db is None:
             return True
+        # Defensive: backend hasn't reported a dim yet (un-initialized
+        # / un-probed). Treat as needs re-embed so the upcoming
+        # store_embedding picks a fresh dim from the backend handshake.
+        if self._backend.dim == 0:
+            return True
         meta = await self.db.fetchone(
-            """SELECT content_hash
+            """SELECT content_hash, model_name, dimensions
                FROM embedding_metadata
                WHERE project_id = ? AND entity_type = ? AND entity_id = ?""",
             [project_id, entity_type, entity_id],
         )
         if meta is None:
             return True
-        return meta["content_hash"] != self.content_hash(text)
+        if meta["content_hash"] != self.content_hash(text):
+            return True
+        if meta["model_name"] != self.model_name:
+            return True
+        if int(meta["dimensions"]) != int(self._backend.dim):
+            return True
+        return False
 
     async def store_embedding(
         self,

--- a/rka/services/embedding_backfill.py
+++ b/rka/services/embedding_backfill.py
@@ -1,16 +1,26 @@
 """Embedding-backfill orchestration.
 
-Phase 1 in v2.4.0: **synchronous foreground** job. "Synchronous" per the
-Brain T2-gate clarification means: "no Redis/Celery — runs in the API
-container process." It does NOT mean PUT blocks for 7-14 minutes — see
-`rka/api/routes/config.py:PUT /api/config/embedding`, which kicks off
-the backfill via FastAPI BackgroundTask and returns 202 + {job_id,
-status_url}.
+v2.4 (Mission D T2-gate): synchronous foreground job ("synchronous" =
+no Redis/Celery; runs in the API container's process). The PUT
+/api/config/embedding handler returns 202 + {job_id, status_url}
+immediately and the actual loop runs via FastAPI BackgroundTask.
 
-This module owns the **job-status registry** that T3's REST PUT/status
-endpoints use. T5 fills in `BackfillService.run_backfill`.
+v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR Bug 3): the loop is generalized
+over all six entity types backed by a vec_* table — claim, journal,
+decision, literature, mission, artifact. The v2.4 implementation hit
+only `claims WHERE embedding_pending=1`, leaving the other five vec_*
+tables empty after a config change because nothing else ever ran a
+backfill cursor against them.
 
-Status snapshot shape (T3 status endpoint returns this verbatim):
+Pending-signal per entity type:
+  - `claim` uses the v2.4 `claims.embedding_pending` flag (the cursor
+    filters on it; we clear it post-embed).
+  - the other five use `embedding_metadata` absence — `reshape_vec_table`
+    (T1) DELETEs metadata rows on dim change, and the cursor here picks
+    up entities without a metadata row.
+
+Status snapshot shape (unchanged from v2.4 — T3 status endpoint returns
+it verbatim):
 
     {
       "job_id":          str,
@@ -26,11 +36,12 @@ Status snapshot shape (T3 status endpoint returns this verbatim):
 from __future__ import annotations
 
 import logging
+import struct
 import time
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Literal
+from typing import Any, Awaitable, Callable, Iterable, Literal, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +58,8 @@ class JobStatus:
     """Per-run snapshot read by the GET status endpoint.
 
     `started_at` is set when the job is registered; `elapsed_seconds` is
-    computed from a monotonic clock so it remains correct across daylight-
-    savings + system-clock adjustments.
+    computed from a monotonic clock so it remains correct across
+    daylight-savings + system-clock adjustments.
     """
 
     job_id: str
@@ -62,24 +73,22 @@ class JobStatus:
     _started_perf: float = 0.0
 
     def snapshot(self) -> dict[str, Any]:
-        """Public-facing dict (excludes the underscored bookkeeping field)."""
         out = asdict(self)
         out.pop("_started_perf", None)
-        # Refresh elapsed_seconds at snapshot time so polling reflects reality.
         if self._started_perf > 0:
             out["elapsed_seconds"] = round(time.monotonic() - self._started_perf, 3)
         return out
 
 
 # ---------------------------------------------------------------------------
-# Job registry (module-level; one backfill at a time in v2.4.0)
+# Job registry (module-level; one backfill at a time)
 # ---------------------------------------------------------------------------
+
 
 _REGISTRY: dict[str, JobStatus] = {}
 
 
 def register_job() -> JobStatus:
-    """Create a new pending-state job; return its snapshot to the caller."""
     job_id = f"bf_{uuid.uuid4().hex[:12]}"
     status = JobStatus(
         job_id=job_id,
@@ -97,37 +106,225 @@ def get_status(job_id: str) -> JobStatus | None:
 
 
 def latest_status() -> JobStatus | None:
-    """Most recent job by insertion order (Python dict preserves it)."""
     if not _REGISTRY:
         return None
     return next(reversed(_REGISTRY.values()))
 
 
 def clear_registry() -> None:
-    """Test-only: wipe the in-memory registry between cases."""
     _REGISTRY.clear()
 
 
 # ---------------------------------------------------------------------------
-# BackfillService skeleton (T5 fills the loop)
+# Per-entity-type backfill configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _EntityBackfillConfig:
+    """Parameterises the backfill cursor + write path for one entity type.
+
+    `pending_cursor_sql` MUST take two `?` placeholders for `last_id`
+    and `LIMIT`; `pending_count_sql` takes no placeholders. The cursor
+    must `SELECT id, project_id, ...content_columns...` so the loop
+    can compose text + write metadata under the right project.
+    """
+
+    entity_type: str
+    source_table: str
+    vec_table: str
+    pending_cursor_sql: str
+    pending_count_sql: str
+    compose_text: Callable[[Mapping[str, Any]], str]
+    post_embed_sql: str | None = None
+    id_column: str = "id"
+
+
+def _join_parts(*parts: Any) -> str:
+    """Join non-empty stripped string parts with single spaces."""
+    return " ".join(
+        str(p).strip() for p in parts if p and str(p).strip()
+    ).strip()
+
+
+def _build_artifact_text_from_row(r: Mapping[str, Any]) -> str:
+    # Imported lazily to avoid an import cycle with rka.services.artifacts.
+    from rka.services.artifacts import build_artifact_text
+
+    return build_artifact_text(
+        filename=r.get("filename") or "",
+        filetype=r.get("filetype"),
+        mime=r.get("mime"),
+        metadata=r.get("metadata"),
+    )
+
+
+# Cursor templates: each non-claims template uses an anti-join against
+# embedding_metadata so we only pull entities that lack a matching row.
+# Combined with T1's DELETE-on-reshape and T3's 3-tuple needs_reembed
+# gate, this is the v2.5.5 pending signal for the five new types.
+
+
+_ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
+    "claim": _EntityBackfillConfig(
+        entity_type="claim",
+        source_table="claims",
+        vec_table="vec_claims",
+        compose_text=lambda r: (r.get("content") or "").strip(),
+        pending_cursor_sql=(
+            "SELECT id, content, project_id FROM claims "
+            "WHERE embedding_pending = 1 AND id > ? "
+            "ORDER BY id LIMIT ?"
+        ),
+        pending_count_sql=(
+            "SELECT COUNT(*) AS n FROM claims WHERE embedding_pending = 1"
+        ),
+        post_embed_sql="UPDATE claims SET embedding_pending = 0 WHERE id = ?",
+    ),
+    "journal": _EntityBackfillConfig(
+        entity_type="journal",
+        source_table="journal",
+        vec_table="vec_journal",
+        compose_text=lambda r: _join_parts(r.get("content"), r.get("summary")),
+        pending_cursor_sql=(
+            "SELECT j.id, j.content, j.summary, j.project_id FROM journal j "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'journal' AND m.entity_id = j.id"
+            ") AND j.id > ? "
+            "ORDER BY j.id LIMIT ?"
+        ),
+        pending_count_sql=(
+            "SELECT COUNT(*) AS n FROM journal j "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'journal' AND m.entity_id = j.id"
+            ")"
+        ),
+    ),
+    "decision": _EntityBackfillConfig(
+        entity_type="decision",
+        source_table="decisions",
+        vec_table="vec_decisions",
+        compose_text=lambda r: _join_parts(r.get("question"), r.get("rationale")),
+        pending_cursor_sql=(
+            "SELECT d.id, d.question, d.rationale, d.project_id FROM decisions d "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'decision' AND m.entity_id = d.id"
+            ") AND d.id > ? "
+            "ORDER BY d.id LIMIT ?"
+        ),
+        pending_count_sql=(
+            "SELECT COUNT(*) AS n FROM decisions d "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'decision' AND m.entity_id = d.id"
+            ")"
+        ),
+    ),
+    "literature": _EntityBackfillConfig(
+        entity_type="literature",
+        source_table="literature",
+        vec_table="vec_literature",
+        compose_text=lambda r: _join_parts(r.get("title"), r.get("abstract")),
+        pending_cursor_sql=(
+            "SELECT l.id, l.title, l.abstract, l.project_id FROM literature l "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'literature' AND m.entity_id = l.id"
+            ") AND l.id > ? "
+            "ORDER BY l.id LIMIT ?"
+        ),
+        pending_count_sql=(
+            "SELECT COUNT(*) AS n FROM literature l "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'literature' AND m.entity_id = l.id"
+            ")"
+        ),
+    ),
+    "mission": _EntityBackfillConfig(
+        entity_type="mission",
+        source_table="missions",
+        vec_table="vec_missions",
+        compose_text=lambda r: _join_parts(r.get("objective"), r.get("context")),
+        pending_cursor_sql=(
+            "SELECT mi.id, mi.objective, mi.context, mi.project_id "
+            "FROM missions mi "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'mission' AND m.entity_id = mi.id"
+            ") AND mi.id > ? "
+            "ORDER BY mi.id LIMIT ?"
+        ),
+        pending_count_sql=(
+            "SELECT COUNT(*) AS n FROM missions mi "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'mission' AND m.entity_id = mi.id"
+            ")"
+        ),
+    ),
+    "artifact": _EntityBackfillConfig(
+        entity_type="artifact",
+        source_table="artifacts",
+        vec_table="vec_artifacts",
+        compose_text=_build_artifact_text_from_row,
+        pending_cursor_sql=(
+            "SELECT a.id, a.filename, a.filetype, a.mime, a.metadata, a.project_id "
+            "FROM artifacts a "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'artifact' AND m.entity_id = a.id"
+            ") AND a.id > ? "
+            "ORDER BY a.id LIMIT ?"
+        ),
+        pending_count_sql=(
+            "SELECT COUNT(*) AS n FROM artifacts a "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'artifact' AND m.entity_id = a.id"
+            ")"
+        ),
+    ),
+}
+
+
+_DEFAULT_ENTITY_TYPES: tuple[str, ...] = tuple(_ENTITY_BACKFILL_CONFIGS.keys())
+
+
+# ---------------------------------------------------------------------------
+# BackfillService
 # ---------------------------------------------------------------------------
 
 
 ProgressCallback = Callable[[JobStatus], Awaitable[None] | None]
 
 
-class BackfillService:
-    """Iterates `claims WHERE embedding_pending=1` and re-embeds them.
+class _BackfillBatchError(Exception):
+    """Per-type embed_batch failure; carries the formatted detail."""
 
-      - `run_backfill(progress_callback=None)` is async.
-      - Default batch_size = 8 (v2.4.1: lowered from 32 so local 8B-class
-        embedding servers don't time out on a single batch).
-      - Per-claim failures get logged + the claim left with
-        embedding_pending=1 so a later run retries.
-      - Batch-level failures (embed_batch raised) abort the run with
-        status.state = "failed"; remaining claims keep their flag for
-        the next attempt.
-      - On clean exit, status.state = "complete".
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
+class BackfillService:
+    """Iterates one or more entity types and (re-)embeds them.
+
+      - `run_backfill(status, progress_callback=None, entity_types=None)`
+        is async. With `entity_types=None` it processes all six known
+        types in stable order (claim → journal → decision → literature
+        → mission → artifact).
+      - Default `batch_size = 8` (v2.4.1: lowered from 32 so local
+        8B-class embedding backends don't time out on a single batch).
+      - Per-row write failures get logged + the row is left "pending"
+        for a later run.
+      - Per-type embed_batch failures are recorded as the type's error
+        but the loop continues to the next type (v2.5.5: isolated
+        failure). The final state is "failed" if any type errored,
+        "complete" otherwise.
     """
 
     def __init__(self, *, db: Any, embeddings: Any, batch_size: int = 8) -> None:
@@ -139,25 +336,38 @@ class BackfillService:
         self,
         status: JobStatus,
         progress_callback: ProgressCallback | None = None,
+        entity_types: Sequence[str] | None = None,
     ) -> JobStatus:
-        """Embed every pending claim in batches.
+        """Embed every pending entity, batch by batch.
 
-        Cursor pattern: claims are iterated in `id`-ascending order with a
-        `id > last_id` filter so persistent per-claim failures (which keep
-        `embedding_pending=1`) don't trigger an infinite loop on re-fetch.
+        Cursor pattern: rows are iterated in `id`-ascending order with an
+        `id > last_id` filter so persistent per-row failures don't
+        trigger an infinite re-fetch loop.
 
-        Wall-clock target per mission spec: ~0.5–1s per claim with
-        LM Studio qwen3-8b; 827 claims ≈ 7–14 min.
+        Wall-clock target per the v2.4 mission spec: ~0.5–1s per entity
+        with LM Studio qwen3-8b; the v2.5.5 surface includes the other
+        five entity types so the upper-bound batch is somewhat larger.
         """
-        import struct
-
         status.state = "running"
 
-        # Step 1: count pending claims (status.total snapshot for the polling UI).
-        row = await self._db.fetchone(
-            "SELECT COUNT(*) AS n FROM claims WHERE embedding_pending = 1"
-        )
-        status.total = int((row or {}).get("n") or 0)
+        if entity_types is None:
+            types = _DEFAULT_ENTITY_TYPES
+        else:
+            types = tuple(entity_types)
+            for et in types:
+                if et not in _ENTITY_BACKFILL_CONFIGS:
+                    raise ValueError(
+                        f"run_backfill: unknown entity_type {et!r}; "
+                        f"expected one of {_DEFAULT_ENTITY_TYPES}"
+                    )
+
+        # Step 1: snapshot per-type pending counts; total is the sum.
+        per_type_totals: dict[str, int] = {}
+        for et in types:
+            cfg = _ENTITY_BACKFILL_CONFIGS[et]
+            row = await self._db.fetchone(cfg.pending_count_sql)
+            per_type_totals[et] = int((row or {}).get("n") or 0)
+        status.total = sum(per_type_totals.values())
         await _emit_progress(progress_callback, status)
 
         if status.total == 0:
@@ -165,77 +375,144 @@ class BackfillService:
             await _emit_progress(progress_callback, status)
             return status
 
-        # Step 2: cursor-paginate through pending claims.
-        last_id = ""
-        vec_available = bool(getattr(self._db, "vec_available", False))
+        # Step 2: iterate entity types, isolating per-type batch failures.
+        type_errors: list[str] = []
+        for et in types:
+            if per_type_totals[et] == 0:
+                continue
+            cfg = _ENTITY_BACKFILL_CONFIGS[et]
+            try:
+                await self._backfill_one_type(cfg, status, progress_callback)
+            except _BackfillBatchError as exc:
+                type_errors.append(f"{et}: {exc.detail}")
+                logger.warning(
+                    "backfill %s batch failed: %s", et, exc.detail
+                )
 
+        # Step 3: terminal state.
+        if type_errors:
+            status.state = "failed"
+            if len(type_errors) == 1:
+                # v2.4 single-type error format: "batch embed failed (...)".
+                status.error = f"batch embed failed: {type_errors[0]}"
+            else:
+                status.error = (
+                    "batch embed failed across multiple types: "
+                    + "; ".join(type_errors)
+                )
+        else:
+            status.state = "complete"
+
+        await _emit_progress(progress_callback, status)
+        return status
+
+    async def _backfill_one_type(
+        self,
+        cfg: _EntityBackfillConfig,
+        status: JobStatus,
+        progress_callback: ProgressCallback | None,
+    ) -> None:
+        """Cursor-paginate through one entity type's pending rows."""
+        # Lazily import to avoid a hot-path import on every method call.
+        from rka.infra.embeddings import EmbeddingService as _ES
+
+        vec_available = bool(getattr(self._db, "vec_available", False))
+        model_name: str = getattr(self._embeddings, "model_name", "unknown")
+        embed_dim: int = int(getattr(self._embeddings, "dim", 0) or 0)
+
+        last_id = ""
         while True:
             rows = await self._db.fetchall(
-                "SELECT id, content FROM claims "
-                "WHERE embedding_pending = 1 AND id > ? "
-                "ORDER BY id LIMIT ?",
-                [last_id, self._batch_size],
+                cfg.pending_cursor_sql, [last_id, self._batch_size]
             )
             if not rows:
                 break
 
-            ids = [r["id"] for r in rows]
-            texts = [r["content"] for r in rows]
-            last_id = rows[-1]["id"]
-
-            # Step 3: embed the batch. Batch-level failure → mark failed + exit.
-            try:
-                vectors = await self._embeddings.embed_batch(texts, is_query=False)
-            except Exception as exc:  # noqa: BLE001
-                status.state = "failed"
-                status.error = (
-                    f"batch embed failed (cursor at {last_id}): "
-                    f"{type(exc).__name__}: {exc!s}"
-                )
-                logger.exception("backfill batch embed failed at cursor %s", last_id)
-                await _emit_progress(progress_callback, status)
-                return status
-
-            # Step 4: write vec_claims rows + clear the per-claim flag.
-            for claim_id, vec in zip(ids, vectors):
+            # Compose text per row; drop rows whose composed text is empty.
+            work: list[tuple[Mapping[str, Any], str]] = []
+            for r in rows:
                 try:
+                    text = cfg.compose_text(r)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "%s %s compose_text failed (skipping): %s",
+                        cfg.entity_type, r.get(cfg.id_column), exc,
+                    )
+                    continue
+                if text:
+                    work.append((r, text))
+
+            last_id = rows[-1][cfg.id_column]
+
+            if not work:
+                # Whole batch was empty-text; advance cursor and continue.
+                continue
+
+            # Batch-embed; a failure aborts THIS type only (the outer
+            # loop catches and continues to the next type).
+            try:
+                vectors = await self._embeddings.embed_batch(
+                    [t for _, t in work], is_query=False
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise _BackfillBatchError(
+                    f"(cursor at {last_id}): "
+                    f"{type(exc).__name__}: {exc!s}"
+                ) from exc
+
+            # Per-row: write vec_* + embedding_metadata + post_embed.
+            for (row, text), vec in zip(work, vectors):
+                entity_id = row[cfg.id_column]
+                try:
+                    project_id = row.get("project_id") or "proj_default"
                     if vec_available:
                         vec_blob = struct.pack(f"{len(vec)}f", *vec)
                         await self._db.execute(
-                            "INSERT OR REPLACE INTO vec_claims (id, embedding) VALUES (?, ?)",
-                            [claim_id, vec_blob],
+                            f"INSERT OR REPLACE INTO {cfg.vec_table} "
+                            "(id, embedding) VALUES (?, ?)",
+                            [entity_id, vec_blob],
                         )
+                    # Always update metadata — the v2.5.5 3-tuple
+                    # needs_reembed gate reads it. Skipping the metadata
+                    # write was the v2.4 oversight that left the stale
+                    # nomic-768 model_name in place across config switches.
                     await self._db.execute(
-                        "UPDATE claims SET embedding_pending = 0 WHERE id = ?",
-                        [claim_id],
+                        """INSERT OR REPLACE INTO embedding_metadata
+                           (project_id, entity_type, entity_id,
+                            content_hash, model_name, dimensions)
+                           VALUES (?, ?, ?, ?, ?, ?)""",
+                        [
+                            project_id,
+                            cfg.entity_type,
+                            entity_id,
+                            _ES.content_hash(text),
+                            model_name,
+                            embed_dim,
+                        ],
                     )
+                    if cfg.post_embed_sql:
+                        await self._db.execute(cfg.post_embed_sql, [entity_id])
                     status.processed += 1
                 except Exception as exc:  # noqa: BLE001
-                    # Per-claim failure: leave the flag set, log, continue.
+                    # Per-row failure: leave any pending signal intact,
+                    # log, continue.
                     logger.warning(
-                        "claim %s vec-write failed (flag stays set for retry): %s",
-                        claim_id,
-                        exc,
+                        "%s %s vec-write failed (leaving pending for retry): %s",
+                        cfg.entity_type, entity_id, exc,
                     )
 
             await self._db.commit()
             await _emit_progress(progress_callback, status)
 
-        status.state = "complete"
-        await _emit_progress(progress_callback, status)
-        return status
-
 
 async def _emit_progress(
     cb: ProgressCallback | None, status: JobStatus
 ) -> None:
-    """Fire the optional progress callback, awaiting if it returns a coroutine."""
     if cb is None:
         return
     await _maybe_await(cb(status))
 
 
 async def _maybe_await(value: Any) -> None:
-    """If `value` is awaitable, await it; otherwise no-op."""
     if hasattr(value, "__await__"):
         await value

--- a/rka/services/embedding_reshape.py
+++ b/rka/services/embedding_reshape.py
@@ -1,20 +1,37 @@
-"""Drop + recreate the vec_claims virtual table at a config-driven dim.
+"""Drop + recreate vec_* virtual tables at a config-driven dim.
 
-Called in two places:
+v2.5.5 (`mis_01KS1RFNM2T1HTB077G507T1FR`) generalizes the v2.5.x
+claims-only pattern to all six vec_* tables — Bug 1 of the
+embedding-dim-mismatch cluster. The v2.4-era `reshape_vec_claims*` and
+`current_vec_claims_dim` symbols stay as thin wrappers so the existing
+boot + test surface remains stable.
 
-  1. **App startup**: after `Database.initialize_phase2_schema()`, we read
-     the current embedding config and reshape vec_claims if its dim no
-     longer matches. Safe to skip if sqlite-vec isn't loaded.
+Two calling sites:
 
-  2. **PUT /api/config/embedding**: when the backend/model/dim signature
-     changes (T3 route handler), we reshape then kick off backfill.
+  1. **App startup** (`rka/api/app.py`): after
+     `Database.initialize_phase2_schema()`, the configured embedding dim
+     is compared against each vec_* table; any mismatch triggers a
+     drop+recreate at the configured dim plus a pending-flag flip so
+     backfill can pick the work up on next PUT.
 
-Pre-flight backup is the responsibility of T2's
+  2. **PUT /api/config/embedding** (`rka/api/routes/config.py`): when
+     the backend/model/dim signature changes, every vec_* table is
+     reshape-checked before the BackfillService kicks off.
+
+Pending-signal per entity type:
+
+  - `claim` keeps the v2.4 `claims.embedding_pending` flag — existing
+    tests + backfill cursor depend on it.
+  - the other five (`journal | decision | literature | mission |
+    artifact`) use the `embedding_metadata`-absence signal: reshape
+    DELETEs metadata rows for that entity_type so v2.5.5's 3-tuple
+    `needs_reembed` (model_name + dimensions + content_hash) returns
+    True until backfill repopulates them.
+
+Pre-flight backup is the responsibility of
 `EmbeddingConfigService.save_config()` — it copies the prior
-`embedding_config.json` to `embedding_config.backup.json` on every save,
-so by the time PUT calls reshape, the backup already exists. For
-startup-time reshape, the backup is whatever the most recent save left
-behind.
+`embedding_config.json` to `embedding_config.backup.json` on every
+save, so by the time PUT calls reshape the backup already exists.
 """
 
 from __future__ import annotations
@@ -29,12 +46,37 @@ logger = logging.getLogger(__name__)
 _VEC_DIM_RX = re.compile(r"embedding\s+float\[(\d+)\]", re.IGNORECASE)
 
 
-async def current_vec_claims_dim(db: Any) -> int | None:
-    """Inspect sqlite_master to find vec_claims' current dim, or None if absent."""
+# vec_table → (entity_type, entity_table). entity_type is the canonical
+# `embedding_metadata.entity_type` string; entity_table is the SQL table
+# that holds the source rows.
+_TABLE_TO_ENTITY: dict[str, tuple[str, str]] = {
+    "vec_claims":    ("claim",      "claims"),
+    "vec_journal":   ("journal",    "journal"),
+    "vec_decisions": ("decision",   "decisions"),
+    "vec_literature":("literature", "literature"),
+    "vec_missions":  ("mission",    "missions"),
+    "vec_artifacts": ("artifact",   "artifacts"),
+}
+
+_VEC_TABLE_NAMES: tuple[str, ...] = tuple(_TABLE_TO_ENTITY.keys())
+
+
+# ---------------------------------------------------------------------------
+# Dim inspection
+# ---------------------------------------------------------------------------
+
+
+async def current_vec_table_dim(db: Any, table_name: str) -> int | None:
+    """Inspect sqlite_master to find `table_name`'s current dim, or None.
+
+    Returns None when sqlite-vec isn't loaded, the table doesn't exist,
+    or its CREATE SQL doesn't carry a parseable `embedding float[N]`
+    column (defensive — every vec0 table this codebase creates does).
+    """
     if not getattr(db, "vec_available", False):
         return None
     row = await db.fetchone(
-        "SELECT sql FROM sqlite_master WHERE name = 'vec_claims'"
+        "SELECT sql FROM sqlite_master WHERE name = ?", [table_name]
     )
     if not row:
         return None
@@ -45,75 +87,172 @@ async def current_vec_claims_dim(db: Any) -> int | None:
     return int(match.group(1))
 
 
-async def reshape_vec_claims(db: Any, *, dim: int) -> int:
-    """Drop + recreate `vec_claims` at `dim`; mark every claim pending.
+async def current_vec_claims_dim(db: Any) -> int | None:
+    """Backward-compat thin wrapper for the v2.4 single-table surface."""
+    return await current_vec_table_dim(db, "vec_claims")
 
-    Returns the number of claims now flagged `embedding_pending = 1`
-    (= total row count of `claims`). Safe to call when vec_claims is
-    already at `dim` — falls through to a flag-pending no-op without
-    dropping the table (avoids redundant work + lock churn).
 
-    Raises `ValueError` for non-positive dim.
+# ---------------------------------------------------------------------------
+# Reshape (generic)
+# ---------------------------------------------------------------------------
+
+
+async def reshape_vec_table(db: Any, table_name: str, *, dim: int) -> int:
+    """Drop + recreate `table_name` at `dim`; mark its entities pending.
+
+    Returns the count of entities in the corresponding entity table
+    (claims for vec_claims, journal for vec_journal, etc.) — the same
+    number that `needs_reembed` will report True for until backfill
+    repopulates them. Safe to call when the table is already at `dim`
+    (idempotent fast-path: skip drop, return current pending count).
+
+    Pending-signal logic per entity type:
+      - `vec_claims`: `UPDATE claims SET embedding_pending = 1`
+      - all others: `DELETE FROM embedding_metadata WHERE entity_type = ?`
+        — the v2.5.5 3-tuple `needs_reembed` returns True for any entity
+        without a current-config-matching metadata row.
+
+    Raises:
+      ValueError for non-positive `dim` or unknown `table_name`.
     """
     if dim <= 0:
-        raise ValueError(f"reshape_vec_claims: dim must be positive (got {dim})")
+        raise ValueError(f"reshape_vec_table: dim must be positive (got {dim})")
+    if table_name not in _TABLE_TO_ENTITY:
+        raise ValueError(
+            f"reshape_vec_table: unknown table {table_name!r}; "
+            f"expected one of {_VEC_TABLE_NAMES}"
+        )
+    entity_type, entity_table = _TABLE_TO_ENTITY[table_name]
 
     if not getattr(db, "vec_available", False):
-        # No sqlite-vec → no vec_claims to reshape. Still flag pending so
-        # the moment vec loads (e.g. via a config update or extension
+        # No sqlite-vec → no vec_* table to reshape. Still flag pending
+        # so the moment vec loads (e.g. via a config update or extension
         # install), backfill picks the work up.
-        await db.execute("UPDATE claims SET embedding_pending = 1")
+        await _mark_pending(db, table_name, entity_type, entity_table)
         await db.commit()
-        return await _count_claims(db)
+        return await _count_entity_rows(db, entity_table)
 
-    existing_dim = await current_vec_claims_dim(db)
+    existing_dim = await current_vec_table_dim(db, table_name)
     if existing_dim == dim:
-        # Idempotent fast-path: dim unchanged → just ensure pending flag.
-        # (Skipping the drop avoids invalidating any embeddings already
-        # written at the right dim — the backfill loop will skip rows
-        # that don't actually need re-embed via its own per-row check.)
         logger.info(
-            "reshape_vec_claims: vec_claims already at dim=%d; no-op", dim
+            "reshape_vec_table: %s already at dim=%d; no-op", table_name, dim
         )
-        return await _count_claims_pending(db)
+        return await _count_pending(db, table_name, entity_type, entity_table)
 
     logger.info(
-        "reshape_vec_claims: dropping vec_claims (was dim=%s) and recreating at dim=%d",
-        existing_dim,
-        dim,
+        "reshape_vec_table: dropping %s (was dim=%s) and recreating at dim=%d",
+        table_name, existing_dim, dim,
     )
-    await db.execute("DROP TABLE IF EXISTS vec_claims")
+    await db.execute(f"DROP TABLE IF EXISTS {table_name}")
     await db.execute(
-        f"CREATE VIRTUAL TABLE vec_claims USING vec0("
+        f"CREATE VIRTUAL TABLE {table_name} USING vec0("
         f"id TEXT PRIMARY KEY, embedding float[{dim}])"
     )
-    await db.execute("UPDATE claims SET embedding_pending = 1")
+    await _mark_pending(db, table_name, entity_type, entity_table)
     await db.commit()
-    return await _count_claims(db)
+    return await _count_entity_rows(db, entity_table)
 
 
-async def reshape_vec_claims_if_needed(
+async def reshape_all_vec_tables_if_needed(
     db: Any, *, dim: int
-) -> tuple[bool, int]:
-    """Convenience wrapper used by app startup.
+) -> dict[str, tuple[bool, int]]:
+    """Iterate every known vec_* table; reshape-if-needed; return per-table outcome.
 
-    Returns `(did_reshape, claims_pending)`. `did_reshape` is True only
-    when vec_claims was actually dropped and rebuilt at a new dim.
+    Output shape: `{ table_name: (did_reshape, pending_count) }`.
+    `did_reshape` is True iff the table was actually dropped and rebuilt
+    at a new dim; `pending_count` is the post-operation pending count.
     """
-    existing_dim = await current_vec_claims_dim(db)
+    out: dict[str, tuple[bool, int]] = {}
+    for tbl in _VEC_TABLE_NAMES:
+        entity_type, entity_table = _TABLE_TO_ENTITY[tbl]
+        existing_dim = await current_vec_table_dim(db, tbl)
+        if existing_dim == dim:
+            pending = await _count_pending(db, tbl, entity_type, entity_table)
+            out[tbl] = (False, pending)
+        else:
+            pending = await reshape_vec_table(db, tbl, dim=dim)
+            out[tbl] = (True, pending)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat thin wrappers (v2.4 surface)
+# ---------------------------------------------------------------------------
+
+
+async def reshape_vec_claims(db: Any, *, dim: int) -> int:
+    """v2.4-compat: reshape vec_claims and mark its claims pending."""
+    return await reshape_vec_table(db, "vec_claims", dim=dim)
+
+
+async def reshape_vec_claims_if_needed(db: Any, *, dim: int) -> tuple[bool, int]:
+    """v2.4-compat startup-hook wrapper for vec_claims only.
+
+    Returns `(did_reshape, claims_pending)`. New code should prefer
+    `reshape_all_vec_tables_if_needed` which covers every entity type.
+    """
+    existing_dim = await current_vec_table_dim(db, "vec_claims")
     if existing_dim == dim:
-        return (False, await _count_claims_pending(db))
-    pending = await reshape_vec_claims(db, dim=dim)
+        return (False, await _count_pending(db, "vec_claims", "claim", "claims"))
+    pending = await reshape_vec_table(db, "vec_claims", dim=dim)
     return (True, pending)
 
 
-async def _count_claims(db: Any) -> int:
-    row = await db.fetchone("SELECT COUNT(*) AS n FROM claims")
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _mark_pending(
+    db: Any, table_name: str, entity_type: str, entity_table: str
+) -> None:
+    """Flip the pending signal for every entity of this type.
+
+    `vec_claims` keeps the v2.4 `embedding_pending` flag pattern (the
+    BackfillService cursor reads it directly); the other five use
+    metadata-absence as the signal.
+    """
+    if table_name == "vec_claims":
+        await db.execute(f"UPDATE {entity_table} SET embedding_pending = 1")
+    else:
+        await db.execute(
+            "DELETE FROM embedding_metadata WHERE entity_type = ?",
+            [entity_type],
+        )
+
+
+async def _count_entity_rows(db: Any, entity_table: str) -> int:
+    row = await db.fetchone(f"SELECT COUNT(*) AS n FROM {entity_table}")
     return int((row or {}).get("n") or 0)
+
+
+async def _count_pending(
+    db: Any, table_name: str, entity_type: str, entity_table: str
+) -> int:
+    """Post-op pending count, using the appropriate signal per table."""
+    if table_name == "vec_claims":
+        row = await db.fetchone(
+            f"SELECT COUNT(*) AS n FROM {entity_table} WHERE embedding_pending = 1"
+        )
+    else:
+        row = await db.fetchone(
+            f"""
+            SELECT COUNT(*) AS n FROM {entity_table} e
+            WHERE NOT EXISTS (
+                SELECT 1 FROM embedding_metadata m
+                WHERE m.entity_type = ? AND m.entity_id = e.id
+            )
+            """,
+            [entity_type],
+        )
+    return int((row or {}).get("n") or 0)
+
+
+async def _count_claims(db: Any) -> int:
+    """Backward-compat: kept because external code may import it."""
+    return await _count_entity_rows(db, "claims")
 
 
 async def _count_claims_pending(db: Any) -> int:
-    row = await db.fetchone(
-        "SELECT COUNT(*) AS n FROM claims WHERE embedding_pending = 1"
-    )
-    return int((row or {}).get("n") or 0)
+    """Backward-compat: kept because external code may import it."""
+    return await _count_pending(db, "vec_claims", "claim", "claims")

--- a/tests/test_infra/test_embeddings_needs_reembed.py
+++ b/tests/test_infra/test_embeddings_needs_reembed.py
@@ -1,0 +1,171 @@
+"""needs_reembed 3-tuple gate tests (v2.5.5 / mis_01KS1RFNM2T1HTB077G507T1FR T3).
+
+Before v2.5.5, needs_reembed only compared content_hash, so a backend
+swap (e.g. nomic-embed-text-v1.5 @ 768 → qwen3-embedding-8b @ 4096)
+silently left every unchanged entity flagged "not stale" — its stored
+vector belonged to a retired model + dim. These tests lock down the
+3-tuple gate (content_hash, model_name, dimensions) plus the defensive
+behavior when the backend hasn't reported a dim yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from rka.infra.database import Database
+from rka.infra.embeddings import EmbeddingService
+
+
+class _StubBackend:
+    """Minimal EmbeddingBackend stub configurable per-test."""
+
+    def __init__(self, *, model_name: str, dim: int) -> None:
+        self.model_name = model_name
+        self.dim = dim
+
+    async def embed(self, text: str, is_query: bool = False) -> list[float]:
+        return [0.0] * self.dim
+
+    async def embed_batch(
+        self, texts: list[str], is_query: bool = False
+    ) -> list[list[float]]:
+        return [[0.0] * self.dim for _ in texts]
+
+
+def _service(db: Database, *, model_name: str = "nomic-768", dim: int = 768) -> EmbeddingService:
+    backend = _StubBackend(model_name=model_name, dim=dim)
+    return EmbeddingService(model_name=model_name, db=db, backend=backend)
+
+
+async def _plant_metadata(
+    db: Database,
+    *,
+    entity_type: str,
+    entity_id: str,
+    content_hash: str,
+    model_name: str,
+    dimensions: int,
+    project_id: str = "proj_default",
+) -> None:
+    await db.execute(
+        """INSERT OR REPLACE INTO embedding_metadata
+           (project_id, entity_type, entity_id, content_hash, model_name, dimensions)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        [project_id, entity_type, entity_id, content_hash, model_name, dimensions],
+    )
+    await db.commit()
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# False when the full identity tuple matches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_reembed_false_when_full_tuple_matches(db):
+    """All three of content_hash, model_name, dimensions match → False."""
+    svc = _service(db, model_name="nomic-768", dim=768)
+    text = "hello"
+    await _plant_metadata(
+        db,
+        entity_type="journal",
+        entity_id="jrn_match",
+        content_hash=_hash(text),
+        model_name="nomic-768",
+        dimensions=768,
+    )
+    result = await svc.needs_reembed("journal", "jrn_match", text)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# True on any single field mismatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_reembed_true_when_content_hash_mismatches(db):
+    """v2.4 behavior preserved: content change → stale."""
+    svc = _service(db, model_name="nomic-768", dim=768)
+    await _plant_metadata(
+        db,
+        entity_type="journal",
+        entity_id="jrn_content_drift",
+        content_hash=_hash("OLD content"),
+        model_name="nomic-768",
+        dimensions=768,
+    )
+    result = await svc.needs_reembed("journal", "jrn_content_drift", "NEW content")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_needs_reembed_true_when_model_name_mismatches(db):
+    """The Bug-2 trigger: nomic→qwen3 swap MUST flag every entity stale."""
+    text = "hello"
+    # Service runs the qwen3-4096 backend; metadata still claims nomic-768.
+    svc = _service(db, model_name="qwen3-4096", dim=4096)
+    await _plant_metadata(
+        db,
+        entity_type="journal",
+        entity_id="jrn_model_swap",
+        content_hash=_hash(text),
+        model_name="nomic-768",  # mismatch
+        dimensions=4096,         # match
+    )
+    result = await svc.needs_reembed("journal", "jrn_model_swap", text)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_needs_reembed_true_when_dimensions_mismatches(db):
+    """Same model name string but different dim → stale (defensive)."""
+    text = "hello"
+    svc = _service(db, model_name="some-model", dim=4096)
+    await _plant_metadata(
+        db,
+        entity_type="journal",
+        entity_id="jrn_dim_swap",
+        content_hash=_hash(text),
+        model_name="some-model",  # match
+        dimensions=768,           # mismatch
+    )
+    result = await svc.needs_reembed("journal", "jrn_dim_swap", text)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_needs_reembed_true_when_metadata_row_absent(db):
+    """No prior embedding ever recorded → stale (the backfill trigger)."""
+    svc = _service(db, model_name="nomic-768", dim=768)
+    result = await svc.needs_reembed("journal", "jrn_never_embedded", "hello")
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Defensive: zero-dim backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_reembed_true_when_backend_dim_zero(db):
+    """Un-initialized backend (dim == 0) is treated as needs-reembed so
+    the next embed cycle re-handshakes instead of writing a zero-dim row."""
+    svc = _service(db, model_name="zero-dim", dim=0)
+    # Even with a perfectly matching metadata row, dim=0 short-circuits to True.
+    await _plant_metadata(
+        db,
+        entity_type="journal",
+        entity_id="jrn_zero_dim",
+        content_hash=_hash("hello"),
+        model_name="zero-dim",
+        dimensions=0,
+    )
+    result = await svc.needs_reembed("journal", "jrn_zero_dim", "hello")
+    assert result is True

--- a/tests/test_services/test_embedding_backfill.py
+++ b/tests/test_services/test_embedding_backfill.py
@@ -362,3 +362,253 @@ def test_ollama_default_timeout_is_600_v241():
 
     b = OllamaBackend(base_url="http://x", model="m", dim=4)
     assert b._timeout == 600.0
+
+
+# ---------------------------------------------------------------------------
+# v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR T5) — all-entity-types iteration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _AllTypesEmbedder:
+    """FakeEmbedder variant exposing dim + model_name for metadata writes."""
+
+    dim: int = 4
+    model_name: str = "fake-embedder-v0"
+    fail_on_text: str | None = None
+    calls: list[list[str]] = field(default_factory=list)
+
+    async def embed_batch(
+        self, texts: list[str], *, is_query: bool = False
+    ) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if self.fail_on_text is not None and any(self.fail_on_text in t for t in texts):
+            raise RuntimeError(f"deliberate fault on text containing {self.fail_on_text!r}")
+        return [[float(i)] * self.dim for i in range(len(texts))]
+
+
+async def _seed_journal(db, *, jid: str, content: str = "journal body") -> None:
+    await db.execute(
+        "INSERT INTO journal (id, type, content, source, created_at) "
+        "VALUES (?, 'note', ?, 'pi', strftime('%Y-%m-%dT%H:%M:%SZ','now'))",
+        [jid, content],
+    )
+
+
+async def _seed_decision(db, *, did: str, question: str = "Why?") -> None:
+    await db.execute(
+        "INSERT INTO decisions (id, phase, question, rationale, decided_by) "
+        "VALUES (?, 'design', ?, ?, 'pi')",
+        [did, question, "because reasons"],
+    )
+
+
+async def _seed_literature(db, *, lid: str) -> None:
+    await db.execute(
+        "INSERT INTO literature (id, title, abstract) VALUES (?, ?, ?)",
+        [lid, f"title-{lid}", f"abstract-{lid}"],
+    )
+
+
+async def _seed_mission(db, *, mid: str) -> None:
+    await db.execute(
+        "INSERT INTO missions (id, phase, objective, context) "
+        "VALUES (?, 'design', ?, ?)",
+        [mid, f"objective-{mid}", f"context-{mid}"],
+    )
+
+
+async def _metadata_count_for(db, entity_type: str) -> int:
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata WHERE entity_type = ?",
+        [entity_type],
+    )
+    return int(row["n"])
+
+
+async def _reshape_all_to(db, dim: int) -> None:
+    """Bring every vec_* table to `dim` so the FakeEmbedder dim works."""
+    if not db.vec_available:
+        return
+    from rka.services.embedding_reshape import reshape_all_vec_tables_if_needed
+    await reshape_all_vec_tables_if_needed(db, dim=dim)
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_iterates_all_six_default_entity_types(db):
+    """entity_types=None → claim + journal + decision + literature + mission
+    + artifact get embedded. status.processed = sum across types."""
+    clear_registry()
+    await _reshape_all_to(db, dim=4)
+    await _seed_journal(db, jid="jrn_all_a")
+    await _insert_pending_claims(db, jid="jrn_all_a", count=2, prefix="clm_all_")
+    await _seed_journal(db, jid="jrn_all_b")
+    await _seed_decision(db, did="dec_all_a")
+    await _seed_literature(db, lid="lit_all_a")
+    await _seed_mission(db, mid="mis_all_a")
+
+    status = register_job()
+    svc = BackfillService(
+        db=db, embeddings=_AllTypesEmbedder(dim=4), batch_size=4
+    )
+    result = await svc.run_backfill(status)  # default: all six types
+
+    assert result.state == "complete"
+    # 2 claims + 2 journals + 1 decision + 1 literature + 1 mission = 7
+    # (artifact table is empty so it contributes 0)
+    assert result.processed == 7
+    assert result.total == 7
+    # Metadata is populated for every embedded type.
+    assert await _metadata_count_for(db, "claim") == 2
+    assert await _metadata_count_for(db, "journal") == 2
+    assert await _metadata_count_for(db, "decision") == 1
+    assert await _metadata_count_for(db, "literature") == 1
+    assert await _metadata_count_for(db, "mission") == 1
+    # Recorded model + dim reflect the active embedder, not stale data.
+    row = await db.fetchone(
+        "SELECT model_name, dimensions FROM embedding_metadata "
+        "WHERE entity_type='journal' LIMIT 1"
+    )
+    assert row["model_name"] == "fake-embedder-v0"
+    assert int(row["dimensions"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_restricts_to_named_entity_types(db):
+    """entity_types=('journal',) → claims left untouched even though pending."""
+    clear_registry()
+    await _reshape_all_to(db, dim=4)
+    await _seed_journal(db, jid="jrn_restrict")
+    claim_ids = await _insert_pending_claims(
+        db, jid="jrn_restrict", count=3, prefix="clm_restrict_"
+    )
+    await _seed_journal(db, jid="jrn_restrict_extra")
+
+    status = register_job()
+    svc = BackfillService(
+        db=db, embeddings=_AllTypesEmbedder(dim=4), batch_size=2
+    )
+    result = await svc.run_backfill(status, entity_types=("journal",))
+
+    assert result.state == "complete"
+    # Only the 2 journals counted; claims excluded.
+    assert result.total == 2
+    assert result.processed == 2
+    # Claims still pending (untouched).
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM claims WHERE embedding_pending = 1 AND id IN "
+        "(" + ",".join(["?"] * len(claim_ids)) + ")",
+        claim_ids,
+    )
+    assert row["n"] == 3
+    assert await _metadata_count_for(db, "claim") == 0
+    assert await _metadata_count_for(db, "journal") == 2
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_per_entity_type_failure_isolates(db):
+    """A batch-embed failure for one entity type does not stop the others."""
+    clear_registry()
+    await _reshape_all_to(db, dim=4)
+    await _seed_journal(db, jid="jrn_iso_target")  # FK for claims AND a journal we want embedded
+    claim_ids = await _insert_pending_claims(
+        db, jid="jrn_iso_target", count=2, prefix="clm_iso_fail_"
+    )
+    # Add another journal to ensure journals have rows to embed too.
+    await _seed_journal(db, jid="jrn_iso_other")
+
+    # Embedder fails when it sees the claim-text marker, but never the
+    # journal text (journals seed with "journal body").
+    embedder = _AllTypesEmbedder(dim=4, fail_on_text="clm_iso_fail_")
+    status = register_job()
+    svc = BackfillService(db=db, embeddings=embedder, batch_size=2)
+    result = await svc.run_backfill(status)
+
+    assert result.state == "failed", "any-type failure marks the run failed"
+    assert "claim" in (result.error or "")
+    # Journals still got embedded — failure isolation.
+    assert await _metadata_count_for(db, "journal") == 2
+    # Claims kept their pending flag for retry.
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM claims WHERE embedding_pending = 1 AND id IN "
+        "(" + ",".join(["?"] * len(claim_ids)) + ")",
+        claim_ids,
+    )
+    assert row["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_rejects_unknown_entity_type(db):
+    """entity_types containing an unknown name → ValueError up front."""
+    clear_registry()
+    status = register_job()
+    svc = BackfillService(db=db, embeddings=_AllTypesEmbedder(dim=4))
+    with pytest.raises(ValueError, match="unknown entity_type"):
+        await svc.run_backfill(status, entity_types=("not_a_thing",))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_reshape_then_backfill_clears_stale_metadata(db):
+    """End-to-end: plant stale metadata for journal+decision → reshape
+    invalidates it → backfill repopulates with current model/dim."""
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+    from rka.services.embedding_reshape import reshape_all_vec_tables_if_needed
+
+    # Plant entities + stale metadata that simulates the production bug
+    # state: rows exist, metadata says nomic-768, but the configured
+    # backend is now hypothetically fake-embedder-v0 / dim=4.
+    await _seed_journal(db, jid="jrn_e2e_a")
+    await _seed_decision(db, did="dec_e2e_a")
+    await db.execute(
+        "INSERT INTO embedding_metadata "
+        "(project_id, entity_type, entity_id, content_hash, model_name, dimensions) "
+        "VALUES "
+        "('proj_default', 'journal',  'jrn_e2e_a', 'stale', 'nomic-768', 768), "
+        "('proj_default', 'decision', 'dec_e2e_a', 'stale', 'nomic-768', 768)"
+    )
+    await db.commit()
+
+    # Reshape simulating PUT /api/config/embedding handler.
+    await reshape_all_vec_tables_if_needed(db, dim=4)
+    # Stale metadata gone for both types (non-claims path).
+    assert await _metadata_count_for(db, "journal") == 0
+    assert await _metadata_count_for(db, "decision") == 0
+
+    # Backfill repopulates.
+    clear_registry()
+    status = register_job()
+    svc = BackfillService(
+        db=db, embeddings=_AllTypesEmbedder(dim=4), batch_size=4
+    )
+    result = await svc.run_backfill(status)
+
+    assert result.state == "complete"
+    assert await _metadata_count_for(db, "journal") == 1
+    assert await _metadata_count_for(db, "decision") == 1
+    # The repopulated rows carry the CURRENT model_name + dim, not the stale ones.
+    row = await db.fetchone(
+        "SELECT model_name, dimensions FROM embedding_metadata "
+        "WHERE entity_type='journal' AND entity_id='jrn_e2e_a'"
+    )
+    assert row["model_name"] == "fake-embedder-v0"
+    assert int(row["dimensions"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_e2e_no_op_when_nothing_pending(db):
+    """Fresh DB with no entities anywhere → default backfill completes
+    immediately with total=0 (the v2.5.5 'idle' path covering all six
+    types simultaneously)."""
+    clear_registry()
+    status = register_job()
+    svc = BackfillService(db=db, embeddings=_AllTypesEmbedder(dim=4))
+    result = await svc.run_backfill(status)  # default all-six entity_types
+    assert result.state == "complete"
+    assert result.total == 0
+    assert result.processed == 0

--- a/tests/test_services/test_embedding_backfill.py
+++ b/tests/test_services/test_embedding_backfill.py
@@ -77,7 +77,10 @@ async def test_run_backfill_empty_pending_completes_immediately(db):
     await db.execute("UPDATE claims SET embedding_pending = 0")
     await db.commit()
 
-    result = await svc.run_backfill(status)
+    # v2.5.5: scope to claim type only — the v2.4 surface this test
+    # locks down. With entity_types=None the loop sweeps all six types
+    # which is exercised separately in the new T5 tests.
+    result = await svc.run_backfill(status, entity_types=("claim",))
     assert result.state == "complete"
     assert result.total == 0
     assert result.processed == 0
@@ -97,7 +100,7 @@ async def test_run_backfill_processes_all_pending_claims(db):
     ids = await _insert_pending_claims(db, jid="jrn_t5_full", count=7)
 
     svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=3)
-    result = await svc.run_backfill(status)
+    result = await svc.run_backfill(status, entity_types=("claim",))
 
     assert result.state == "complete"
     assert result.total == 7
@@ -140,7 +143,7 @@ async def test_run_backfill_progress_callback_receives_status(db):
         captured.append(s.snapshot())
 
     svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=2)
-    await svc.run_backfill(status, progress_callback=cb)
+    await svc.run_backfill(status, progress_callback=cb, entity_types=("claim",))
 
     # Callback fires at least at start + per-batch + at end.
     assert len(captured) >= 3
@@ -166,7 +169,7 @@ async def test_run_backfill_progress_callback_can_be_async(db):
         captured.append(s.processed)
 
     svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=2)
-    await svc.run_backfill(status, progress_callback=cb)
+    await svc.run_backfill(status, progress_callback=cb, entity_types=("claim",))
     assert captured  # at least one progress event recorded
 
 
@@ -186,7 +189,7 @@ async def test_run_backfill_marks_failed_on_batch_embed_error(db):
     # The embedder explodes when it sees content "text-clm_t5_fail_002".
     embedder = FakeEmbedder(dim=4, fail_on_text="clm_t5_fail_002")
     svc = BackfillService(db=db, embeddings=embedder, batch_size=4)
-    result = await svc.run_backfill(status)
+    result = await svc.run_backfill(status, entity_types=("claim",))
 
     assert result.state == "failed"
     assert "batch embed failed" in result.error
@@ -220,7 +223,7 @@ async def test_run_backfill_resumes_remaining_after_partial_completion(db):
     status1 = register_job()
     embedder1 = FakeEmbedder(dim=4, fail_on_text="clm_t5_resume_004")
     svc1 = BackfillService(db=db, embeddings=embedder1, batch_size=2)
-    r1 = await svc1.run_backfill(status1)
+    r1 = await svc1.run_backfill(status1, entity_types=("claim",))
     assert r1.state == "failed"
     # 4 claims succeeded before the failure.
     assert r1.processed == 4
@@ -237,7 +240,7 @@ async def test_run_backfill_resumes_remaining_after_partial_completion(db):
     status2 = register_job()
     embedder2 = FakeEmbedder(dim=4)  # no fault
     svc2 = BackfillService(db=db, embeddings=embedder2, batch_size=2)
-    r2 = await svc2.run_backfill(status2)
+    r2 = await svc2.run_backfill(status2, entity_types=("claim",))
     assert r2.state == "complete"
     assert r2.total == 2
     assert r2.processed == 2
@@ -270,7 +273,7 @@ async def test_run_backfill_iterates_in_id_ascending_order(db):
 
     embedder = FakeEmbedder(dim=4)
     svc = BackfillService(db=db, embeddings=embedder, batch_size=2)
-    await svc.run_backfill(status)
+    await svc.run_backfill(status, entity_types=("claim",))
 
     # Flatten all embed_batch calls in order and verify the texts are
     # monotonically increasing in id (which equals text order since the
@@ -291,7 +294,7 @@ async def test_run_backfill_status_total_set_to_initial_count(db):
     await _insert_pending_claims(db, jid="jrn_t5_total", count=4, prefix="clm_t5_total_")
 
     svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=2)
-    result = await svc.run_backfill(status)
+    result = await svc.run_backfill(status, entity_types=("claim",))
     assert result.total == 4
 
 
@@ -328,7 +331,7 @@ async def test_backfill_error_includes_exception_class_when_message_empty(db):
     await _insert_pending_claims(db, jid="jrn_v241_err", count=2, prefix="clm_v241_err_")
 
     svc = BackfillService(db=db, embeddings=_NoMessageEmbedder(), batch_size=2)
-    result = await svc.run_backfill(status)
+    result = await svc.run_backfill(status, entity_types=("claim",))
 
     assert result.state == "failed"
     # The class name MUST appear in status.error even when the exception has

--- a/tests/test_services/test_embedding_reshape.py
+++ b/tests/test_services/test_embedding_reshape.py
@@ -1,4 +1,8 @@
-"""Tests for migration 022 + the vec_claims reshape service (Mission D T4)."""
+"""Tests for migration 022 + the vec_claims reshape service (Mission D T4).
+
+v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR T5) extends coverage to the
+five other vec_* tables generalised in T1.
+"""
 
 from __future__ import annotations
 
@@ -6,8 +10,11 @@ import pytest
 
 from rka.services.embedding_reshape import (
     current_vec_claims_dim,
+    current_vec_table_dim,
+    reshape_all_vec_tables_if_needed,
     reshape_vec_claims,
     reshape_vec_claims_if_needed,
+    reshape_vec_table,
 )
 
 
@@ -186,3 +193,102 @@ async def test_reshape_if_needed_returns_true_on_dim_change(db):
     assert did_reshape is True
     new_dim = await current_vec_claims_dim(db)
     assert new_dim == 4096
+
+
+# ---------------------------------------------------------------------------
+# v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR T5) — generic reshape across 6 tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "vec_table",
+    ["vec_journal", "vec_decisions", "vec_literature", "vec_missions", "vec_artifacts"],
+)
+@pytest.mark.asyncio
+async def test_reshape_each_new_vec_table_at_target_dim(db, vec_table):
+    """Every non-claims vec_* table reshapes from float[768] to a new dim."""
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+    # Baseline from schema_phase2.sql / migration 002.
+    baseline_dim = await current_vec_table_dim(db, vec_table)
+    assert baseline_dim == 768
+
+    await reshape_vec_table(db, vec_table, dim=4096)
+    new_dim = await current_vec_table_dim(db, vec_table)
+    assert new_dim == 4096
+
+
+@pytest.mark.asyncio
+async def test_reshape_vec_table_rejects_unknown_table(db):
+    with pytest.raises(ValueError, match="unknown table"):
+        await reshape_vec_table(db, "vec_does_not_exist", dim=4096)
+
+
+@pytest.mark.asyncio
+async def test_reshape_non_claims_deletes_matching_embedding_metadata(db):
+    """Reshape for journal/decision/literature/mission/artifact DELETEs
+    matching embedding_metadata rows so v2.5.5's 3-tuple needs_reembed
+    returns True for every affected entity until backfill repopulates."""
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+    # Plant stale metadata for journal AND claim. Claim must survive
+    # the reshape (uses the flag-based signal); journal must be wiped.
+    await db.execute(
+        "INSERT INTO embedding_metadata "
+        "(project_id, entity_type, entity_id, content_hash, model_name, dimensions) "
+        "VALUES "
+        "('proj_default', 'journal', 'jrn_stale', 'h1', 'old-model', 768), "
+        "('proj_default', 'claim',   'clm_stale', 'h2', 'old-model', 768)"
+    )
+    await db.commit()
+
+    await reshape_vec_table(db, "vec_journal", dim=4096)
+
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata WHERE entity_type = 'journal'"
+    )
+    assert row["n"] == 0
+
+    # Claim metadata is untouched — claims rely on embedding_pending flag.
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata WHERE entity_type = 'claim'"
+    )
+    assert row["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reshape_all_vec_tables_if_needed_iterates_every_table(db):
+    """reshape_all_vec_tables_if_needed reports per-table outcome for all six."""
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+
+    results = await reshape_all_vec_tables_if_needed(db, dim=4096)
+
+    expected_tables = {
+        "vec_claims", "vec_journal", "vec_decisions",
+        "vec_literature", "vec_missions", "vec_artifacts",
+    }
+    assert set(results.keys()) == expected_tables
+
+    # Every table should report did_reshape=True (all were at 768 → 4096)
+    # except vec_claims which is also at 768 by default, so also True.
+    for table_name, (did_reshape, _pending) in results.items():
+        assert did_reshape is True, f"{table_name} should have reshaped"
+        dim = await current_vec_table_dim(db, table_name)
+        assert dim == 4096, f"{table_name} should be at dim=4096"
+
+
+@pytest.mark.asyncio
+async def test_reshape_all_vec_tables_if_needed_idempotent_no_op(db):
+    """Calling reshape_all_vec_tables_if_needed twice in a row at the same
+    dim → first call reshapes; second call reports did_reshape=False for
+    every table (idempotent fast-path)."""
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+
+    await reshape_all_vec_tables_if_needed(db, dim=4096)
+    results = await reshape_all_vec_tables_if_needed(db, dim=4096)
+    for table_name, (did_reshape, _pending) in results.items():
+        assert did_reshape is False, (
+            f"second call must be a no-op for {table_name}"
+        )


### PR DESCRIPTION
## Summary

Three coupled bug fixes that surfaced empirically when PI switched embedding backends from nomic-768 to qwen3-4096 on 2026-05-15. Semantic search across journals was permanently returning vectors from the retired nomic model; the fix bundles the three defects atomically.

- **Bug 1** (`rka/services/embedding_reshape.py` + `rka/api/app.py` + `rka/api/routes/config.py`): only \`vec_claims\` had dim-flex reshape. \`vec_journal\`, \`vec_decisions\`, \`vec_literature\`, \`vec_missions\`, \`vec_artifacts\` were hardcoded \`float[768]\`. Generalized via \`reshape_vec_table\` + \`reshape_all_vec_tables_if_needed\` (T1, T2).
- **Bug 2** (`rka/infra/embeddings.py`): \`needs_reembed\` checked only \`content_hash\`. Widened to a 3-tuple gate (\`content_hash + model_name + dimensions\`) so backend swaps invalidate stale entries (T3).
- **Bug 3** (`rka/services/embedding_backfill.py`): \`BackfillService.run_backfill\` iterated claims-only. Generalized to all six entity types via \`_ENTITY_BACKFILL_CONFIGS\`. Per-type failure isolation; \`entity_types=None\` defaults to the full set; v2.4 single-claim-type callers preserved by explicit \`entity_types=(\"claim\",)\` (T4).

## Mission + decision

- **Mission**: \`mis_01KS1RFNM2T1HTB077G507T1FR\`
- **Motivating decision**: \`dec_01KS1RAAN8RNAAEYP2TEQPPAA9\` (Option A bundled fix)
- **Backbrief**: \`jrn_01KS1S2QMVQPMXS8KHK1JS6HS1\` (full T0 empirical baseline)
- **Branch model**: 6 atomic commits T1→T6 + this PR. Fast-forward merge to main, then v2.5.5 tag.

## Sequencing

This fix lands BEFORE \`mis_01KS0QEW21N2NG4EJTKJ3JTWTE\` (Eval-v2 corpus refresh). The corpus refresh re-annotates expected_entities against current RKA state; if non-claims journals etc. are still embedded with stale nomic-768, the refresh computes against wrong embeddings. **Corpus refresh shifts from v2.5.5 to v2.5.6**.

## Live verification (already performed against the production container)

Before \`docker compose up -d --build\`:
\`\`\`
vec_claims=4096; vec_journal/decisions/literature/missions/artifacts all at dim=768 (Bug 1)
embedding_metadata: claim/decision/journal/mission all at dim=768 model=nomic (Bug 2)
\`\`\`
After:
\`\`\`
All 6 vec_* tables at dim=4096
embedding_metadata: journal/decision/mission rows DELETEd by startup hook
claim metadata preserved (by design — claims use the embedding_pending flag)
\`\`\`

## Test plan

- [x] \`pytest tests/test_services/test_embedding_reshape.py tests/test_services/test_embedding_backfill.py tests/test_services/test_embedding_audit_symmetry.py tests/test_services/test_embeddings_phase1.py tests/test_api/test_config_routes.py tests/test_api/test_app_lifespan.py tests/test_infra/test_embeddings_needs_reembed.py -q\` → all green (46 + new T5 tests)
- [x] Full suite \`pytest -q\` → **732 → 753 passing** (no regression; +21 net new tests)
- [x] Live container rebuild verifies reshape propagation across all 6 vec_* tables
- [x] Live metadata-DELETE verified for non-claims entity types

## Operational user note

Users upgrading across this release whose \`embedding_metadata\` rows still carry a stale \`model_name\` or \`dimensions\` tuple should either:
1. Re-PUT \`/api/config/embedding\` with a non-trivially-different signature to trigger the all-entity backfill, OR
2. Let the 3-tuple \`needs_reembed\` gate refresh entities individually as they are touched (read/write paths trigger embed-on-stale).

The startup hook brings vec_* table dims into parity automatically on container restart without invoking the backfill loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)