### PR TITLE
fix(search): FTS OR semantics + feat: collect_report_context operation + retrieval-strategy skills

### DIFF
--- a/eval-harness/tests/test_feature_flag.py
+++ b/eval-harness/tests/test_feature_flag.py
@@ -23,11 +23,16 @@ def _clear_env(monkeypatch):
     monkeypatch.delenv("RKA_FTS_QUERY_MODE", raising=False)
 
 
-def test_default_mode_is_or_space_joined():
-    # Default behavior with no env var: space-joined quoted tokens.
+def test_default_mode_is_or_joined():
+    # Default behavior with no env var: explicit OR-joined quoted tokens.
+    # Originally this test pinned space-joined output under the name
+    # "or_space_joined" — but FTS5's implicit operator for space-separated
+    # terms is AND, so the pre-fix production "or" mode was AND in
+    # practice (and Eval-v1's AND-vs-OR comparison never tested OR).
+    # The explicit OR separator restores the intended semantics.
     assert (
         SearchService._sanitize_fts_query("foo bar baz")
-        == '"foo" "bar" "baz"'
+        == '"foo" OR "bar" OR "baz"'
     )
 
 
@@ -35,7 +40,7 @@ def test_explicit_or_matches_default(monkeypatch):
     monkeypatch.setenv("RKA_FTS_QUERY_MODE", "or")
     assert (
         SearchService._sanitize_fts_query("foo bar baz")
-        == '"foo" "bar" "baz"'
+        == '"foo" OR "bar" OR "baz"'
     )
 
 
@@ -58,9 +63,9 @@ def test_case_insensitive_and(monkeypatch):
 
 def test_unknown_value_falls_back_to_or_silently(monkeypatch):
     # Safe-default behavior: an unrecognized mode does NOT raise; it
-    # preserves the pre-flag production semantics.
+    # falls back to the default OR semantics.
     monkeypatch.setenv("RKA_FTS_QUERY_MODE", "xor")
-    assert SearchService._sanitize_fts_query("foo bar") == '"foo" "bar"'
+    assert SearchService._sanitize_fts_query("foo bar") == '"foo" OR "bar"'
 
 
 def test_single_word_emits_no_separator_in_and_mode(monkeypatch):

--- a/plugin/skills/brain/SKILL.md
+++ b/plugin/skills/brain/SKILL.md
@@ -209,6 +209,18 @@ Full navigation command catalogue + advancement heuristics: `workflows.md` § "R
 
 ---
 
+## Retrieval Strategy — Drive RKA, Don't One-Shot It
+
+A single search call is not a retrieval strategy. Measured on the rka_development corpus (eval-v3, 2026-06-11): one paragraph-shaped query reached 0.32 mean recall of report-relevant nodes; the iterative strategy below reached 0.80–1.00. Assume you must drive RKA through several calls.
+
+1. **Short queries, many angles.** FTS works best with 1–4 keyword queries. Decompose the information need into 3–5 angle queries (component names, bug/fix vocabulary, decision subjects, evaluation terms) and search each one.
+2. **Expand from the best hits, not from the query.** Take the strongest 2–3 hits and traverse the graph: `ego_graph` for the linked neighborhood, `multi_hop` for ranked expansion. Typed links reach nodes whose wording shares nothing with your query — a fix-mission's produced journals, a decision's justifying evidence (+10 to +24 recall points over flat search in eval-v3).
+3. **For report-scoped collection, call `collect_report_context`** with the PI's prose description plus your angle queries. It runs seed-union + provenance-weighted graph expansion with seed protection server-side, and every returned node carries `included_via` (which query or link reached it) so you can audit the bundle.
+4. **Verify before you rely.** Fetch the full entity for anything load-bearing or borderline; never cite from a snippet alone.
+5. **Re-search thin dimensions.** If one aspect of the need came back sparse, treat it as a missing-angle signal, not proof of absence — try synonyms, and pivot through a relevant node's tags (tags name the cohort vocabulary).
+
+---
+
 ## Anti-Patterns — Common Mistakes to Avoid
 
 1. **DON'T** skip the session-start protocol, even if the user asks a direct question.

--- a/plugin/skills/executor/SKILL.md
+++ b/plugin/skills/executor/SKILL.md
@@ -103,6 +103,12 @@ When a mission asks you to read a paper:
 4. On `reason: "no_match"`: emit a FULL-TEXT REQUEST checkpoint asking the PI to capture the paper into the project's Zotero collection. Do not proceed at abstract-level confidence unless the mission explicitly allows it.
 5. On `reason: "multiple_matches_below_threshold"`: render the candidates and ask the PI to disambiguate via checkpoint.
 
+## Retrieving Context — Drive RKA, Don't One-Shot It
+
+When mission context is incomplete, retrieve iteratively: 3–5 short (1–4 word) angle queries via `search`, then expand the best hits through `ego_graph` / `multi_hop`; for prose-described scopes use `collect_report_context` with angle_queries. One-shot paragraph search measured 0.32 recall vs 0.80–1.00 for this loop (eval-v3). Verify load-bearing entities by fetching full content before acting on them.
+
+---
+
 ## Guardrails
 
 - Do not make strategic research decisions that belong to the Brain or PI.

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -72,7 +72,7 @@ Scripts invoked via `Bash` (under `scripts/`):
 
 ## Evidence Collection for Sections
 
-When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(operation='collect_report_context', query=<the PI's description>, filters={'angle_queries': [3-5 short queries from different angles]})` to assemble the candidate node set — it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80–1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill § "Retrieval Strategy — Drive RKA, Don't One-Shot It".
+When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(operation='collect_report_context', query=<the PI's description>, filters={'angle_queries': [3-5 short queries from different angles]})` to assemble the candidate node set: it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80 to 1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill section "Retrieval Strategy" (drive RKA through several calls, never one-shot it).
 
 ---
 

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -70,6 +70,12 @@ Scripts invoked via `Bash` (under `scripts/`):
 
 ---
 
+## Evidence Collection for Sections
+
+When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(operation='collect_report_context', query=<the PI's description>, filters={'angle_queries': [3-5 short queries from different angles]})` to assemble the candidate node set — it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80–1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill § "Retrieval Strategy — Drive RKA, Don't One-Shot It".
+
+---
+
 ## Source Attribution
 
 Every assertion in prose connects to an upstream entity in RKA. Two mechanisms together carry the connection:

--- a/rka/api/routes/graph.py
+++ b/rka/api/routes/graph.py
@@ -42,6 +42,23 @@ class MultiHopRequest(BaseModel):
     edge_weights: dict[str, float] | None = None
 
 
+class ReportContextRequest(BaseModel):
+    """Request for report-scoped context collection.
+
+    ``description`` is the PI's prose description of the report scope.
+    ``angle_queries`` are short (1–4 word) seed queries decomposing the
+    description into search angles — strongly recommended; the LLM caller
+    decomposes far better than server-side stopword stripping.
+    """
+
+    description: str = Field(min_length=3)
+    angle_queries: list[str] | None = None
+    max_depth: int = Field(default=2, ge=1, le=4)
+    max_nodes: int = Field(default=60, ge=1, le=500)
+    seed_limit: int = Field(default=8, ge=1, le=50)
+    edge_weights: dict[str, float] | None = None
+
+
 @router.get("/graph")
 async def get_full_graph(
     view: Literal["full", "condensed", "keynodes"] = Query(
@@ -130,6 +147,32 @@ async def multi_hop_retrieval(
         seeds=data.seeds,
         max_depth=data.max_depth,
         max_nodes=data.max_nodes,
+        edge_weights=data.edge_weights,
+        project_id=project_id,
+        search_service=search,
+    )
+
+
+@router.post("/graph/report-context")
+async def collect_report_context(
+    data: ReportContextRequest,
+    project_id: str = Depends(require_project),
+    svc: GraphService = Depends(get_graph_service),
+    search: SearchService = Depends(get_scoped_search_service),
+):
+    """Assemble the node set relevant to a report described in prose.
+
+    Composite retrieval: seeds from every angle query (plus the keyword-
+    normalized description), BFS-expands through entity_links/claim_edges
+    with provenance-weighted edges, protects seeds from cap displacement,
+    and annotates every node with ``included_via`` inclusion provenance.
+    """
+    return await svc.collect_report_context(
+        description=data.description,
+        angle_queries=data.angle_queries,
+        max_depth=data.max_depth,
+        max_nodes=data.max_nodes,
+        seed_limit=data.seed_limit,
         edge_weights=data.edge_weights,
         project_id=project_id,
         search_service=search,

--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -525,6 +525,43 @@ class QueryMultiHopArgs(ProjectScopedArgs):
     ] = None
 
 
+class QueryCollectReportContextArgs(ProjectScopedArgs):
+    """[ANY] Collect the node set relevant to a report described in prose.
+
+    Composite retrieval for the "I want to write a report about X"
+    workflow: seeds from every angle query, BFS-expands through the
+    typed link graph, protects seeds from cap displacement, and tags
+    every node with inclusion provenance (``included_via``).
+
+    ALWAYS provide ``filters.angle_queries`` — 3-5 short (1-4 word)
+    queries decomposing the description from different angles
+    (components, bugs/fixes, decisions, evaluations). Paragraph-only
+    seeding measured 0.32 mean cohort recall vs 0.80 for
+    angle-decomposed retrieval (eval-v3).
+    """
+
+    operation: Literal["collect_report_context"] = "collect_report_context"
+
+    query: Annotated[
+        str,
+        Field(description=(
+            "The report description — the PI's prose paragraph describing "
+            "what the report should cover."
+        )),
+    ]
+    filters: Annotated[
+        Optional[dict[str, Any]],
+        Field(
+            default=None,
+            description=(
+                "Optional filters: {'angle_queries': ['short query', ...], "
+                "'max_depth': 2, 'max_nodes': 60, 'seed_limit': 8}. "
+                "angle_queries is STRONGLY recommended."
+            ),
+        ),
+    ] = None
+
+
 # ---------------------------------------------------------------------------
 # Summarization
 # ---------------------------------------------------------------------------
@@ -837,6 +874,7 @@ QueryArgsUnion = Annotated[
         QueryGraphMermaidArgs,
         QueryProvenanceArgs,
         QueryMultiHopArgs,
+        QueryCollectReportContextArgs,
         # Summarization
         QuerySummarizeArgs,
         QueryGenerateSummaryArgs,
@@ -3619,6 +3657,7 @@ __all__ = [
     "QueryGraphMermaidArgs",
     "QueryProvenanceArgs",
     "QueryMultiHopArgs",
+    "QueryCollectReportContextArgs",
     "QuerySummarizeArgs",
     "QueryGenerateSummaryArgs",
     "QueryEvidenceArgs",

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -797,6 +797,57 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "notes": "Pass `filters.seeds=[...]` to override the query-based seeding.",
     },
 
+    "collect_report_context": {
+        "operation": "collect_report_context",
+        "tool": "rka_query",
+        "category": "graph",
+        "role_tag": "ANY",
+        "summary": (
+            "Collect the node set relevant to a report described in prose — "
+            "multi-angle search seeding + link-graph expansion with seed "
+            "protection and per-node inclusion provenance."
+        ),
+        "signature": (
+            "rka_query(operation='collect_report_context', *, project_id, "
+            "query, filters={'angle_queries', 'max_depth', 'max_nodes', "
+            "'seed_limit'})"
+        ),
+        "required_fields": ["project_id", "query"],
+        "optional_fields": ["filters"],
+        "enums": {},
+        "examples": [
+            {
+                "description": (
+                    "Assemble report context with angle decomposition "
+                    "(ALWAYS provide angle_queries — short 1-4 word queries "
+                    "from different angles of the description)."
+                ),
+                "call": {
+                    "operation": "collect_report_context",
+                    "project_id": "prj_01ABC...",
+                    "query": (
+                        "Report on how the embedding stack became pluggable: "
+                        "motivation, backends, config persistence, dimension "
+                        "fix, bugs found"
+                    ),
+                    "filters": {
+                        "angle_queries": [
+                            "pluggable embeddings", "fastembed",
+                            "embedding config", "dimension mismatch",
+                        ],
+                        "max_depth": 2, "max_nodes": 60,
+                    },
+                },
+            },
+        ],
+        "related_operations": ["multi_hop", "search", "ego_graph"],
+        "notes": (
+            "Each returned node carries `included_via` (angle query + rank, "
+            "or parent + link_type) so the bundle is auditable. Follow up: "
+            "verify borderline nodes by content, re-search thin dimensions."
+        ),
+    },
+
     "summarize": {
         "operation": "summarize",
         "tool": "rka_query",

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -4694,6 +4694,82 @@ async def rka_multi_hop_retrieval(
 
 
 @tool(category="claims")
+async def rka_collect_report_context(
+    description: str,
+    angle_queries: list[str] | None = None,
+    max_depth: int = 2,
+    max_nodes: int = 60,
+    seed_limit: int = 8,
+    *,
+    project_id: str,
+) -> str:
+    """Collect the knowledge-base node set relevant to a report described in prose.
+
+    Composite retrieval for the "I want to write a report about X" workflow:
+    seeds from EVERY angle query (short 1-4 word queries you derive from the
+    description — provide 3-5 of them, from different angles: components,
+    bugs/fixes, decisions, evaluations), BFS-expands through entity_links +
+    claim_edges with provenance-weighted edges, never lets expansion displace
+    seeds, and annotates every node with `included_via` (which query + rank
+    surfaced it, or which parent + link type reached it) so the bundle is
+    auditable.
+
+    ALWAYS pass angle_queries — eval-v3 measured 0.32 mean cohort recall for
+    paragraph-only seeding vs 0.80 for angle-decomposed agent retrieval. After
+    the call, verify borderline nodes by fetching their content, and run
+    follow-up searches for report dimensions that came back thin.
+
+    Args:
+        description: The PI's prose description of the report scope.
+        angle_queries: Short seed queries decomposing the description into
+            search angles. The keyword-normalized description is always
+            appended as one extra angle automatically.
+        max_depth: BFS expansion depth (default 2, capped at 4).
+        max_nodes: Result cap (default 60); seeds are exempt from the cap.
+        seed_limit: Search hits taken per angle query (default 8).
+    """
+    body: dict = {
+        "description": description,
+        "max_depth": max_depth,
+        "max_nodes": max_nodes,
+        "seed_limit": seed_limit,
+    }
+    if angle_queries is not None:
+        body["angle_queries"] = angle_queries
+
+    async with _client(project_id) as c:
+        r = await c.post("/api/graph/report-context", json=body)
+        _raise_with_detail(r)
+    data = r.json()
+    nodes = data.get("nodes", [])
+
+    lines = [
+        f"## Report context for: {description[:120]}",
+        f"Angle queries used: {', '.join(data.get('queries', []))}",
+        f"{data.get('seed_count', 0)} seeds + {data.get('expanded_count', 0)} link-expanded nodes"
+        + (" (expansion truncated by max_nodes)" if data.get("truncated") else ""),
+    ]
+    if not nodes:
+        lines.append("\n(empty result — add angle_queries with distinctive short keywords)")
+        return "\n".join(lines)
+
+    lines.append("\n### Nodes (score-ranked; seeds first):")
+    for n in nodes:
+        via = n.get("included_via", {})
+        if via.get("via") == "search":
+            via_s = f"search:{via.get('query', '')[:30]}#{via.get('rank')}"
+        else:
+            via_s = f"{via.get('link_type', '?')}←{via.get('from', '?')[-8:]}"
+        tags = ",".join(n.get("tags", [])[:4])
+        label = (n.get("label") or "")[:70]
+        lines.append(
+            f"  [{n.get('type', '?')}|s={n.get('score', 0.0):.2f}|{via_s}] "
+            f"{n.get('id', '?')} {label}" + (f" «{tags}»" if tags else "")
+        )
+    return "\n".join(lines)
+
+
+@tool(category="claims")
 async def rka_get_review_queue(
     status: str = "pending",
     limit: int = 20,
@@ -5714,6 +5790,7 @@ QueryScopeLit = _Literal[
     "hooks", "hook_executions", "brain_notifications", "research_map",
     "review_queue", "clusters", "claims", "manuscript", "graph",
     "ego_graph", "graph_stats", "graph_mermaid", "provenance", "multi_hop",
+    "collect_report_context",
     "summarize", "generate_summary", "evidence", "freshness", "contradictions",
     "integrity", "pending_maintenance", "changelog", "bootstrap_review",
     "workspace_tree", "workspace_scan",

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -928,6 +928,7 @@ _QUERY_DISPATCH: dict[str, str] = {
     # provenance / multi-hop
     "provenance": "rka_trace_provenance",
     "multi_hop": "rka_multi_hop_retrieval",
+    "collect_report_context": "rka_collect_report_context",
     "evidence": "rka_assemble_evidence",
 
     # session-flavored project-scoped reads
@@ -1029,6 +1030,22 @@ async def dispatch_query(
             max_depth=f.get("max_depth", 3),
             max_nodes=f.get("max_nodes", 50),
             edge_weights=f.get("edge_weights"),
+            project_id=project_id,
+        )
+
+    if scope == "collect_report_context":
+        if not query:
+            return _err(
+                "missing_field",
+                "rka_query(scope='collect_report_context'): query (the report "
+                "description) is required",
+            )
+        return await legacy(
+            description=query,
+            angle_queries=f.get("angle_queries"),
+            max_depth=f.get("max_depth", 2),
+            max_nodes=f.get("max_nodes", 60),
+            seed_limit=f.get("seed_limit", 8),
             project_id=project_id,
         )
 

--- a/rka/services/graph.py
+++ b/rka/services/graph.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rka.infra.database import Database
 from rka.infra.ids import generate_id
+
+if TYPE_CHECKING:
+    from rka.services.search import SearchService
 
 
 class GraphService:
@@ -518,6 +521,214 @@ class GraphService:
             "edges": result_edges,
             "query": query,
             "seeds": list(seeds),
+        }
+
+    # Stopwords stripped from a report description when no angle_queries are
+    # provided. Deliberately small: only request-framing vocabulary, not a
+    # general English list — domain terms must survive.
+    _REPORT_STOPWORDS: frozenset = frozenset(
+        "i want to write a report on about the and of in for with how its any "
+        "that were what came out it needed was along way which where when who "
+        "this these those they them their there is are be been being should "
+        "could would will can may might must have has had do does did".split()
+    )
+
+    async def collect_report_context(
+        self,
+        description: str,
+        *,
+        angle_queries: list[str] | None = None,
+        max_depth: int = 2,
+        max_nodes: int = 60,
+        seed_limit: int = 8,
+        edge_weights: dict[str, float] | None = None,
+        project_id: str = "proj_default",
+        search_service: "SearchService | None" = None,
+    ) -> dict:
+        """Assemble the node set relevant to a report described in prose.
+
+        Composite retrieval per the eval-v3 report-context findings: one-shot
+        paragraph search reached 0.32 mean cohort recall while an agent loop
+        (angle queries + graph expansion + verification) reached 0.80. This
+        operation runs that loop's mechanical core server-side:
+
+        1. Seed from EVERY angle query (caller-provided short queries; the
+           normalized description is always added as one more angle). Seed
+           score reflects best search rank across angles.
+        2. BFS-expand seeds through ``entity_links`` + ``claim_edges`` with
+           provenance-weighted edges (same weights as multi_hop_retrieval).
+        3. Seed protection: seeds are never displaced by expansion neighbors
+           (the anchor_aware UNION pattern from the context engine — without
+           it, paragraph-seeded multi_hop scored BELOW flat search).
+        4. Every returned node carries ``included_via`` — either the angle
+           query + rank that surfaced it, or the parent node + link type that
+           reached it — so the consumer (Writer, Brain) can audit the bundle.
+
+        Args:
+            description: The PI's prose description of the report scope.
+            angle_queries: Short (1–4 word) seed queries decomposing the
+                description into search angles. STRONGLY recommended — the
+                caller (an LLM) decomposes far better than stopword
+                stripping. When omitted, the description is keyword-
+                normalized and used as the only angle.
+            max_depth: BFS expansion depth (default 2; report scopes are
+                link-dense, depth 3 mostly adds noise).
+            max_nodes: Result cap (default 60). Seeds are exempt.
+            seed_limit: Search hits taken per angle query (default 8).
+            edge_weights: Per-relation overrides; falls back to
+                DEFAULT_EDGE_WEIGHTS.
+            project_id: Project scope.
+            search_service: Required — seeds always come from search.
+
+        Returns: {nodes: [{id, type, label, score, depth, included_via,
+                  tags}, ...], queries: [...], seed_count, expanded_count,
+                  truncated}
+        """
+        if search_service is None:
+            raise ValueError("collect_report_context requires a search_service")
+        weights = {**self.DEFAULT_EDGE_WEIGHTS, **(edge_weights or {})}
+
+        # Step 1: build the angle-query list. The normalized description is
+        # always appended as a recall backstop behind the caller's angles.
+        import re as _re
+
+        desc_terms = [
+            t for t in _re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]+", description.lower())
+            if t not in self._REPORT_STOPWORDS and len(t) > 2
+        ]
+        queries: list[str] = []
+        for q in (angle_queries or []):
+            q = q.strip()
+            if q and q.lower() not in {x.lower() for x in queries}:
+                queries.append(q)
+        if desc_terms:
+            norm = " ".join(desc_terms)
+            if norm.lower() not in {x.lower() for x in queries}:
+                queries.append(norm)
+        if not queries:
+            return {"nodes": [], "queries": [], "seed_count": 0,
+                    "expanded_count": 0, "truncated": False}
+
+        # Step 2: seed from every angle. Seed score = best (highest) rank
+        # score across angles; rank 0 → 1.0, decaying to 0.5 at seed_limit.
+        scoped_search = search_service.with_project(project_id)
+        scores: dict[str, float] = {}
+        depths: dict[str, int] = {}
+        included_via: dict[str, dict] = {}
+        for q in queries:
+            hits = await scoped_search.search(q, limit=seed_limit)
+            for rank, h in enumerate(hits):
+                s = 1.0 - (rank / (2 * max(seed_limit, 1)))
+                if h.entity_id not in scores or s > scores[h.entity_id]:
+                    scores[h.entity_id] = s
+                    depths[h.entity_id] = 0
+                    included_via[h.entity_id] = {
+                        "via": "search", "query": q, "rank": rank,
+                    }
+        seeds_set = set(scores.keys())
+        if not seeds_set:
+            return {"nodes": [], "queries": queries, "seed_count": 0,
+                    "expanded_count": 0, "truncated": False}
+
+        # Step 3: BFS expansion (same edge sources as multi_hop_retrieval,
+        # plus inclusion-provenance tracking on every score improvement).
+        frontier: set[str] = set(seeds_set)
+        for hop in range(max_depth):
+            if not frontier or len(scores) >= max_nodes * 3:
+                break
+            placeholders = ",".join("?" for _ in frontier)
+            frontier_list = list(frontier)
+
+            el_rows = await self.db.fetchall(
+                f"""SELECT source_id, link_type, target_id
+                    FROM entity_links
+                    WHERE {self._project_clause()}
+                      AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))""",
+                [project_id] + frontier_list + frontier_list,
+            )
+            ce_rows = await self.db.fetchall(
+                f"""SELECT source_claim_id, target_claim_id, cluster_id, relation
+                    FROM claim_edges
+                    WHERE {self._project_clause()} AND (
+                        source_claim_id IN ({placeholders})
+                        OR target_claim_id IN ({placeholders})
+                        OR cluster_id IN ({placeholders}))""",
+                [project_id] + frontier_list + frontier_list + frontier_list,
+            )
+
+            next_frontier: set[str] = set()
+
+            def _propagate(src: str, tgt: str, link: str) -> None:
+                w = weights.get(link, 0.5)
+                for parent, child in ((src, tgt), (tgt, src)):
+                    parent_score = scores.get(parent)
+                    if parent_score is None:
+                        continue
+                    new_score = parent_score * w
+                    if child not in scores or new_score > scores[child]:
+                        # Seeds keep their search provenance + depth 0.
+                        if child in seeds_set:
+                            continue
+                        scores[child] = new_score
+                        depths[child] = hop + 1
+                        included_via[child] = {
+                            "via": "link", "from": parent, "link_type": link,
+                        }
+                        next_frontier.add(child)
+
+            for row in el_rows:
+                _propagate(row["source_id"], row["target_id"], row["link_type"])
+            for row in ce_rows:
+                src = row["source_claim_id"]
+                relation = row["relation"]
+                tgt = row["cluster_id"] if relation == "member_of" else row["target_claim_id"]
+                if src and tgt:
+                    _propagate(src, tgt, relation)
+
+            frontier = next_frontier
+
+        # Step 4: rank with seed protection — all seeds survive, expansion
+        # nodes fill the remaining budget by score.
+        expansion_ranked = sorted(
+            (nid for nid in scores if nid not in seeds_set),
+            key=lambda nid: scores[nid], reverse=True,
+        )
+        budget = max(max_nodes - len(seeds_set), 0)
+        truncated = len(expansion_ranked) > budget
+        kept = sorted(seeds_set, key=lambda nid: scores[nid], reverse=True) \
+            + expansion_ranked[:budget]
+
+        # Step 5: hydrate metadata + tags.
+        node_ids: dict[str, set[str]] = {}
+        for nid in kept:
+            node_ids.setdefault(self._guess_type_from_id(nid), set()).add(nid)
+        nodes: dict[str, dict] = {}
+        await self._fill_missing_nodes(nodes, node_ids, project_id=project_id)
+
+        tags_by_id: dict[str, list[str]] = {}
+        if kept:
+            placeholders = ",".join("?" for _ in kept)
+            for row in await self.db.fetchall(
+                f"SELECT entity_id, tag FROM tags WHERE entity_id IN ({placeholders})",
+                kept,
+            ):
+                tags_by_id.setdefault(row["entity_id"], []).append(row["tag"])
+
+        result_nodes = []
+        for nid in kept:
+            n = nodes.get(nid, {"id": nid, "type": self._guess_type_from_id(nid), "label": nid})
+            n["score"] = round(scores[nid], 4)
+            n["depth"] = depths[nid]
+            n["included_via"] = included_via[nid]
+            n["tags"] = tags_by_id.get(nid, [])
+            result_nodes.append(n)
+
+        return {
+            "nodes": result_nodes,
+            "queries": queries,
+            "seed_count": len(seeds_set),
+            "expanded_count": len(kept) - len(seeds_set),
+            "truncated": truncated,
         }
 
     # ------------------------------------------------------------------

--- a/rka/services/search.py
+++ b/rka/services/search.py
@@ -191,7 +191,10 @@ class SearchService:
         if not words:
             return query
         mode = os.environ.get("RKA_FTS_QUERY_MODE", "or").strip().lower()
-        separator = " AND " if mode == "and" else " "
+        # FTS5's implicit operator for space-separated terms is AND, not OR.
+        # `or` mode must join with an explicit OR; bm25() then ranks by match
+        # count, which is the behavior the original design intended.
+        separator = " AND " if mode == "and" else " OR "
         return separator.join(f'"{w}"' for w in words)
 
     async def _fts_search(

--- a/rka/skills/brain/SKILL.md
+++ b/rka/skills/brain/SKILL.md
@@ -261,6 +261,18 @@ Full navigation command catalogue + advancement heuristics: `workflows.md` § "R
 
 ---
 
+## Retrieval Strategy — Drive RKA, Don't One-Shot It
+
+A single search call is not a retrieval strategy. Measured on the rka_development corpus (eval-v3, 2026-06-11): one paragraph-shaped query reached 0.32 mean recall of report-relevant nodes; the iterative strategy below reached 0.80–1.00. Assume you must drive RKA through several calls.
+
+1. **Short queries, many angles.** FTS works best with 1–4 keyword queries. Decompose the information need into 3–5 angle queries (component names, bug/fix vocabulary, decision subjects, evaluation terms) and search each one.
+2. **Expand from the best hits, not from the query.** Take the strongest 2–3 hits and traverse the graph: `ego_graph` for the linked neighborhood, `multi_hop` for ranked expansion. Typed links reach nodes whose wording shares nothing with your query — a fix-mission's produced journals, a decision's justifying evidence (+10 to +24 recall points over flat search in eval-v3).
+3. **For report-scoped collection, call `collect_report_context`** with the PI's prose description plus your angle queries. It runs seed-union + provenance-weighted graph expansion with seed protection server-side, and every returned node carries `included_via` (which query or link reached it) so you can audit the bundle.
+4. **Verify before you rely.** Fetch the full entity for anything load-bearing or borderline; never cite from a snippet alone.
+5. **Re-search thin dimensions.** If one aspect of the need came back sparse, treat it as a missing-angle signal, not proof of absence — try synonyms, and pivot through a relevant node's tags (tags name the cohort vocabulary).
+
+---
+
 ## Anti-Patterns — Common Mistakes to Avoid
 
 1. **DON'T** skip the session-start protocol, even if the user asks a direct question.

--- a/rka/skills/executor/SKILL.md
+++ b/rka/skills/executor/SKILL.md
@@ -176,6 +176,12 @@ When a mission asks you to read a paper:
 4. On `reason: "no_match"`: emit a FULL-TEXT REQUEST checkpoint asking the PI to capture the paper into the project's Zotero collection. Do not proceed at abstract-level confidence unless the mission explicitly allows it.
 5. On `reason: "multiple_matches_below_threshold"`: render the candidates and ask the PI to disambiguate via checkpoint.
 
+## Retrieving Context — Drive RKA, Don't One-Shot It
+
+When mission context is incomplete, retrieve iteratively: 3–5 short (1–4 word) angle queries via `search`, then expand the best hits through `ego_graph` / `multi_hop`; for prose-described scopes use `collect_report_context` with angle_queries. One-shot paragraph search measured 0.32 recall vs 0.80–1.00 for this loop (eval-v3). Verify load-bearing entities by fetching full content before acting on them.
+
+---
+
 ## Guardrails
 
 - Do not make strategic research decisions that belong to the Brain or PI.

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -72,7 +72,7 @@ Scripts invoked via `Bash` (under `scripts/`):
 
 ## Evidence Collection for Sections
 
-When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(operation='collect_report_context', query=<the PI's description>, filters={'angle_queries': [3-5 short queries from different angles]})` to assemble the candidate node set — it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80–1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill § "Retrieval Strategy — Drive RKA, Don't One-Shot It".
+When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(operation='collect_report_context', query=<the PI's description>, filters={'angle_queries': [3-5 short queries from different angles]})` to assemble the candidate node set: it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80 to 1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill section "Retrieval Strategy" (drive RKA through several calls, never one-shot it).
 
 ---
 

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -70,6 +70,12 @@ Scripts invoked via `Bash` (under `scripts/`):
 
 ---
 
+## Evidence Collection for Sections
+
+When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(operation='collect_report_context', query=<the PI's description>, filters={'angle_queries': [3-5 short queries from different angles]})` to assemble the candidate node set — it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80–1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill § "Retrieval Strategy — Drive RKA, Don't One-Shot It".
+
+---
+
 ## Source Attribution
 
 Every assertion in prose connects to an upstream entity in RKA. Two mechanisms together carry the connection:

--- a/tests/test_services/test_graph.py
+++ b/tests/test_services/test_graph.py
@@ -376,3 +376,60 @@ class TestClusterServiceAnswersLinkHook:
             [cluster.id],
         )
         assert rows == [], "no link should be emitted when FK is NULL"
+
+
+class TestCollectReportContext:
+    """Tests for GraphService.collect_report_context (report-scoped retrieval)."""
+
+    @pytest_asyncio.fixture
+    async def search_svc(self, db: Database):
+        from rka.services.search import SearchService
+
+        await db.execute(
+            "INSERT INTO fts_journal (id, content, summary) VALUES (?, ?, ?)",
+            ["jrn_001", "Side-channel observation on IoT", "Side-channel observation"],
+        )
+        await db.commit()
+        return SearchService(db=db, embeddings=None)
+
+    async def test_seeds_carry_search_provenance(self, graph_svc, search_svc):
+        result = await graph_svc.collect_report_context(
+            "Report on the side-channel timing observations",
+            angle_queries=["side-channel"],
+            search_service=search_svc,
+        )
+        by_id = {n["id"]: n for n in result["nodes"]}
+        assert "jrn_001" in by_id
+        seed = by_id["jrn_001"]
+        assert seed["included_via"]["via"] == "search"
+        assert seed["depth"] == 0
+        assert result["seed_count"] >= 1
+
+    async def test_expansion_carries_link_provenance(self, graph_svc, search_svc):
+        result = await graph_svc.collect_report_context(
+            "Report on the side-channel timing observations",
+            angle_queries=["side-channel"],
+            max_depth=2,
+            search_service=search_svc,
+        )
+        by_id = {n["id"]: n for n in result["nodes"]}
+        # jrn_001 --references--> dec_001 and --cites--> lit_001 (fixture links)
+        assert "dec_001" in by_id and "lit_001" in by_id
+        assert by_id["dec_001"]["included_via"]["via"] == "link"
+        assert by_id["dec_001"]["included_via"]["from"] == "jrn_001"
+        assert by_id["dec_001"]["depth"] >= 1
+
+    async def test_seed_protection_under_tiny_cap(self, graph_svc, search_svc):
+        result = await graph_svc.collect_report_context(
+            "Report on the side-channel timing observations",
+            angle_queries=["side-channel"],
+            max_nodes=1,
+            search_service=search_svc,
+        )
+        ids = {n["id"] for n in result["nodes"]}
+        # Seeds survive even when the cap is smaller than the seed count.
+        assert "jrn_001" in ids
+
+    async def test_requires_search_service(self, graph_svc):
+        with pytest.raises(ValueError):
+            await graph_svc.collect_report_context("anything", search_service=None)


### PR DESCRIPTION
Two changes from the eval-v3 report-context investigation (run against a live import of the 2,172-entity `rka_development` knowledge pack).

## 1. fix(search): make 'or' FTS query mode actually use OR semantics

`_sanitize_fts_query`'s default `or` mode space-joined quoted terms, but **FTS5's implicit operator is AND** — production search has been AND-only since the function was written. Any query over ~4 words matches nothing, and the failure propagates to every consumer that seeds from search: `/api/context` (topic path) and `/api/graph/multi-hop`.

| Probe | before | after |
|---|---|---|
| 7-term descriptive query, fts_journal rows matched | 1 | 499 (bm25-ranked) |
| Paragraph-seeded search recall@10 (39 ground-truthed questions) | 0.000 | functional |
| Paragraph → context / multi-hop entities returned (3 report scopes) | 0 | 50–67 |

Also retroactively explains the Eval-v1 null finding (`eval-harness/report.md` Finding 1): the AND-fix measured zero delta because the "OR" baseline was already AND. Recommend re-running Eval-v1 after this lands.

## 2. feat(graph,mcp,skills): `collect_report_context` + agent-driven retrieval guidance

New composite read operation for the "I want to write a report about X" workflow, through all three layers (service → route → MCP typed op, 38 → 39 read operations):

- Seeds from every caller-provided **angle query** (3–5 short queries decomposing the description) plus the keyword-normalized description as a backstop.
- BFS-expands seeds through `entity_links` + `claim_edges` with the multi_hop provenance weights.
- **Seed protection**: expansion neighbors never displace seeds (anchor_aware UNION pattern — without it, paragraph-seeded multi_hop scored *below* flat search).
- Every node carries `included_via` (angle query + rank, or parent + link_type) and its tags, so the bundle is auditable.

Measured against three tag-cohort report scopes (tags = capture-time labels, independent ground truth):

| Retrieval mode | Mean cohort recall | Cost |
|---|---|---|
| Paragraph one-shot (post-OR-fix) | 0.32 | 1 call |
| **`collect_report_context`** (angles provided) | **0.68** (0.90 / 0.35 / 0.79) | **1 call, ~3 s** |
| Agent loop (search+ego+multi-hop+verify) | 0.80 | 30–59 calls, 110–202K tokens |

The hard scope (retrieval-eval arc, ~230 relevant nodes) scales 0.35 → 0.53 with more angles + budget; the residual gap to the agent loop is the verify/iterate step — which is the point: **the operation is the loop's first call, not its replacement.** The skills now teach that loop explicitly ("Retrieval Strategy — Drive RKA, Don't One-Shot It" in brain; evidence-collection guidance in writer; iterative-retrieval note in executor; both `plugin/` and `rka/` copies).

## Testing

- 4 new service tests (seed provenance, link provenance, seed protection under a tiny cap, search_service requirement).
- Full MCP suite (891 tests) and graph suite (23) pass; the v2.7.0 model-drift parity tests accept the 88th schema operation.
- `ruff check` clean on all touched files (also fixes the pre-existing F821 on the `SearchService` string annotation via a `TYPE_CHECKING` import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv