### PR TITLE
docs(install,readme): v2.5.10 — INSTALL.md + README.md staleness cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to RKA are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) + semver.
 
+## [2.5.10] — 2026-05-20 (docs-only patch; INSTALL.md + README.md staleness cleanup)
+
+**Surfaced by**: PI audit immediately following v2.5.9 GitHub release — checked whether the installation guide was fully consistent and correct with current state.
+
+Docs-only patch. No code changes. No test changes (suite stays at 799 passing). Ships to address documentation drift between INSTALL.md / README.md and the actual v2.4.0+ feature surface.
+
+### INSTALL.md — fixes
+
+- **5 stale `v2.3.x` / `v2.3.2` version references** replaced with `v2.5.x` (`/api/health` example output, SessionStart hook example line) or `v2.5.10` (integration.json `version` field example).
+- **2 stale "~110 tools" claims** corrected to "~90 tools" (actual count: 89 `rka_*` tools in `rka/mcp/server.py`).
+- **§10 "What this guide intentionally doesn't cover"** rewritten:
+  - Old text claimed `rka_ask` / `rka_generate_summary` are "optional tools" that require an LLM key. These tools were **removed in v2.4.0** per `jrn_01KRNZBS50K250HHHHEC58E4GC`; server-side code preserved for future re-wiring through the orchestrator's Claude Code SDK.
+  - New text correctly states the tool removal, then notes that v2.4.0+ does support **pluggable embedding backends** (FastEmbed default; OpenAI-compatible HTTP like LM Studio / vLLM; Ollama), configurable via **Settings → Embeddings** in the web dashboard. Links to [`docs/embedding_backends.md`](docs/embedding_backends.md).
+
+### README.md — fixes
+
+- **Infrastructure Layer description** (line 242) updated:
+  - Was: "embeddings (FastEmbed). An optional LiteLLM gateway powers `rka_ask` / `rka_generate_summary` only when the user wires up a cloud-LLM API key."
+  - Now: "pluggable embedding backends (FastEmbed default; OpenAI-compatible HTTP; Ollama — configurable via Settings → Embeddings)" + accurate note that the LLM-gated tools were removed in v2.4.0.
+- **Tool table** (line 852) removed the `rka_ask` row — tool no longer exposed.
+
+### Scope discipline
+
+Bookkeeper-strict observed. Touched files:
+- `INSTALL.md` (8 in-place edits, all surgical)
+- `README.md` (2 in-place edits)
+- `pyproject.toml` + `rka/__init__.py` + `CHANGELOG.md` — version bump 2.5.9 → 2.5.10 + this entry
+
+NOT touched: `rka/services/`, `rka/api/`, `rka/mcp/`, `web/`, tests, schema migrations.
+
+### Operator impact
+
+None at runtime. No rebuild required (`docker compose ps` will continue showing v2.5.9 containers as healthy; v2.5.10 brings nothing new at the API/MCP surface). Operators who fetch the v2.5.10 tag will see the corrected docs. A container rebuild is optional and only useful if the operator wants the `/api/health` `version` field to report `2.5.10`.
+
 ## [2.5.9] — 2026-05-20 (patch release; Phase-3.1 metric tuning — cfg11 sweep winner pinned; Phase-3 chapter closes PARTIAL)
 
 **Mission**: `mis_01KS3EB2671CDD4V9RZCMYCEH1`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@
 | Surface | What you'll have |
 |---|---|
 | **RKA backend** | FastAPI + worker + SQLite + FTS5 + sqlite-vec running in Docker on `localhost:9712`. Web dashboard at the same URL. |
-| **Claude Code (Executor)** | Full plugin: 3 role skills (`rka:rka-brain`, `rka:rka-executor`, `rka:rka-pi`), 5 slash commands (`/rka-status`, `/rka-search`, `/rka-pending`, `/rka-set-project`, `/rka-setup-claude-desktop`), a SessionStart hook that pings the backend on every new session, and the full `mcp__plugin_rka_rka__*` tool surface (~110 tools). |
+| **Claude Code (Executor)** | Full plugin: 3 role skills (`rka:rka-brain`, `rka:rka-executor`, `rka:rka-pi`), 5 slash commands (`/rka-status`, `/rka-search`, `/rka-pending`, `/rka-set-project`, `/rka-setup-claude-desktop`), a SessionStart hook that pings the backend on every new session, and the full `mcp__plugin_rka_rka__*` tool surface (~90 tools). |
 | **Claude Desktop (Brain)** | `mcp__rka__*` tool surface via the `mcpServers.rka` entry in `claude_desktop_config.json`. Wrapper-based config gives you version-checking + auto-pin to your active project. Skills and slash commands are Claude Code only (Claude Desktop's plugin format is separate). |
 
 ---
@@ -49,7 +49,7 @@ Wait ~1 minute. Verify:
 
 ```bash
 curl http://localhost:9712/api/health
-# Expect: {"status":"ok","version":"2.3.x", ...}
+# Expect: {"status":"ok","version":"2.5.x", ...}
 ```
 
 Open http://localhost:9712 in your browser to confirm the dashboard loads.
@@ -110,7 +110,7 @@ Open a fresh chat in Claude Desktop. Ask:
 
 > List my RKA projects.
 
-Brain should call `rka_list_projects` and return the list (empty on a fresh install). If you also see a SessionStart hook line like `✅ RKA reachable at http://localhost:9712 (version 2.3.2, default project ...)` at session start in Claude Code, you're done.
+Brain should call `rka_list_projects` and return the list (empty on a fresh install). If you also see a SessionStart hook line like `✅ RKA reachable at http://localhost:9712 (version 2.5.x, default project ...)` at session start in Claude Code, you're done.
 
 ---
 
@@ -143,7 +143,7 @@ After Step 5, run these checks:
 1. `/help` should list five `rka:rka` slash commands: `/rka-status`, `/rka-search`, `/rka-pending`, `/rka-set-project`, `/rka-setup-claude-desktop`.
 2. `/context` should show three `rka:rka-*` skills available.
 3. Run `/rka-status`. Expected output: project name, phase, focus, open checkpoints (or "none").
-4. New chat sessions should start with an automatic line: `✅ RKA reachable at http://localhost:9712 (version 2.3.2, default project ...)`.
+4. New chat sessions should start with an automatic line: `✅ RKA reachable at http://localhost:9712 (version 2.5.x, default project ...)`.
 
 ### In Claude Desktop
 
@@ -151,7 +151,7 @@ Ask in any new chat:
 
 > What RKA tools do you have access to?
 
-Brain should respond with a list including `rka_list_projects`, `rka_get_status`, `rka_add_note`, etc. (~110 tools).
+Brain should respond with a list including `rka_list_projects`, `rka_get_status`, `rka_add_note`, etc. (~90 tools).
 
 ### Backend
 
@@ -160,7 +160,7 @@ docker compose ps
 # Expect both rka-server and rka-worker as "Up" / "healthy"
 
 curl http://localhost:9712/api/health
-# Expect {"status":"ok","version":"2.3.x", ...}
+# Expect {"status":"ok","version":"2.5.x", ...}
 ```
 
 ---
@@ -214,7 +214,7 @@ If the user does want to pin a default project (recommended once the user knows 
 
 ```json
 {
-  "version": "2.3.2",
+  "version": "2.5.10",
   "binary_path": "/Users/<you>/.local/bin/rka",
   "default_project_id": "prj_01ABC...",
   "api_endpoint_url": "http://localhost:9712"
@@ -395,8 +395,8 @@ Same JSON shape, in `.claude/mcp.json` (per-project) or `~/.claude/settings.json
 
 ## 10. What this guide intentionally doesn't cover
 
-- **Local LLM setup (LM Studio, Ollama, etc.)** — RKA v2.3+ doesn't require a local LLM. The Brain (Claude Desktop) handles all knowledge enrichment during normal sessions.
-- **Cloud LLM API setup (OpenAI, Anthropic API key)** — same reason; not needed for the core workflow. The optional `rka_ask` and `rka_generate_summary` tools do require an LLM key configured in the backend; see `docs/USER_MANUAL.md` Chapter 14 if you want them.
+- **Local LLM setup (LM Studio, Ollama, etc.) for chat/enrichment** — Chat-style enrichment tools (`rka_ask`, `rka_generate_summary`) were removed in v2.4.0 per `jrn_01KRNZBS50K250HHHHEC58E4GC`. The Brain (Claude Desktop) handles all knowledge enrichment during normal sessions. **However**, RKA v2.4.0+ supports pluggable embedding backends — configure FastEmbed (default, runs in-container), OpenAI-compatible HTTP (e.g., LM Studio, vLLM), or Ollama via **Settings → Embeddings** in the web dashboard at `http://localhost:9712`. Full reference: [`docs/embedding_backends.md`](docs/embedding_backends.md).
+- **Cloud LLM API setup (OpenAI, Anthropic API key)** — not required by RKA's core workflow.
 - **Knowledge pack import/export** — covered in [USAGE_GUIDE.md](USAGE_GUIDE.md) and [docs/USER_MANUAL.md](docs/USER_MANUAL.md).
 - **Per-project conventions** (Brain orientation, Executor mission flow, PI attribution) — covered by the role skills the plugin loads automatically. Once installed, ask Claude Code to "load the rka brain skill" or "show me the executor session protocol" for the workflow guides.
 - **Migrating from a pre-v2.3 RKA install** — for users who set up RKA before the plugin existed. See the upgrade notes in [USAGE_GUIDE.md](USAGE_GUIDE.md).

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ graph TD
 1. **MCP Tools Layer** — Thin adapter exposing `rka_*` tools over stdio. Keeps lightweight per-session state for output compaction and digests, but no core business logic.
 2. **REST API Layer** — FastAPI endpoints under `/api`. Same thin-adapter pattern, delegates to services.
 3. **Service Layer** — All business logic. CRUD operations, auto-enrichment, event emission, context preparation, distillation pipeline. Shared identically by MCP and REST.
-4. **Infrastructure Layer** — Database (SQLite + FTS5 + sqlite-vec), embeddings (FastEmbed), file storage. An optional LiteLLM gateway powers `rka_ask` / `rka_generate_summary` only when the user wires up a cloud-LLM API key.
+4. **Infrastructure Layer** — Database (SQLite + FTS5 + sqlite-vec), pluggable embedding backends (FastEmbed default; OpenAI-compatible HTTP; Ollama — configurable via Settings → Embeddings in the web dashboard, see [`docs/embedding_backends.md`](docs/embedding_backends.md)), file storage. The LiteLLM-gated `rka_ask` / `rka_generate_summary` tools were removed in v2.4.0; server-side code is preserved for future re-wiring through the orchestrator's Claude Code SDK.
 
 ### Three-Process Model
 
@@ -849,7 +849,6 @@ All tools are prefixed with `rka_` and available through the MCP stdio interface
 | `rka_search`         | Hybrid search across all entity types                                |
 | `rka_get_context`    | Importance-ranked context package (v2.4: no token budget; ordered by importance × centrality × recency) |
 | `rka_multi_hop_retrieval` | Query-anchored relevance-ranked subgraph traversing typed edges with per-relation weights |
-| `rka_ask`            | Ask a question grounded in the knowledge base (RAG)                  |
 | `rka_summarize`      | On-demand topic summarization                                        |
 | `rka_eviction_sweep` | Propose entries for archival based on staleness                      |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rka"
-version = "2.5.9"
+version = "2.5.10"
 description = "Research Knowledge Agent — MCP server + REST API for AI-assisted research orchestration"
 requires-python = ">=3.11"
 dependencies = [

--- a/rka/__init__.py
+++ b/rka/__init__.py
@@ -1,3 +1,3 @@
 """Research Knowledge Agent — MCP server + REST API for AI-assisted research."""
 
-__version__ = "2.5.9"
+__version__ = "2.5.10"


### PR DESCRIPTION
## Summary

Docs-only patch surfaced by PI audit immediately following v2.5.9 release. Addresses drift between installation guide and actual v2.4.0+ feature surface. **No code changes; test suite stays at 799 passing. No rebuild required.**

## Changes

### INSTALL.md
- **5 stale `v2.3.x` / `v2.3.2` version references** → `v2.5.x` (curl output examples, SessionStart hook example) or `v2.5.10` (integration.json example)
- **2 stale "~110 tools" claims** → `~90 tools` (verified actual count: 89 `rka_*` tools)
- **§10 "What this guide intentionally doesn't cover"** rewritten:
  - Old text described `rka_ask` / `rka_generate_summary` as optional tools requiring LLM key — these were **removed in v2.4.0** per `jrn_01KRNZBS50K250HHHHEC58E4GC`
  - New text correctly states the removal, then notes v2.4.0+ pluggable embedding backends (FastEmbed default; OpenAI-compatible HTTP; Ollama) configurable via Settings → Embeddings

### README.md
- **Infrastructure Layer description** (line 242) updated: was "embeddings (FastEmbed). An optional LiteLLM gateway powers `rka_ask`..." — now correctly describes pluggable backends + notes v2.4.0 LLM-tool removal
- **Tool table** (line 852) removed `rka_ask` row (tool no longer exposed)

## Scope discipline

Bookkeeper-strict. Touched files:
- `INSTALL.md` (8 in-place edits)
- `README.md` (2 in-place edits)
- `pyproject.toml` + `rka/__init__.py` + `CHANGELOG.md` (version bump 2.5.9 → 2.5.10 + new entry)

**NOT touched**: `rka/services/`, `rka/api/`, `rka/mcp/`, `web/`, tests, schema migrations.

## Operator impact

Zero at runtime. v2.5.10 brings nothing new at the API/MCP surface. Operators fetching the v2.5.10 tag will see corrected docs. Container rebuild is optional — useful only if you want `/api/health`'s `version` field to report `2.5.10`.

## Test plan
- [x] `INSTALL.md` no longer contains `v2.3.x` / `v2.3.2` version refs (verified via grep)
- [x] `README.md` no longer lists `rka_ask` in tool table (verified)
- [x] Version parity: `pyproject.toml` + `rka/__init__.py` both at `2.5.10`
- [x] Scope check: no files outside docs + version touched
- [ ] After merge, optionally rebuild container to surface v2.5.10 at `/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)