### PR TITLE
feat(skills): mcp-credentials — guided setup for Zotero / S2 / Claude OAuth / SerpAPI / OpenAlex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 All notable changes to RKA are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) + semver.
 
+## [Unreleased] — `mcp-credentials` skill
+
+New skill at `rka/skills/mcp-credentials/` (mirrored to
+`plugin/skills/mcp-credentials/`) that walks users through provisioning
+credentials for the cross-project MCP servers commonly used alongside
+RKA: Claude OAuth (for the orchestrator daemon's SDK subprocess),
+Zotero, Semantic Scholar, SerpAPI, and OpenAlex.
+
+### What's in the skill
+
+- **`SKILL.md`** — top-level orchestration: identify → walkthrough →
+  sanity-check → persist → restart. Operating principles for
+  plaintext credentials (the platform default), atomic writes, deep
+  merging, backup discipline, and credential-masking-in-chat
+  guardrails.
+- **`catalog.md`** — quick-reference table: every service, its env
+  vars, target config block, validation regex, and link to the
+  detailed walkthrough.
+- **`config-ops.md`** — the load-bearing read/parse/merge/backup/write
+  pattern for `claude_desktop_config.json`, `~/.claude.json`,
+  per-repo `.claude/mcp.json`, and `orchestrator/.env`. Cross-platform
+  paths, atomic-write discipline, restore-from-backup escape hatch.
+- **`walkthroughs/{claude-oauth,zotero,semantic-scholar,serpapi,openalex}.md`** —
+  per-service cards: what you need, where to get it, validation regex,
+  optional API sanity-check (with shell-history-safe variants for
+  long-lived keys), target env vars + file path, restart instructions,
+  common pitfalls.
+
+### Design decisions
+
+- **Plaintext in JSON** — the platform's de-facto pattern for every
+  existing MCP server (Zotero, GitHub, Slack, …). The skill follows
+  it; users who want Keychain-backed secrets can build a wrapper in
+  a follow-up.
+- **Single skill, not per-service skills** — the procedure is the
+  same across services (issue → validate → persist → restart); only
+  the walkthrough card differs. One skill keeps the registration
+  overhead manageable.
+- **No dynamic registry** — the catalog is static markdown, not a
+  parsed registry. Adding a new service = drop a markdown card + add
+  a row to `catalog.md`. Stays low-overhead.
+- **Mirrored to `plugin/skills/`** for the plugin-marketplace install
+  path. The two copies are kept in sync per the existing pattern
+  (brain, executor, pi, writer).
+
 ## [Unreleased] - v2.6.0 — `project_id` required on every MCP tool (BREAKING)
 
 Branch: `feat/project-id-required`. Eliminates a long-standing

--- a/plugin/skills/mcp-credentials/SKILL.md
+++ b/plugin/skills/mcp-credentials/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: mcp-credentials
+description: Set up credentials for MCP servers (Zotero, Semantic Scholar, Claude OAuth, SerpAPI, OpenAlex) by walking the user through key issuance and editing their Claude Desktop / Claude Code MCP config file. Load when the user asks "set up Zotero" or "add Semantic Scholar credentials" or "configure my MCP servers" or any similar credential-provisioning request.
+version: 1.0.0
+---
+
+# MCP Credentials Setup
+
+You are configuring an MCP server's credentials for a Claude Desktop or Claude Code install. Most cross-project MCP servers (Zotero, Semantic Scholar, Claude OAuth for the orchestrator's SDK, SerpAPI, OpenAlex) need credentials that the user obtains once and then reuses across every project.
+
+This skill walks you through:
+
+1. **Identifying** which service(s) the user wants to set up.
+2. **Issuing** the credential (you guide the user to the right URL with the right form fields).
+3. **Validating** the credential format (and optionally testing it against the live API).
+4. **Persisting** the credential to `claude_desktop_config.json` (and/or `~/.claude.json` for Claude Code, and/or `orchestrator/.env` for the RKA orchestrator daemon).
+5. **Telling the user to restart** the Claude app so the new MCP server entries load.
+
+## Operating principles
+
+- **Plaintext credentials are the platform default.** macOS / Windows / Linux MCP configs store credentials as plaintext JSON. The user has accepted this trade-off (most existing MCP servers — GitHub, Slack, Zotero, etc. — work the same way). Do not engineer a Keychain wrapper unless the user explicitly asks.
+- **Never overwrite without backup.** Before writing any config file, copy it to `<file>.bak.<ISO-timestamp>` so the user can recover.
+- **Deep-merge, don't replace.** The user likely already has other MCP servers configured. Read → parse → merge new entries → write back. Never overwrite the whole `mcpServers` block.
+- **Atomic writes.** Write to a temp file, validate the JSON parses, then move into place. A botched write would prevent Claude Desktop from starting.
+- **One service at a time, even if the user asks for several.** Walk through each one fully (issue → validate → persist) before moving to the next, so a failure on service 3 doesn't lose progress on services 1 and 2.
+
+## Available walkthroughs (load on demand)
+
+- [`walkthroughs/claude-oauth.md`](walkthroughs/claude-oauth.md) — `CLAUDE_CODE_OAUTH_TOKEN` for the RKA orchestrator daemon's claude-agent-sdk subprocess. Long-lived (~1 year). Mint via `claude setup-token` on the host.
+- [`walkthroughs/zotero.md`](walkthroughs/zotero.md) — `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` + `ZOTERO_LIBRARY_TYPE` for the zotero-mcp server. Per-user library, scope-restrictable.
+- [`walkthroughs/semantic-scholar.md`](walkthroughs/semantic-scholar.md) — `SEMANTIC_SCHOLAR_API_KEY` for the rka MCP server's `rka_search_semantic_scholar` tool. Raises the rate limit from 100 req/5min to 1 req/sec.
+- [`walkthroughs/serpapi.md`](walkthroughs/serpapi.md) — `SERPAPI_KEY` for the rka MCP server's deep-research augmentation. 250 free searches/month.
+- [`walkthroughs/openalex.md`](walkthroughs/openalex.md) — `OPENALEX_MAILTO` (just an email, not a secret) for the OpenAlex polite-pool, granting a higher rate limit.
+
+## Reference docs (load on demand)
+
+- [`catalog.md`](catalog.md) — registry of every supported service with envvar names, target config blocks, and validation regex. Use when you need a quick lookup.
+- [`config-ops.md`](config-ops.md) — the read/parse/merge/backup/write pattern for `claude_desktop_config.json`, including cross-platform paths and atomic-write discipline.
+
+## Standard flow
+
+When the user asks you to set up one or more credentials, do this:
+
+### Step 1 — Identify
+
+Ask which service(s) the user wants if not stated. Surface the available walkthroughs so they know what's supported.
+
+> *"Which credentials would you like to set up? I can walk you through Zotero, Semantic Scholar, Claude OAuth (for the RKA orchestrator), SerpAPI, or OpenAlex. You can do one or several."*
+
+### Step 2 — Walkthrough (per service)
+
+Load the relevant walkthrough card from `walkthroughs/<service>.md`. Each card has the same shape:
+
+- **What you need** — list of fields the service requires
+- **Where to get it** — step-by-step URL navigation
+- **Validation** — regex for the key format, expected length, etc.
+- **Optional sanity check** — a one-shot API call to confirm the credential works
+- **Target env vars** — exact env-var names and which MCP server block they belong in
+
+Walk the user through the steps. Use `AskUserQuestion` for branching choices (e.g., "personal library vs group library"). When they paste the key in chat, validate it against the regex; if it fails, point at the likely typo (wrong length, wrong charset).
+
+### Step 3 — Sanity check (optional but recommended)
+
+If the walkthrough card has a `Sanity check` block, run the curl command via Bash to confirm the credential works. Non-200 response → tell the user, suggest the most likely cause (wrong scope, expired, wrong ID), don't proceed to persist.
+
+### Step 4 — Persist
+
+Use the procedure in [`config-ops.md`](config-ops.md):
+
+1. Read `claude_desktop_config.json` (or `~/.claude.json` for Claude Code, or `orchestrator/.env` for the orchestrator — the walkthrough card tells you which).
+2. Parse as JSON (skip for `.env` — it's KEY=VALUE).
+3. Deep-merge the new env entries into the target MCP server block.
+4. Backup the original to `<file>.bak.<ISO-timestamp>`.
+5. Write the new content atomically (temp file → validate parse → move).
+6. Show the user the diff so they see exactly what changed.
+
+### Step 5 — Restart instruction
+
+```
+✓ Done. Credentials persisted to <path>.
+Backup saved at <path>.bak.<timestamp>.
+
+To activate, **fully quit and reopen Claude Desktop**:
+  - macOS: Cmd+Q, then reopen from Applications
+  - Windows: right-click tray icon → Quit, then reopen from Start Menu
+  - Linux: close the app entirely, then reopen
+
+Once Claude Desktop is back up, ask me to "list Zotero items" (or
+"search Semantic Scholar for X") to confirm the new MCP server
+is active.
+```
+
+For Claude Code: reload the VS Code window (Cmd+Shift+P → "Developer: Reload Window") instead of full quit.
+
+## Guardrails
+
+- **Never paste credentials back to chat after persisting.** When you confirm persistence, refer to the credential as "the key you provided" or "the token now in your config" — don't echo it. This avoids accidental exposure in conversation logs or screenshots.
+- **Don't run sanity-check curl commands in the foreground if the key is long-lived.** The shell history may persist the key. Use a pipe (`echo "$KEY" | curl --data-binary @-`) or a heredoc to avoid putting the key on the command line.
+- **Don't edit `claude_desktop_config.json` if it currently fails to parse.** Show the user the parse error, ask them to fix it manually first. A botched JSON would prevent Claude Desktop from starting.
+- **Don't proceed if the user pastes a credential that looks like it might already be in use elsewhere.** If the key format suggests it's a SSH key, GPG passphrase, AWS secret, etc. — confirm with the user before persisting.
+
+## When the user asks for something this skill doesn't cover
+
+If the user asks for a service not in [`catalog.md`](catalog.md), say so clearly and offer two paths:
+
+1. **They can register a new MCP server manually** — point them at the MCP docs and the config file path.
+2. **You can add a walkthrough** if they tell you the service's API and which env vars its MCP server expects. Add a new `walkthroughs/<service>.md` following the existing template.
+
+Don't fabricate URLs or env-var names for unfamiliar services — verify against the service's docs first.

--- a/plugin/skills/mcp-credentials/catalog.md
+++ b/plugin/skills/mcp-credentials/catalog.md
@@ -1,0 +1,51 @@
+# Catalog — supported MCP credentials
+
+Quick-reference table for every credential this skill knows how to set up. When you need a deeper walkthrough, load the relevant `walkthroughs/<service>.md`.
+
+| Service | Env var(s) | Target | Validation regex | Walkthrough |
+|---|---|---|---|---|
+| Claude OAuth (RKA orchestrator) | `CLAUDE_CODE_OAUTH_TOKEN` | `orchestrator/.env` | `^sk-ant-oat01-[A-Za-z0-9_-]{80,200}$` | [claude-oauth](walkthroughs/claude-oauth.md) |
+| Zotero | `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE` | `mcpServers.zotero.env` in `claude_desktop_config.json` | key: `^[A-Za-z0-9]{24}$`; id: `^\d+$`; type: `user\|group` | [zotero](walkthroughs/zotero.md) |
+| Semantic Scholar | `SEMANTIC_SCHOLAR_API_KEY` | `mcpServers.rka.env` in `claude_desktop_config.json` AND `orchestrator/.env` | `^[A-Za-z0-9]{32,48}$` (s2k-prefix common but not required) | [semantic-scholar](walkthroughs/semantic-scholar.md) |
+| SerpAPI | `SERPAPI_KEY` | `mcpServers.rka.env` AND `orchestrator/.env` | `^[a-f0-9]{64}$` (lowercase hex, 64 chars) | [serpapi](walkthroughs/serpapi.md) |
+| OpenAlex | `OPENALEX_MAILTO` | `mcpServers.rka.env` (and/or any OpenAlex-aware server's env) | RFC 5322 email | [openalex](walkthroughs/openalex.md) |
+
+## Target file paths
+
+### Claude Desktop config
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+### Claude Code config
+
+| OS | Path |
+|---|---|
+| All | `~/.claude.json` (per-user, all-projects) OR `<repo>/.claude/mcp.json` (per-repo) |
+
+### RKA orchestrator daemon
+
+| File | Purpose |
+|---|---|
+| `<rka-repo>/orchestrator/.env` | Used by the orchestrator daemon's Docker container (loaded via Compose `env_file:`). Gitignored. |
+
+## Standard env-var → MCP server mapping
+
+When you persist a credential, route the env var to the right server block based on this table:
+
+| Env var | Belongs in MCP server block | Why |
+|---|---|---|
+| `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE` | `zotero` (the zotero-mcp server) | Service-specific |
+| `SEMANTIC_SCHOLAR_API_KEY` | `rka` (the rka MCP server) | Read by `rka_search_semantic_scholar` |
+| `SERPAPI_KEY` | `rka` (the rka MCP server) | Used by deep-research augmentation if installed |
+| `OPENALEX_MAILTO` | `rka` (the rka MCP server) AND any OpenAlex-aware server | Polite-pool email, harmless to set broadly |
+| `CLAUDE_CODE_OAUTH_TOKEN` | NOT in MCP config — goes in `orchestrator/.env` | Used by the orchestrator daemon's subprocess, not by a Claude-Desktop-launched MCP child |
+
+## Service-availability check
+
+Before suggesting a service, you can verify the corresponding MCP server is actually installed by reading the user's `claude_desktop_config.json` and checking for the `mcpServers.<service>` block. If absent, the credential won't help — point the user at the MCP server's own install docs first.
+
+The exception is `rka` — assume it's installed (this skill ships inside RKA's own repo). The `orchestrator/.env` target is also RKA-internal; the user controls that file directly.

--- a/plugin/skills/mcp-credentials/config-ops.md
+++ b/plugin/skills/mcp-credentials/config-ops.md
@@ -1,0 +1,165 @@
+# Config operations — read / parse / merge / backup / write
+
+The load-bearing technical pattern for this skill. Every credential persistence runs this exact procedure. A botched write can prevent Claude Desktop from starting, so the discipline here is strict.
+
+## File targets
+
+| Target | Format | Parser |
+|---|---|---|
+| `claude_desktop_config.json` | JSON | Python `json` |
+| `~/.claude.json` | JSON | Python `json` |
+| `<repo>/.claude/mcp.json` | JSON | Python `json` |
+| `orchestrator/.env` | `KEY=VALUE` per line | Plain text, line-oriented |
+
+## The procedure (JSON targets)
+
+### Step 1 — Resolve the path
+
+Cross-platform per [`catalog.md`](catalog.md). Verify the path is absolute and the parent directory exists. If it doesn't, the user hasn't installed Claude Desktop yet — surface that.
+
+### Step 2 — Read the current file
+
+If the file doesn't exist, that's fine — start from `{"mcpServers": {}}`. If it exists but doesn't parse as JSON, **abort**. Show the user the parse error and ask them to fix the file manually first. Do NOT overwrite a file you can't parse — Claude Desktop won't be able to either, but at least the user can recover.
+
+### Step 3 — Deep-merge the new env entries
+
+```python
+import copy
+config = current_config_dict
+config.setdefault("mcpServers", {})
+server_block = config["mcpServers"].setdefault(server_name, {})
+# Preserve any existing command/args; only modify env.
+server_block.setdefault("env", {})
+for key, value in new_env_entries.items():
+    server_block["env"][key] = value
+```
+
+Critical: **don't replace `mcpServers.<server>`** — only set/update `mcpServers.<server>.env.<KEY>`. Existing `command`, `args`, and any other env keys must survive.
+
+### Step 4 — Validate the merged JSON
+
+Before writing, dump and re-parse to confirm the JSON is well-formed:
+
+```python
+import json
+serialized = json.dumps(config, indent=2) + "\n"
+json.loads(serialized)  # raises if malformed; abort if so
+```
+
+### Step 5 — Backup
+
+```python
+from datetime import datetime, timezone
+backup_path = f"{target_path}.bak.{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H-%M-%SZ')}"
+shutil.copy2(target_path, backup_path)  # preserves mtime + permissions
+```
+
+Tell the user the backup path before writing the new file.
+
+### Step 6 — Atomic write
+
+Write to a sibling temp file, then `os.replace()` (which is atomic on POSIX and almost-atomic on Windows):
+
+```python
+import os, tempfile
+fd, tmp = tempfile.mkstemp(
+    prefix=os.path.basename(target_path) + ".",
+    suffix=".tmp",
+    dir=os.path.dirname(target_path),
+)
+with os.fdopen(fd, "w") as f:
+    f.write(serialized)
+os.replace(tmp, target_path)
+```
+
+Why the temp file: if the process dies mid-write, the original file is intact. `os.replace` swaps in the new content atomically.
+
+### Step 7 — Show the diff
+
+After writing, run `diff <backup_path> <target_path>` (or compute it in Python) and show the user exactly what changed. Surface the env keys you added but **mask the values** — print `KEY=<set>` not `KEY=<actual-secret>`. This prevents the credential from appearing in conversation logs you can't delete later.
+
+```
+✓ Persisted credentials. Diff (values masked):
+
+  mcpServers.zotero.env:
+    + ZOTERO_API_KEY = <set>
+    + ZOTERO_LIBRARY_ID = 12345678
+    + ZOTERO_LIBRARY_TYPE = user
+
+Backup at /Users/you/Library/Application Support/Claude/claude_desktop_config.json.bak.2026-05-30T17-32-15Z
+```
+
+Note: numeric IDs (Zotero library ID) and other non-secret config values are fine to show.
+
+## The procedure (`.env` targets)
+
+### Step 1 — Resolve the path
+
+For `orchestrator/.env`, the path is `<rka-repo-root>/orchestrator/.env`. The user must be in or pass the absolute path. Verify the file is gitignored before writing (check `.gitignore` for `.env` or `orchestrator/.env`).
+
+### Step 2 — Read the current file
+
+If absent, start from empty. If present, parse as line-oriented `KEY=VALUE` (skip comments and blank lines, preserve them on rewrite).
+
+```python
+existing = {}
+preserved_lines = []
+for line in current_lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        preserved_lines.append(line)
+        continue
+    if "=" not in stripped:
+        preserved_lines.append(line)
+        continue
+    key, _, value = stripped.partition("=")
+    existing[key.strip()] = value.strip()
+```
+
+### Step 3 — Merge
+
+```python
+for key, value in new_env_entries.items():
+    existing[key] = value
+```
+
+### Step 4 — Write (line-oriented format)
+
+```python
+output = "\n".join(preserved_lines + [
+    f"{k}={v}" for k, v in sorted(existing.items())
+]) + "\n"
+```
+
+Critical detail learned from a prior session bug: **every line MUST end with a newline.** A file that ends with `KEY1=value1KEY2=value2` (no newline between) gets parsed as `KEY1=value1KEY2=value2` and the second key is lost. The `\n` join + trailing `+ "\n"` is the discipline.
+
+### Step 5 — Backup + atomic write + diff (same as JSON)
+
+Same backup naming, same temp-file-then-replace pattern, same masked diff at the end.
+
+## Edge cases worth handling
+
+- **The user has a partially-set config** (e.g., `mcpServers.rka` exists with `command` and `args` but no `env`). Preserve `command` + `args`; just add `env`.
+- **The user has the same env var set via two paths** (e.g., they put `SEMANTIC_SCHOLAR_API_KEY` in both `mcpServers.rka.env` and `mcpServers.zotero.env`). Don't clean up duplicates without asking. Surface them and offer to consolidate.
+- **The user pastes an env var with surrounding quotes** (e.g., `"sk-ant-…"`). Strip outer quotes before persisting — JSON would otherwise nest them as part of the value.
+- **The user is on Windows and the file path contains spaces.** Ensure the path is quoted properly in any shell command you run, and don't rely on shell glob expansion.
+- **The user's `.env` ends without a final newline AND has the concatenation bug already.** Detect by parsing — if a value contains `=` followed by a key-like uppercase identifier, warn and offer to repair before adding new keys.
+
+## What to do when something goes wrong
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| `json.JSONDecodeError` reading the existing file | User hand-edited the file and broke it | Show the parse error with line+col; ask them to fix manually. Do not auto-repair. |
+| `PermissionError` writing the file | Wrong owner / read-only mount / sandboxed app | Print the path; explain the user needs write access. On macOS, this can mean the app is sandboxed. |
+| `OSError: [Errno 28] No space left` | Disk full | Surface clearly. Don't leave the temp file behind — `try/finally` to clean up. |
+| The merged JSON parses but doesn't include the new env entry | Path resolution mismatch (e.g., user wrote to a Claude Code config but Claude Desktop is the one running) | Confirm with the user which app they're using; re-read [`catalog.md`](catalog.md) target table. |
+
+## Restore-from-backup escape hatch
+
+If the user calls you back saying "Claude Desktop won't start after the change" or "the new MCP server isn't showing up":
+
+1. Locate the most recent backup: `ls -t <config-path>.bak.*` — they're ISO-timestamped so sort lexically = sort chronologically.
+2. `cp <backup-path> <config-path>` — restore.
+3. Tell the user to fully quit + reopen.
+
+Always leave the backup in place after a successful write; don't auto-delete. Disk space is cheap; user trust is not.

--- a/plugin/skills/mcp-credentials/walkthroughs/claude-oauth.md
+++ b/plugin/skills/mcp-credentials/walkthroughs/claude-oauth.md
@@ -1,0 +1,96 @@
+# Claude OAuth — `CLAUDE_CODE_OAUTH_TOKEN`
+
+The RKA orchestrator daemon spawns a `claude-agent-sdk` subprocess (the Brain + Executor LLM). That subprocess needs Claude Max credentials. Inside the Docker container, the host's `~/.claude/.credentials.json` and macOS Keychain are NOT accessible — the only working auth path is a long-lived OAuth token in the env, exposed via `orchestrator/.env`.
+
+This walkthrough is unique: the credential goes in **`orchestrator/.env`** (not a Claude Desktop MCP config), and the user mints it via the `claude` CLI on the host (NOT via the web).
+
+## What you need
+
+A long-lived OAuth token of the form `sk-ant-oat01-<80–200 chars>`.
+
+## Where to get it
+
+The user runs **on the host** (NOT inside Docker):
+
+```bash
+claude setup-token
+```
+
+This opens a browser to claude.com, prompts the user to log in (Claude Max account), and prints a long token. Long-lived (default ~1 year, refreshable). The user copies the token from the terminal.
+
+If the user doesn't have the `claude` CLI installed:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+(Or via Homebrew: `brew install claude-code`.)
+
+## Validation
+
+Format: starts with `sk-ant-oat01-`, then 80–200 chars of `[A-Za-z0-9_-]`.
+
+Regex: `^sk-ant-oat01-[A-Za-z0-9_-]{80,200}$`
+
+If the user pastes a string that fails this regex:
+
+- Starts with `sk-ant-api03-` instead of `sk-ant-oat01-` → they pasted an API key, not an OAuth token. API key won't trigger Claude Max billing (would charge per-token). Tell them to run `claude setup-token` instead.
+- Wrong length → they may have truncated when copying. Have them re-run `claude setup-token` to display it fresh.
+
+## Sanity check (optional)
+
+Run a one-shot Claude API ping using the token. The token is used like an API key but the billing path is Max-subscription instead of per-token. The call also confirms the token is currently valid (not expired/revoked).
+
+```bash
+# Use a heredoc so the token doesn't appear on the command line / in shell history
+KEY="$( pbpaste )"  # or have the user paste into a tmp file
+curl -sS -X POST https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-haiku-4-5","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}' \
+  | head -c 200
+unset KEY
+```
+
+Expected: JSON with `"content"` field. 401 means the token is expired or revoked.
+
+## Target env vars + file
+
+Target: **`<rka-repo>/orchestrator/.env`** (line-oriented `KEY=VALUE`, NOT JSON).
+
+```
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-<token>
+```
+
+The file is gitignored. Verify via `git check-ignore -v orchestrator/.env` — must return a `.gitignore` line.
+
+## Refresh discipline
+
+OAuth tokens minted via `claude setup-token` are long-lived but **do expire** (default ~1 year). If the user reports the orchestrator daemon failing auth, run them through this walkthrough again to mint a fresh token.
+
+The daemon doesn't automatically refresh; the user has to re-mint and update `orchestrator/.env`, then `docker compose -f docker-compose.yml -f orchestrator/docker-compose.yml up -d --force-recreate rka-orchestrator` to pick up the new value.
+
+## Restart instruction
+
+```
+✓ CLAUDE_CODE_OAUTH_TOKEN persisted to orchestrator/.env.
+
+To activate, restart the orchestrator container:
+
+  docker compose -f docker-compose.yml \
+                 -f orchestrator/docker-compose.yml \
+                 up -d --force-recreate rka-orchestrator
+
+Verify via:
+  curl -sf http://localhost:9713/health
+
+Then try starting an orchestrator workflow — if auth was the
+issue, it should now reach the Claude API successfully.
+```
+
+## Common pitfalls
+
+- **Token in `claude_desktop_config.json` instead of `orchestrator/.env`** — wrong file. The Claude Desktop app reads `claude_desktop_config.json` for its own MCP servers; the orchestrator daemon (a separate process inside Docker) reads `orchestrator/.env`. Setting it in the wrong place silently fails.
+- **`ANTHROPIC_API_KEY` set instead of `CLAUDE_CODE_OAUTH_TOKEN`** — API key routes to per-token billing; OAuth token routes to Max subscription. The `_RealSDKClient` in `orchestrator/orchestrator/llm_client.py` scrubs `ANTHROPIC_API_KEY` from the subprocess env specifically to prevent this misroute.
+- **Token wrapped in quotes** — `.env` should have the value bare, no `""` around it. The line `CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-…"` would persist the quotes as part of the value and fail auth.

--- a/plugin/skills/mcp-credentials/walkthroughs/openalex.md
+++ b/plugin/skills/mcp-credentials/walkthroughs/openalex.md
@@ -1,0 +1,87 @@
+# OpenAlex — `OPENALEX_MAILTO`
+
+OpenAlex (the open citation graph from OurResearch) is free and unauthenticated. There's no API key. But if you set `OPENALEX_MAILTO=<your-email>`, OpenAlex routes you to their **polite pool**: same data, but a substantially higher rate limit and prioritized request handling.
+
+**This is the only walkthrough in this skill where the "credential" is not a secret — it's just an email address.** Treat it accordingly: no need to mask it in diffs, no need for `pbpaste`, no need for a sanity check.
+
+## What you need
+
+An email address — preferably one the user actually reads. OpenAlex may contact this address if:
+
+- They detect an unusual request pattern from the user's mailto and want to confirm it's intentional
+- A major API change is coming and they want to give heads-up
+- (Rarely) An issue with the user's specific usage needs discussion
+
+Use a real email, not a placeholder. `user@example.com` will not get the polite-pool treatment if OpenAlex's anti-abuse heuristics flag it.
+
+## Where to get it
+
+Not applicable — the user types in their own email. Just ask them.
+
+> *"What email should I use for OpenAlex's polite pool? It should be one you actually read, since they may reach out if there's an issue with your usage."*
+
+## Validation
+
+Standard RFC 5322 email regex (a permissive one):
+
+`^[^\s@]+@[^\s@]+\.[^\s@]+$`
+
+This catches obvious typos (`foo@bar`, no TLD; `@bar.com`, no local part) without rejecting weird-but-valid addresses (sub-addresses with `+`, internationalized domains, etc.).
+
+If the regex fails: ask the user to confirm.
+
+## Sanity check
+
+Not really necessary — OpenAlex doesn't reject anonymous calls, so there's no authentication test to run. But you can confirm the polite pool is honoring the mailto by checking the response headers:
+
+```bash
+curl -sSI "https://api.openalex.org/works?per-page=1&mailto=<email>" | grep -i "X-Polite-Pool"
+```
+
+If the response includes `X-Polite-Pool: true`, you're in. (As of late 2025 this header is not yet standardized; absence doesn't mean rejection. The mailto routing is mostly invisible to clients beyond the rate limit difference.)
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.rka.env`** (the rka MCP server passes mailto on every OpenAlex call when set).
+
+If the orchestrator daemon is installed, **also** persist to **`orchestrator/.env`**.
+
+If any other MCP server is OpenAlex-aware (e.g., a future literature-search server), set it in that server's env block too. Setting `OPENALEX_MAILTO` broadly is harmless — it's not a secret.
+
+```json
+{
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<you>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "OPENALEX_MAILTO": "you@institution.edu"
+      }
+    }
+  }
+}
+```
+
+## Restart instruction
+
+```
+✓ OPENALEX_MAILTO persisted.
+
+Claude Desktop: fully quit (Cmd+Q) and reopen.
+RKA orchestrator: docker compose -f docker-compose.yml \
+                                 -f orchestrator/docker-compose.yml \
+                                 up -d --force-recreate
+
+There's no live-API test for this one — the only observable
+effect is a higher rate limit, which you'd only notice if you
+were doing batch queries. If OpenAlex queries through Claude
+suddenly start failing with 429 errors, the mailto wasn't
+picked up; check the env block via `docker compose config`.
+```
+
+## Common pitfalls
+
+- **Wrong email field** — OpenAlex used to accept the mailto via a `User-Agent` header (e.g., `User-Agent: my-app/1.0 (mailto:user@example.com)`). The current preferred path is the `mailto` query param OR header `User-Agent: my-app (mailto:user@example.com)`. Either works; the rka MCP server's OpenAlex client handles both.
+- **University domain that bounces** — if the user's institutional email bounces (left the institution, address retired), OpenAlex may eventually de-prioritize. Use a personal email that will outlive the user's affiliation for long-running projects.
+- **GDPR / privacy concerns** — OpenAlex publishes their rate-limit logs by mailto for transparency. The user's email may appear in public OpenAlex traffic logs. If that's a concern, use a research-aliased email rather than a primary personal one.
+- **Free tier confusion** — OpenAlex doesn't have paid tiers. The polite pool is just the rate-limit-uplift; nothing else. Don't confuse with services where mailto unlocks paid features.

--- a/plugin/skills/mcp-credentials/walkthroughs/semantic-scholar.md
+++ b/plugin/skills/mcp-credentials/walkthroughs/semantic-scholar.md
@@ -1,0 +1,81 @@
+# Semantic Scholar — `SEMANTIC_SCHOLAR_API_KEY`
+
+The RKA MCP server's `rka_search_semantic_scholar` tool can call Semantic Scholar anonymously (rate-limited: 100 req per 5 min, shared globally), or with an API key (rate-limited: 1 req/sec per key — much more usable for batch lookups). The key is free; the user requests it via a form.
+
+## What you need
+
+One API key, currently issued as 32–48 chars of alphanumeric. Common prefix: `s2k-` (but not required — Semantic Scholar has issued keys without the prefix historically).
+
+## Where to get it
+
+1. Visit https://www.semanticscholar.org/product/api#api-key-form
+2. Fill out the form:
+   - Name + email + organization
+   - **Intended use**: brief description (e.g., "Personal research assistant for literature review and citation graph navigation" — short and honest is fine)
+   - Check the terms-of-use checkbox
+3. Submit. Semantic Scholar reviews requests manually; turnaround is usually 1–3 business days, occasionally same-day.
+4. When approved, an email arrives with the key. Copy it.
+
+If the user submitted the form some time ago and didn't get a response, they should check spam first, then re-submit if there's no record. There's no online status portal.
+
+## Validation
+
+Regex: `^(s2k-)?[A-Za-z0-9]{28,48}$`
+
+The `s2k-` prefix is optional. Reject if too short or contains non-alphanumeric (apart from the prefix's hyphen).
+
+## Sanity check (recommended)
+
+```bash
+KEY="$( pbpaste )"
+curl -sS -H "x-api-key: $KEY" \
+  "https://api.semanticscholar.org/graph/v1/paper/search?query=mcp&limit=1" \
+  | head -c 200
+unset KEY
+```
+
+Expected: JSON with `total` and `data` fields. 401 means the key is wrong; 429 means you hit the rate limit (shouldn't happen on a single request with a fresh key).
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.rka.env`** (the rka MCP server reads this).
+
+If the orchestrator daemon is installed, **also** persist to **`orchestrator/.env`**. The daemon's SDK subprocess passes this env to the `rka mcp` child it spawns; without it the Brain's `rka_search_semantic_scholar` calls fall back to anonymous rate limits.
+
+```json
+{
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<you>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "SEMANTIC_SCHOLAR_API_KEY": "s2k-<key>"
+      }
+    }
+  }
+}
+```
+
+## Restart instruction
+
+```
+✓ SEMANTIC_SCHOLAR_API_KEY persisted.
+
+Claude Desktop: fully quit (Cmd+Q) and reopen.
+RKA orchestrator: docker compose -f docker-compose.yml \
+                                 -f orchestrator/docker-compose.yml \
+                                 up -d --force-recreate
+
+Verify in a Claude Desktop conversation by asking:
+  "Search Semantic Scholar for 'graph neural networks on protein structures'"
+
+If you see results within ~1 second, the key is active. If
+you see a 429 rate-limit error, anonymous mode is still in
+effect — restart wasn't picked up.
+```
+
+## Common pitfalls
+
+- **Key approval pending** — the form turnaround is variable. If you're walking the user through this and they don't have a key yet, defer the persist step until they receive one. There's no point setting a placeholder.
+- **Multiple keys** — Semantic Scholar allows multiple keys per user but doesn't surface them on a dashboard. If the user has issued keys previously and lost track, the cleanest fix is requesting a new one (the old ones don't auto-revoke; that's a Semantic Scholar limitation).
+- **Used by both `claude_desktop_config.json` AND `orchestrator/.env`** — easy to set in one and forget the other, leading to "it works in Claude Desktop but the orchestrator's Brain still gets rate-limited". Always set both if RKA is installed.

--- a/plugin/skills/mcp-credentials/walkthroughs/serpapi.md
+++ b/plugin/skills/mcp-credentials/walkthroughs/serpapi.md
@@ -1,0 +1,96 @@
+# SerpAPI — `SERPAPI_KEY`
+
+SerpAPI proxies Google / Bing / Scholar / News searches into a clean JSON API. The RKA orchestrator's research-toolkit nodes use it to augment web research without scraping. Free tier: 250 searches/month. Paid tiers start at $50/month for 5,000 searches.
+
+## What you need
+
+A 64-char lowercase-hex API key.
+
+## Where to get it
+
+1. Visit https://serpapi.com/users/sign_up
+2. Sign up (email + password). SerpAPI also offers GitHub / Google OAuth signup — either works.
+3. Verify email (link sent automatically).
+4. After verification, visit https://serpapi.com/manage-api-key
+5. The dashboard shows the key under **"Your Private API Key"**. Copy it — 64 hex chars, e.g., `f6852adc74c93a038d45562ba52958ef763e825d678f25a0aa47ce05dd40fba2`.
+
+## Validation
+
+Regex: `^[a-f0-9]{64}$`
+
+Strictly lowercase hex, exactly 64 chars. If the user pastes:
+- Uppercase chars → wrong key or wrong copy. SerpAPI keys are always lowercase.
+- Wrong length → truncated paste; re-copy from the dashboard.
+- Non-hex chars → likely they copied the surrounding HTML or a different field.
+
+## Sanity check (recommended)
+
+```bash
+KEY="$( pbpaste )"
+curl -sS "https://serpapi.com/search.json?engine=google&q=mcp+protocol&num=1&api_key=$KEY" \
+  | head -c 300
+unset KEY
+```
+
+Expected: JSON with `organic_results` array (1 entry). On 401, the key is wrong. On `error` field saying "Your account has run out of searches" → the user hit the free-tier limit; they need to upgrade or wait until next month.
+
+**Discipline note**: putting the key in the URL query string echoes it into shell history. If the user is on a shared machine, prefer the heredoc + POST variant:
+
+```bash
+KEY="$( pbpaste )"
+curl -sS -G "https://serpapi.com/search.json" \
+  --data-urlencode "engine=google" \
+  --data-urlencode "q=test" \
+  --data-urlencode "api_key=$KEY" \
+  --data-urlencode "num=1" \
+  | head -c 300
+unset KEY
+```
+
+Same end-effect; the key doesn't appear in `ps aux` mid-call.
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.rka.env`** (the rka MCP server's deep-research path uses it).
+
+If the orchestrator daemon is installed, **also** persist to **`orchestrator/.env`**.
+
+```json
+{
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<you>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "SERPAPI_KEY": "f6852adc74c93a038d45562ba52958ef763e825d678f25a0aa47ce05dd40fba2"
+      }
+    }
+  }
+}
+```
+
+## Restart instruction
+
+```
+✓ SERPAPI_KEY persisted.
+
+Claude Desktop: fully quit (Cmd+Q) and reopen.
+RKA orchestrator: docker compose -f docker-compose.yml \
+                                 -f orchestrator/docker-compose.yml \
+                                 up -d --force-recreate
+
+Verify by asking me to run a deep-research query that hits
+SerpAPI under the hood. You should see results within a few
+seconds and the SerpAPI dashboard's "Searches Used This
+Month" counter should tick up by 1.
+
+Free-tier reminder: 250 searches/month. The dashboard shows
+remaining at https://serpapi.com/manage-api-key
+```
+
+## Common pitfalls
+
+- **Free-tier limit consumed silently** — once you hit 250, calls return `error` in the JSON body but with HTTP 200. The user might think the key works while it actually doesn't return data. Watch for the dashboard's monthly counter.
+- **Two separate accounts** — if the user has both a free SerpAPI account and a paid one (e.g., personal + work), confirm which one they're using. Different keys; different budgets.
+- **Key rotation** — SerpAPI lets you regenerate keys via the dashboard. The old key is revoked instantly. If the user rotates, this walkthrough has to re-run for both targets.
+- **EROFS in orchestrator/.env line concat (historical)** — a prior session-bug where the .env was written without a trailing newline glued `SERPAPI_KEY=…` to the next env var. The config-ops procedure's atomic-write discipline (always end with `\n`) prevents recurrence — but if the user's existing `.env` shows the glued state, repair before adding new keys.

--- a/plugin/skills/mcp-credentials/walkthroughs/zotero.md
+++ b/plugin/skills/mcp-credentials/walkthroughs/zotero.md
@@ -1,0 +1,128 @@
+# Zotero — `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE`
+
+The `zotero-mcp` server lets Claude search the user's Zotero library, retrieve full-text PDFs they've captured via the Zotero Connector, and link bibliographic metadata into RKA. Three env vars are required.
+
+## What you need
+
+| Field | Format | Notes |
+|---|---|---|
+| `ZOTERO_API_KEY` | 24-char alphanumeric | Per-user, scope-restrictable |
+| `ZOTERO_LIBRARY_ID` | Numeric (user) or group ID | User ID = a number on the user's account page; group ID = the number in the group's URL |
+| `ZOTERO_LIBRARY_TYPE` | `user` or `group` | Tells zotero-mcp which Zotero API base path to use |
+
+Most users want their personal library → `user`.
+
+## Where to get it
+
+### Step A — Generate the API key
+
+1. Visit https://www.zotero.org/settings/keys (the user needs to be logged in)
+2. Click **"Create new private key"**
+3. Set:
+   - **Description**: `Claude Desktop` (or anything memorable)
+   - **Personal Library** section: check **"Allow library access"**. Decide read-only vs read/write based on what you'll do — read-only is safer if Claude will only fetch references; read/write enables RKA's literature-linking flow to update Zotero items.
+   - **Default group permissions**: `Read Only` is fine unless the user works in a shared group library and wants Claude to modify it.
+4. Click **Save Key**. Zotero shows the key once — copy it immediately. It will look like 24 chars of `A-Za-z0-9` (e.g., `Pgxxxxxxxxxxxxxxxxxxxxxx`).
+
+### Step B — Find the Library ID
+
+**For personal library** (most common):
+
+1. Visit https://www.zotero.org/settings/keys
+2. At the top of the page, the section "Your userID for use in API calls" shows a number (e.g., `9646912`). That's the `ZOTERO_LIBRARY_ID`.
+
+**For group library**:
+
+1. Visit https://www.zotero.org/groups
+2. Click into the relevant group
+3. The URL ends with `/groups/<number>/<groupname>`. The `<number>` is the `ZOTERO_LIBRARY_ID`.
+
+### Step C — Pick the type
+
+- Personal library → `user`
+- Group library → `group`
+
+If the user wants both (search across both), you can't do it in one MCP server entry — they'd need two server entries with different names (`zotero-personal`, `zotero-group-X`). Default to whichever they care about most.
+
+## Validation
+
+| Field | Regex |
+|---|---|
+| `ZOTERO_API_KEY` | `^[A-Za-z0-9]{24}$` |
+| `ZOTERO_LIBRARY_ID` | `^\d+$` |
+| `ZOTERO_LIBRARY_TYPE` | `^(user\|group)$` |
+
+If the key fails:
+- Length off by 1 or 2 → likely paste truncation. Have them re-copy.
+- Contains special chars → they pasted the key with surrounding markup or whitespace. Strip and retry.
+
+## Sanity check (recommended)
+
+Hit the Zotero API with the user's credentials to confirm both the key and library ID are valid:
+
+```bash
+KEY="$( pbpaste )"
+ID=9646912           # the library id they just provided
+TYPE=user            # or group
+
+# List 1 item from the library
+curl -sS -H "Zotero-API-Key: $KEY" \
+  "https://api.zotero.org/${TYPE}s/${ID}/items?limit=1&format=json" \
+  | head -c 300
+
+unset KEY
+```
+
+Expected: JSON array (possibly empty if the user's library has no items). 403 or 404 means the key doesn't have permission for that library — usually wrong library ID or wrong type.
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.zotero.env`**
+
+After persistence:
+
+```json
+{
+  "mcpServers": {
+    "zotero": {
+      "command": "<existing command — DO NOT change>",
+      "args": ["<existing args — DO NOT change>"],
+      "env": {
+        "ZOTERO_API_KEY": "Pgxxxxxxxxxxxxxxxxxxxxxx",
+        "ZOTERO_LIBRARY_ID": "9646912",
+        "ZOTERO_LIBRARY_TYPE": "user"
+      }
+    }
+  }
+}
+```
+
+If `mcpServers.zotero` doesn't exist yet, the user hasn't installed the `zotero-mcp` server — surface that. The credentials alone don't give Claude Desktop the tools; they need the server entry too. Point them at https://github.com/54yyyu/zotero-mcp for install instructions, then re-run this walkthrough.
+
+The orchestrator daemon **also** uses these env vars (for the `rka_link_literature_to_zotero` flow). If RKA is installed, additionally persist to **`orchestrator/.env`**.
+
+## Restart instruction
+
+```
+✓ Zotero credentials persisted.
+
+To activate in Claude Desktop:
+  Fully quit (Cmd+Q) and reopen.
+
+To activate in the RKA orchestrator daemon:
+  docker compose -f docker-compose.yml \
+                 -f orchestrator/docker-compose.yml \
+                 up -d --force-recreate rka-orchestrator
+
+Verify by asking me to "list recent items in my Zotero library"
+(Claude Desktop will call zotero_get_recent), or by checking the
+orchestrator's `/health` endpoint then trying a literature
+linkage.
+```
+
+## Common pitfalls
+
+- **User ID vs username** — `ZOTERO_LIBRARY_ID` is a number, not the user's screen name. The username (`carolus_linnaeus`) won't work.
+- **Type mismatch** — using `type=user` with a group ID, or vice versa, returns 404 from the Zotero API. The error doesn't say "wrong type" — it says "not found".
+- **Read-only key + RKA write flow** — `rka_link_literature_to_zotero` may want to write back tags or attached files to Zotero. If the user wants that, the key needs read+write permission. Re-mint if necessary.
+- **Library with many items + first call** — zotero-mcp may cache locally on first call; the user might see a delay. Normal.

--- a/rka/skills/mcp-credentials/SKILL.md
+++ b/rka/skills/mcp-credentials/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: mcp-credentials
+description: Set up credentials for MCP servers (Zotero, Semantic Scholar, Claude OAuth, SerpAPI, OpenAlex) by walking the user through key issuance and editing their Claude Desktop / Claude Code MCP config file. Load when the user asks "set up Zotero" or "add Semantic Scholar credentials" or "configure my MCP servers" or any similar credential-provisioning request.
+version: 1.0.0
+---
+
+# MCP Credentials Setup
+
+You are configuring an MCP server's credentials for a Claude Desktop or Claude Code install. Most cross-project MCP servers (Zotero, Semantic Scholar, Claude OAuth for the orchestrator's SDK, SerpAPI, OpenAlex) need credentials that the user obtains once and then reuses across every project.
+
+This skill walks you through:
+
+1. **Identifying** which service(s) the user wants to set up.
+2. **Issuing** the credential (you guide the user to the right URL with the right form fields).
+3. **Validating** the credential format (and optionally testing it against the live API).
+4. **Persisting** the credential to `claude_desktop_config.json` (and/or `~/.claude.json` for Claude Code, and/or `orchestrator/.env` for the RKA orchestrator daemon).
+5. **Telling the user to restart** the Claude app so the new MCP server entries load.
+
+## Operating principles
+
+- **Plaintext credentials are the platform default.** macOS / Windows / Linux MCP configs store credentials as plaintext JSON. The user has accepted this trade-off (most existing MCP servers — GitHub, Slack, Zotero, etc. — work the same way). Do not engineer a Keychain wrapper unless the user explicitly asks.
+- **Never overwrite without backup.** Before writing any config file, copy it to `<file>.bak.<ISO-timestamp>` so the user can recover.
+- **Deep-merge, don't replace.** The user likely already has other MCP servers configured. Read → parse → merge new entries → write back. Never overwrite the whole `mcpServers` block.
+- **Atomic writes.** Write to a temp file, validate the JSON parses, then move into place. A botched write would prevent Claude Desktop from starting.
+- **One service at a time, even if the user asks for several.** Walk through each one fully (issue → validate → persist) before moving to the next, so a failure on service 3 doesn't lose progress on services 1 and 2.
+
+## Available walkthroughs (load on demand)
+
+- [`walkthroughs/claude-oauth.md`](walkthroughs/claude-oauth.md) — `CLAUDE_CODE_OAUTH_TOKEN` for the RKA orchestrator daemon's claude-agent-sdk subprocess. Long-lived (~1 year). Mint via `claude setup-token` on the host.
+- [`walkthroughs/zotero.md`](walkthroughs/zotero.md) — `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` + `ZOTERO_LIBRARY_TYPE` for the zotero-mcp server. Per-user library, scope-restrictable.
+- [`walkthroughs/semantic-scholar.md`](walkthroughs/semantic-scholar.md) — `SEMANTIC_SCHOLAR_API_KEY` for the rka MCP server's `rka_search_semantic_scholar` tool. Raises the rate limit from 100 req/5min to 1 req/sec.
+- [`walkthroughs/serpapi.md`](walkthroughs/serpapi.md) — `SERPAPI_KEY` for the rka MCP server's deep-research augmentation. 250 free searches/month.
+- [`walkthroughs/openalex.md`](walkthroughs/openalex.md) — `OPENALEX_MAILTO` (just an email, not a secret) for the OpenAlex polite-pool, granting a higher rate limit.
+
+## Reference docs (load on demand)
+
+- [`catalog.md`](catalog.md) — registry of every supported service with envvar names, target config blocks, and validation regex. Use when you need a quick lookup.
+- [`config-ops.md`](config-ops.md) — the read/parse/merge/backup/write pattern for `claude_desktop_config.json`, including cross-platform paths and atomic-write discipline.
+
+## Standard flow
+
+When the user asks you to set up one or more credentials, do this:
+
+### Step 1 — Identify
+
+Ask which service(s) the user wants if not stated. Surface the available walkthroughs so they know what's supported.
+
+> *"Which credentials would you like to set up? I can walk you through Zotero, Semantic Scholar, Claude OAuth (for the RKA orchestrator), SerpAPI, or OpenAlex. You can do one or several."*
+
+### Step 2 — Walkthrough (per service)
+
+Load the relevant walkthrough card from `walkthroughs/<service>.md`. Each card has the same shape:
+
+- **What you need** — list of fields the service requires
+- **Where to get it** — step-by-step URL navigation
+- **Validation** — regex for the key format, expected length, etc.
+- **Optional sanity check** — a one-shot API call to confirm the credential works
+- **Target env vars** — exact env-var names and which MCP server block they belong in
+
+Walk the user through the steps. Use `AskUserQuestion` for branching choices (e.g., "personal library vs group library"). When they paste the key in chat, validate it against the regex; if it fails, point at the likely typo (wrong length, wrong charset).
+
+### Step 3 — Sanity check (optional but recommended)
+
+If the walkthrough card has a `Sanity check` block, run the curl command via Bash to confirm the credential works. Non-200 response → tell the user, suggest the most likely cause (wrong scope, expired, wrong ID), don't proceed to persist.
+
+### Step 4 — Persist
+
+Use the procedure in [`config-ops.md`](config-ops.md):
+
+1. Read `claude_desktop_config.json` (or `~/.claude.json` for Claude Code, or `orchestrator/.env` for the orchestrator — the walkthrough card tells you which).
+2. Parse as JSON (skip for `.env` — it's KEY=VALUE).
+3. Deep-merge the new env entries into the target MCP server block.
+4. Backup the original to `<file>.bak.<ISO-timestamp>`.
+5. Write the new content atomically (temp file → validate parse → move).
+6. Show the user the diff so they see exactly what changed.
+
+### Step 5 — Restart instruction
+
+```
+✓ Done. Credentials persisted to <path>.
+Backup saved at <path>.bak.<timestamp>.
+
+To activate, **fully quit and reopen Claude Desktop**:
+  - macOS: Cmd+Q, then reopen from Applications
+  - Windows: right-click tray icon → Quit, then reopen from Start Menu
+  - Linux: close the app entirely, then reopen
+
+Once Claude Desktop is back up, ask me to "list Zotero items" (or
+"search Semantic Scholar for X") to confirm the new MCP server
+is active.
+```
+
+For Claude Code: reload the VS Code window (Cmd+Shift+P → "Developer: Reload Window") instead of full quit.
+
+## Guardrails
+
+- **Never paste credentials back to chat after persisting.** When you confirm persistence, refer to the credential as "the key you provided" or "the token now in your config" — don't echo it. This avoids accidental exposure in conversation logs or screenshots.
+- **Don't run sanity-check curl commands in the foreground if the key is long-lived.** The shell history may persist the key. Use a pipe (`echo "$KEY" | curl --data-binary @-`) or a heredoc to avoid putting the key on the command line.
+- **Don't edit `claude_desktop_config.json` if it currently fails to parse.** Show the user the parse error, ask them to fix it manually first. A botched JSON would prevent Claude Desktop from starting.
+- **Don't proceed if the user pastes a credential that looks like it might already be in use elsewhere.** If the key format suggests it's a SSH key, GPG passphrase, AWS secret, etc. — confirm with the user before persisting.
+
+## When the user asks for something this skill doesn't cover
+
+If the user asks for a service not in [`catalog.md`](catalog.md), say so clearly and offer two paths:
+
+1. **They can register a new MCP server manually** — point them at the MCP docs and the config file path.
+2. **You can add a walkthrough** if they tell you the service's API and which env vars its MCP server expects. Add a new `walkthroughs/<service>.md` following the existing template.
+
+Don't fabricate URLs or env-var names for unfamiliar services — verify against the service's docs first.

--- a/rka/skills/mcp-credentials/catalog.md
+++ b/rka/skills/mcp-credentials/catalog.md
@@ -1,0 +1,51 @@
+# Catalog — supported MCP credentials
+
+Quick-reference table for every credential this skill knows how to set up. When you need a deeper walkthrough, load the relevant `walkthroughs/<service>.md`.
+
+| Service | Env var(s) | Target | Validation regex | Walkthrough |
+|---|---|---|---|---|
+| Claude OAuth (RKA orchestrator) | `CLAUDE_CODE_OAUTH_TOKEN` | `orchestrator/.env` | `^sk-ant-oat01-[A-Za-z0-9_-]{80,200}$` | [claude-oauth](walkthroughs/claude-oauth.md) |
+| Zotero | `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE` | `mcpServers.zotero.env` in `claude_desktop_config.json` | key: `^[A-Za-z0-9]{24}$`; id: `^\d+$`; type: `user\|group` | [zotero](walkthroughs/zotero.md) |
+| Semantic Scholar | `SEMANTIC_SCHOLAR_API_KEY` | `mcpServers.rka.env` in `claude_desktop_config.json` AND `orchestrator/.env` | `^[A-Za-z0-9]{32,48}$` (s2k-prefix common but not required) | [semantic-scholar](walkthroughs/semantic-scholar.md) |
+| SerpAPI | `SERPAPI_KEY` | `mcpServers.rka.env` AND `orchestrator/.env` | `^[a-f0-9]{64}$` (lowercase hex, 64 chars) | [serpapi](walkthroughs/serpapi.md) |
+| OpenAlex | `OPENALEX_MAILTO` | `mcpServers.rka.env` (and/or any OpenAlex-aware server's env) | RFC 5322 email | [openalex](walkthroughs/openalex.md) |
+
+## Target file paths
+
+### Claude Desktop config
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+### Claude Code config
+
+| OS | Path |
+|---|---|
+| All | `~/.claude.json` (per-user, all-projects) OR `<repo>/.claude/mcp.json` (per-repo) |
+
+### RKA orchestrator daemon
+
+| File | Purpose |
+|---|---|
+| `<rka-repo>/orchestrator/.env` | Used by the orchestrator daemon's Docker container (loaded via Compose `env_file:`). Gitignored. |
+
+## Standard env-var → MCP server mapping
+
+When you persist a credential, route the env var to the right server block based on this table:
+
+| Env var | Belongs in MCP server block | Why |
+|---|---|---|
+| `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE` | `zotero` (the zotero-mcp server) | Service-specific |
+| `SEMANTIC_SCHOLAR_API_KEY` | `rka` (the rka MCP server) | Read by `rka_search_semantic_scholar` |
+| `SERPAPI_KEY` | `rka` (the rka MCP server) | Used by deep-research augmentation if installed |
+| `OPENALEX_MAILTO` | `rka` (the rka MCP server) AND any OpenAlex-aware server | Polite-pool email, harmless to set broadly |
+| `CLAUDE_CODE_OAUTH_TOKEN` | NOT in MCP config — goes in `orchestrator/.env` | Used by the orchestrator daemon's subprocess, not by a Claude-Desktop-launched MCP child |
+
+## Service-availability check
+
+Before suggesting a service, you can verify the corresponding MCP server is actually installed by reading the user's `claude_desktop_config.json` and checking for the `mcpServers.<service>` block. If absent, the credential won't help — point the user at the MCP server's own install docs first.
+
+The exception is `rka` — assume it's installed (this skill ships inside RKA's own repo). The `orchestrator/.env` target is also RKA-internal; the user controls that file directly.

--- a/rka/skills/mcp-credentials/config-ops.md
+++ b/rka/skills/mcp-credentials/config-ops.md
@@ -1,0 +1,165 @@
+# Config operations — read / parse / merge / backup / write
+
+The load-bearing technical pattern for this skill. Every credential persistence runs this exact procedure. A botched write can prevent Claude Desktop from starting, so the discipline here is strict.
+
+## File targets
+
+| Target | Format | Parser |
+|---|---|---|
+| `claude_desktop_config.json` | JSON | Python `json` |
+| `~/.claude.json` | JSON | Python `json` |
+| `<repo>/.claude/mcp.json` | JSON | Python `json` |
+| `orchestrator/.env` | `KEY=VALUE` per line | Plain text, line-oriented |
+
+## The procedure (JSON targets)
+
+### Step 1 — Resolve the path
+
+Cross-platform per [`catalog.md`](catalog.md). Verify the path is absolute and the parent directory exists. If it doesn't, the user hasn't installed Claude Desktop yet — surface that.
+
+### Step 2 — Read the current file
+
+If the file doesn't exist, that's fine — start from `{"mcpServers": {}}`. If it exists but doesn't parse as JSON, **abort**. Show the user the parse error and ask them to fix the file manually first. Do NOT overwrite a file you can't parse — Claude Desktop won't be able to either, but at least the user can recover.
+
+### Step 3 — Deep-merge the new env entries
+
+```python
+import copy
+config = current_config_dict
+config.setdefault("mcpServers", {})
+server_block = config["mcpServers"].setdefault(server_name, {})
+# Preserve any existing command/args; only modify env.
+server_block.setdefault("env", {})
+for key, value in new_env_entries.items():
+    server_block["env"][key] = value
+```
+
+Critical: **don't replace `mcpServers.<server>`** — only set/update `mcpServers.<server>.env.<KEY>`. Existing `command`, `args`, and any other env keys must survive.
+
+### Step 4 — Validate the merged JSON
+
+Before writing, dump and re-parse to confirm the JSON is well-formed:
+
+```python
+import json
+serialized = json.dumps(config, indent=2) + "\n"
+json.loads(serialized)  # raises if malformed; abort if so
+```
+
+### Step 5 — Backup
+
+```python
+from datetime import datetime, timezone
+backup_path = f"{target_path}.bak.{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H-%M-%SZ')}"
+shutil.copy2(target_path, backup_path)  # preserves mtime + permissions
+```
+
+Tell the user the backup path before writing the new file.
+
+### Step 6 — Atomic write
+
+Write to a sibling temp file, then `os.replace()` (which is atomic on POSIX and almost-atomic on Windows):
+
+```python
+import os, tempfile
+fd, tmp = tempfile.mkstemp(
+    prefix=os.path.basename(target_path) + ".",
+    suffix=".tmp",
+    dir=os.path.dirname(target_path),
+)
+with os.fdopen(fd, "w") as f:
+    f.write(serialized)
+os.replace(tmp, target_path)
+```
+
+Why the temp file: if the process dies mid-write, the original file is intact. `os.replace` swaps in the new content atomically.
+
+### Step 7 — Show the diff
+
+After writing, run `diff <backup_path> <target_path>` (or compute it in Python) and show the user exactly what changed. Surface the env keys you added but **mask the values** — print `KEY=<set>` not `KEY=<actual-secret>`. This prevents the credential from appearing in conversation logs you can't delete later.
+
+```
+✓ Persisted credentials. Diff (values masked):
+
+  mcpServers.zotero.env:
+    + ZOTERO_API_KEY = <set>
+    + ZOTERO_LIBRARY_ID = 12345678
+    + ZOTERO_LIBRARY_TYPE = user
+
+Backup at /Users/you/Library/Application Support/Claude/claude_desktop_config.json.bak.2026-05-30T17-32-15Z
+```
+
+Note: numeric IDs (Zotero library ID) and other non-secret config values are fine to show.
+
+## The procedure (`.env` targets)
+
+### Step 1 — Resolve the path
+
+For `orchestrator/.env`, the path is `<rka-repo-root>/orchestrator/.env`. The user must be in or pass the absolute path. Verify the file is gitignored before writing (check `.gitignore` for `.env` or `orchestrator/.env`).
+
+### Step 2 — Read the current file
+
+If absent, start from empty. If present, parse as line-oriented `KEY=VALUE` (skip comments and blank lines, preserve them on rewrite).
+
+```python
+existing = {}
+preserved_lines = []
+for line in current_lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        preserved_lines.append(line)
+        continue
+    if "=" not in stripped:
+        preserved_lines.append(line)
+        continue
+    key, _, value = stripped.partition("=")
+    existing[key.strip()] = value.strip()
+```
+
+### Step 3 — Merge
+
+```python
+for key, value in new_env_entries.items():
+    existing[key] = value
+```
+
+### Step 4 — Write (line-oriented format)
+
+```python
+output = "\n".join(preserved_lines + [
+    f"{k}={v}" for k, v in sorted(existing.items())
+]) + "\n"
+```
+
+Critical detail learned from a prior session bug: **every line MUST end with a newline.** A file that ends with `KEY1=value1KEY2=value2` (no newline between) gets parsed as `KEY1=value1KEY2=value2` and the second key is lost. The `\n` join + trailing `+ "\n"` is the discipline.
+
+### Step 5 — Backup + atomic write + diff (same as JSON)
+
+Same backup naming, same temp-file-then-replace pattern, same masked diff at the end.
+
+## Edge cases worth handling
+
+- **The user has a partially-set config** (e.g., `mcpServers.rka` exists with `command` and `args` but no `env`). Preserve `command` + `args`; just add `env`.
+- **The user has the same env var set via two paths** (e.g., they put `SEMANTIC_SCHOLAR_API_KEY` in both `mcpServers.rka.env` and `mcpServers.zotero.env`). Don't clean up duplicates without asking. Surface them and offer to consolidate.
+- **The user pastes an env var with surrounding quotes** (e.g., `"sk-ant-…"`). Strip outer quotes before persisting — JSON would otherwise nest them as part of the value.
+- **The user is on Windows and the file path contains spaces.** Ensure the path is quoted properly in any shell command you run, and don't rely on shell glob expansion.
+- **The user's `.env` ends without a final newline AND has the concatenation bug already.** Detect by parsing — if a value contains `=` followed by a key-like uppercase identifier, warn and offer to repair before adding new keys.
+
+## What to do when something goes wrong
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| `json.JSONDecodeError` reading the existing file | User hand-edited the file and broke it | Show the parse error with line+col; ask them to fix manually. Do not auto-repair. |
+| `PermissionError` writing the file | Wrong owner / read-only mount / sandboxed app | Print the path; explain the user needs write access. On macOS, this can mean the app is sandboxed. |
+| `OSError: [Errno 28] No space left` | Disk full | Surface clearly. Don't leave the temp file behind — `try/finally` to clean up. |
+| The merged JSON parses but doesn't include the new env entry | Path resolution mismatch (e.g., user wrote to a Claude Code config but Claude Desktop is the one running) | Confirm with the user which app they're using; re-read [`catalog.md`](catalog.md) target table. |
+
+## Restore-from-backup escape hatch
+
+If the user calls you back saying "Claude Desktop won't start after the change" or "the new MCP server isn't showing up":
+
+1. Locate the most recent backup: `ls -t <config-path>.bak.*` — they're ISO-timestamped so sort lexically = sort chronologically.
+2. `cp <backup-path> <config-path>` — restore.
+3. Tell the user to fully quit + reopen.
+
+Always leave the backup in place after a successful write; don't auto-delete. Disk space is cheap; user trust is not.

--- a/rka/skills/mcp-credentials/walkthroughs/claude-oauth.md
+++ b/rka/skills/mcp-credentials/walkthroughs/claude-oauth.md
@@ -1,0 +1,96 @@
+# Claude OAuth — `CLAUDE_CODE_OAUTH_TOKEN`
+
+The RKA orchestrator daemon spawns a `claude-agent-sdk` subprocess (the Brain + Executor LLM). That subprocess needs Claude Max credentials. Inside the Docker container, the host's `~/.claude/.credentials.json` and macOS Keychain are NOT accessible — the only working auth path is a long-lived OAuth token in the env, exposed via `orchestrator/.env`.
+
+This walkthrough is unique: the credential goes in **`orchestrator/.env`** (not a Claude Desktop MCP config), and the user mints it via the `claude` CLI on the host (NOT via the web).
+
+## What you need
+
+A long-lived OAuth token of the form `sk-ant-oat01-<80–200 chars>`.
+
+## Where to get it
+
+The user runs **on the host** (NOT inside Docker):
+
+```bash
+claude setup-token
+```
+
+This opens a browser to claude.com, prompts the user to log in (Claude Max account), and prints a long token. Long-lived (default ~1 year, refreshable). The user copies the token from the terminal.
+
+If the user doesn't have the `claude` CLI installed:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+(Or via Homebrew: `brew install claude-code`.)
+
+## Validation
+
+Format: starts with `sk-ant-oat01-`, then 80–200 chars of `[A-Za-z0-9_-]`.
+
+Regex: `^sk-ant-oat01-[A-Za-z0-9_-]{80,200}$`
+
+If the user pastes a string that fails this regex:
+
+- Starts with `sk-ant-api03-` instead of `sk-ant-oat01-` → they pasted an API key, not an OAuth token. API key won't trigger Claude Max billing (would charge per-token). Tell them to run `claude setup-token` instead.
+- Wrong length → they may have truncated when copying. Have them re-run `claude setup-token` to display it fresh.
+
+## Sanity check (optional)
+
+Run a one-shot Claude API ping using the token. The token is used like an API key but the billing path is Max-subscription instead of per-token. The call also confirms the token is currently valid (not expired/revoked).
+
+```bash
+# Use a heredoc so the token doesn't appear on the command line / in shell history
+KEY="$( pbpaste )"  # or have the user paste into a tmp file
+curl -sS -X POST https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-haiku-4-5","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}' \
+  | head -c 200
+unset KEY
+```
+
+Expected: JSON with `"content"` field. 401 means the token is expired or revoked.
+
+## Target env vars + file
+
+Target: **`<rka-repo>/orchestrator/.env`** (line-oriented `KEY=VALUE`, NOT JSON).
+
+```
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-<token>
+```
+
+The file is gitignored. Verify via `git check-ignore -v orchestrator/.env` — must return a `.gitignore` line.
+
+## Refresh discipline
+
+OAuth tokens minted via `claude setup-token` are long-lived but **do expire** (default ~1 year). If the user reports the orchestrator daemon failing auth, run them through this walkthrough again to mint a fresh token.
+
+The daemon doesn't automatically refresh; the user has to re-mint and update `orchestrator/.env`, then `docker compose -f docker-compose.yml -f orchestrator/docker-compose.yml up -d --force-recreate rka-orchestrator` to pick up the new value.
+
+## Restart instruction
+
+```
+✓ CLAUDE_CODE_OAUTH_TOKEN persisted to orchestrator/.env.
+
+To activate, restart the orchestrator container:
+
+  docker compose -f docker-compose.yml \
+                 -f orchestrator/docker-compose.yml \
+                 up -d --force-recreate rka-orchestrator
+
+Verify via:
+  curl -sf http://localhost:9713/health
+
+Then try starting an orchestrator workflow — if auth was the
+issue, it should now reach the Claude API successfully.
+```
+
+## Common pitfalls
+
+- **Token in `claude_desktop_config.json` instead of `orchestrator/.env`** — wrong file. The Claude Desktop app reads `claude_desktop_config.json` for its own MCP servers; the orchestrator daemon (a separate process inside Docker) reads `orchestrator/.env`. Setting it in the wrong place silently fails.
+- **`ANTHROPIC_API_KEY` set instead of `CLAUDE_CODE_OAUTH_TOKEN`** — API key routes to per-token billing; OAuth token routes to Max subscription. The `_RealSDKClient` in `orchestrator/orchestrator/llm_client.py` scrubs `ANTHROPIC_API_KEY` from the subprocess env specifically to prevent this misroute.
+- **Token wrapped in quotes** — `.env` should have the value bare, no `""` around it. The line `CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-…"` would persist the quotes as part of the value and fail auth.

--- a/rka/skills/mcp-credentials/walkthroughs/openalex.md
+++ b/rka/skills/mcp-credentials/walkthroughs/openalex.md
@@ -1,0 +1,87 @@
+# OpenAlex — `OPENALEX_MAILTO`
+
+OpenAlex (the open citation graph from OurResearch) is free and unauthenticated. There's no API key. But if you set `OPENALEX_MAILTO=<your-email>`, OpenAlex routes you to their **polite pool**: same data, but a substantially higher rate limit and prioritized request handling.
+
+**This is the only walkthrough in this skill where the "credential" is not a secret — it's just an email address.** Treat it accordingly: no need to mask it in diffs, no need for `pbpaste`, no need for a sanity check.
+
+## What you need
+
+An email address — preferably one the user actually reads. OpenAlex may contact this address if:
+
+- They detect an unusual request pattern from the user's mailto and want to confirm it's intentional
+- A major API change is coming and they want to give heads-up
+- (Rarely) An issue with the user's specific usage needs discussion
+
+Use a real email, not a placeholder. `user@example.com` will not get the polite-pool treatment if OpenAlex's anti-abuse heuristics flag it.
+
+## Where to get it
+
+Not applicable — the user types in their own email. Just ask them.
+
+> *"What email should I use for OpenAlex's polite pool? It should be one you actually read, since they may reach out if there's an issue with your usage."*
+
+## Validation
+
+Standard RFC 5322 email regex (a permissive one):
+
+`^[^\s@]+@[^\s@]+\.[^\s@]+$`
+
+This catches obvious typos (`foo@bar`, no TLD; `@bar.com`, no local part) without rejecting weird-but-valid addresses (sub-addresses with `+`, internationalized domains, etc.).
+
+If the regex fails: ask the user to confirm.
+
+## Sanity check
+
+Not really necessary — OpenAlex doesn't reject anonymous calls, so there's no authentication test to run. But you can confirm the polite pool is honoring the mailto by checking the response headers:
+
+```bash
+curl -sSI "https://api.openalex.org/works?per-page=1&mailto=<email>" | grep -i "X-Polite-Pool"
+```
+
+If the response includes `X-Polite-Pool: true`, you're in. (As of late 2025 this header is not yet standardized; absence doesn't mean rejection. The mailto routing is mostly invisible to clients beyond the rate limit difference.)
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.rka.env`** (the rka MCP server passes mailto on every OpenAlex call when set).
+
+If the orchestrator daemon is installed, **also** persist to **`orchestrator/.env`**.
+
+If any other MCP server is OpenAlex-aware (e.g., a future literature-search server), set it in that server's env block too. Setting `OPENALEX_MAILTO` broadly is harmless — it's not a secret.
+
+```json
+{
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<you>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "OPENALEX_MAILTO": "you@institution.edu"
+      }
+    }
+  }
+}
+```
+
+## Restart instruction
+
+```
+✓ OPENALEX_MAILTO persisted.
+
+Claude Desktop: fully quit (Cmd+Q) and reopen.
+RKA orchestrator: docker compose -f docker-compose.yml \
+                                 -f orchestrator/docker-compose.yml \
+                                 up -d --force-recreate
+
+There's no live-API test for this one — the only observable
+effect is a higher rate limit, which you'd only notice if you
+were doing batch queries. If OpenAlex queries through Claude
+suddenly start failing with 429 errors, the mailto wasn't
+picked up; check the env block via `docker compose config`.
+```
+
+## Common pitfalls
+
+- **Wrong email field** — OpenAlex used to accept the mailto via a `User-Agent` header (e.g., `User-Agent: my-app/1.0 (mailto:user@example.com)`). The current preferred path is the `mailto` query param OR header `User-Agent: my-app (mailto:user@example.com)`. Either works; the rka MCP server's OpenAlex client handles both.
+- **University domain that bounces** — if the user's institutional email bounces (left the institution, address retired), OpenAlex may eventually de-prioritize. Use a personal email that will outlive the user's affiliation for long-running projects.
+- **GDPR / privacy concerns** — OpenAlex publishes their rate-limit logs by mailto for transparency. The user's email may appear in public OpenAlex traffic logs. If that's a concern, use a research-aliased email rather than a primary personal one.
+- **Free tier confusion** — OpenAlex doesn't have paid tiers. The polite pool is just the rate-limit-uplift; nothing else. Don't confuse with services where mailto unlocks paid features.

--- a/rka/skills/mcp-credentials/walkthroughs/semantic-scholar.md
+++ b/rka/skills/mcp-credentials/walkthroughs/semantic-scholar.md
@@ -1,0 +1,81 @@
+# Semantic Scholar — `SEMANTIC_SCHOLAR_API_KEY`
+
+The RKA MCP server's `rka_search_semantic_scholar` tool can call Semantic Scholar anonymously (rate-limited: 100 req per 5 min, shared globally), or with an API key (rate-limited: 1 req/sec per key — much more usable for batch lookups). The key is free; the user requests it via a form.
+
+## What you need
+
+One API key, currently issued as 32–48 chars of alphanumeric. Common prefix: `s2k-` (but not required — Semantic Scholar has issued keys without the prefix historically).
+
+## Where to get it
+
+1. Visit https://www.semanticscholar.org/product/api#api-key-form
+2. Fill out the form:
+   - Name + email + organization
+   - **Intended use**: brief description (e.g., "Personal research assistant for literature review and citation graph navigation" — short and honest is fine)
+   - Check the terms-of-use checkbox
+3. Submit. Semantic Scholar reviews requests manually; turnaround is usually 1–3 business days, occasionally same-day.
+4. When approved, an email arrives with the key. Copy it.
+
+If the user submitted the form some time ago and didn't get a response, they should check spam first, then re-submit if there's no record. There's no online status portal.
+
+## Validation
+
+Regex: `^(s2k-)?[A-Za-z0-9]{28,48}$`
+
+The `s2k-` prefix is optional. Reject if too short or contains non-alphanumeric (apart from the prefix's hyphen).
+
+## Sanity check (recommended)
+
+```bash
+KEY="$( pbpaste )"
+curl -sS -H "x-api-key: $KEY" \
+  "https://api.semanticscholar.org/graph/v1/paper/search?query=mcp&limit=1" \
+  | head -c 200
+unset KEY
+```
+
+Expected: JSON with `total` and `data` fields. 401 means the key is wrong; 429 means you hit the rate limit (shouldn't happen on a single request with a fresh key).
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.rka.env`** (the rka MCP server reads this).
+
+If the orchestrator daemon is installed, **also** persist to **`orchestrator/.env`**. The daemon's SDK subprocess passes this env to the `rka mcp` child it spawns; without it the Brain's `rka_search_semantic_scholar` calls fall back to anonymous rate limits.
+
+```json
+{
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<you>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "SEMANTIC_SCHOLAR_API_KEY": "s2k-<key>"
+      }
+    }
+  }
+}
+```
+
+## Restart instruction
+
+```
+✓ SEMANTIC_SCHOLAR_API_KEY persisted.
+
+Claude Desktop: fully quit (Cmd+Q) and reopen.
+RKA orchestrator: docker compose -f docker-compose.yml \
+                                 -f orchestrator/docker-compose.yml \
+                                 up -d --force-recreate
+
+Verify in a Claude Desktop conversation by asking:
+  "Search Semantic Scholar for 'graph neural networks on protein structures'"
+
+If you see results within ~1 second, the key is active. If
+you see a 429 rate-limit error, anonymous mode is still in
+effect — restart wasn't picked up.
+```
+
+## Common pitfalls
+
+- **Key approval pending** — the form turnaround is variable. If you're walking the user through this and they don't have a key yet, defer the persist step until they receive one. There's no point setting a placeholder.
+- **Multiple keys** — Semantic Scholar allows multiple keys per user but doesn't surface them on a dashboard. If the user has issued keys previously and lost track, the cleanest fix is requesting a new one (the old ones don't auto-revoke; that's a Semantic Scholar limitation).
+- **Used by both `claude_desktop_config.json` AND `orchestrator/.env`** — easy to set in one and forget the other, leading to "it works in Claude Desktop but the orchestrator's Brain still gets rate-limited". Always set both if RKA is installed.

--- a/rka/skills/mcp-credentials/walkthroughs/serpapi.md
+++ b/rka/skills/mcp-credentials/walkthroughs/serpapi.md
@@ -1,0 +1,96 @@
+# SerpAPI — `SERPAPI_KEY`
+
+SerpAPI proxies Google / Bing / Scholar / News searches into a clean JSON API. The RKA orchestrator's research-toolkit nodes use it to augment web research without scraping. Free tier: 250 searches/month. Paid tiers start at $50/month for 5,000 searches.
+
+## What you need
+
+A 64-char lowercase-hex API key.
+
+## Where to get it
+
+1. Visit https://serpapi.com/users/sign_up
+2. Sign up (email + password). SerpAPI also offers GitHub / Google OAuth signup — either works.
+3. Verify email (link sent automatically).
+4. After verification, visit https://serpapi.com/manage-api-key
+5. The dashboard shows the key under **"Your Private API Key"**. Copy it — 64 hex chars, e.g., `f6852adc74c93a038d45562ba52958ef763e825d678f25a0aa47ce05dd40fba2`.
+
+## Validation
+
+Regex: `^[a-f0-9]{64}$`
+
+Strictly lowercase hex, exactly 64 chars. If the user pastes:
+- Uppercase chars → wrong key or wrong copy. SerpAPI keys are always lowercase.
+- Wrong length → truncated paste; re-copy from the dashboard.
+- Non-hex chars → likely they copied the surrounding HTML or a different field.
+
+## Sanity check (recommended)
+
+```bash
+KEY="$( pbpaste )"
+curl -sS "https://serpapi.com/search.json?engine=google&q=mcp+protocol&num=1&api_key=$KEY" \
+  | head -c 300
+unset KEY
+```
+
+Expected: JSON with `organic_results` array (1 entry). On 401, the key is wrong. On `error` field saying "Your account has run out of searches" → the user hit the free-tier limit; they need to upgrade or wait until next month.
+
+**Discipline note**: putting the key in the URL query string echoes it into shell history. If the user is on a shared machine, prefer the heredoc + POST variant:
+
+```bash
+KEY="$( pbpaste )"
+curl -sS -G "https://serpapi.com/search.json" \
+  --data-urlencode "engine=google" \
+  --data-urlencode "q=test" \
+  --data-urlencode "api_key=$KEY" \
+  --data-urlencode "num=1" \
+  | head -c 300
+unset KEY
+```
+
+Same end-effect; the key doesn't appear in `ps aux` mid-call.
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.rka.env`** (the rka MCP server's deep-research path uses it).
+
+If the orchestrator daemon is installed, **also** persist to **`orchestrator/.env`**.
+
+```json
+{
+  "mcpServers": {
+    "rka": {
+      "command": "/Users/<you>/.local/bin/rka",
+      "args": ["mcp"],
+      "env": {
+        "SERPAPI_KEY": "f6852adc74c93a038d45562ba52958ef763e825d678f25a0aa47ce05dd40fba2"
+      }
+    }
+  }
+}
+```
+
+## Restart instruction
+
+```
+✓ SERPAPI_KEY persisted.
+
+Claude Desktop: fully quit (Cmd+Q) and reopen.
+RKA orchestrator: docker compose -f docker-compose.yml \
+                                 -f orchestrator/docker-compose.yml \
+                                 up -d --force-recreate
+
+Verify by asking me to run a deep-research query that hits
+SerpAPI under the hood. You should see results within a few
+seconds and the SerpAPI dashboard's "Searches Used This
+Month" counter should tick up by 1.
+
+Free-tier reminder: 250 searches/month. The dashboard shows
+remaining at https://serpapi.com/manage-api-key
+```
+
+## Common pitfalls
+
+- **Free-tier limit consumed silently** — once you hit 250, calls return `error` in the JSON body but with HTTP 200. The user might think the key works while it actually doesn't return data. Watch for the dashboard's monthly counter.
+- **Two separate accounts** — if the user has both a free SerpAPI account and a paid one (e.g., personal + work), confirm which one they're using. Different keys; different budgets.
+- **Key rotation** — SerpAPI lets you regenerate keys via the dashboard. The old key is revoked instantly. If the user rotates, this walkthrough has to re-run for both targets.
+- **EROFS in orchestrator/.env line concat (historical)** — a prior session-bug where the .env was written without a trailing newline glued `SERPAPI_KEY=…` to the next env var. The config-ops procedure's atomic-write discipline (always end with `\n`) prevents recurrence — but if the user's existing `.env` shows the glued state, repair before adding new keys.

--- a/rka/skills/mcp-credentials/walkthroughs/zotero.md
+++ b/rka/skills/mcp-credentials/walkthroughs/zotero.md
@@ -1,0 +1,128 @@
+# Zotero — `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE`
+
+The `zotero-mcp` server lets Claude search the user's Zotero library, retrieve full-text PDFs they've captured via the Zotero Connector, and link bibliographic metadata into RKA. Three env vars are required.
+
+## What you need
+
+| Field | Format | Notes |
+|---|---|---|
+| `ZOTERO_API_KEY` | 24-char alphanumeric | Per-user, scope-restrictable |
+| `ZOTERO_LIBRARY_ID` | Numeric (user) or group ID | User ID = a number on the user's account page; group ID = the number in the group's URL |
+| `ZOTERO_LIBRARY_TYPE` | `user` or `group` | Tells zotero-mcp which Zotero API base path to use |
+
+Most users want their personal library → `user`.
+
+## Where to get it
+
+### Step A — Generate the API key
+
+1. Visit https://www.zotero.org/settings/keys (the user needs to be logged in)
+2. Click **"Create new private key"**
+3. Set:
+   - **Description**: `Claude Desktop` (or anything memorable)
+   - **Personal Library** section: check **"Allow library access"**. Decide read-only vs read/write based on what you'll do — read-only is safer if Claude will only fetch references; read/write enables RKA's literature-linking flow to update Zotero items.
+   - **Default group permissions**: `Read Only` is fine unless the user works in a shared group library and wants Claude to modify it.
+4. Click **Save Key**. Zotero shows the key once — copy it immediately. It will look like 24 chars of `A-Za-z0-9` (e.g., `Pgxxxxxxxxxxxxxxxxxxxxxx`).
+
+### Step B — Find the Library ID
+
+**For personal library** (most common):
+
+1. Visit https://www.zotero.org/settings/keys
+2. At the top of the page, the section "Your userID for use in API calls" shows a number (e.g., `9646912`). That's the `ZOTERO_LIBRARY_ID`.
+
+**For group library**:
+
+1. Visit https://www.zotero.org/groups
+2. Click into the relevant group
+3. The URL ends with `/groups/<number>/<groupname>`. The `<number>` is the `ZOTERO_LIBRARY_ID`.
+
+### Step C — Pick the type
+
+- Personal library → `user`
+- Group library → `group`
+
+If the user wants both (search across both), you can't do it in one MCP server entry — they'd need two server entries with different names (`zotero-personal`, `zotero-group-X`). Default to whichever they care about most.
+
+## Validation
+
+| Field | Regex |
+|---|---|
+| `ZOTERO_API_KEY` | `^[A-Za-z0-9]{24}$` |
+| `ZOTERO_LIBRARY_ID` | `^\d+$` |
+| `ZOTERO_LIBRARY_TYPE` | `^(user\|group)$` |
+
+If the key fails:
+- Length off by 1 or 2 → likely paste truncation. Have them re-copy.
+- Contains special chars → they pasted the key with surrounding markup or whitespace. Strip and retry.
+
+## Sanity check (recommended)
+
+Hit the Zotero API with the user's credentials to confirm both the key and library ID are valid:
+
+```bash
+KEY="$( pbpaste )"
+ID=9646912           # the library id they just provided
+TYPE=user            # or group
+
+# List 1 item from the library
+curl -sS -H "Zotero-API-Key: $KEY" \
+  "https://api.zotero.org/${TYPE}s/${ID}/items?limit=1&format=json" \
+  | head -c 300
+
+unset KEY
+```
+
+Expected: JSON array (possibly empty if the user's library has no items). 403 or 404 means the key doesn't have permission for that library — usually wrong library ID or wrong type.
+
+## Target env vars + file
+
+Target: **`claude_desktop_config.json` → `mcpServers.zotero.env`**
+
+After persistence:
+
+```json
+{
+  "mcpServers": {
+    "zotero": {
+      "command": "<existing command — DO NOT change>",
+      "args": ["<existing args — DO NOT change>"],
+      "env": {
+        "ZOTERO_API_KEY": "Pgxxxxxxxxxxxxxxxxxxxxxx",
+        "ZOTERO_LIBRARY_ID": "9646912",
+        "ZOTERO_LIBRARY_TYPE": "user"
+      }
+    }
+  }
+}
+```
+
+If `mcpServers.zotero` doesn't exist yet, the user hasn't installed the `zotero-mcp` server — surface that. The credentials alone don't give Claude Desktop the tools; they need the server entry too. Point them at https://github.com/54yyyu/zotero-mcp for install instructions, then re-run this walkthrough.
+
+The orchestrator daemon **also** uses these env vars (for the `rka_link_literature_to_zotero` flow). If RKA is installed, additionally persist to **`orchestrator/.env`**.
+
+## Restart instruction
+
+```
+✓ Zotero credentials persisted.
+
+To activate in Claude Desktop:
+  Fully quit (Cmd+Q) and reopen.
+
+To activate in the RKA orchestrator daemon:
+  docker compose -f docker-compose.yml \
+                 -f orchestrator/docker-compose.yml \
+                 up -d --force-recreate rka-orchestrator
+
+Verify by asking me to "list recent items in my Zotero library"
+(Claude Desktop will call zotero_get_recent), or by checking the
+orchestrator's `/health` endpoint then trying a literature
+linkage.
+```
+
+## Common pitfalls
+
+- **User ID vs username** — `ZOTERO_LIBRARY_ID` is a number, not the user's screen name. The username (`carolus_linnaeus`) won't work.
+- **Type mismatch** — using `type=user` with a group ID, or vice versa, returns 404 from the Zotero API. The error doesn't say "wrong type" — it says "not found".
+- **Read-only key + RKA write flow** — `rka_link_literature_to_zotero` may want to write back tags or attached files to Zotero. If the user wants that, the key needs read+write permission. Re-mint if necessary.
+- **Library with many items + first call** — zotero-mcp may cache locally on first call; the user might see a delay. Normal.


### PR DESCRIPTION
## Summary

New skill at `rka/skills/mcp-credentials/` that walks users through provisioning credentials for the five cross-project MCP servers commonly used alongside RKA: **Claude OAuth** (for the orchestrator daemon's SDK subprocess), **Zotero**, **Semantic Scholar**, **SerpAPI**, and **OpenAlex**.

Each install I've done this session has hit at least one of these credential pain points (wrong Zotero permissions; wrong library type; wrong target file; the `orchestrator/.env` newline-concat bug). The skill captures each as a "common pitfalls" section so future installs don't repeat them.

## Why ship it now

- PI explicitly raised this during v2.6 PR planning: *"can we have another skill to assist the users on putting their credentials"*
- The orchestrator already depends on most of these creds being in `orchestrator/.env` (Claude OAuth, Semantic Scholar, SerpAPI). New PIs onboarding hit the wall hard.
- Five services covered are the long tail; once configured, they live for ~a year before any rotation is needed.

## Layout

```
rka/skills/mcp-credentials/
├── SKILL.md           dispatcher + operating principles
├── catalog.md         registry + envvar mapping table
├── config-ops.md      read/parse/merge/backup/write pattern
└── walkthroughs/
    ├── claude-oauth.md       CLAUDE_CODE_OAUTH_TOKEN → orchestrator/.env
    ├── zotero.md             ZOTERO_API_KEY + ID + TYPE → mcpServers.zotero.env
    ├── semantic-scholar.md   SEMANTIC_SCHOLAR_API_KEY → mcpServers.rka.env + orchestrator/.env
    ├── serpapi.md            SERPAPI_KEY → mcpServers.rka.env + orchestrator/.env
    └── openalex.md           OPENALEX_MAILTO (not a secret) → mcpServers.rka.env
```

Mirrored to `plugin/skills/mcp-credentials/` for the plugin-marketplace install path, same as brain/executor/pi/writer.

## Design

- **Plaintext credentials in JSON** — the platform's de-facto pattern. PI confirmed: *"I think the credential could just live in the json file."* No Keychain wrapper.
- **Single skill, multi-walkthrough** — procedure is identical across services; only the per-service card differs. catalog.md + config-ops.md hold the load-bearing technical content; SKILL.md is the dispatcher.
- **No new code** — pure markdown. The LLM uses its existing Read / Write / Edit / Bash tools to execute the procedure config-ops.md describes.

## Guardrails

- Never write a config file that doesn't parse — surface the parse error first.
- Always backup before write (`<file>.bak.<ISO-timestamp>`).
- Atomic write via temp-file + `os.replace`.
- Mask credential values in any post-write diff shown to the user (prevents accidental exposure in conversation logs).
- Heredoc / pipe variants for sanity-check curl commands so long-lived keys don't land in shell history.
- The `orchestrator/.env` flow explicitly disciplines trailing newlines so the historical `SERPAPI_KEY=…ZOTERO_API_KEY=…` concat bug cannot recur.

## Tests

No automated tests (skill files are markdown; the LLM executes the procedure via its file tools). Existing skill files in `rka/skills/{brain,executor,pi,writer}` also don't have automated tests.

Manual verification:
- [x] SKILL.md, catalog.md, config-ops.md, 5 walkthroughs render cleanly
- [x] Walkthrough cards each have: what-you-need, where-to-get-it, validation regex, sanity-check (where applicable), target env vars + file, restart instructions, common pitfalls
- [x] catalog.md table covers all 5 services with correct env-var → file mapping
- [x] config-ops.md covers both JSON (claude_desktop_config) and line-oriented (.env) targets
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)