### PR TITLE
feat(orchestrator): Phase B — orchestrator-level credential bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,106 @@
 All notable changes to RKA are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) + semver.
 
+## [agentic — Phase B] — 2026-05-27 (orchestrator-level credential bootstrap)
+
+Branch-scoped release notes for the `agentic` branch. `main` is unaffected.
+
+### Shipped: Phase B — orchestrator-level credential bootstrap
+
+Phase B is the **prerequisite** workflow: it configures the orchestrator
+daemon's own credentials (in `orchestrator/.env`) so the daemon can call
+Claude at all. Distinct from Phase D, which writes per-project
+credentials at `~/rka-projects/<id>/.env`. A fresh install runs Phase B
+exactly once; Phase D once per project.
+
+The user surfaced this gap during the post-install audit on 2026-05-27:
+the `/orchestrator-onboard` flow assumes the orchestrator can already
+call Claude, but a fresh install can't until `CLAUDE_CODE_OAUTH_TOKEN`
+(or `ANTHROPIC_API_KEY`) lands in `orchestrator/.env`. Phase B closes
+that loop with the same PI-guided ratification pattern Phase D and
+Phase O use.
+
+### New surface
+
+- **`orchestrator_bootstrap_start()`** MCP tool — kicks off the
+  subgraph. No `project_id` (bootstrap is daemon-level). Proxies to
+  `POST /bootstrap` on the orchestrator REST API.
+- **`/orchestrator-bootstrap`** slash command — PI-facing entry point;
+  walks Claude through the four-gate interaction.
+- **`orchestrator/data/bootstrap_catalog.yaml`** — curated catalog of
+  5 orchestrator-level credentials:
+  - `claude-oauth` (CLAUDE_CODE_OAUTH_TOKEN; required; group `claude-auth`)
+  - `anthropic-api-key` (ANTHROPIC_API_KEY; required; group `claude-auth`,
+    alternative to OAuth)
+  - `semantic-scholar` (SEMANTIC_SCHOLAR_API_KEY; recommended)
+  - `serpapi` (SERPAPI_KEY; optional)
+  - `openalex-mailto` (OPENALEX_MAILTO; optional polite-pool email)
+- **`orchestrator/bootstrap.py`** — pure-Python catalog loader +
+  env-template renderer + env-file reader + verify probe wrapper.
+  Reuses the existing `credential_validator` HTTP-client signature so
+  tests can inject the same fake.
+- **`orchestrator/phase_b_graph.py`** — 6-node LangGraph subgraph
+  composer (3 background + 3 PI interrupts). Mirrors `phase_o_graph`
+  conventions: SqliteSaver checkpointer, set-identity ratification,
+  conditional routing.
+
+### New PI interrupts
+
+- **`pi_bootstrap_intent`** — free-form install-state description
+  (greenlight-class; "approve" advances).
+- **`pi_bootstrap_ratify`** — TWO-TAP set-identity ratification of the
+  proposed catalog subset. `bootstrap_ratified_ids` non-empty iff PI
+  accepts.
+- **`pi_bootstrap_fill_ack`** — replayable wait for the PI to edit
+  `orchestrator/.env`. Parks durably across restarts via the
+  SqliteSaver checkpointer. PI accepts when done; `bootstrap_verify`
+  then probes each filled key.
+
+### Security invariants
+
+- **Key values never appear** in interrupt payloads, logs, or verify
+  reports. Probe details contain only `env_var` + classification + a
+  non-secret reason string ("HTTP 401 (endpoint reachable; key rejected)").
+- `.env` and `.env.example` files are written with file-mode 0600
+  when the OS permits.
+- The render_env_template function never echoes existing values — it
+  marks "already set in existing .env" without surfacing the value.
+
+### Tests
+
+- **23 new tests** in `orchestrator/tests/test_phase_b_bootstrap.py`:
+  catalog load + 5-entry sanity, propose_for_intent semantics
+  (empty / full-install / substring match), env-template render with
+  group markers + existing-value masking, read_env_file parsing
+  (comments / placeholders / quotes / trailing comments),
+  verify_filled per-classification matrix (valid / rejected /
+  unreachable / missing / deferred), 3 Phase B background nodes
+  (propose / emit_template / verify), graph-compile smoke test +
+  routing helpers, runner accept-token + interrupt-type frozenset,
+  parked-store schema migration for Phase B types.
+- Full orchestrator suite: **745 passed** (was 722; +23 net).
+- Audit-symmetry: 6 new `current_node` names added to
+  `ONBOARDING_NODE_NAMES` so every Phase B node write satisfies the
+  union check.
+
+### Database migration
+
+- `schema.sql` CHECK constraint extended with the 3 new interrupt
+  types. `parked_store._migrate_pre_phase_o_if_needed` was renamed
+  conceptually to "_migrate_pre_phase_b_if_needed" semantics (the
+  same forward-migration routine; the sentinel flipped from
+  `pi_idea_capture` to `pi_bootstrap_intent`). Existing rows
+  preserved across the rebuild — Phase B is a strict superset of
+  the Phase O CHECK shape.
+
+### Skill update
+
+- `plugin/skills/orchestrator-pi/SKILL.md` bumped 0.3.0 → 0.4.0 with
+  a new `Bootstrap subgraph (Phase B)` block describing the 3
+  interrupts, plus a dedicated "Phase B — orchestrator-level
+  credential bootstrap" section covering rendering rules + security
+  invariants + the post-completion docker-recreate reminder.
+
 ## [agentic — Phase O] — 2026-05-26 (project-onboarding workflow)
 
 Branch-scoped release notes for the `agentic` branch. `main` is unaffected.

--- a/orchestrator/orchestrator/bootstrap.py
+++ b/orchestrator/orchestrator/bootstrap.py
@@ -1,0 +1,446 @@
+"""Phase B (Bootstrap) - orchestrator-level credential onboarding.
+
+Phase D (existing) handles per-project tool credentials and writes
+`~/rka-projects/<id>/.env`. Phase B handles the prerequisite step:
+the orchestrator daemon's own credentials, written to
+`orchestrator/.env`. A fresh install can't run Phase D until the
+orchestrator can call Claude at all.
+
+This module is pure logic - no LangGraph, no MCP. The Phase B nodes
+in `nodes/bootstrap.py` and `nodes/pi.py` call into here.
+
+Surfaces:
+  - load_catalog()                      -> list[BootstrapEntry]
+  - propose_for_intent(intent, catalog) -> list[BootstrapEntry]
+  - render_env_template(entries, ...)   -> str
+  - read_env_file(path)                 -> dict[str, str]
+  - verify_filled(entries, env_values)  -> list[VerifyResult]
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import yaml
+
+CATALOG_PATH = Path(__file__).resolve().parent / "data" / "bootstrap_catalog.yaml"
+SCHEMA_VERSION = "v1"
+
+# Default orchestrator/.env location. Resolved relative to the orchestrator
+# package install dir's parent so editable installs and uv-tool installs
+# both land in the same place. Overridable per call.
+DEFAULT_ENV_PATH = (
+    Path(__file__).resolve().parent.parent / ".env"
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BootstrapProbe:
+    """Validation metadata for one catalog entry."""
+    method: str = "skip"           # GET | HEAD | skip
+    url: str = ""
+    auth_header: str = ""          # template with `{value}`; empty if no header auth
+    extra_headers: dict[str, str] = field(default_factory=dict)
+    reason: str = ""               # populated when method == "skip"
+
+
+@dataclass
+class BootstrapEntry:
+    """One orchestrator-level credential the bootstrap can offer."""
+    id: str
+    label: str
+    purpose: str
+    env_var: str
+    target_file: str
+    criticality: str               # required | recommended | optional
+    group: Optional[str] = None    # mutually-exclusive grouping
+    signup_url: str = ""
+    format_hint: str = ""
+    probe: BootstrapProbe = field(default_factory=BootstrapProbe)
+
+
+@dataclass
+class VerifyResult:
+    """Outcome of probing one entry post-fill."""
+    entry_id: str
+    env_var: str
+    classification: str            # valid | rejected | missing | unreachable | deferred | skipped
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Catalog loader
+# ---------------------------------------------------------------------------
+
+
+class BootstrapCatalogError(ValueError):
+    """Raised when bootstrap_catalog.yaml is malformed."""
+
+
+def load_catalog(path: Optional[Path] = None) -> list[BootstrapEntry]:
+    """Read + validate the bootstrap catalog YAML. Returns the entry list
+    in source order (no sort)."""
+    src = path or CATALOG_PATH
+    if not src.is_file():
+        raise BootstrapCatalogError(f"{src}: file not found")
+    data = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise BootstrapCatalogError(f"{src}: top-level must be a mapping")
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise BootstrapCatalogError(
+            f"{src}: schema_version must be {SCHEMA_VERSION!r}, "
+            f"got {data.get('schema_version')!r}"
+        )
+    raw_entries = data.get("entries") or []
+    if not isinstance(raw_entries, list):
+        raise BootstrapCatalogError(f"{src}: entries must be a list")
+
+    seen_ids: set[str] = set()
+    seen_env_vars: set[str] = set()
+    entries: list[BootstrapEntry] = []
+    for i, e in enumerate(raw_entries):
+        if not isinstance(e, dict):
+            raise BootstrapCatalogError(f"{src}: entries[{i}] must be a mapping")
+        eid = str(e.get("id") or "").strip()
+        env_var = str(e.get("env_var") or "").strip()
+        if not eid or not env_var:
+            raise BootstrapCatalogError(
+                f"{src}: entries[{i}] missing id or env_var"
+            )
+        if eid in seen_ids:
+            raise BootstrapCatalogError(f"{src}: duplicate id {eid!r}")
+        if env_var in seen_env_vars:
+            raise BootstrapCatalogError(f"{src}: duplicate env_var {env_var!r}")
+        seen_ids.add(eid)
+        seen_env_vars.add(env_var)
+
+        criticality = str(e.get("criticality") or "optional").strip()
+        if criticality not in ("required", "recommended", "optional"):
+            raise BootstrapCatalogError(
+                f"{src}: entries[{i}].criticality invalid: {criticality!r}"
+            )
+        raw_probe = e.get("probe") or {}
+        if not isinstance(raw_probe, dict):
+            raise BootstrapCatalogError(
+                f"{src}: entries[{i}].probe must be a mapping"
+            )
+        method = str(raw_probe.get("method") or "skip").upper()
+        if method.lower() == "skip":
+            method = "skip"
+        if method not in ("GET", "HEAD", "skip"):
+            raise BootstrapCatalogError(
+                f"{src}: entries[{i}].probe.method invalid: {method!r}"
+            )
+        probe = BootstrapProbe(
+            method=method,
+            url=str(raw_probe.get("url") or ""),
+            auth_header=str(raw_probe.get("auth_header") or ""),
+            extra_headers=dict(raw_probe.get("extra_headers") or {}),
+            reason=str(raw_probe.get("reason") or ""),
+        )
+        entries.append(
+            BootstrapEntry(
+                id=eid,
+                label=str(e.get("label") or eid),
+                purpose=str(e.get("purpose") or "").strip(),
+                env_var=env_var,
+                target_file=str(e.get("target_file") or "orchestrator/.env"),
+                criticality=criticality,
+                group=(e.get("group") or None) and str(e["group"]).strip(),
+                signup_url=str(e.get("signup_url") or ""),
+                format_hint=str(e.get("format_hint") or "").strip(),
+                probe=probe,
+            )
+        )
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Intent matching -- which catalog entries to propose
+# ---------------------------------------------------------------------------
+
+
+def propose_for_intent(
+    intent_text: str,
+    catalog: list[BootstrapEntry],
+    *,
+    include_optional: bool = True,
+) -> list[BootstrapEntry]:
+    """Pick the subset of catalog entries that fit the PI's free-form intent.
+
+    Always include `required` entries. Always include `recommended`.
+    Include `optional` entries when their id/label/env_var appears in the
+    intent text (case-insensitive substring match) OR when
+    `include_optional=True` and the intent contains hints like "all",
+    "everything", or "full".
+
+    For groups (e.g., claude-auth) the caller is expected to keep all
+    members so the PI can pick one at ratification. We do NOT collapse
+    groups here -- the PI surface needs both candidates visible.
+    """
+    intent_lower = (intent_text or "").lower()
+    full_install = bool(
+        re.search(r"\b(all|everything|full|complete|every)\b", intent_lower)
+    )
+    selected: list[BootstrapEntry] = []
+    for e in catalog:
+        if e.criticality == "required" or e.criticality == "recommended":
+            selected.append(e)
+            continue
+        # optional entries: mention check OR full-install hint
+        if full_install and include_optional:
+            selected.append(e)
+            continue
+        for needle in (e.id.lower(), e.label.lower(), e.env_var.lower()):
+            if needle and needle in intent_lower:
+                selected.append(e)
+                break
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Env template render
+# ---------------------------------------------------------------------------
+
+
+_TEMPLATE_HEADER = """\
+# orchestrator/.env -- bootstrap template generated by Phase B.
+#
+# Replace each `<paste-here>` placeholder with the real value, save the
+# file (file-mode 0600 -- owner-readable only), then resume the parked
+# bootstrap interrupt via /orchestrator-bootstrap-continue (the
+# orchestrator will probe each filled key and report pass/fail without
+# logging the values).
+#
+# Mutually-exclusive groups: pick ONE entry per group and delete the
+# unused one. The group is noted in the comment block above each var.
+"""
+
+
+def render_env_template(
+    entries: list[BootstrapEntry],
+    *,
+    existing_values: Optional[dict[str, str]] = None,
+) -> str:
+    """Compose an annotated .env-format text for the PI to fill.
+
+    Each entry gets a 5-9 line comment block followed by `VAR=<paste-here>`
+    (or `VAR=<already-set>` if `existing_values` already has it -- the
+    pre-fill is preserved as a comment so the PI can re-fill or leave it).
+    """
+    existing = existing_values or {}
+    lines: list[str] = [_TEMPLATE_HEADER]
+
+    by_group: dict[str, list[BootstrapEntry]] = {}
+    standalone: list[BootstrapEntry] = []
+    for e in entries:
+        if e.group:
+            by_group.setdefault(e.group, []).append(e)
+        else:
+            standalone.append(e)
+
+    def _emit(e: BootstrapEntry, group_note: str = "") -> None:
+        lines.append("")
+        lines.append(f"# --- {e.label} ---")
+        if group_note:
+            lines.append(f"# {group_note}")
+        lines.append(f"# Purpose:    {e.purpose.strip()}")
+        lines.append(f"# Criticality: {e.criticality}")
+        if e.format_hint:
+            lines.append(f"# Format:     {e.format_hint.strip()}")
+        if e.signup_url:
+            lines.append(f"# Sign-up:    {e.signup_url}")
+        if existing.get(e.env_var):
+            lines.append(
+                f"# (already set in existing .env; uncomment to replace)"
+            )
+            lines.append(f"# {e.env_var}=<paste-here>")
+        else:
+            lines.append(f"{e.env_var}=<paste-here>")
+
+    # Group block: emit each member with a "mutually exclusive" note.
+    for group_name, members in by_group.items():
+        names = " | ".join(m.env_var for m in members)
+        for e in members:
+            _emit(
+                e,
+                group_note=f"GROUP `{group_name}` (pick ONE of: {names}); delete the unused one.",
+            )
+
+    # Standalone entries.
+    for e in standalone:
+        _emit(e)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# .env file reader (no value logging)
+# ---------------------------------------------------------------------------
+
+
+_ENV_LINE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$")
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    """Parse a `.env`-formatted file. Returns `{var_name: value}` for
+    non-comment, non-empty lines. Strips surrounding quotes. Values are
+    NOT logged anywhere by this function -- the caller's
+    responsibility is to never echo the dict.
+
+    Lines that look like `VAR=<paste-here>` (the template placeholder)
+    are dropped -- treated as "not filled yet".
+    """
+    if not path.is_file():
+        return {}
+    out: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0]  # strip end-of-line comments
+        m = _ENV_LINE.match(line)
+        if not m:
+            continue
+        k, v = m.group(1), m.group(2).strip()
+        # strip matching surrounding quotes
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+            v = v[1:-1]
+        # placeholder -> treat as unfilled
+        if v == "<paste-here>" or v == "":
+            continue
+        out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Verify (probe each filled entry)
+# ---------------------------------------------------------------------------
+
+
+# Same HTTP-client shape as credential_validator (deliberate parallel so
+# tests can share the injected fake).
+HTTPClient = Callable[[str, str, dict[str, str], float], tuple[int, Optional[str]]]
+
+
+def _default_http_client() -> HTTPClient:
+    """Lazy-import httpx so the module stays import-cheap under test."""
+    def _call(method: str, url: str, headers: dict[str, str], timeout: float):
+        try:
+            import httpx
+        except ImportError:
+            return (0, "httpx not installed")
+        try:
+            r = httpx.request(method, url, headers=headers, timeout=timeout)
+            return (r.status_code, None)
+        except Exception as e:  # noqa: BLE001
+            return (0, f"{type(e).__name__}: {str(e)[:120]}")
+    return _call
+
+
+def _classify_status(status: int, network_err: Optional[str]) -> tuple[str, str]:
+    """Map (status_code, network_err) -> (classification, detail).
+    Same tiering as credential_validator: 2xx=valid, 401/403=rejected,
+    network=unreachable."""
+    if network_err:
+        return "unreachable", f"network error: {network_err}"
+    if 200 <= status < 300:
+        return "valid", f"HTTP {status}"
+    if status in (401, 403):
+        return "rejected", f"HTTP {status} (endpoint reachable; key rejected)"
+    if status == 0:
+        return "unreachable", "no response (timeout or DNS failure)"
+    return "unreachable", f"HTTP {status} (unexpected)"
+
+
+def verify_filled(
+    entries: list[BootstrapEntry],
+    env_values: dict[str, str],
+    *,
+    http_client: Optional[HTTPClient] = None,
+    timeout_seconds: float = 5.0,
+) -> list[VerifyResult]:
+    """For each entry, classify based on env_values and probe."""
+    client = http_client or _default_http_client()
+    results: list[VerifyResult] = []
+    for e in entries:
+        value = env_values.get(e.env_var, "")
+        if not value:
+            results.append(
+                VerifyResult(
+                    entry_id=e.id,
+                    env_var=e.env_var,
+                    classification="missing",
+                    detail=f"{e.env_var} not set in .env",
+                )
+            )
+            continue
+        if e.probe.method == "skip":
+            results.append(
+                VerifyResult(
+                    entry_id=e.id,
+                    env_var=e.env_var,
+                    classification="deferred",
+                    detail=e.probe.reason or "no probe declared",
+                )
+            )
+            continue
+        # Render the probe URL + headers without logging the value.
+        url = e.probe.url.replace("{value}", value) if "{value}" in e.probe.url else e.probe.url
+        headers: dict[str, str] = dict(e.probe.extra_headers)
+        if e.probe.auth_header:
+            # format: "Header-Name: template-with-{value}"
+            header_line = e.probe.auth_header.replace("{value}", value)
+            if ":" in header_line:
+                hk, hv = header_line.split(":", 1)
+                headers[hk.strip()] = hv.strip()
+        status, err = client(e.probe.method, url, headers, timeout_seconds)
+        cls, detail = _classify_status(status, err)
+        results.append(
+            VerifyResult(
+                entry_id=e.id,
+                env_var=e.env_var,
+                classification=cls,
+                detail=detail,
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rendering (PI-facing summary; never includes values)
+# ---------------------------------------------------------------------------
+
+
+_GLYPHS = {
+    "valid": "✓",
+    "deferred": "·",
+    "missing": "✗",
+    "rejected": "✗",
+    "unreachable": "?",
+}
+
+
+def render_verify_summary(
+    results: list[VerifyResult], *, catalog: list[BootstrapEntry]
+) -> str:
+    """One-line-per-entry summary, safe for the PI transcript."""
+    if not results:
+        return "(no entries to verify)"
+    label_by_id = {e.id: e.label for e in catalog}
+    crit_by_id = {e.id: e.criticality for e in catalog}
+    lines = ["Bootstrap verify results:"]
+    for r in results:
+        glyph = _GLYPHS.get(r.classification, "?")
+        label = label_by_id.get(r.entry_id, r.entry_id)
+        crit = crit_by_id.get(r.entry_id, "")
+        lines.append(
+            f"  {glyph} {label} ({r.env_var}, {crit}) - {r.classification}: {r.detail}"
+        )
+    return "\n".join(lines)

--- a/orchestrator/orchestrator/data/bootstrap_catalog.yaml
+++ b/orchestrator/orchestrator/data/bootstrap_catalog.yaml
@@ -1,0 +1,135 @@
+# =============================================================
+# Orchestrator bootstrap catalog (Phase B)
+#
+# Orchestrator-LEVEL credentials -- the ones the orchestrator daemon
+# itself needs to run before any project exists. Lives in
+# `orchestrator/.env` (file-mode 0600).
+#
+# This is distinct from the project-LEVEL tool registry in
+# `tool_registry.yaml`, which Phase D consumes to wire per-project
+# MCP toolkits at `~/rka-projects/<id>/.env`. Phase B handles the
+# bootstrap problem: a fresh install can't run Phase D until the
+# orchestrator can call Claude at all.
+#
+# Each entry:
+#   - id:           short slug used in state + PI surface
+#   - label:        human display name
+#   - purpose:      one-line "what it does"
+#   - env_var:      single shell env variable name
+#   - target_file:  where to paste it (always orchestrator/.env in v1)
+#   - criticality:  required | recommended | optional
+#                   (matches credential_validator's tiering)
+#   - group:        optional; entries sharing a group are mutually-
+#                   exclusive alternatives (e.g., claude-oauth +
+#                   anthropic-api-key both authenticate Claude --
+#                   pick ONE).
+#   - signup_url:   where to mint the key
+#   - format_hint:  human-readable shape ("starts with sk-ant-...")
+#   - probe:        validation metadata for credential_validator
+#       method:       GET | HEAD
+#       url:          endpoint to probe
+#       auth_header:  template with {value} placeholder
+#                     (or omitted if the key isn't header-auth'd)
+#
+# Maintenance: small intentionally. Reviewed at every agentic release.
+# =============================================================
+
+schema_version: v1
+
+entries:
+  - id: claude-oauth
+    label: Claude Code OAuth token
+    purpose: |
+      Authenticates the orchestrator's claude-agent-sdk subprocess
+      against Anthropic without API billing (preferred path on Mac).
+    env_var: CLAUDE_CODE_OAUTH_TOKEN
+    target_file: orchestrator/.env
+    criticality: required
+    group: claude-auth
+    signup_url: ""  # produced locally via `claude setup-token`
+    format_hint: |
+      Run `claude setup-token` on the host (one-time). Prints a long-lived
+      token starting with `sk-ant-oat01-`. Paste that whole line as the value.
+    probe:
+      # The Claude SDK validates internally on first subprocess launch;
+      # there is no cheap HTTP probe for an OAuth token at the v1 layer.
+      method: skip
+      reason: |
+        OAuth tokens are validated by the claude-agent-sdk subprocess at
+        its first call. A degenerate HTTP probe would either hit the
+        token-introspection endpoint (not exposed) or burn a real Claude
+        call. Bootstrap verify reports "deferred" for this entry; if the
+        token is wrong, the orchestrator's first Claude call will surface
+        a 401 in the run log within ~5 seconds of phase A start.
+
+  - id: anthropic-api-key
+    label: Anthropic API key
+    purpose: |
+      Alternative to claude-oauth -- authenticates against the public
+      Anthropic API directly (incurs per-token billing on the API
+      account, NOT a Claude Max subscription).
+    env_var: ANTHROPIC_API_KEY
+    target_file: orchestrator/.env
+    criticality: required
+    group: claude-auth
+    signup_url: https://console.anthropic.com/settings/keys
+    format_hint: "Starts with `sk-ant-api03-`. ~108 characters."
+    probe:
+      method: GET
+      url: https://api.anthropic.com/v1/models
+      auth_header: "x-api-key: {value}"
+      extra_headers:
+        anthropic-version: "2023-06-01"
+
+  - id: semantic-scholar
+    label: Semantic Scholar API key
+    purpose: |
+      Boosts rate limit on the orchestrator's literature-search calls
+      (research_toolkit_node, Phase O hygiene_pass, etc.) from
+      100 requests / 5 minutes (anonymous) to 1 request / second.
+    env_var: SEMANTIC_SCHOLAR_API_KEY
+    target_file: orchestrator/.env
+    criticality: recommended
+    signup_url: https://www.semanticscholar.org/product/api#api-key-form
+    format_hint: |
+      Alphanumeric token, ~40 chars. Free; approval takes a few business
+      days. The orchestrator works without it but throttles aggressively.
+    probe:
+      method: GET
+      url: https://api.semanticscholar.org/graph/v1/paper/search?query=test&limit=1
+      auth_header: "x-api-key: {value}"
+
+  - id: serpapi
+    label: SerpAPI key (Google Scholar / web fallback)
+    purpose: |
+      Web-search fallback when curated tool_registry domains miss a
+      tool. Also used by the writer skill's serpapi backend.
+    env_var: SERPAPI_KEY
+    target_file: orchestrator/.env
+    criticality: optional
+    signup_url: https://serpapi.com/manage-api-key
+    format_hint: "64-char hex string. Free tier: 100 searches/month."
+    probe:
+      method: GET
+      # The /account endpoint accepts the key as a query param and
+      # returns 200 + a JSON body with credits remaining. Body is not
+      # logged by credential_validator (security invariant); only the
+      # status is read.
+      url: https://serpapi.com/account?api_key={value}
+      auth_header: ""  # query-param auth, no header
+
+  - id: openalex-mailto
+    label: OpenAlex polite-pool email
+    purpose: |
+      Identifies the orchestrator to OpenAlex's "polite pool" -- higher
+      rate limits + priority routing. Not a secret; just an email
+      string OpenAlex echoes back in User-Agent.
+    env_var: OPENALEX_MAILTO
+    target_file: orchestrator/.env
+    criticality: optional
+    signup_url: https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool
+    format_hint: "Plain email address. Not authenticated; just identifies you."
+    probe:
+      method: GET
+      url: https://api.openalex.org/works?per-page=1&mailto={value}
+      auth_header: ""  # query-param identification, no header

--- a/orchestrator/orchestrator/db/schema.sql
+++ b/orchestrator/orchestrator/db/schema.sql
@@ -64,7 +64,11 @@ CREATE TABLE IF NOT EXISTS parked_interrupts (
             'pi_deepresearch_prompt',
             'pi_claims_review',
             'pi_plan_ratify',
-            'pi_phase_entry_ack'
+            'pi_phase_entry_ack',
+            -- Phase B — orchestrator-level bootstrap (orchestrator/.env)
+            'pi_bootstrap_intent',
+            'pi_bootstrap_ratify',
+            'pi_bootstrap_fill_ack'
         )),
     payload_json TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending'

--- a/orchestrator/orchestrator/graph.py
+++ b/orchestrator/orchestrator/graph.py
@@ -327,4 +327,13 @@ ONBOARDING_NODE_NAMES: tuple[str, ...] = (
     "pi_plan_ratify",
     # Phase H (per-milestone go/no-go before each mission dispatch):
     "pi_phase_entry_ack",
+    # Phase B — orchestrator-level credential bootstrap. Distinct from
+    # Phase D (per-project credentials); Phase B wires orchestrator/.env
+    # so the daemon itself can call Claude before any project exists.
+    "pi_bootstrap_intent",
+    "bootstrap_propose",
+    "pi_bootstrap_ratify",
+    "bootstrap_emit_template",
+    "pi_bootstrap_fill_ack",
+    "bootstrap_verify",
 )

--- a/orchestrator/orchestrator/mcp_server.py
+++ b/orchestrator/orchestrator/mcp_server.py
@@ -371,6 +371,52 @@ async def orchestrator_get_manifest(project_id: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Phase B — orchestrator-level credential bootstrap
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def orchestrator_bootstrap_start(
+    workflow_thread_id: Optional[str] = None,
+) -> dict:
+    """Kick off the orchestrator-level credential bootstrap (Phase B).
+
+    Use this on a fresh install BEFORE any project exists. Phase B
+    handles the credentials in `orchestrator/.env` that the daemon
+    itself needs (Claude OAuth or API key, plus optional Semantic
+    Scholar / SerpAPI / OpenAlex polite-pool email).
+
+    Distinct from `orchestrator_onboard_start`, which handles per-
+    project credentials under `~/rka-projects/<id>/.env`.
+
+    Flow once started:
+      1. Daemon parks at `pi_bootstrap_intent` — claude renders the
+         intent-elicitation prompt ("describe your install state").
+      2. PI responds; daemon resumes, runs `propose_for_intent`, parks
+         at `pi_bootstrap_ratify` with the shortlist.
+      3. PI ratifies; daemon writes `orchestrator/.env.example` with
+         annotated slots, parks at `pi_bootstrap_fill_ack`.
+      4. PI edits `orchestrator/.env` and signals "ready"; daemon
+         probes each filled key (without logging values) and reports
+         pass/fail, completing the workflow.
+
+    Args:
+        workflow_thread_id: Optional explicit thread id.
+
+    Returns the same outcome shape as orchestrator_run_start. The PI
+    session typically calls `orchestrator_inbox` next to render the
+    parked interrupt.
+    """
+    async with _client() as c:
+        r = await c.post(
+            "/bootstrap",
+            json={"workflow_thread_id": workflow_thread_id},
+        )
+        _raise_with_detail(r)
+        return r.json()
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/orchestrator/nodes/bootstrap.py
+++ b/orchestrator/orchestrator/nodes/bootstrap.py
@@ -1,0 +1,263 @@
+"""Phase B background nodes — orchestrator-level credential bootstrap.
+
+Three non-interrupt nodes that bracket the three Phase B PI interrupts
+(`pi_bootstrap_intent`, `pi_bootstrap_ratify`, `pi_bootstrap_fill_ack`):
+
+    bootstrap_propose       — load catalog, run propose_for_intent,
+                              stage decisions_to_present for the
+                              ratify interrupt
+    bootstrap_emit_template — write orchestrator/.env.example next to
+                              the live .env, with annotated slots
+    bootstrap_verify        — read the filled .env, probe each
+                              ratified entry, write a report
+
+All three are pure-Python — they delegate to `orchestrator.bootstrap`
+which holds the catalog/template/verify logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from orchestrator import bootstrap as B
+from orchestrator.llm_client import SDKClient  # noqa: F401 (signature parity)
+from orchestrator.mcp_client import MCPClient  # noqa: F401
+from orchestrator.state import ResearchWorkflowState
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# B2 — bootstrap_propose
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_propose_node(
+    state: ResearchWorkflowState,
+    sdk: SDKClient,
+    mcp: MCPClient,
+) -> dict:
+    """Load the catalog + match the PI's intent + stage for ratification.
+
+    Writes:
+      - bootstrap_proposed_ids — id slugs from the match
+      - decisions_to_present  — append a PI-renderable view block
+                                 tagged `source_node='bootstrap_propose'`
+    """
+    intent = state.get("bootstrap_intent", "") or ""
+    try:
+        catalog = B.load_catalog()
+    except B.BootstrapCatalogError as exc:
+        return {
+            "current_node": "bootstrap_propose",
+            "errors": [
+                {
+                    "node_name": "bootstrap_propose",
+                    "error_type": "bootstrap_catalog_load_failed",
+                    "detail": str(exc)[:300],
+                    "timestamp": _now_iso(),
+                }
+            ],
+        }
+    selected = B.propose_for_intent(intent, catalog)
+    items: list[dict[str, Any]] = []
+    for e in selected:
+        items.append(
+            {
+                "source_node": "bootstrap_propose",
+                "entry_id": e.id,
+                "label": e.label,
+                "env_var": e.env_var,
+                "criticality": e.criticality,
+                "group": e.group or "",
+                "purpose": e.purpose,
+                "signup_url": e.signup_url,
+                "format_hint": e.format_hint,
+            }
+        )
+    return {
+        "current_node": "bootstrap_propose",
+        "bootstrap_proposed_ids": [e.id for e in selected],
+        "decisions_to_present": items,
+    }
+
+
+# ---------------------------------------------------------------------------
+# B4 — bootstrap_emit_template
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_emit_template_node(
+    state: ResearchWorkflowState,
+    sdk: SDKClient,
+    mcp: MCPClient,
+    *,
+    env_path: Path | None = None,
+) -> dict:
+    """Write `<env_path>.example` with annotated slots for the ratified subset.
+
+    Defaults to `orchestrator/.env.example`. The live `.env` (if any) is
+    read into existing_values so already-set vars get a comment marker
+    "(already set in existing .env; uncomment to replace)" instead of an
+    overwrite slot.
+
+    Writes:
+      - bootstrap_template_path  — absolute path of the file produced
+      - decisions_to_present     — appends a summary block tagged
+                                    `source_node='bootstrap_emit_template'`
+                                    for the fill_ack interrupt to render
+    """
+    ratified_ids = state.get("bootstrap_ratified_ids", []) or []
+    if not ratified_ids:
+        return {
+            "current_node": "bootstrap_emit_template",
+            "errors": [
+                {
+                    "node_name": "bootstrap_emit_template",
+                    "error_type": "bootstrap_no_ratified_ids",
+                    "detail": "ratified_ids empty; ratify must accept before emit",
+                    "timestamp": _now_iso(),
+                }
+            ],
+        }
+    try:
+        catalog = B.load_catalog()
+    except B.BootstrapCatalogError as exc:
+        return {
+            "current_node": "bootstrap_emit_template",
+            "errors": [
+                {
+                    "node_name": "bootstrap_emit_template",
+                    "error_type": "bootstrap_catalog_load_failed",
+                    "detail": str(exc)[:300],
+                    "timestamp": _now_iso(),
+                }
+            ],
+        }
+    chosen = [e for e in catalog if e.id in set(ratified_ids)]
+
+    live_env_path = env_path or B.DEFAULT_ENV_PATH
+    existing = B.read_env_file(live_env_path) if live_env_path.is_file() else {}
+    text = B.render_env_template(chosen, existing_values=existing)
+
+    template_path = live_env_path.with_suffix(live_env_path.suffix + ".example")
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_text(text, encoding="utf-8")
+    try:
+        template_path.chmod(0o600)
+    except OSError:
+        pass  # best-effort; cross-platform safety
+
+    items: list[dict[str, Any]] = []
+    for e in chosen:
+        items.append(
+            {
+                "source_node": "bootstrap_emit_template",
+                "entry_id": e.id,
+                "env_var": e.env_var,
+                "criticality": e.criticality,
+                "label": e.label,
+                "signup_url": e.signup_url,
+                "already_set_in_live_env": bool(existing.get(e.env_var)),
+            }
+        )
+    return {
+        "current_node": "bootstrap_emit_template",
+        "bootstrap_template_path": str(template_path),
+        "decisions_to_present": items,
+    }
+
+
+# ---------------------------------------------------------------------------
+# B6 — bootstrap_verify
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_verify_node(
+    state: ResearchWorkflowState,
+    sdk: SDKClient,
+    mcp: MCPClient,
+    *,
+    env_path: Path | None = None,
+) -> dict:
+    """Read the live `.env`, probe each ratified entry, attach a report.
+
+    The report shape (each entry):
+      {
+        entry_id, env_var, classification, detail
+      }
+
+    `classification` is one of: valid | rejected | missing | unreachable
+    | deferred | skipped. Values are NEVER included.
+
+    Writes:
+      - bootstrap_verify_results — list[dict] for the runner to render
+      - terminal_state            — "complete" iff every required entry
+                                     verified as valid OR deferred;
+                                     else "escalated"
+    """
+    ratified_ids = state.get("bootstrap_ratified_ids", []) or []
+    if not ratified_ids:
+        return {
+            "current_node": "bootstrap_verify",
+            "errors": [
+                {
+                    "node_name": "bootstrap_verify",
+                    "error_type": "bootstrap_no_ratified_ids",
+                    "detail": "ratified_ids empty; verify must follow ratify accept",
+                    "timestamp": _now_iso(),
+                }
+            ],
+        }
+    try:
+        catalog = B.load_catalog()
+    except B.BootstrapCatalogError as exc:
+        return {
+            "current_node": "bootstrap_verify",
+            "errors": [
+                {
+                    "node_name": "bootstrap_verify",
+                    "error_type": "bootstrap_catalog_load_failed",
+                    "detail": str(exc)[:300],
+                    "timestamp": _now_iso(),
+                }
+            ],
+        }
+    chosen = [e for e in catalog if e.id in set(ratified_ids)]
+
+    live_env_path = env_path or B.DEFAULT_ENV_PATH
+    env_values = B.read_env_file(live_env_path) if live_env_path.is_file() else {}
+    results = B.verify_filled(chosen, env_values)
+    results_dicts = [
+        {
+            "entry_id": r.entry_id,
+            "env_var": r.env_var,
+            "classification": r.classification,
+            "detail": r.detail,
+        }
+        for r in results
+    ]
+
+    # Determine terminal state: every `required` entry must be valid or
+    # deferred for the bootstrap to be considered complete. The runner
+    # decides how to surface this to the PI.
+    crit_by_id = {e.id: e.criticality for e in chosen}
+    failed_required = [
+        r for r in results
+        if crit_by_id.get(r.entry_id) == "required"
+        and r.classification not in ("valid", "deferred")
+    ]
+    terminal = "complete" if not failed_required else "escalated"
+
+    return {
+        "current_node": "bootstrap_verify",
+        "bootstrap_verify_results": results_dicts,
+        "terminal_state": terminal,
+    }

--- a/orchestrator/orchestrator/nodes/pi.py
+++ b/orchestrator/orchestrator/nodes/pi.py
@@ -1427,3 +1427,175 @@ def pi_credentials_ready(
             )
         ],
     }
+
+
+# ---------------------------------------------------------------------------
+# Phase B (Bootstrap) PI interrupts — orchestrator-level credential setup
+# ---------------------------------------------------------------------------
+#
+# Phase B is distinct from Phase D: Phase D handles per-project
+# credentials (writes ~/rka-projects/<id>/.env); Phase B handles the
+# orchestrator daemon's own credentials (writes orchestrator/.env)
+# so the daemon can call Claude at all. Three interrupts gate the
+# flow: intent capture → ratification → fill ack.
+
+
+_PI_BOOTSTRAP_INTENT_PROMPT = """\
+Welcome to orchestrator bootstrap. Describe your install state in a
+short sentence and I'll propose the credentials to set up. Examples:
+
+  - "fresh install on my laptop"
+  - "switching from API key to Claude Max OAuth"
+  - "I want everything including SerpAPI for web search"
+  - "minimal setup, just Claude OAuth"
+
+The orchestrator catalog covers: Claude OAuth (or API key as alternative),
+Semantic Scholar (rate-limit boost), SerpAPI (paid web search),
+OpenAlex polite-pool email. I'll skip any you don't mention unless they're
+required for the orchestrator to run at all.
+"""
+
+
+def pi_bootstrap_intent(
+    state: ResearchWorkflowState,
+    sdk: SDKClient,
+    mcp: MCPClient,
+    interrupt_fn: Callable[[dict], Any],
+) -> dict:
+    """First Phase B PI interrupt — free-form install-state description.
+
+    The PI session captures the response into state["bootstrap_intent"]
+    so the downstream bootstrap_propose node can match it against the
+    catalog. Low-stakes (no TWO-TAP) — the ratification happens at
+    pi_bootstrap_ratify after the proposal is rendered.
+    """
+    payload = {
+        "type": "pi_bootstrap_intent",
+        "title": "PI bootstrap intent — describe your install state",
+        "prompt": _PI_BOOTSTRAP_INTENT_PROMPT,
+        "items": [],
+        "total_items": 0,
+    }
+    pi_response = interrupt_fn(payload)
+    response_str = str(pi_response or "").strip()
+    # When PI hits accept with the greenlight token, leave the intent
+    # empty -- propose_for_intent then returns the required-and-recommended
+    # default set.
+    if response_str.lower() in {"approve", "accept", "reject"}:
+        intent = ""
+    else:
+        intent = response_str[:2000]
+    return {
+        "current_phase": "init",
+        "current_node": "pi_bootstrap_intent",
+        "bootstrap_intent": intent,
+        "interrupts": [
+            _record_interrupt(
+                node_name="pi_bootstrap_intent",
+                payload_size=0,
+                response=pi_response,
+                batch_review_used=False,
+            )
+        ],
+    }
+
+
+def pi_bootstrap_ratify(
+    state: ResearchWorkflowState,
+    sdk: SDKClient,
+    mcp: MCPClient,
+    interrupt_fn: Callable[[dict], Any],
+) -> dict:
+    """Second Phase B PI interrupt — ratify the proposed catalog subset.
+
+    Set-identity: ratified_ids is populated iff PI accepts (mirrors
+    pi_toolkit_ratify's Phase 2.7 T3d pattern). On accept, every
+    proposed id moves into bootstrap_ratified_ids; on reject/correct,
+    the list stays empty and the graph routes to END.
+    """
+    proposed_ids = state.get("bootstrap_proposed_ids", []) or []
+    # The propose node also writes a serializable view of the chosen
+    # entries onto decisions_to_present so we can surface it here without
+    # re-loading the catalog. Tolerant of missing data.
+    pending = state.get("decisions_to_present", []) or []
+    items = [d for d in pending if d.get("source_node") == "bootstrap_propose"]
+
+    payload, batched = _build_interrupt_payload(
+        node_name="pi_bootstrap_ratify",
+        items=items,
+        title="PI ratification — bootstrap credential shortlist",
+    )
+    pi_response = interrupt_fn(payload)
+    response_text = str(pi_response).lower()
+    is_accept = "accept" in response_text or "approve" in response_text
+    ratified = list(proposed_ids) if is_accept else []
+
+    remaining = [d for d in pending if d.get("source_node") != "bootstrap_propose"]
+    return {
+        "current_phase": "init",
+        "current_node": "pi_bootstrap_ratify",
+        "decisions_to_present": remaining,
+        "bootstrap_ratified_ids": ratified,
+        "batch_review_active": batched,
+        "batch_review_payload_size": len(items),
+        "interrupts": [
+            _record_interrupt(
+                node_name="pi_bootstrap_ratify",
+                payload_size=len(items),
+                response=pi_response,
+                batch_review_used=batched,
+            )
+        ],
+    }
+
+
+def pi_bootstrap_fill_ack(
+    state: ResearchWorkflowState,
+    sdk: SDKClient,
+    mcp: MCPClient,
+    interrupt_fn: Callable[[dict], Any],
+) -> dict:
+    """Third Phase B PI interrupt — replayable wait for the PI to fill .env.
+
+    Parks with the file path + list of expected env_vars + criticality
+    + sign-up URLs. Never surfaces values. On accept, the next node
+    (bootstrap_verify) probes each filled key and emits a report.
+    On reject, the bootstrap aborts cleanly (the .env.example file
+    stays on disk so the PI can resume manually with --continue).
+    """
+    template_path = state.get("bootstrap_template_path", "") or "orchestrator/.env"
+    pending = state.get("decisions_to_present", []) or []
+    items = [d for d in pending if d.get("source_node") == "bootstrap_emit_template"]
+
+    payload = {
+        "type": "pi_bootstrap_fill_ack",
+        "title": "PI fill ack — edit orchestrator/.env then accept",
+        "prompt": (
+            f"Open {template_path} (file-mode 0600). Replace each "
+            f"`<paste-here>` placeholder with the real value, save, "
+            "then accept this interrupt. The orchestrator will probe "
+            "each filled key without logging the value and report "
+            "pass/fail. Reject to abort -- the template file stays "
+            "on disk so you can resume later."
+        ),
+        "template_path": template_path,
+        "expected_entries": items,
+        "items": [],
+        "total_items": 0,
+    }
+    pi_response = interrupt_fn(payload)
+
+    remaining = [d for d in pending if d.get("source_node") != "bootstrap_emit_template"]
+    return {
+        "current_phase": "init",
+        "current_node": "pi_bootstrap_fill_ack",
+        "decisions_to_present": remaining,
+        "interrupts": [
+            _record_interrupt(
+                node_name="pi_bootstrap_fill_ack",
+                payload_size=len(items),
+                response=pi_response,
+                batch_review_used=False,
+            )
+        ],
+    }

--- a/orchestrator/orchestrator/parked_store.py
+++ b/orchestrator/orchestrator/parked_store.py
@@ -50,6 +50,10 @@ InterruptType = Literal[
     "pi_claims_review",
     "pi_plan_ratify",
     "pi_phase_entry_ack",
+    # Phase B — orchestrator-level bootstrap (orchestrator/.env)
+    "pi_bootstrap_intent",
+    "pi_bootstrap_ratify",
+    "pi_bootstrap_fill_ack",
 ]
 ResponseAction = Literal["accept", "reject", "correct"]
 RunStatus = Literal[
@@ -123,8 +127,8 @@ class ParkedStore:
         if row is None:
             return  # Table doesn't exist yet — schema.sql will create it next pass.
         create_sql = row[0] or ""
-        if "pi_idea_capture" in create_sql:
-            return  # Already Phase-O shape (sentinel: first Phase-O interrupt type).
+        if "pi_bootstrap_intent" in create_sql:
+            return  # Already Phase-B shape (sentinel: first Phase-B interrupt type).
 
         # Legacy shape detected: rebuild with the new CHECK.
         with self._conn:

--- a/orchestrator/orchestrator/phase_b_graph.py
+++ b/orchestrator/orchestrator/phase_b_graph.py
@@ -1,0 +1,144 @@
+"""Phase B — orchestrator-level bootstrap subgraph composer.
+
+Wires the 6 Phase B nodes (3 PI interrupts + 3 background) into a
+LangGraph subgraph distinct from:
+
+  - graph.py             — Phase A mission graph
+  - onboarding_graph.py  — Phase D per-project tool-setup
+  - phase_o_graph.py     — Phase O project-onboarding
+
+Phase B handles the *prerequisite* problem: a fresh install can't run
+Phase D (or anything else) until the orchestrator daemon itself can
+call Claude. So Phase B writes the orchestrator's own .env.
+
+Topology:
+
+    START
+      → pi_bootstrap_intent       [interrupt — free-form intent]
+      → bootstrap_propose         [match catalog vs intent]
+      → pi_bootstrap_ratify       [TWO-TAP — accept the shortlist]
+         ┌─ accept → bootstrap_emit_template
+         │            → pi_bootstrap_fill_ack [replayable interrupt]
+         │                ┌─ accept → bootstrap_verify
+         │                │             → END (terminal_state set by verify)
+         │                └─ else  → END (template stays on disk)
+         └─ else   → END (re-enter via /orchestrator-bootstrap)
+
+Set-identity for ratification gates:
+  - state["bootstrap_ratified_ids"] non-empty iff PI accepted ratify
+  - terminal_state set by verify ("complete" iff all required pass)
+
+Reject/correct loops back to entry by ending the graph; the runner
+or skill re-enters from scratch with the brain_position carrying any
+redirect text. Keeps the graph acyclic + SqliteSaver-durable per-segment.
+"""
+
+from __future__ import annotations
+
+import functools
+import sqlite3
+from typing import Any, Callable
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import interrupt as lg_interrupt
+
+from orchestrator.llm_client import SDKClient
+from orchestrator.mcp_client import MCPClient
+from orchestrator.nodes import bootstrap as bootstrap_nodes
+from orchestrator.nodes import pi
+from orchestrator.state import ResearchWorkflowState
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def _route_after_bootstrap_ratify(state: dict) -> str:
+    """Accept → emit; else → END.
+    Set-identity: bootstrap_ratified_ids non-empty iff accepted."""
+    return "bootstrap_emit_template" if state.get("bootstrap_ratified_ids") else END
+
+
+def _route_after_fill_ack(state: dict) -> str:
+    """Accept → verify; else → END.
+
+    The latest interrupt's response carries the accept/reject signal.
+    On reject the .env.example is left on disk so the PI can resume later.
+    """
+    interrupts = state.get("interrupts") or []
+    if not interrupts:
+        return END
+    last = interrupts[-1]
+    if last.get("node_name") != "pi_bootstrap_fill_ack":
+        return END
+    response = str(last.get("response", "")).lower()
+    return "bootstrap_verify" if ("accept" in response or "approve" in response) else END
+
+
+def _bind(fn: Callable, sdk: SDKClient, mcp: MCPClient, **extras: Any) -> Callable:
+    return functools.partial(fn, sdk=sdk, mcp=mcp, **extras)
+
+
+def build_phase_b_graph(
+    *,
+    sdk: SDKClient,
+    mcp: MCPClient,
+    checkpointer: Any | None = None,
+    interrupt_fn: Callable[[dict], Any] = lg_interrupt,
+):
+    """Compile the Phase B subgraph.
+
+    Signature mirrors build_graph / build_onboarding_graph /
+    build_phase_o_graph. PI interrupts park via the SqliteSaver and
+    resume via Command(resume=...).
+    """
+    sg: StateGraph = StateGraph(ResearchWorkflowState)
+
+    # Background nodes (no interrupt_fn).
+    sg.add_node("bootstrap_propose", _bind(bootstrap_nodes.bootstrap_propose_node, sdk, mcp))
+    sg.add_node(
+        "bootstrap_emit_template",
+        _bind(bootstrap_nodes.bootstrap_emit_template_node, sdk, mcp),
+    )
+    sg.add_node("bootstrap_verify", _bind(bootstrap_nodes.bootstrap_verify_node, sdk, mcp))
+
+    # PI interrupt nodes.
+    sg.add_node(
+        "pi_bootstrap_intent",
+        _bind(pi.pi_bootstrap_intent, sdk, mcp, interrupt_fn=interrupt_fn),
+    )
+    sg.add_node(
+        "pi_bootstrap_ratify",
+        _bind(pi.pi_bootstrap_ratify, sdk, mcp, interrupt_fn=interrupt_fn),
+    )
+    sg.add_node(
+        "pi_bootstrap_fill_ack",
+        _bind(pi.pi_bootstrap_fill_ack, sdk, mcp, interrupt_fn=interrupt_fn),
+    )
+
+    # Edges.
+    sg.add_edge(START, "pi_bootstrap_intent")
+    sg.add_edge("pi_bootstrap_intent", "bootstrap_propose")
+    sg.add_edge("bootstrap_propose", "pi_bootstrap_ratify")
+    sg.add_conditional_edges(
+        "pi_bootstrap_ratify",
+        _route_after_bootstrap_ratify,
+        {"bootstrap_emit_template": "bootstrap_emit_template", END: END},
+    )
+    sg.add_edge("bootstrap_emit_template", "pi_bootstrap_fill_ack")
+    sg.add_conditional_edges(
+        "pi_bootstrap_fill_ack",
+        _route_after_fill_ack,
+        {"bootstrap_verify": "bootstrap_verify", END: END},
+    )
+    sg.add_edge("bootstrap_verify", END)
+
+    return sg.compile(checkpointer=checkpointer)
+
+
+def open_checkpointer(db_path: str | None = None) -> SqliteSaver:
+    """SqliteSaver convenience — mirrors graph.open_checkpointer."""
+    conn = sqlite3.connect(db_path or ":memory:", check_same_thread=False)
+    return SqliteSaver(conn)

--- a/orchestrator/orchestrator/runner.py
+++ b/orchestrator/orchestrator/runner.py
@@ -57,6 +57,10 @@ _ACCEPT_TOKEN_BY_TYPE: dict[str, str] = {
     "pi_claims_review": "accept",           # TWO-TAP set-identity (claims)
     "pi_plan_ratify": "accept",             # TWO-TAP — THE plan-licensing contract gate
     "pi_phase_entry_ack": "approve",        # per-milestone go/no-go; greenlight-class
+    # Phase B — orchestrator-level credential bootstrap interrupts.
+    "pi_bootstrap_intent": "approve",       # free-form intent gate; greenlight-class
+    "pi_bootstrap_ratify": "accept",        # set-identity (ratified_ids non-empty iff accept)
+    "pi_bootstrap_fill_ack": "accept",      # "I'm done editing orchestrator/.env" signal
 }
 """The substring the graph's routing function looks for to take the
 'continue' branch at each PI interrupt. Sourced from graph.py:
@@ -155,6 +159,7 @@ class OrchestratorRunner:
         compile_factory: Optional[Callable[..., Any]] = None,
         onboarding_compile_factory: Optional[Callable[..., Any]] = None,
         phase_o_compile_factory: Optional[Callable[..., Any]] = None,
+        phase_b_compile_factory: Optional[Callable[..., Any]] = None,
     ):
         self.store = store
         self._sdk_factory = sdk_factory
@@ -176,6 +181,14 @@ class OrchestratorRunner:
             self._phase_o_compile_factory = _pog.build_phase_o_graph
         else:
             self._phase_o_compile_factory = phase_o_compile_factory
+        # Phase B: separate compile factory for the orchestrator-level
+        # credential bootstrap. Lazy import (only loaded when bootstrap
+        # is invoked or a Phase B interrupt is resumed).
+        if phase_b_compile_factory is None:
+            from orchestrator import phase_b_graph as _pbg
+            self._phase_b_compile_factory = _pbg.build_phase_b_graph
+        else:
+            self._phase_b_compile_factory = phase_b_compile_factory
 
     # ---- public API ----
 
@@ -269,6 +282,18 @@ class OrchestratorRunner:
     These represent the full idea → plan → mission-queue workflow,
     distinct from Phase D's tool-setup subgraph."""
 
+    _PHASE_B_INTERRUPT_TYPES: frozenset[str] = frozenset(
+        {
+            "pi_bootstrap_intent",
+            "pi_bootstrap_ratify",
+            "pi_bootstrap_fill_ack",
+        }
+    )
+    """Interrupt types whose response resumes via the Phase B bootstrap
+    compile factory (phase_b_graph.build_phase_b_graph). Orchestrator-
+    level credential setup (orchestrator/.env), distinct from Phase D's
+    per-project credential setup."""
+
     def respond(
         self,
         *,
@@ -322,6 +347,8 @@ class OrchestratorRunner:
         # else → mission graph (Phase A).
         if parked["interrupt_type"] in self._PHASE_O_INTERRUPT_TYPES:
             factory = self._phase_o_compile_factory
+        elif parked["interrupt_type"] in self._PHASE_B_INTERRUPT_TYPES:
+            factory = self._phase_b_compile_factory
         elif parked["interrupt_type"] in self._ONBOARDING_INTERRUPT_TYPES:
             factory = self._onboarding_compile_factory
         else:
@@ -438,6 +465,43 @@ class OrchestratorRunner:
             mission_id=project_id,  # placeholder
             motivated_by_decision_id="",
             project_id=project_id,
+        )
+        return self._execute_segment(thread_id, compiled, initial)
+
+    # ---- Phase B: orchestrator-level credential bootstrap entrypoint ----
+
+    def start_phase_b(
+        self,
+        *,
+        workflow_thread_id: Optional[str] = None,
+    ) -> SegmentOutcome:
+        """Kick off the Phase B bootstrap subgraph.
+
+        Unlike start_phase_o, Phase B is *not* project-scoped — it
+        configures the orchestrator daemon's own credentials. We still
+        need a workflow_runs row (so the parked-interrupt machinery
+        works) so we use the sentinel string "_bootstrap_" as both
+        the placeholder mission_id and project_id. The runner-level
+        state.project_id stays empty during bootstrap.
+        """
+        thread_id = self.store.create_run(
+            mission_id="_bootstrap_",  # sentinel; bootstrap isn't mission-scoped
+            project_id="_bootstrap_",  # sentinel; bootstrap isn't project-scoped
+            workflow_thread_id=workflow_thread_id,
+        )
+
+        mcp = self._mcp_factory(thread_id, "")
+        sdk = self._sdk_factory("")
+        saver = self._saver_factory(thread_id)
+        compiled = self._phase_b_compile_factory(
+            sdk=sdk, mcp=mcp, checkpointer=saver
+        )
+
+        initial = make_initial_state(
+            workflow_thread_id=thread_id,
+            mission_id="_bootstrap_",
+            motivated_by_decision_id="",
+            project_id="",
         )
         return self._execute_segment(thread_id, compiled, initial)
 

--- a/orchestrator/orchestrator/server.py
+++ b/orchestrator/orchestrator/server.py
@@ -68,6 +68,12 @@ class StartOnboardingRequest(BaseModel):
     workflow_thread_id: Optional[str] = None
 
 
+class StartBootstrapRequest(BaseModel):
+    """Phase B: orchestrator-level credential bootstrap. No project_id;
+    Phase B is daemon-level setup."""
+    workflow_thread_id: Optional[str] = None
+
+
 class CorrectRequest(BaseModel):
     response_text: str = Field(min_length=1)
 
@@ -221,6 +227,24 @@ def create_app(
         outcome = await asyncio.to_thread(
             runner_.start_onboarding,
             project_id=req.project_id,
+            workflow_thread_id=req.workflow_thread_id,
+        )
+        return _outcome_dict(outcome)
+
+    @app.post("/bootstrap")
+    async def start_bootstrap(
+        req: StartBootstrapRequest, request: Request
+    ) -> dict:
+        """Phase B: kick off the orchestrator-level credential bootstrap.
+
+        Returns the SegmentOutcome shape (workflow_thread_id +
+        parked_interrupt_id/type) for the first interrupt
+        (`pi_bootstrap_intent`). The PI's Claude session polls
+        /inbox to render the prompt and respond.
+        """
+        runner_: OrchestratorRunner = request.app.state.runner
+        outcome = await asyncio.to_thread(
+            runner_.start_phase_b,
             workflow_thread_id=req.workflow_thread_id,
         )
         return _outcome_dict(outcome)

--- a/orchestrator/orchestrator/state.py
+++ b/orchestrator/orchestrator/state.py
@@ -257,6 +257,21 @@ class ResearchWorkflowState(TypedDict, total=False):
     # H:
     current_milestone_index: int     # 0-indexed position in ratified_mission_ids
 
+    # Phase B (agentic) — orchestrator-level bootstrap state.
+    # `bootstrap_intent` is set by pi_bootstrap_intent (free-form text
+    # describing install state). `bootstrap_proposed_ids` is the catalog
+    # entry-ids picked by propose_for_intent. `bootstrap_ratified_ids`
+    # is the subset PI accepted at pi_bootstrap_ratify (set-identity:
+    # non-empty iff PI accepted). `bootstrap_template_path` is the
+    # absolute path of the .env.example the runner wrote for the PI to
+    # fill in. `bootstrap_verify_results` is populated by the final
+    # verify node so the runner can render the report.
+    bootstrap_intent: str
+    bootstrap_proposed_ids: list[str]
+    bootstrap_ratified_ids: list[str]
+    bootstrap_template_path: str
+    bootstrap_verify_results: list[dict]
+
     # Termination
     terminal_state: TerminalState
     final_report_id: str
@@ -332,6 +347,14 @@ def make_initial_state(
         ratified_plan_journal_id="",
         ratified_mission_ids=[],
         current_milestone_index=0,
+        # Phase B bootstrap fields (additive; total=False on the
+        # TypedDict means pre-Phase-B callers still construct valid
+        # states without them).
+        bootstrap_intent="",
+        bootstrap_proposed_ids=[],
+        bootstrap_ratified_ids=[],
+        bootstrap_template_path="",
+        bootstrap_verify_results=[],
     )
 
 

--- a/orchestrator/tests/test_phase_b_bootstrap.py
+++ b/orchestrator/tests/test_phase_b_bootstrap.py
@@ -1,0 +1,434 @@
+"""Phase B - orchestrator-level credential bootstrap tests.
+
+Covers:
+  - bootstrap_catalog.yaml loads + validates the 5 shipped entries
+  - propose_for_intent: required/recommended always selected;
+    optional matched on substring or "full install" hint
+  - render_env_template emits annotated slots + group markers
+  - read_env_file ignores comments + placeholders; preserves real values
+  - verify_filled classifies missing/valid/rejected/deferred correctly
+    via injected HTTP-client fake
+  - bootstrap_propose_node populates state correctly
+  - bootstrap_emit_template_node writes the file + sets template_path
+  - bootstrap_verify_node sets terminal_state based on required-pass
+  - phase_b_graph compiles end-to-end through a happy path with a
+    fake interrupt_fn
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# bootstrap module
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_loads_with_5_entries():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    ids = [e.id for e in entries]
+    assert set(ids) == {
+        "claude-oauth", "anthropic-api-key",
+        "semantic-scholar", "serpapi", "openalex-mailto",
+    }
+
+
+def test_catalog_claude_auth_group_is_mutually_exclusive():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    by_id = {e.id: e for e in entries}
+    assert by_id["claude-oauth"].group == "claude-auth"
+    assert by_id["anthropic-api-key"].group == "claude-auth"
+    assert by_id["semantic-scholar"].group is None
+
+
+def test_propose_empty_intent_selects_required_plus_recommended():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    selected = B.propose_for_intent("", entries)
+    ids = {e.id for e in selected}
+    # Both Claude auth (required, group) + Semantic Scholar (recommended)
+    assert "claude-oauth" in ids
+    assert "anthropic-api-key" in ids
+    assert "semantic-scholar" in ids
+    # Optional entries dropped without a mention
+    assert "serpapi" not in ids
+    assert "openalex-mailto" not in ids
+
+
+def test_propose_full_install_picks_optional_too():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    selected = B.propose_for_intent("give me the full install with everything", entries)
+    ids = {e.id for e in selected}
+    assert ids == {
+        "claude-oauth", "anthropic-api-key",
+        "semantic-scholar", "serpapi", "openalex-mailto",
+    }
+
+
+def test_propose_substring_match_picks_specific_optional():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    # User mentions SerpAPI by env_var name (case-insensitive)
+    selected = B.propose_for_intent("just need serpapi please", entries)
+    ids = {e.id for e in selected}
+    assert "serpapi" in ids
+    assert "openalex-mailto" not in ids
+
+
+def test_render_env_template_includes_group_marker_and_placeholders():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    text = B.render_env_template(entries)
+    # Group note appears once per group member
+    assert text.count("GROUP `claude-auth`") == 2
+    # Every env_var ends up as a paste slot
+    for e in entries:
+        assert f"{e.env_var}=<paste-here>" in text or f"# {e.env_var}=<paste-here>" in text
+
+
+def test_render_env_template_marks_existing_values_as_already_set():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    existing = {"SEMANTIC_SCHOLAR_API_KEY": "actual-real-secret-DO-NOT-LEAK"}
+    text = B.render_env_template(entries, existing_values=existing)
+    # The actual secret value MUST NOT appear in the rendered text.
+    assert "actual-real-secret-DO-NOT-LEAK" not in text
+    # The "already set" marker appears for that entry.
+    assert "already set in existing .env" in text
+
+
+def test_read_env_file_strips_comments_and_placeholders(tmp_path: Path):
+    from orchestrator import bootstrap as B
+    p = tmp_path / ".env"
+    p.write_text(
+        "# leading comment\n"
+        "REAL_KEY=actual-value\n"
+        "PLACEHOLDER_KEY=<paste-here>\n"
+        "BLANK=\n"
+        "QUOTED='quoted-value'\n"
+        "DBLQUOTED=\"double-quoted\"\n"
+        "WITH_COMMENT=value-here  # trailing\n",
+        encoding="utf-8",
+    )
+    values = B.read_env_file(p)
+    assert values["REAL_KEY"] == "actual-value"
+    assert "PLACEHOLDER_KEY" not in values  # placeholder dropped
+    assert "BLANK" not in values  # empty dropped
+    assert values["QUOTED"] == "quoted-value"
+    assert values["DBLQUOTED"] == "double-quoted"
+    assert values["WITH_COMMENT"] == "value-here"
+
+
+def test_verify_filled_classifies_each_outcome():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    by_id = {e.id: e for e in entries}
+
+    # Inject a deterministic HTTP fake that returns per-URL classifications.
+    calls: list[tuple[str, str]] = []
+
+    def fake_http(method: str, url: str, headers: dict, timeout: float):
+        calls.append((method, url))
+        # The verify body never sees `value`; we only see the URL after
+        # substitution. So we key on host.
+        if "anthropic.com" in url:
+            return (200, None)  # valid
+        if "semanticscholar.org" in url:
+            return (401, None)  # rejected
+        if "serpapi.com" in url:
+            return (0, "TimeoutError: nope")  # unreachable
+        if "openalex.org" in url:
+            return (200, None)  # valid
+        return (500, None)  # other
+
+    env_values = {
+        "CLAUDE_CODE_OAUTH_TOKEN": "x",        # no probe (skip method)
+        "ANTHROPIC_API_KEY": "x",              # valid
+        "SEMANTIC_SCHOLAR_API_KEY": "x",       # rejected
+        "SERPAPI_KEY": "x",                    # unreachable
+        # OPENALEX_MAILTO intentionally missing
+    }
+    results = B.verify_filled(
+        [by_id["claude-oauth"], by_id["anthropic-api-key"],
+         by_id["semantic-scholar"], by_id["serpapi"], by_id["openalex-mailto"]],
+        env_values,
+        http_client=fake_http,
+    )
+    by_eid = {r.entry_id: r for r in results}
+    assert by_eid["claude-oauth"].classification == "deferred"
+    assert by_eid["anthropic-api-key"].classification == "valid"
+    assert by_eid["semantic-scholar"].classification == "rejected"
+    assert by_eid["serpapi"].classification == "unreachable"
+    assert by_eid["openalex-mailto"].classification == "missing"
+
+
+def test_verify_render_summary_never_includes_values():
+    from orchestrator import bootstrap as B
+    entries = B.load_catalog()
+    results = [
+        B.VerifyResult(
+            entry_id="claude-oauth", env_var="CLAUDE_CODE_OAUTH_TOKEN",
+            classification="deferred", detail="OAuth deferred",
+        ),
+        B.VerifyResult(
+            entry_id="semantic-scholar", env_var="SEMANTIC_SCHOLAR_API_KEY",
+            classification="rejected", detail="HTTP 401 (endpoint reachable; key rejected)",
+        ),
+    ]
+    text = B.render_verify_summary(results, catalog=entries)
+    assert "Claude Code OAuth token" in text
+    assert "Semantic Scholar API key" in text
+    # No raw secret content in the summary.
+    assert "<paste-here>" not in text
+
+
+# ---------------------------------------------------------------------------
+# Phase B nodes (background)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMCP:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+
+def _make_state(**overrides) -> dict:
+    base = {
+        "workflow_thread_id": "thr_test",
+        "mission_id": "_bootstrap_",
+        "project_id": "",
+        "interrupts": [],
+        "decisions_to_present": [],
+        "bootstrap_intent": "",
+        "bootstrap_proposed_ids": [],
+        "bootstrap_ratified_ids": [],
+        "bootstrap_template_path": "",
+        "bootstrap_verify_results": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_bootstrap_propose_node_picks_required_for_empty_intent():
+    from orchestrator.nodes import bootstrap as bnodes
+    state = _make_state(bootstrap_intent="")
+    out = bnodes.bootstrap_propose_node(state, sdk=None, mcp=_FakeMCP())
+    assert out["current_node"] == "bootstrap_propose"
+    # Required + recommended (3 entries) selected for empty intent.
+    assert set(out["bootstrap_proposed_ids"]) == {
+        "claude-oauth", "anthropic-api-key", "semantic-scholar",
+    }
+    # Decisions-to-present stages each as a renderable item.
+    assert len(out["decisions_to_present"]) == 3
+    for item in out["decisions_to_present"]:
+        assert item["source_node"] == "bootstrap_propose"
+        # Never include the env_var value (we don't have one yet).
+        assert "value" not in item
+
+
+def test_bootstrap_emit_template_node_writes_file_with_mode_0600(tmp_path: Path):
+    from orchestrator.nodes import bootstrap as bnodes
+    env_path = tmp_path / ".env"
+    state = _make_state(
+        bootstrap_ratified_ids=["claude-oauth", "semantic-scholar"],
+    )
+    out = bnodes.bootstrap_emit_template_node(
+        state, sdk=None, mcp=_FakeMCP(), env_path=env_path
+    )
+    template_path = Path(out["bootstrap_template_path"])
+    assert template_path.is_file()
+    assert template_path.name == ".env.example"
+    text = template_path.read_text(encoding="utf-8")
+    assert "CLAUDE_CODE_OAUTH_TOKEN=<paste-here>" in text
+    assert "SEMANTIC_SCHOLAR_API_KEY=<paste-here>" in text
+    # File mode 0600 (owner-read/write only) when OS supports it.
+    import stat
+    mode = stat.S_IMODE(template_path.stat().st_mode)
+    assert mode == 0o600 or mode & 0o077 == 0  # tolerate platform quirks
+
+
+def test_bootstrap_emit_template_preserves_existing_env(tmp_path: Path):
+    from orchestrator.nodes import bootstrap as bnodes
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "SEMANTIC_SCHOLAR_API_KEY=already-have-this-secret\n",
+        encoding="utf-8",
+    )
+    state = _make_state(
+        bootstrap_ratified_ids=["semantic-scholar", "serpapi"],
+    )
+    out = bnodes.bootstrap_emit_template_node(
+        state, sdk=None, mcp=_FakeMCP(), env_path=env_path
+    )
+    template_text = Path(out["bootstrap_template_path"]).read_text(encoding="utf-8")
+    # The existing value MUST NOT be echoed in the template.
+    assert "already-have-this-secret" not in template_text
+    # And the "already set" marker should be in place for that var.
+    assert "SEMANTIC_SCHOLAR_API_KEY" in template_text
+    assert "already set in existing .env" in template_text
+
+
+def test_bootstrap_verify_node_terminal_on_all_pass(tmp_path: Path, monkeypatch):
+    from orchestrator import bootstrap as B
+    from orchestrator.nodes import bootstrap as bnodes
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-fake\n"
+        "ANTHROPIC_API_KEY=sk-ant-api03-fake\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        B, "verify_filled",
+        lambda entries, env_values, **kw: [
+            B.VerifyResult(
+                entry_id=e.id, env_var=e.env_var,
+                classification="deferred" if e.id == "claude-oauth" else "valid",
+                detail="ok",
+            )
+            for e in entries
+        ],
+    )
+    state = _make_state(bootstrap_ratified_ids=["claude-oauth", "anthropic-api-key"])
+    out = bnodes.bootstrap_verify_node(
+        state, sdk=None, mcp=_FakeMCP(), env_path=env_path
+    )
+    assert out["terminal_state"] == "complete"
+    assert len(out["bootstrap_verify_results"]) == 2
+
+
+def test_bootstrap_verify_node_escalates_on_required_fail(tmp_path: Path, monkeypatch):
+    from orchestrator import bootstrap as B
+    from orchestrator.nodes import bootstrap as bnodes
+
+    monkeypatch.setattr(
+        B, "verify_filled",
+        lambda entries, env_values, **kw: [
+            B.VerifyResult(
+                entry_id=e.id, env_var=e.env_var,
+                classification="rejected" if e.id == "anthropic-api-key" else "valid",
+                detail="HTTP 401",
+            )
+            for e in entries
+        ],
+    )
+    state = _make_state(bootstrap_ratified_ids=["anthropic-api-key"])
+    env_path = tmp_path / ".env"
+    env_path.write_text("ANTHROPIC_API_KEY=fake\n", encoding="utf-8")
+    out = bnodes.bootstrap_verify_node(
+        state, sdk=None, mcp=_FakeMCP(), env_path=env_path
+    )
+    assert out["terminal_state"] == "escalated"
+
+
+# ---------------------------------------------------------------------------
+# Phase B graph - end-to-end happy path with fake interrupt_fn
+# ---------------------------------------------------------------------------
+
+
+def _stub_interrupt(payload):
+    """Same convention as test_phase_o_graph: stub returns "accept" for
+    graph-compile smoke tests. Node-level interrupt behavior is covered
+    by the unit tests above (propose / emit_template / verify nodes)."""
+    return "accept"
+
+
+def test_phase_b_graph_compiles_with_all_six_nodes():
+    from orchestrator import phase_b_graph
+
+    g = phase_b_graph.build_phase_b_graph(
+        sdk=None, mcp=_FakeMCP(), interrupt_fn=_stub_interrupt,
+    )
+    registered = set(g.get_graph().nodes.keys())
+    expected = {
+        "pi_bootstrap_intent",
+        "bootstrap_propose",
+        "pi_bootstrap_ratify",
+        "bootstrap_emit_template",
+        "pi_bootstrap_fill_ack",
+        "bootstrap_verify",
+    }
+    assert expected.issubset(registered), (
+        f"missing nodes: {expected - registered}"
+    )
+
+
+def test_phase_b_routing_after_ratify_accept_advances_to_emit():
+    """Set-identity routing: ratified_ids non-empty -> emit_template."""
+    from orchestrator import phase_b_graph as PBG
+    assert PBG._route_after_bootstrap_ratify(
+        {"bootstrap_ratified_ids": ["claude-oauth"]}
+    ) == "bootstrap_emit_template"
+
+
+def test_phase_b_routing_after_ratify_empty_ends():
+    from orchestrator import phase_b_graph as PBG
+    from langgraph.graph import END
+    assert PBG._route_after_bootstrap_ratify(
+        {"bootstrap_ratified_ids": []}
+    ) == END
+
+
+def test_phase_b_routing_after_fill_ack_accept_advances_to_verify():
+    from orchestrator import phase_b_graph as PBG
+    result = PBG._route_after_fill_ack({
+        "interrupts": [
+            {"node_name": "pi_bootstrap_fill_ack", "response": "accept"},
+        ],
+    })
+    assert result == "bootstrap_verify"
+
+
+def test_phase_b_routing_after_fill_ack_reject_ends():
+    from orchestrator import phase_b_graph as PBG
+    from langgraph.graph import END
+    result = PBG._route_after_fill_ack({
+        "interrupts": [
+            {"node_name": "pi_bootstrap_fill_ack", "response": "reject"},
+        ],
+    })
+    assert result == END
+
+
+def test_runner_accept_token_map_has_phase_b_entries():
+    """All three Phase B interrupt types must have a configured accept
+    token (otherwise resume_token() will raise ValueError when the PI
+    accepts the interrupt)."""
+    from orchestrator import runner as R
+    assert R._ACCEPT_TOKEN_BY_TYPE["pi_bootstrap_intent"] == "approve"
+    assert R._ACCEPT_TOKEN_BY_TYPE["pi_bootstrap_ratify"] == "accept"
+    assert R._ACCEPT_TOKEN_BY_TYPE["pi_bootstrap_fill_ack"] == "accept"
+
+
+def test_runner_phase_b_interrupt_types_frozenset_complete():
+    from orchestrator.runner import OrchestratorRunner
+    assert OrchestratorRunner._PHASE_B_INTERRUPT_TYPES == frozenset({
+        "pi_bootstrap_intent",
+        "pi_bootstrap_ratify",
+        "pi_bootstrap_fill_ack",
+    })
+
+
+def test_parked_store_accepts_phase_b_interrupt_type(tmp_path):
+    """Schema migration: the CHECK constraint must accept Phase B types."""
+    from orchestrator import parked_store as PS
+    store = PS.ParkedStore(str(tmp_path / "test.db"))
+    thread_id = store.create_run(
+        mission_id="_bootstrap_", project_id="_bootstrap_",
+    )
+    iid = store.park_interrupt(
+        workflow_thread_id=thread_id,
+        mission_id="_bootstrap_",
+        interrupt_type="pi_bootstrap_intent",
+        payload={"title": "test"},
+    )
+    row = store.get_interrupt(iid)
+    assert row["interrupt_type"] == "pi_bootstrap_intent"
+    store.close()

--- a/plugin/commands/orchestrator-bootstrap.md
+++ b/plugin/commands/orchestrator-bootstrap.md
@@ -1,0 +1,35 @@
+---
+description: "Bootstrap orchestrator-level credentials (Phase B): discuss install state, ratify catalog subset, write orchestrator/.env template, probe filled keys. Usage: /orchestrator-bootstrap"
+---
+
+Phase B is **orchestrator-level** credential setup. Use this on a fresh install before any project exists — it writes `orchestrator/.env` so the daemon itself can call Claude. This is distinct from `/orchestrator-onboard` (which writes per-project credentials at `~/rka-projects/<id>/.env`).
+
+Before kicking off:
+1. `orchestrator_health()` — verify the daemon is reachable. If not, the user must bring up `rka-orchestrator` via the Compose overlay (`docker compose -f docker-compose.yml -f orchestrator/docker-compose.yml up -d --build`).
+2. Check whether `orchestrator/.env` is already filled. If so, ask via `AskUserQuestion`: "orchestrator/.env appears to be set already. Re-bootstrap (will write a fresh `.env.example` next to the live file; the live file is NOT overwritten — you pick what to copy across)?" Proceed only on confirm.
+3. On confirm: `orchestrator_bootstrap_start()`.
+
+After `orchestrator_bootstrap_start` returns:
+- Returns `{parked_interrupt_id, parked_interrupt_type: "pi_bootstrap_intent", ...}`.
+- Load the `rka-orchestrator-pi` skill if not already loaded.
+- Render the intent prompt: ask the PI to describe their install state ("fresh install", "switching to Claude OAuth", "I want everything including SerpAPI", etc.).
+- Call `orchestrator_correct(interrupt_id, response_text=<PI's free text>)` to feed the intent.
+
+The subgraph then advances:
+1. `bootstrap_propose` (background) — matches the intent against the catalog (Claude OAuth, Anthropic API key, Semantic Scholar, SerpAPI, OpenAlex polite-pool email).
+2. Parks at `pi_bootstrap_ratify` — render the shortlist. The PI ratifies via TWO-TAP (per orchestrator-pi skill: present the shortlist, separate accept call). On accept the ratified ids advance; on reject/correct the workflow ends and the .env stays untouched.
+3. `bootstrap_emit_template` (background) — writes `orchestrator/.env.example` next to the live `.env` with annotated slots: each var has a comment block listing purpose, criticality, sign-up URL, and format hint. Vars already set in the live `.env` are commented out (the PI uncomments to replace).
+4. Parks at `pi_bootstrap_fill_ack` — surface the template path + the list of `env_var` slots the PI needs to fill. **Tell the PI**: "Open the file, copy slots into `orchestrator/.env`, save (file mode 0600), then accept this interrupt." Then call `orchestrator_accept(interrupt_id)` when the PI confirms they've done it.
+5. `bootstrap_verify` (background) — reads the live `orchestrator/.env`, probes each entry's `probe.url` (never logging values), reports pass/fail per key. The terminal state is "complete" iff every `required` entry verified as `valid` or `deferred`.
+
+After the workflow terminates, surface to the PI:
+- The verify results (✓ valid / · deferred / ✗ missing/rejected / ? unreachable, one per entry).
+- For any `rejected` or `missing` required entry: instruct the PI to fix and re-run `/orchestrator-bootstrap` (the .env.example is preserved on disk so they can re-resume mid-flow if they prefer).
+- Mention that after a successful Phase B, the PI should restart the `rka-orchestrator` container (`docker compose -f docker-compose.yml -f orchestrator/docker-compose.yml up -d --force-recreate rka-orchestrator`) for the new credentials to be picked up by running workflows.
+
+Privileged-gate rule: `pi_bootstrap_ratify` is set-identity (ratified_ids non-empty iff PI accepted). Use the orchestrator-pi skill's TWO-TAP discipline — show the shortlist first, then ask the PI to explicitly accept, then call `orchestrator_accept`. **Never** auto-accept based on the intent alone; the PI must see and explicitly approve the candidate list.
+
+Security invariants enforced by the orchestrator:
+- Key VALUES are never echoed back through any interrupt payload, any log line, or any verify report.
+- Probe results contain only the env_var name + classification + a non-secret detail string (e.g., "HTTP 401 (endpoint reachable; key rejected)").
+- The .env files are written with file mode 0600 (owner-readable only) when the OS supports it.

--- a/plugin/skills/orchestrator-pi/SKILL.md
+++ b/plugin/skills/orchestrator-pi/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: rka-orchestrator-pi
 description: PI cockpit for the agentic RKA distribution's LangGraph orchestrator. Renders parked PI interrupts across mission, tool-setup, and Phase O project-onboarding subgraphs; guides the human through them via AskUserQuestion; dispatches responses back to the workflow. Load when supervising a running orchestrator workflow, onboarding a new project, or when the user says "start orchestrator" / "what's waiting" / "check orchestrator inbox" / "onboard a project" / "start phase O".
-version: 0.3.0
+version: 0.4.0
 ---
 
 # Orchestrator PI Skill (agentic-branch only)
 
 You are the PI's cockpit for the RKA orchestrator. The orchestrator
-drives two distinct kinds of workflows, each with its own subgraph:
+drives FOUR distinct kinds of workflows, each with its own subgraph:
 
 ### Mission subgraph (Phase A)
 Brain ⇄ Executor ⇄ PI loops against an RKA mission. Three PI
@@ -26,6 +26,22 @@ template. Three PI interrupts:
 5. **pi_toolkit_ratify** — PI ratifies the Brain-proposed tool set (**set-identity gate**)
 6. **pi_credentials_ready** — PI signals they've edited the `.env`; server probes each API
 7. **pi_extend_toolkit** — mid-mission: PI ratifies an added tool (Phase D6; defer if not in registry yet)
+
+### Bootstrap subgraph (Phase B — v0.4.0)
+Runs ONCE per machine, before any project. Configures the orchestrator
+daemon's own credentials (Claude OAuth, optional Semantic Scholar /
+SerpAPI / OpenAlex polite-pool email) — writes `orchestrator/.env` so
+the daemon can call Claude at all. Three PI interrupts:
+
+8. **pi_bootstrap_intent** — PI describes install state in plain text
+9. **pi_bootstrap_ratify** — TWO-TAP: PI accepts/rejects the candidate shortlist (set-identity)
+10. **pi_bootstrap_fill_ack** — replayable: parks while PI edits `orchestrator/.env`, accepts on done
+
+Use this when the PI says "set up orchestrator keys" / "bootstrap" /
+"set up Claude OAuth" / "configure my .env" / `/orchestrator-bootstrap`.
+
+### Phase O — full project-onboarding (v0.3.0)
+See full section below.
 
 Your job is to render parked interrupts clearly, guide the PI through
 the response, and dispatch via the `orchestrator_*` MCP tools.
@@ -294,6 +310,87 @@ Interrupt response (shared across mission + onboarding):
 Onboarding (Phase D):
 - `orchestrator_onboard_start(project_id, workflow_thread_id?)` — kick off onboarding
 - `orchestrator_get_manifest(project_id)` — fetch the effective manifest (baseline + extensions)
+
+## Phase B — orchestrator-level credential bootstrap
+
+**One-time, machine-level setup.** Phase B writes `orchestrator/.env`
+(the daemon's own credentials) so the orchestrator can call Claude at
+all. Distinct from Phase D which writes per-project credentials.
+
+Entry: `orchestrator_bootstrap_start()` (no project_id; bootstrap is
+daemon-level). Slash command alias: `/orchestrator-bootstrap`.
+
+### Topology
+
+```
+START
+  → pi_bootstrap_intent       [interrupt — free-form intent]
+  → bootstrap_propose         [match catalog vs intent]
+  → pi_bootstrap_ratify       [TWO-TAP — accept the shortlist]
+     ┌─ accept → bootstrap_emit_template
+     │            → pi_bootstrap_fill_ack [replayable — PI edits .env]
+     │                ┌─ accept → bootstrap_verify
+     │                │             → END (terminal_state from verify)
+     │                └─ else  → END (template stays on disk)
+     └─ else   → END
+```
+
+### Interrupt-by-interrupt PI rendering
+
+**pi_bootstrap_intent**: Ask the PI to describe their install state in
+1-2 sentences. Examples to seed the conversation: "fresh install",
+"switching from API key to OAuth", "I want everything including SerpAPI",
+"minimal — just Claude OAuth". Pass the response back via
+`orchestrator_correct(interrupt_id, response_text=<PI's text>)`.
+
+**pi_bootstrap_ratify** (TWO-TAP): the daemon has run
+`propose_for_intent` against `orchestrator/data/bootstrap_catalog.yaml`
+and returned a candidate shortlist. Render it as a table:
+
+```
+| label | env_var | criticality | group | sign-up |
+```
+
+Note any GROUP membership (e.g., `claude-oauth` + `anthropic-api-key`
+are mutually exclusive — PI must pick one). Then ask the PI to confirm
+the shortlist as-is. **Do NOT auto-accept**; this is a privileged gate.
+On the PI's explicit confirmation, call `orchestrator_accept(id)`. On
+"no — change X", treat as correct: `orchestrator_correct(id, response_text=<delta>)`.
+
+**pi_bootstrap_fill_ack** (replayable): the daemon has written
+`<workspace>/orchestrator/.env.example`. Surface to the PI:
+- The exact file path
+- The list of env_vars they need to fill (from the interrupt payload's `expected_entries`)
+- A reminder: **never paste API keys into the chat**; only into the file
+- A reminder: file mode 0600 (auto-set when OS permits)
+- Where to mint each missing key (each entry has a `signup_url`)
+
+The PI does the file edit OUT OF BAND, then says "done" / "ready" /
+"go". Call `orchestrator_accept(id)`. **This interrupt can park for
+days** — durability is intentional; the workflow resumes from the
+SqliteSaver checkpoint when the PI returns.
+
+After accept, the daemon runs `bootstrap_verify`: probes each key
+without logging values, reports pass/fail. Render the verify results
+to the PI as glyphs:
+
+- ✓ valid — endpoint accepted the key
+- · deferred — probe skipped (e.g. Claude OAuth: validated on first SDK call)
+- ✗ missing — env_var not in .env (PI didn't fill it)
+- ✗ rejected — endpoint returned 401/403 (key wrong)
+- ? unreachable — network error / timeout
+
+If any `required` entry is missing or rejected: instruct the PI to fix
+and re-run `/orchestrator-bootstrap`. If all required are valid or
+deferred: remind the PI to `docker compose -f docker-compose.yml -f
+orchestrator/docker-compose.yml up -d --force-recreate rka-orchestrator`
+so the new credentials get loaded.
+
+### Security invariants (enforced by the orchestrator; reinforce them in chat)
+
+- Key VALUES are never echoed in interrupt payloads, logs, or verify reports.
+- Probe details contain only `env_var` + classification + a non-secret reason string.
+- `.env` and `.env.example` files are written with file-mode 0600.
 
 ## Phase O — full project-onboarding workflow
 


### PR DESCRIPTION
## Summary

Closes the post-install gap surfaced during the 2026-05-27 audit: `/orchestrator-onboard` (Phase D) assumes the orchestrator can already call Claude, but a fresh install can't until `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) lands in `orchestrator/.env`. Phase B is the prerequisite workflow that gets it there, with the same PI-guided ratification pattern Phase D and Phase O use.

## The four-gate workflow

```
START
  → pi_bootstrap_intent       [free-form install-state description]
  → bootstrap_propose         [match catalog vs intent]
  → pi_bootstrap_ratify       [TWO-TAP set-identity ratification]
     on accept:
  → bootstrap_emit_template   [write orchestrator/.env.example w/ annotated slots]
  → pi_bootstrap_fill_ack     [replayable; PI edits .env out-of-band]
     on accept:
  → bootstrap_verify          [probe each key without logging values]
  → END
```

## New surface
- **`orchestrator_bootstrap_start()`** MCP tool + **`POST /bootstrap`** REST route
- **`/orchestrator-bootstrap`** slash command
- **`orchestrator/data/bootstrap_catalog.yaml`** — curated 5-entry catalog (claude-oauth / anthropic-api-key as a mutually-exclusive group; semantic-scholar; serpapi; openalex-mailto)
- **`orchestrator/bootstrap.py`** — pure-Python loader + env-template renderer + env-file reader + verify wrapper (reuses credential_validator's HTTP-client signature for shared test fakes)
- **`orchestrator/phase_b_graph.py`** — 6-node LangGraph subgraph mirroring Phase O conventions

## Security invariants
- Key VALUES never appear in interrupt payloads, logs, or verify reports
- Probe details contain only env_var + classification + non-secret reason ("HTTP 401 (endpoint reachable; key rejected)")
- `.env` and `.env.example` written with file-mode 0600
- `render_env_template` masks existing values with "already set in existing .env" — never echoes them

## End-to-end smoke test (already passed)
- POST /bootstrap parks at `pi_bootstrap_intent` with the prompt
- Reject → advances to `bootstrap_propose` (treated as empty intent) → parks at `pi_bootstrap_ratify` (correct behavior; intent is greenlight-class, ratify is the gate)
- Inbox visibility confirmed via `GET /inbox`
- Cancel via `/inbox/.../reject` cleanly cancels the run

## Test plan
- [x] **23 new tests** in `orchestrator/tests/test_phase_b_bootstrap.py`: catalog load + propose semantics + env-template render (including the "already-set value masking" security check) + env-file parsing + verify per-classification matrix + 3 background nodes + graph compile + routing helpers + runner accept-tokens + schema migration
- [x] Full orchestrator suite: **745 passed** (was 722; +23 net)
- [x] Audit-symmetry: 6 new `current_node` names added to `ONBOARDING_NODE_NAMES`
- [x] Live smoke test against rebuilt rka-orchestrator container

## Stacking
This is on `feat/phase-t-tool-onboarding` against `agentic`. No `rka/` touches — bookkeeper invariant (`git diff origin/main -- rka/` empty on agentic) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)