### PR TITLE
Fix embedding subsystem bug-pair (BackfillService metadata guard + worker config loading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,77 @@
 All notable changes to RKA are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) + semver.
 
+## [2.5.8] — 2026-05-20 (patch release; embedding subsystem bug-pair fix: BackfillService metadata guard + worker startup loads persisted config)
+
+**Mission**: `mis_01KS3E4S33B13EGR2NWRQM2QG4`
+**Motivating decision**: `dec_01KS3E1FGSK530N8HM04BNMCEW` (Option A: single bundled bug-pair fix with scope-limited bookkeeper exemption for `rka/cli.py`)
+**Surfaced by**: `mis_01KS0QEW21N2NG4EJTKJ3JTWTE` (Eval-v2 corpus refresh) — both bugs are pre-existing; corpus refresh exposed the silent-under-embedding failure mode.
+
+### Bug 1 — `BackfillService` writes `embedding_metadata` when `vec_available=False`
+
+`rka/services/embedding_backfill.py:run_backfill` unconditionally wrote rows into `embedding_metadata` for every batch element, including when `Database.vec_available` was `False` (sqlite-vec extension not loaded — vec_* INSERT was skipped). The v2.5.5 3-tuple `needs_reembed` then returned `False` permanently for these rows because metadata-by-content-hash matched, even though no vec_* row existed. Net effect: rows claimed to be "embedded at <model>/<dim>" with no underlying vector — silent under-embedding.
+
+**Fix**: moved the `embedding_metadata` INSERT inside the `if vec_available:` block. Metadata write is now **coupled** to the vec_* write — both gate on `vec_available`. Documented as an invariant in the source.
+
+**Tests added** (`tests/test_services/test_embedding_backfill.py`, +2 tests; suite 18 → 20):
+- `test_metadata_not_written_when_vec_available_false`: patches `Database.vec_available=False` at the class level (property has no setter) and asserts no metadata row is written.
+- `test_metadata_written_when_vec_available_true`: backward-compatibility positive case.
+
+### Bug 2 — `rka-worker` startup ignores `/data/embedding_config.json`
+
+`rka/cli.py:worker_main` constructed `EmbeddingService` directly from env vars (`RKA_EMBEDDING_MODEL` etc.) and passed it to `EnrichmentWorker(embeddings=...)`. The api-server boot path (`rka/api/app.py` v2.4.0+) had been updated to read the persisted config from `<data_dir>/embedding_config.json` via `EmbeddingConfigService.load_config()`, but the worker boot path was left on the legacy env-only constructor. Net effect: PI changing the embedding backend via webui (`PUT /api/config/embedding`) took effect for the api-server's hot path but **not** for the worker — every worker restart re-loaded the env-defaulted backend, silently serving stale embeddings until container rebuild.
+
+**Fix**: added `EnrichmentWorker.boot()` classmethod + `_resolve_embeddings()` staticmethod in `rka/services/worker.py`. Resolution order matches the api-server boot path:
+
+1. `embeddings_enabled=False` → worker has `embeddings=None`.
+2. Otherwise, attempt to read `<data_dir>/embedding_config.json` via `EmbeddingConfigService.load_config()` and construct `EmbeddingService.from_config(...)`.
+3. On any failure (file missing, corrupt, construction error), fall back to the legacy env-driven constructor (`EmbeddingService(model_name=env_fallback_model)`) and log WARNING.
+
+`rka/cli.py:worker_main` swapped to a 1-line `EnrichmentWorker.boot(...)` invocation (Brain-ratified `cli.py` exemption-extension; see below).
+
+**Tests added** (`tests/test_services/test_worker.py`, NEW file, +4 tests):
+- `test_resolve_embeddings_uses_persisted_config`: writes a fastembed config to tmp_path, mocks `EmbeddingService.from_config`, asserts the persisted config (not env) was passed.
+- `test_boot_classmethod_threads_data_dir_through`: smoke test for `EnrichmentWorker.boot()`.
+- `test_resolve_embeddings_falls_back_to_env_when_config_missing`: empty tmp_path; asserts env_fallback_model was used and the log line confirms the fallback path.
+- `test_resolve_embeddings_disabled_returns_none`: `embeddings_enabled=False` short-circuit.
+
+### Scope-limited bookkeeper exemption (binding for THIS mission only)
+
+This release is **bookkeeper-strict** for everything except a single 1-line glue change in `rka/cli.py` (Brain-ratified mid-mission per `dec_01KS3E1FGSK530N8HM04BNMCEW`).
+
+**ALLOWED for this mission:**
+
+- `rka/services/embedding_backfill.py`: Bug 1 fix (metadata-write guard).
+- `rka/services/worker.py`: Bug 2 fix (`boot()` + `_resolve_embeddings()`).
+- `rka/cli.py`: 1-line glue swap to `EnrichmentWorker.boot(...)` (Brain-ratified exemption-extension; Bug 2's env-only path lived in `cli.py:worker_main`, not `worker.py`).
+- `tests/test_services/test_embedding_backfill.py`: extended (+2 tests).
+- `tests/test_services/test_worker.py`: NEW (+4 tests).
+- `pyproject.toml`, `rka/__init__.py`, `CHANGELOG.md`: version bump.
+
+**NOT ALLOWED (remained strict):**
+
+- Other `rka/services/*` files: 0 modified.
+- `rka/api/`: 0 modified.
+- `rka/mcp/`: 0 modified.
+- `web/`: 0 modified.
+- Schema migrations: none.
+
+**Post-mission invariant**: future patch missions return to fully-strict bookkeeper (the `cli.py` exemption is for THIS mission's scope only; documented in `dec_01KS3E1FGSK530N8HM04BNMCEW`).
+
+### Ops note
+
+After deploying v2.5.8, **rebuild the container** (`docker compose up -d --build --force-recreate`) and **restart the worker** explicitly. The worker boot log will now indicate which config-resolution path was taken:
+
+- `worker boot: reading config from /data/embedding_config.json (backend=<backend>, dim=<dim>)` — persisted config loaded.
+- `worker boot: falling back to env defaults; persisted config not found at <path>` — file absent.
+- `worker boot: failed to load persisted config (<exc>); falling back to env defaults (model=<env_model>)` — load attempt errored.
+
+Operators can correlate these lines with webui config-changed events when troubleshooting embedding-drift symptoms.
+
+### Test count
+
+787 passing (including +6 new tests from this mission). No regressions.
+
 ## [2.5.7] — 2026-05-20 (patch release; Writer skill Phase 3: revision-loop handler + Brain mission integration + 3 optional MCP tools; BOOKKEEPER-EXEMPT)
 
 **Mission**: `mis_01KS2WW6MRN6AXP11EMCSCDFAR`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rka"
-version = "2.5.7"
+version = "2.5.8"
 description = "Research Knowledge Agent — MCP server + REST API for AI-assisted research orchestration"
 requires-python = ">=3.11"
 dependencies = [

--- a/rka/__init__.py
+++ b/rka/__init__.py
@@ -1,3 +1,3 @@
 """Research Knowledge Agent — MCP server + REST API for AI-assisted research."""
 
-__version__ = "2.5.7"
+__version__ = "2.5.8"

--- a/rka/cli.py
+++ b/rka/cli.py
@@ -152,14 +152,16 @@ def worker(
         await db.initialize_phase2_schema()
 
         try:
-            embeddings = (
-                EmbeddingService(model_name=config.embedding_model, db=db)
-                if config.embeddings_enabled
-                else None
-            )
-            runner = EnrichmentWorker(
+            # v2.5.8 (mis_01KS3E4S33B13EGR2NWRQM2QG4 T2; Brain-ratified
+            # exemption-extension): use EnrichmentWorker.boot() so the
+            # worker reads persisted /data/embedding_config.json rather
+            # than env-only. Falls back to env automatically when config
+            # missing or corrupt.
+            runner = EnrichmentWorker.boot(
                 db=db,
-                embeddings=embeddings,
+                data_dir=config.data_dir,
+                embeddings_enabled=config.embeddings_enabled,
+                env_fallback_model=config.embedding_model,
                 poll_interval=poll_interval or config.job_poll_interval,
                 lease_seconds=lease_seconds or config.job_lease_seconds,
                 max_attempts=max_attempts or config.job_max_attempts,

--- a/rka/services/embedding_backfill.py
+++ b/rka/services/embedding_backfill.py
@@ -461,6 +461,27 @@ class BackfillService:
                 ) from exc
 
             # Per-row: write vec_* + embedding_metadata + post_embed.
+            #
+            # Invariant (per dec_01KS3E1FGSK530N8HM04BNMCEW, surfaced empirically
+            # by corpus refresh mis_01KS0QEW21N2NG4EJTKJ3JTWTE):
+            #   metadata write is COUPLED to vec_* write; both gate on
+            #   vec_available to prevent silent under-embedding.
+            #
+            # Pre-fix behavior (v2.5.5 latent edge case): when vec_available=False,
+            # the vec_* INSERT was skipped but the metadata INSERT ran unconditionally,
+            # leaving the row claiming "embedded at <model>/<dim>" with no actual
+            # vec_* row. The v2.5.5 3-tuple needs_reembed gate then returned False
+            # permanently for those rows even after vec_available flipped True;
+            # the entity was never re-embedded.
+            #
+            # Note: the pre-fix "always update metadata" rationale (preserving
+            # model_name across config switches) is preserved by Bug 1 fix
+            # because the vec_available=True path still updates metadata on
+            # every backfill pass. The False path now leaves metadata in its
+            # prior state, which means stale model_name is possible during
+            # vec_available=False windows; that surfaces correctly as
+            # needs_reembed=True once vec_available recovers (the entity's
+            # stale row gets re-examined and re-embedded).
             for (row, text), vec in zip(work, vectors):
                 entity_id = row[cfg.id_column]
                 try:
@@ -472,24 +493,20 @@ class BackfillService:
                             "(id, embedding) VALUES (?, ?)",
                             [entity_id, vec_blob],
                         )
-                    # Always update metadata — the v2.5.5 3-tuple
-                    # needs_reembed gate reads it. Skipping the metadata
-                    # write was the v2.4 oversight that left the stale
-                    # nomic-768 model_name in place across config switches.
-                    await self._db.execute(
-                        """INSERT OR REPLACE INTO embedding_metadata
-                           (project_id, entity_type, entity_id,
-                            content_hash, model_name, dimensions)
-                           VALUES (?, ?, ?, ?, ?, ?)""",
-                        [
-                            project_id,
-                            cfg.entity_type,
-                            entity_id,
-                            _ES.content_hash(text),
-                            model_name,
-                            embed_dim,
-                        ],
-                    )
+                        await self._db.execute(
+                            """INSERT OR REPLACE INTO embedding_metadata
+                               (project_id, entity_type, entity_id,
+                                content_hash, model_name, dimensions)
+                               VALUES (?, ?, ?, ?, ?, ?)""",
+                            [
+                                project_id,
+                                cfg.entity_type,
+                                entity_id,
+                                _ES.content_hash(text),
+                                model_name,
+                                embed_dim,
+                            ],
+                        )
                     if cfg.post_embed_sql:
                         await self._db.execute(cfg.post_embed_sql, [entity_id])
                     status.processed += 1

--- a/rka/services/worker.py
+++ b/rka/services/worker.py
@@ -4,6 +4,13 @@ Only processes embedding jobs. LLM-dependent enrichment (auto-tag, auto-link,
 auto-summarize, claim extraction, verification, theme synthesis, contradiction
 checks) has been removed — those tasks are now handled by the Brain during
 maintenance sessions.
+
+Worker boot reads the persisted embedding config from
+`/data/embedding_config.json` via `EmbeddingConfigService.load_config()`
+(see `EnrichmentWorker.boot()`). This matches the api-server boot path
+established in v2.4.0 (rka/api/app.py) and was added in v2.5.8 per
+dec_01KS3E1FGSK530N8HM04BNMCEW (Bug 2 fix; pre-existing bug surfaced by
+corpus refresh mis_01KS0QEW21N2NG4EJTKJ3JTWTE).
 """
 
 from __future__ import annotations
@@ -12,6 +19,7 @@ import asyncio
 import logging
 import os
 import socket
+from pathlib import Path
 from typing import Any
 
 from rka.infra.database import Database
@@ -38,6 +46,119 @@ class EnrichmentWorker:
         self.poll_interval = poll_interval
         self.queue = JobQueue(db, lease_seconds=lease_seconds, default_max_attempts=max_attempts)
         self.worker_id = worker_id or f"{socket.gethostname()}:{os.getpid()}"
+
+    # ------------------------------------------------------------------
+    # v2.5.8 boot path (Bug 2 fix per dec_01KS3E1FGSK530N8HM04BNMCEW)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def boot(
+        cls,
+        *,
+        db: Database,
+        data_dir: Path | str = Path("/data"),
+        embeddings_enabled: bool = True,
+        env_fallback_model: str = "nomic-ai/nomic-embed-text-v1.5",
+        poll_interval: float = 1.0,
+        lease_seconds: int = 300,
+        max_attempts: int = 5,
+        worker_id: str | None = None,
+    ) -> "EnrichmentWorker":
+        """Construct a worker with embeddings loaded from persisted config.
+
+        Resolution order matches the api-server boot path (rka/api/app.py
+        v2.4.0+):
+
+        1. If embeddings_enabled is False: worker has embeddings=None.
+        2. Otherwise, attempt to read `<data_dir>/embedding_config.json`
+           via `EmbeddingConfigService.load_config()` and construct an
+           `EmbeddingService.from_config(...)`.
+        3. On any failure (file missing, corrupt, EmbeddingService
+           construction error), fall back to the legacy env-driven
+           constructor (`EmbeddingService(model_name=env_fallback_model)`)
+           and log WARNING.
+
+        Log lines explicitly indicate which path was taken so operators
+        can correlate worker boot logs with config-changed-via-webui events.
+        """
+        embeddings = cls._resolve_embeddings(
+            db=db,
+            data_dir=data_dir,
+            embeddings_enabled=embeddings_enabled,
+            env_fallback_model=env_fallback_model,
+        )
+        return cls(
+            db=db,
+            embeddings=embeddings,
+            poll_interval=poll_interval,
+            lease_seconds=lease_seconds,
+            max_attempts=max_attempts,
+            worker_id=worker_id,
+        )
+
+    @staticmethod
+    def _resolve_embeddings(
+        *,
+        db: Database,
+        data_dir: Path | str,
+        embeddings_enabled: bool,
+        env_fallback_model: str,
+    ):
+        """Load EmbeddingService from persisted config or fall back to env.
+
+        Isolated as a staticmethod so unit tests can exercise the resolution
+        logic without instantiating a full worker. Logs are informative-only
+        (no exceptions raised on fallback).
+        """
+        if not embeddings_enabled:
+            logger.info(
+                "worker boot: embeddings_enabled=False; running without EmbeddingService"
+            )
+            return None
+
+        # Lazy imports keep the worker.py top-level import surface small
+        # (embedding_config + embedding_backends pull in optional deps).
+        try:
+            from rka.infra.embeddings import EmbeddingService
+            from rka.services.embedding_config import EmbeddingConfigService
+
+            cfg_svc = EmbeddingConfigService(config_dir=data_dir)
+            if not cfg_svc.config_path.exists():
+                logger.info(
+                    "worker boot: falling back to env defaults; persisted config "
+                    "not found at %s",
+                    cfg_svc.config_path,
+                )
+                return EmbeddingService(model_name=env_fallback_model, db=db)
+
+            embedding_cfg = cfg_svc.load_config()
+            embeddings = EmbeddingService.from_config(
+                embedding_cfg.model_dump(), db=db
+            )
+            logger.info(
+                "worker boot: reading config from %s (backend=%s, dim=%d)",
+                cfg_svc.config_path,
+                embedding_cfg.backend,
+                embeddings.dim,
+            )
+            return embeddings
+        except Exception as exc:
+            logger.warning(
+                "worker boot: failed to load persisted config (%s); falling back "
+                "to env defaults (model=%s)",
+                exc,
+                env_fallback_model,
+            )
+            try:
+                from rka.infra.embeddings import EmbeddingService
+                return EmbeddingService(model_name=env_fallback_model, db=db)
+            except Exception as inner_exc:
+                logger.error(
+                    "worker boot: env-fallback EmbeddingService construction also "
+                    "failed (%s); running without embeddings",
+                    inner_exc,
+                )
+                return None
 
     async def run_once(self) -> bool:
         """Process one job if available."""

--- a/tests/test_services/test_embedding_backfill.py
+++ b/tests/test_services/test_embedding_backfill.py
@@ -612,3 +612,86 @@ async def test_e2e_no_op_when_nothing_pending(db):
     assert result.state == "complete"
     assert result.total == 0
     assert result.processed == 0
+
+
+# ---------------------------------------------------------------------------
+# v2.5.8 Bug 1 regression: BackfillService metadata write coupled to vec_available
+# ---------------------------------------------------------------------------
+# Per dec_01KS3E1FGSK530N8HM04BNMCEW, surfaced empirically by corpus refresh
+# mis_01KS0QEW21N2NG4EJTKJ3JTWTE. Pre-fix behavior: vec_* INSERT was guarded
+# by `if vec_available` but the metadata INSERT was unconditional, leaving
+# rows claiming "embedded at <model>/<dim>" with no actual vec_* row. The
+# v2.5.5 3-tuple needs_reembed gate then returned False permanently. Fix
+# moves metadata INSERT inside the same vec_available guard.
+
+
+@pytest.mark.asyncio
+async def test_metadata_not_written_when_vec_available_false(db, monkeypatch):
+    """vec_available=False -> no vec_* INSERT and no metadata INSERT.
+
+    The entity must remain in "needs embedding" state (no metadata row)
+    so a later vec_available=True window triggers a re-embed instead of
+    silently skipping the row because needs_reembed returned False.
+    """
+    clear_registry()
+    status = register_job()
+    await _insert_journal(db, jid="jrn_bug1_skip")
+    ids = await _insert_pending_claims(db, jid="jrn_bug1_skip", count=3)
+
+    # Simulate sqlite-vec disabled (the bug's trigger scenario).
+    # vec_available is a property; patch at class level so getattr() resolves
+    # to the False shadow rather than the descriptor.
+    monkeypatch.setattr(type(db), "vec_available", False, raising=False)
+
+    svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=3)
+    result = await svc.run_backfill(status, entity_types=("claim",))
+
+    # The backfill reports the rows as "processed" (they completed without
+    # error), but the metadata table receives NO inserts because the
+    # vec_available guard skipped both the vec_* and metadata writes.
+    assert result.state == "complete"
+    metadata_rows = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata "
+        "WHERE entity_type = 'claim' AND entity_id IN "
+        "(" + ",".join(["?"] * len(ids)) + ")",
+        ids,
+    )
+    assert metadata_rows["n"] == 0, (
+        "vec_available=False must NOT write metadata; otherwise needs_reembed "
+        "returns False permanently for the under-embedded row (Bug 1)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_written_when_vec_available_true(db):
+    """vec_available=True -> both vec_* and metadata INSERT (backward compat).
+
+    Explicit positive-case regression test: the pre-fix happy path must
+    continue to write metadata when vec_available is True. Other tests in
+    this file exercise this implicitly; this test makes it explicit so
+    future refactors of the vec_available guard structure can be evaluated
+    against both halves of the invariant.
+    """
+    if not db.vec_available:
+        pytest.skip("vec_available=False in this test environment; positive case unreachable.")
+
+    clear_registry()
+    await _setup_vec_claims_at_dim(db, dim=4)
+    status = register_job()
+    await _insert_journal(db, jid="jrn_bug1_ok")
+    ids = await _insert_pending_claims(db, jid="jrn_bug1_ok", count=2)
+
+    svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=2)
+    result = await svc.run_backfill(status, entity_types=("claim",))
+
+    assert result.state == "complete"
+    metadata_rows = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata "
+        "WHERE entity_type = 'claim' AND entity_id IN "
+        "(" + ",".join(["?"] * len(ids)) + ")",
+        ids,
+    )
+    assert metadata_rows["n"] == 2, (
+        "vec_available=True must write metadata for each processed row "
+        "(positive-case backward compat)."
+    )

--- a/tests/test_services/test_worker.py
+++ b/tests/test_services/test_worker.py
@@ -1,0 +1,168 @@
+"""Tests for EnrichmentWorker.boot() embedding config loading (v2.5.8 Bug 2 fix).
+
+Per dec_01KS3E1FGSK530N8HM04BNMCEW: the worker startup must load the
+persisted embedding config from `<data_dir>/embedding_config.json` so
+PI changes via the webui take effect across restarts. Pre-fix worker
+boot used env vars only, which left the worker serving stale embeddings
+after PI swapped the embedding backend via PUT /api/config/embedding.
+
+Tests exercise `EnrichmentWorker._resolve_embeddings()` directly so we
+do not depend on a real EmbeddingService construction (which requires
+optional fastembed dependencies).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Lazy import inside the test so we surface the import error if worker.py
+# refactor breaks the module.
+def _import_worker():
+    from rka.services.worker import EnrichmentWorker
+    return EnrichmentWorker
+
+
+def _write_config(data_dir: Path, *, backend: str, model_name: str, dim: int) -> Path:
+    """Write a minimal embedding_config.json that EmbeddingConfigService.load_config can parse."""
+    config_path = data_dir / "embedding_config.json"
+    payload = {
+        "backend": backend,
+        "config": {"model_name": model_name, "dim": dim},
+        "updated_at": None,
+        "updated_by": "test-fixture",
+    }
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    return config_path
+
+
+class TestWorkerStartupReadsPersistedConfig:
+    """When /data/embedding_config.json exists, _resolve_embeddings loads it."""
+
+    def test_resolve_embeddings_uses_persisted_config(self, tmp_path: Path) -> None:
+        EnrichmentWorker = _import_worker()
+
+        # Write a fastembed config the loader will accept.
+        _write_config(
+            tmp_path,
+            backend="fastembed",
+            model_name="nomic-ai/nomic-embed-text-v1.5",
+            dim=768,
+        )
+
+        # Mock EmbeddingService.from_config so we do not need a real
+        # fastembed install to run the test. Capture the kwargs the loader
+        # passes through.
+        fake_embedding_service = MagicMock()
+        fake_embedding_service.dim = 768
+
+        with patch(
+            "rka.infra.embeddings.EmbeddingService.from_config",
+            return_value=fake_embedding_service,
+        ) as patched:
+            mock_db = MagicMock()
+            result = EnrichmentWorker._resolve_embeddings(
+                db=mock_db,
+                data_dir=tmp_path,
+                embeddings_enabled=True,
+                env_fallback_model="some-other-model",
+            )
+
+        assert result is fake_embedding_service
+        # The from_config call should have used the persisted backend / model_name,
+        # not the env_fallback_model.
+        assert patched.called
+        call_kwargs = patched.call_args.kwargs
+        call_args_payload = patched.call_args.args[0] if patched.call_args.args else None
+        # Confirm the persisted config (not env) was passed in.
+        payload = call_args_payload if call_args_payload is not None else call_kwargs.get("config")
+        assert payload is not None
+        assert payload.get("backend") == "fastembed"
+        assert payload["config"]["model_name"] == "nomic-ai/nomic-embed-text-v1.5"
+
+    def test_boot_classmethod_threads_data_dir_through(self, tmp_path: Path) -> None:
+        """Smoke test of boot(): the classmethod returns an EnrichmentWorker with embeddings set."""
+        EnrichmentWorker = _import_worker()
+
+        _write_config(
+            tmp_path,
+            backend="fastembed",
+            model_name="nomic-ai/nomic-embed-text-v1.5",
+            dim=768,
+        )
+
+        fake_embedding_service = MagicMock()
+        fake_embedding_service.dim = 768
+
+        with patch(
+            "rka.infra.embeddings.EmbeddingService.from_config",
+            return_value=fake_embedding_service,
+        ):
+            mock_db = MagicMock()
+            worker = EnrichmentWorker.boot(
+                db=mock_db,
+                data_dir=tmp_path,
+                embeddings_enabled=True,
+            )
+
+        assert worker.embeddings is fake_embedding_service
+        assert worker.db is mock_db
+
+
+class TestWorkerStartupFallsBackToEnvWhenConfigAbsent:
+    """When /data/embedding_config.json is missing, _resolve_embeddings falls back to env."""
+
+    def test_resolve_embeddings_falls_back_to_env_when_config_missing(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        EnrichmentWorker = _import_worker()
+
+        # Intentionally do NOT write embedding_config.json; tmp_path is empty.
+        assert not (tmp_path / "embedding_config.json").exists()
+
+        # Mock the env-fallback EmbeddingService constructor so we do not
+        # need real fastembed.
+        fake_embedding_service = MagicMock()
+        fake_embedding_service.dim = 768
+
+        with patch(
+            "rka.infra.embeddings.EmbeddingService",
+            return_value=fake_embedding_service,
+        ) as patched:
+            mock_db = MagicMock()
+            with caplog.at_level(logging.INFO):
+                result = EnrichmentWorker._resolve_embeddings(
+                    db=mock_db,
+                    data_dir=tmp_path,
+                    embeddings_enabled=True,
+                    env_fallback_model="env-fallback-model",
+                )
+
+        assert result is fake_embedding_service
+        # Verify the env_fallback_model was used (not whatever from_config
+        # would have produced).
+        call_kwargs = patched.call_args.kwargs
+        assert call_kwargs.get("model_name") == "env-fallback-model"
+        # Verify the log message confirms the fallback path was taken.
+        assert any(
+            "falling back to env defaults" in record.message
+            and "persisted config" in record.message
+            for record in caplog.records
+        )
+
+    def test_resolve_embeddings_disabled_returns_none(self, tmp_path: Path) -> None:
+        """embeddings_enabled=False short-circuits to None without loading config."""
+        EnrichmentWorker = _import_worker()
+        mock_db = MagicMock()
+        result = EnrichmentWorker._resolve_embeddings(
+            db=mock_db,
+            data_dir=tmp_path,
+            embeddings_enabled=False,
+            env_fallback_model="any",
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

Patch release v2.5.8 fixing two pre-existing embedding-subsystem bugs surfaced by the Eval-v2 corpus refresh (`mis_01KS0QEW21N2NG4EJTKJ3JTWTE`).

**Mission**: `mis_01KS3E4S33B13EGR2NWRQM2QG4`
**Motivating decision**: `dec_01KS3E1FGSK530N8HM04BNMCEW` (Option A: single bundled bug-pair fix with scope-limited bookkeeper exemption for `rka/cli.py` glue)

### Bug 1 — `BackfillService` writes `embedding_metadata` when `vec_available=False`

`rka/services/embedding_backfill.py:run_backfill` unconditionally wrote rows into `embedding_metadata`, including when `Database.vec_available=False` (sqlite-vec extension not loaded — vec_* INSERT skipped). The v2.5.5 3-tuple `needs_reembed` then returned `False` permanently for these rows because metadata-by-content-hash matched, even though no vec_* row existed. Net effect: rows claimed to be "embedded at <model>/<dim>" with no underlying vector — silent under-embedding.

**Fix** (T1, `16f11f2`): moved the `embedding_metadata` INSERT inside the `if vec_available:` block. Metadata write is now coupled to the vec_* write — both gate on `vec_available`. Tests: +2 (`tests/test_services/test_embedding_backfill.py` 18 → 20).

### Bug 2 — `rka-worker` startup ignores `/data/embedding_config.json`

`rka/cli.py:worker_main` constructed `EmbeddingService` directly from env vars and passed it to `EnrichmentWorker(...)`. The api-server boot path (`rka/api/app.py` v2.4.0+) reads the persisted config from `<data_dir>/embedding_config.json` via `EmbeddingConfigService.load_config()`, but the worker boot path was left on the legacy env-only constructor. Net effect: PI config changes via webui (`PUT /api/config/embedding`) took effect for api-server but NOT for the worker — every worker restart re-loaded the env-defaulted backend, silently serving stale embeddings until container rebuild.

**Fix** (T2, `6caa947`): added `EnrichmentWorker.boot()` classmethod + `_resolve_embeddings()` staticmethod in `rka/services/worker.py`. Resolution order matches the api-server boot path: `embeddings_enabled=False` → None; persisted config exists → `EmbeddingService.from_config(...)`; fallback → env-driven constructor with WARNING. `rka/cli.py:worker_main` swapped to a 1-line `.boot(...)` invocation (Brain-ratified `cli.py` exemption-extension). Tests: +4 (NEW `tests/test_services/test_worker.py`).

### Scope-limited bookkeeper exemption

This release is **bookkeeper-strict** except for the Brain-ratified 1-line glue change in `rka/cli.py` (per `dec_01KS3E1FGSK530N8HM04BNMCEW`). Future patch missions return to fully-strict.

### Test verification

787/787 passing (suite includes +6 new tests from this mission). No regressions.

## Ops note (post-merge)

After deploying v2.5.8: **rebuild the container** (`docker compose up -d --build --force-recreate`) and **restart the worker** explicitly. The worker boot log will indicate which config-resolution path was taken:

- `worker boot: reading config from /data/embedding_config.json (backend=<backend>, dim=<dim>)` — persisted config loaded
- `worker boot: falling back to env defaults; persisted config not found at <path>` — file absent
- `worker boot: failed to load persisted config (<exc>); falling back to env defaults` — load attempt errored

## Test plan

- [x] All 787 tests pass (Bug 1 +2, Bug 2 +4 new tests included)
- [x] Bookkeeper file-name check clean (only Brain-ratified exemption scope touched)
- [x] Version bump parity verified (`pyproject.toml` and `rka/__init__.py` both at 2.5.8)
- [x] Em-dash absolute ban (Writer-managed files): N/A — no Writer-managed files touched
- [ ] **PI explicit authorization required for merge** (auto-mode push-to-main restriction)
- [ ] Post-merge: PI rebuilds container + restarts worker, verifies boot log reports config-resolution path

🤖 Generated with [Claude Code](https://claude.com/claude-code)