### PR TITLE
feat(orchestrator): eval-v3 architecture-review fixes — drift detector, v2.8.0 wiring, doc-truth sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ When working here you are modifying the tool itself, not using it for research.
 - **MCP prompts**: defined at end of `server.py` via `@mcp.prompt()`
 - **API routes**: thin adapters only — no business logic, always delegate to service layer
 - **Tests**: `tests/` using pytest; run with `docker compose exec rka pytest`
-- **v2.7.0+ tool surface (MCP)**: 3 always-on dispatch tools (`rka_query` / `rka_execute` / `rka_describe`) + 2 escape hatches (`rka_load_tools` / `rka_help`) = 5 broadcast tools. 91 typed Pydantic operation models in `rka/mcp/operation_args.py` provide per-branch enum + required-field enforcement at the FastMCP `inputSchema` layer (`Union[Args1, …, Args91]` rendered as `oneOf` with `discriminator='operation'`). Operations split: 42 read (`rka_query`, incl. v2.8.0 `collect_report_context` / `staleness_impact` / `mission_guard` / `belief_as_of`) + 49 write/lifecycle (`rka_execute`). 91 legacy tools + 8 v2.7.0a2 verbs remain at `tier='deferred'`, callable via `rka_load_tools`. Setting `RKA_LEGACY_TOOLS=1` in env restores the v2.7.0a2 surface (20 always-on tools) — used in `orchestrator/docker-compose.yml` (this branch) to preserve TWO-TAP gate granularity at `pi_decision_select`. Full empirical arc + 4 pre-mortem compromises (all closed at schema layer) documented in [`docs/v2.6.x-v2.7.0-tool-surface-arc.md`](docs/v2.6.x-v2.7.0-tool-surface-arc.md) and `CHANGELOG.md` v2.7.0 entry.
+- **v2.7.0+ tool surface (MCP)**: 3 always-on dispatch tools (`rka_query` / `rka_execute` / `rka_describe`) + 2 escape hatches (`rka_load_tools` / `rka_help`) = 5 broadcast tools. 91 typed Pydantic operation models in `rka/mcp/operation_args.py` provide per-branch enum + required-field enforcement at the FastMCP `inputSchema` layer (`Union[Args1, …, Args91]` rendered as `oneOf` with `discriminator='operation'`). Operations split: 42 read (`rka_query`, incl. v2.8.0 `collect_report_context` / `staleness_impact` / `mission_guard` / `belief_as_of`) + 49 write/lifecycle (`rka_execute`). 91 legacy tools + 8 v2.7.0a2 verbs remain at `tier='deferred'`, callable via `rka_load_tools`. Setting `RKA_LEGACY_TOOLS=1` in env restores the v2.7.0a2 surface (20 always-on tools). NOTE (eval-v3 architecture review): this is NOT currently set in `orchestrator/docker-compose.yml` — grep confirms zero occurrences; the SDK subprocess uses the default v2.7.0+ surface, and TWO-TAP granularity is enforced parent-side at `pi_decision_select` regardless of the subprocess tool surface. Full empirical arc + 4 pre-mortem compromises (all closed at schema layer) documented in [`docs/v2.6.x-v2.7.0-tool-surface-arc.md`](docs/v2.6.x-v2.7.0-tool-surface-arc.md) and `CHANGELOG.md` v2.7.0 entry.
 - **Credential management**: use `rka cred` subcommands (`init` / `set` / `get` / `env` / `propagate` / `check`) — vault lives at `~/.config/rka/creds.env` (XDG-compliant, mode 0600). Never commit creds to any repo or `.env` tracked by git. Full reference: [`docs/CRED_VAULT.md`](docs/CRED_VAULT.md).
 
 ## Running (Docker only)
@@ -84,7 +84,7 @@ After code changes to `rka/mcp/server.py` or other source files:
 - There is no local `.venv` — all server/worker processes run in Docker
 - `docker compose restart` does **not** reload service code — always use `docker compose up -d --build` for any change under `rka/`. Restart only suffices for migration-only changes (the migration runner queries `schema_migrations` on startup).
 - **Auto-mode push-to-main is gated**: when an Executor session runs in auto-mode (no per-tool-call confirmation), direct `git push origin main` is blocked by a safety classifier and requires explicit PI authorization in the transcript (a sentence like *"push to main"* or *"go ahead and push to main"*) to unblock. For any main-branch mission spec, the T5/release task should anticipate this and PI should plan to ratify the push step explicitly. The block is one-shot per push — after PI authorizes, the push proceeds and subsequent operations resume normal flow. Surfaced empirically during D4 mission (v2.5.4) per `dec_01KS0BVPCYK4CBG5TKKG1QK4HM` close-out.
-- **v2.7.0 dispatch surface (current MCP shape)**: only 5 tools broadcast on connect — 3 always-on dispatch (`rka_query` / `rka_execute` / `rka_describe`) + 2 escape hatches (`rka_load_tools` / `rka_help`). The legacy 91 tools + 8 v2.7.0a2 verbs are tier=`deferred`; load them on demand via `rka_load_tools(names=[…])`. To restore the v2.7.0a2 surface (20 always-on tools, e.g. for orchestrator subprocesses that depend on per-tool dispatch for autonomy-contract granularity), set `RKA_LEGACY_TOOLS=1` in env — already wired into `orchestrator/docker-compose.yml` on this branch. Enum hallucinations (e.g. `confidence='confirmed'`) and missing-required-field errors are caught at the `inputSchema` `oneOf` branch level — they fail BEFORE leaving the cockpit, not as 422s at the API. Empirical proof + 4 pre-mortem compromises closed: see [`docs/v2.6.x-v2.7.0-tool-surface-arc.md`](docs/v2.6.x-v2.7.0-tool-surface-arc.md). Pre-v2.7 docs may still teach the v2.6.3 "navigator architecture" (12 always-on + ~79 deferred) — that surface is superseded.
+- **v2.7.0 dispatch surface (current MCP shape)**: only 5 tools broadcast on connect — 3 always-on dispatch (`rka_query` / `rka_execute` / `rka_describe`) + 2 escape hatches (`rka_load_tools` / `rka_help`). The legacy 91 tools + 8 v2.7.0a2 verbs are tier=`deferred`; load them on demand via `rka_load_tools(names=[…])`. To restore the v2.7.0a2 surface (20 always-on tools, e.g. for orchestrator subprocesses that depend on per-tool dispatch for autonomy-contract granularity), set `RKA_LEGACY_TOOLS=1` in env. NOTE (eval-v3 architecture review): despite earlier notes here, `RKA_LEGACY_TOOLS=1` is NOT currently set in `orchestrator/docker-compose.yml` — grep confirms zero occurrences in the orchestrator tree; the SDK subprocess uses the default v2.7.0+ typed-dispatch surface. The orchestrator's parent-side WRITE_TOOLS dispatch is independent of which RKA tool surface the subprocess sees (it speaks raw REST via `RestMCPClient`), so the legacy pin is not required for autonomy-contract granularity. Set it explicitly if a future subprocess flow needs per-tool dispatch. Enum hallucinations (e.g. `confidence='confirmed'`) and missing-required-field errors are caught at the `inputSchema` `oneOf` branch level — they fail BEFORE leaving the cockpit, not as 422s at the API. Empirical proof + 4 pre-mortem compromises closed: see [`docs/v2.6.x-v2.7.0-tool-surface-arc.md`](docs/v2.6.x-v2.7.0-tool-surface-arc.md). Pre-v2.7 docs may still teach the v2.6.3 "navigator architecture" (12 always-on + ~79 deferred) — that surface is superseded.
 
 ## Embedding backend configuration (v2.4.0+)
 
@@ -1323,32 +1323,41 @@ land before the next major orchestrator pass:
 - **`pi_extend_toolkit`** is registered in the type literal +
   `_ACCEPT_TOKEN_BY_TYPE` + `_ONBOARDING_INTERRUPT_TYPES` but
   has no node and no graph wiring — half-built feature.
-- **`loop_iterations` / `usd_spent`** are read by `budget_check`
-  + `consensus_check` but never written by any node — the
-  MAX_LOOP_DEPTH and budget caps are unreachable. SDK token-cost
-  threading + per-node loop increment needed.
+- **`loop_iterations` / `usd_spent`** — **CLOSED (Phase E4 + consensus_check).**
+  `usd_spent` is now written via `_accrue_cost()` from every LLM-calling node
+  (`nodes/brain.py`, `nodes/executor.py`); `loop_iterations` is written by
+  `consensus_check` (`nodes/utility.py`). `budget_check` escalates on
+  `spent >= cap_usd` and `consensus_check` on `loops >= MAX_LOOP_DEPTH` — both
+  caps are reachable today. (Was: "read but never written → caps unreachable.")
 - **`Phase B bootstrap` writes `orchestrator/.env` inside the
   container** — host file is consumed via `env_file:` but not
   bind-mounted, so the bootstrap-emit-template and bootstrap-verify
   nodes write/read at `/app/orchestrator/.env` which the PI never
   sees. Needs either a bind mount or a path-translation strategy.
-- **`$HOME` bind-mount over-broad** — when `HOST_WORKSPACE_ROOT`
-  isn't set, the daemon RW-mounts the entire `$HOME` (including
-  `~/.ssh`, `~/.aws`). Workspace-scoped mount needs a refusal to
-  start with a `$HOME`-equivalent root.
-- **`WebFetch` / `WebSearch` un-policed** — granted to the
-  subprocess with `permission_mode='dontAsk'`. No egress allowlist.
+- **`$HOME` bind-mount over-broad** — **CLOSED.** `server.py` raises
+  `WorkspaceMountUnsafeError` at lifespan start when the effective mount
+  resolves to `/`, exactly `$HOME`, or an ancestor of
+  `~/.ssh`/`~/.aws`/`~/.gnupg`/`~/.config`; escape hatch
+  `ORCHESTRATOR_ALLOW_HOME_MOUNT=1`. The compose default
+  `HOST_WORKSPACE_ROOT: "${HOST_WORKSPACE_ROOT:-}"` empty-strings so the
+  in-container check trips on the container `$HOME` and refuses to start.
+- **`WebFetch` / `WebSearch`** — **PARTIALLY CLOSED (v0.6.11).** Granted to
+  the subprocess with `permission_mode='dontAsk'`, but each call is now
+  audited (`llm_client.py`), denied against a `WEBHOOK_BLOCKLIST` telemetry
+  floor, and honors an OPT-IN `ORCHESTRATOR_EGRESS_ALLOWLIST`. Default
+  posture is open-with-audit (research needs the web), not a hard allowlist —
+  promote to a default allowlist only if a real exfil case surfaces.
 - **Brain over-escalation risk** — Brain prompt now mentions FS
   tools but no per-call policy enforces read-only at the host FS;
   audit trail for any Brain-initiated Bash/Write would be valuable.
 - **Phase-X² sibling — `_route_after_pi_decision` dead-end** —
-  `pi_decision_select` `correct` routes to `escalation_router` which
-  synthesizes an unclassified checkpoint and terminates. Same shape
-  as the Phase-X² pi_greenlight bug, but the redraft target is the
-  TWO-TAP autonomy-licensing gate. Fix as separate PR for
-  autonomy-contract review; decide redraft target (`decision_present`
-  cheap re-render vs `strategy_node` full re-strategize) with
-  explicit EC8 set-identity check on the loop-back.
+  **CLOSED (v0.6.12 `mission_redraft`).** `pi_decision_select` `correct`
+  (REDIRECT_SENTINEL token) now routes to the new `mission_redraft` node,
+  which revises `proposed_actions` incorporating the PI redirect and loops
+  back to `decision_present` for re-ratification, bounded by
+  `MAX_DECISION_REDRAFTS=3`. The redraft target chosen was `decision_present`
+  (cheap re-render), not `strategy_node`. (Was: routed to `escalation_router`
+  → synthesized an unclassified checkpoint → terminated.)
 - **Phase-X² polish (from wrhahen1y adversarial review)** —
   non-blocking but worth a sweep: (a) `confirmation_brief_redraft`
   cap-exceeded return omits `greenlight_redrafts: next_count` (counter

--- a/orchestrator/orchestrator/graph.py
+++ b/orchestrator/orchestrator/graph.py
@@ -1,6 +1,6 @@
 """LangGraph topology + SqliteSaver checkpointer.
 
-Wires all 18 mission-graph nodes into a flat `StateGraph` keyed on
+Wires all 19 mission-graph nodes into a flat `StateGraph` keyed on
 `ResearchWorkflowState`. Phase 1 kept the topology single-thread +
 linear-with-escalation-shortcuts; Phase-X² (`confirmation_brief_redraft`)
 introduced the first cycle — a bounded back-edge for in-run pi_greenlight
@@ -10,7 +10,7 @@ Each node-callable is bound to its (sdk, mcp[, interrupt_fn]) dependencies
 via `functools.partial`, so the function LangGraph receives accepts only
 `(state,)` — keeping the engine-facing surface uniform.
 
-Topology (18 mission-graph nodes; 7 conditional branches):
+Topology (19 mission-graph nodes; 7 conditional branches; mission_redraft added v0.6.12):
 
   START
     → strategy_node
@@ -38,7 +38,11 @@ Topology (18 mission-graph nodes; 7 conditional branches):
     → pi_decision_select ── accept → execute_ratified_actions
                                        ── clean → execute_ratified_fs_actions
                                        └─ partial-dispatch → escalation_router
-                         └─ else  → escalation_router
+                         ├─ correct (sentinel) → mission_redraft (v0.6.12)
+                         │     (revises proposed_actions, loops back to
+                         │      decision_present; bounded MAX_DECISION_REDRAFTS=3)
+                         └─ reject/other → escalation_router
+    → mission_redraft   → decision_present   # v0.6.12 bounded back-edge
     → execute_ratified_fs_actions    # Gap 2 — parent-side FS dispatch
     → final_synthesis
     → pi_acceptance     → END

--- a/orchestrator/orchestrator/mcp_client.py
+++ b/orchestrator/orchestrator/mcp_client.py
@@ -161,6 +161,16 @@ class MCPClient(Protocol):
     def rka_check_freshness(self, days_threshold: int = 30) -> dict[str, Any]: ...
     def rka_get_pending_maintenance(self) -> dict[str, Any]: ...
 
+    # v2.8.0 KB-wide verification + temporal currency reads (eval-v3).
+    # All READ-side; no auto-tagging.
+    def rka_collect_report_context(
+        self, description: str, *, angle_queries: list[str] | None = None,
+        max_nodes: int = 60,
+    ) -> dict[str, Any]: ...
+    def rka_mission_guard(self, mission_id: str) -> dict[str, Any]: ...
+    def rka_staleness_impact(self, entity_id: str, *, max_depth: int = 3) -> dict[str, Any]: ...
+    def rka_belief_as_of(self, date: str) -> dict[str, Any]: ...
+
     # Phase O O3.2 — claims surface (POST /api/claims). WRITE-side
     # (each claim is provenance for the plan that follows at O4).
     def rka_create_claim(
@@ -441,6 +451,38 @@ class RestMCPClient:
     def rka_get_pending_maintenance(self) -> dict:
         """GET /api/maintenance — flagged/pending maintenance items."""
         return self._request("GET", "/api/maintenance") or {}
+
+    # v2.8.0 KB-wide verification + temporal currency reads (eval-v3).
+    def rka_collect_report_context(
+        self, description: str, *, angle_queries: list[str] | None = None,
+        max_nodes: int = 60,
+    ) -> dict:
+        """POST /api/graph/report-context — multi-angle seed + provenance-
+        weighted graph expansion. Returns {nodes, queries, seed_count, ...}."""
+        body = _drop_none({
+            "description": description,
+            "angle_queries": angle_queries,
+            "max_nodes": max_nodes,
+        })
+        return self._request("POST", "/api/graph/report-context", json=body) or {}
+
+    def rka_mission_guard(self, mission_id: str) -> dict:
+        """GET /api/missions/{id}/guard — negative knowledge (retracted /
+        superseded / contradicted) relevant to a mission, for pickup."""
+        return self._request("GET", f"/api/missions/{mission_id}/guard") or {}
+
+    def rka_staleness_impact(self, entity_id: str, *, max_depth: int = 3) -> dict:
+        """GET /api/graph/staleness-impact/{id} — downstream blast-radius of a
+        stale entity (dependent-direction links only)."""
+        return self._request(
+            "GET", f"/api/graph/staleness-impact/{entity_id}",
+            params={"max_depth": max_depth},
+        ) or {}
+
+    def rka_belief_as_of(self, date: str) -> dict:
+        """GET /api/graph/as-of?date=ISO — believed-current knowledge state at
+        a past date, plus what changed since."""
+        return self._request("GET", "/api/graph/as-of", params={"date": date}) or {}
 
     # Phase O O3.2 — claims surface.
     def rka_create_claim(

--- a/orchestrator/orchestrator/nodes/brain.py
+++ b/orchestrator/orchestrator/nodes/brain.py
@@ -120,6 +120,14 @@ BRAIN_SYSTEM = (
     "applies to any rka_* in your `proposed_actions` JSON: each action's "
     "`args` must include `project_id`. The pre-v2.6 RKA_PROJECT env var "
     "passing was removed; do not rely on session defaults.\n\n"
+    # v2.8.0 (eval-v3) — report-scoped context assembly
+    "## Report-scoped context (collect_report_context)\n"
+    "When you need the knowledge relevant to a report, section, or themed "
+    "question, prefer ONE rka_collect_report_context call (pass the prose "
+    "description plus 3-5 short angle_queries) over many rka_get_context / "
+    "rka_search calls. It unions multi-angle search seeds with provenance-weighted "
+    "graph expansion and returns per-node inclusion provenance — measured 0.84 "
+    "cohort recall in one call vs 0.32 for one-shot paragraph search.\n\n"
     # v2.6.3 — RKA navigator architecture (always-on + deferred tiers)
     "## Tool surface (v2.6.3+)\n"
     "RKA's MCP server uses a NAVIGATOR architecture. At startup only "

--- a/orchestrator/orchestrator/nodes/executor.py
+++ b/orchestrator/orchestrator/nodes/executor.py
@@ -135,6 +135,14 @@ EXECUTOR_SYSTEM = (
     "mission's task list, not the wrapper's planning structure. A wrapper "
     "Backbrief's T1-T7 are framework metadata describing what the PI/Brain did "
     "to PREPARE this run — they are not your work to re-do.\n\n"
+    # v2.8.0 (eval-v3) — negative knowledge at pickup
+    "## Negative knowledge (mission guard)\n"
+    "Your Backbrief prompt includes a 'Negative knowledge for this mission' "
+    "section, deterministically populated from rka_mission_guard: retracted, "
+    "superseded, or contested findings relevant to this objective. Treat it as "
+    "authoritative. Do NOT re-attempt an approach already falsified there. If a "
+    "warning conflicts with your plan, address it explicitly in your Assumptions "
+    "or Risks rather than silently proceeding.\n\n"
     # v2.6.3 — RKA navigator architecture (always-on + deferred tiers)
     "## Tool surface (v2.6.3+)\n"
     "RKA's MCP server uses a NAVIGATOR architecture. At startup only "
@@ -469,8 +477,26 @@ def _format_mission_body(mission: dict | None, *, task_char_cap: int = 240) -> s
 # ---------------------------------------------------------------------------
 
 
+def _format_mission_guard(guard: dict | None) -> str:
+    """Render mission_guard warnings (negative knowledge) for the Backbrief
+    prompt. Empty/absent → an explicit 'none' line so the LLM sees the check
+    ran. v2.8.0 (eval-v3): retracted / superseded / contradicted findings
+    relevant to the objective — the repeated-mistake failure mode, surfaced
+    deterministically by the parent rather than left to the LLM to query."""
+    warnings = (guard or {}).get("warnings") or []
+    if not warnings:
+        return "(none — no retracted/superseded/contradicted findings relevant to this objective)"
+    lines = []
+    for w in warnings[:10]:
+        kind = w.get("kind", "?")
+        excerpt = (w.get("excerpt") or "")[:160]
+        guidance = w.get("guidance") or ""
+        lines.append(f"  - [{kind}] {excerpt}  -> {guidance}")
+    return "\n".join(lines)
+
+
 def _build_backbrief_prompt(
-    state: ResearchWorkflowState, mission: dict | None
+    state: ResearchWorkflowState, mission: dict | None, guard: dict | None = None
 ) -> str:
     return (
         "Draft an upfront Backbrief for the mission. Cover:\n"
@@ -482,6 +508,10 @@ def _build_backbrief_prompt(
         f"Mission: {state.get('mission_id', '(unset)')}\n"
         f"Motivated-by decision: {state.get('motivated_by_decision_id', '(unset)')}\n"
         f"Mission body:\n{_format_mission_body(mission)}\n\n"
+        "Negative knowledge for this mission (already falsified or contested — "
+        "do NOT repeat these unknowingly; if any conflicts with your plan, address "
+        "it explicitly in your Assumptions or Risks):\n"
+        f"{_format_mission_guard(guard)}\n\n"
         f"Brain's strategy context:\n{state.get('brain_strategy', '(empty)')}\n"
     )
 
@@ -493,7 +523,11 @@ def backbrief_draft(
     # Phase 2.5 T5: same data-flow fix as brain.strategy_node — fetch the
     # mission body so the upfront Backbrief is grounded in objective/tasks/AC.
     mission = mcp.rka_get_mission(id=mission_id) if mission_id else None
-    prompt = _build_backbrief_prompt(state, mission)
+    # v2.8.0 (eval-v3): deterministically surface negative knowledge at pickup.
+    # Parent-side (not LLM-discretionary) so a falsified approach can't slip
+    # through just because the Executor didn't think to query for it.
+    guard = mcp.rka_mission_guard(mission_id) if mission_id else None
+    prompt = _build_backbrief_prompt(state, mission, guard)
     try:
         backbrief_text = sdk.complete(
             prompt=prompt,

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -143,7 +143,7 @@ name = "rka-orchestrator"
 # escalation_router), sentinel short-circuit preserved at the top.
 # NODE_NAMES 18→19. +12 tests (test_mission_redraft.py); 3 lock-tests
 # updated. Full orchestrator suite: 1340 passed.
-version = "0.6.12"
+version = "0.6.13"
 description = "RKA + LangGraph orchestrator (Phase A → Phase-X² polish; agentic branch)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/orchestrator/scripts/rka_enum_drift.py
+++ b/orchestrator/scripts/rka_enum_drift.py
@@ -1,0 +1,147 @@
+"""RKA enum drift checker (eval-v3 architecture-review item 3).
+
+The orchestrator's enum tables in ``orchestrator/orchestrator/rka_enums.py``
+are a HAND-MAINTAINED mirror of RKA's canonical Literal aliases in
+``rka/mcp/_enums.py`` (the bookkeeper invariant forbids importing ``rka.*``
+from the orchestrator package). Historically this drifted silently and was
+reconciled only when a live run hit a 422.
+
+This script makes drift LOUD and mechanical. It AST-parses ``rka/mcp/_enums.py``
+*by file path* (no ``import rka`` — grep-gate safe) and compares each canonical
+Literal set against the orchestrator's vendored frozenset. The companion test
+``orchestrator/tests/test_rka_enum_drift.py`` fails CI when they diverge, naming
+exactly which frozenset to update.
+
+Run standalone for a human-readable report:
+
+    python orchestrator/scripts/rka_enum_drift.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# orchestrator-side frozensets are the orchestrator's own module, importable.
+from orchestrator import rka_enums
+
+# Canonical Literal alias (in rka/mcp/_enums.py)  ->  orchestrator frozenset.
+# All 13 are EQUALITY mappings as of orchestrator 0.6.13: the orchestrator
+# validator must accept exactly what RKA's typed surface accepts. If RKA
+# legitimately diverges (e.g. a tool-specific subset), move that pair to
+# SUBSET_MAP below with a comment.
+EQUALITY_MAP: dict[str, str] = {
+    "ConfidenceLit": "RKA_CONFIDENCES",
+    "ImportanceLit": "RKA_IMPORTANCES",
+    "SourceLit": "RKA_SOURCES",
+    "NoteTypeLit": "RKA_JOURNAL_TYPES_ALL",
+    "DecidedByLit": "RKA_DECISION_DECIDED_BY",
+    "DecisionKindLit": "RKA_DECISION_KINDS",
+    "DecisionStatusLit": "RKA_DECISION_STATUSES",
+    "ChkTypeLit": "RKA_CHECKPOINT_TYPES",
+    "CheckpointResolvedByLit": "RKA_CHECKPOINT_RESOLVED_BY",
+    "MissionStatusLit": "RKA_MISSION_STATUSES",
+    "LitStatusLit": "RKA_LITERATURE_STATUSES",
+    "JournalStatusLit": "RKA_JOURNAL_STATUSES",
+    "IngestSourceLit": "RKA_LITERATURE_ADDED_BY",
+}
+
+
+def find_rka_enums_source() -> Path | None:
+    """Locate rka/mcp/_enums.py relative to this script, or return None.
+
+    Returns None when the RKA source tree is absent (e.g. an
+    orchestrator-only install); callers should skip rather than fail.
+    """
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        candidate = base / "rka" / "mcp" / "_enums.py"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def extract_literals(enums_path: Path) -> dict[str, frozenset[str]]:
+    """AST-parse ``Name = Literal["a", "b", ...]`` assignments by file path.
+
+    No ``import rka`` — the module is parsed as text, so this stays inside
+    the grep-gate. Only string-constant members are collected; any
+    non-string Literal arg is ignored (none exist today).
+    """
+    tree = ast.parse(enums_path.read_text(encoding="utf-8"), filename=str(enums_path))
+    out: dict[str, frozenset[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        value = node.value
+        if not (isinstance(value, ast.Subscript)
+                and isinstance(value.value, ast.Name)
+                and value.value.id == "Literal"):
+            continue
+        # py3.9+: subscript slice is the expression directly (Tuple or Constant).
+        sl = value.slice
+        elts = sl.elts if isinstance(sl, ast.Tuple) else [sl]
+        members = {e.value for e in elts
+                   if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+        if members:
+            out[target.id] = frozenset(members)
+    return out
+
+
+def compute_drift() -> list[str]:
+    """Return human-readable drift messages; empty list means in sync.
+
+    Returns a single sentinel message when the RKA source is unavailable
+    (callers may choose to skip on that).
+    """
+    src = find_rka_enums_source()
+    if src is None:
+        return ["__SOURCE_UNAVAILABLE__"]
+    canonical = extract_literals(src)
+    messages: list[str] = []
+    for lit_name, fs_name in EQUALITY_MAP.items():
+        rka_set = canonical.get(lit_name)
+        orch_set = getattr(rka_enums, fs_name, None)
+        if rka_set is None:
+            messages.append(
+                f"{lit_name}: not found in {src} — RKA may have renamed/removed it; "
+                f"update EQUALITY_MAP and rka_enums.{fs_name}.")
+            continue
+        if orch_set is None:
+            messages.append(f"rka_enums.{fs_name}: missing from the orchestrator mirror.")
+            continue
+        orch_set = frozenset(orch_set)
+        missing = rka_set - orch_set        # RKA accepts, orchestrator would reject (false 422-avoidance gaps)
+        extra = orch_set - rka_set          # orchestrator accepts, RKA rejects (stale-extra)
+        if missing or extra:
+            parts = []
+            if missing:
+                parts.append(f"RKA has but orchestrator MISSING: {sorted(missing)}")
+            if extra:
+                parts.append(f"orchestrator has but RKA dropped: {sorted(extra)}")
+            messages.append(
+                f"DRIFT {fs_name} <-> {lit_name}: " + "; ".join(parts)
+                + f"  (fix: edit orchestrator/orchestrator/rka_enums.py {fs_name})")
+    return messages
+
+
+def main() -> int:
+    drift = compute_drift()
+    if drift == ["__SOURCE_UNAVAILABLE__"]:
+        print("rka/mcp/_enums.py not found next to the orchestrator — nothing to check.")
+        return 0
+    if not drift:
+        print(f"OK — all {len(EQUALITY_MAP)} enum mirrors in sync with rka/mcp/_enums.py.")
+        return 0
+    print("RKA ENUM DRIFT DETECTED:\n")
+    for m in drift:
+        print("  - " + m)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/orchestrator/tests/_fakes.py
+++ b/orchestrator/tests/_fakes.py
@@ -75,6 +75,19 @@ class FakeMCP:
     pending_maintenance_response: dict = field(
         default_factory=lambda: {"items": []}
     )
+    # v2.8.0 verification + currency reads (eval-v3). Default empty/clean.
+    report_context_response: dict = field(
+        default_factory=lambda: {"nodes": [], "queries": [], "seed_count": 0}
+    )
+    mission_guard_response: dict = field(
+        default_factory=lambda: {"warnings": [], "checked": {}}
+    )
+    staleness_impact_response: dict = field(
+        default_factory=lambda: {"impacted": [], "counts": {}}
+    )
+    belief_as_of_response: dict = field(
+        default_factory=lambda: {"then_current": {"decisions": []}, "changed_since": []}
+    )
     # Phase O O3.2 — claims surface.
     claim_counter: int = 0
     claims_response: list = field(default_factory=list)
@@ -144,6 +157,27 @@ class FakeMCP:
     def rka_get_pending_maintenance(self) -> dict:
         self._record("rka_get_pending_maintenance")
         return self.pending_maintenance_response
+
+    # v2.8.0 verification + currency reads (eval-v3).
+    def rka_collect_report_context(
+        self, description: str, *, angle_queries: list | None = None,
+        max_nodes: int = 60,
+    ) -> dict:
+        self._record("rka_collect_report_context", description=description,
+                     angle_queries=angle_queries, max_nodes=max_nodes)
+        return self.report_context_response
+
+    def rka_mission_guard(self, mission_id: str) -> dict:
+        self._record("rka_mission_guard", mission_id=mission_id)
+        return self.mission_guard_response
+
+    def rka_staleness_impact(self, entity_id: str, *, max_depth: int = 3) -> dict:
+        self._record("rka_staleness_impact", entity_id=entity_id, max_depth=max_depth)
+        return self.staleness_impact_response
+
+    def rka_belief_as_of(self, date: str) -> dict:
+        self._record("rka_belief_as_of", date=date)
+        return self.belief_as_of_response
 
     # Phase O O3.2 — claims surface.
     def rka_create_claim(

--- a/orchestrator/tests/test_executor.py
+++ b/orchestrator/tests/test_executor.py
@@ -1469,3 +1469,41 @@ def test_brain_system_and_executor_system_share_forbidden_lifecycle_tools():
         assert f in executor.EXECUTOR_SYSTEM, (
             f"EXECUTOR_SYSTEM missing forbidden tool {f!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# v2.8.0 mission_guard injection at backbrief pickup (eval-v3)
+# ---------------------------------------------------------------------------
+
+
+def test_backbrief_calls_mission_guard_with_mission_id():
+    from orchestrator.nodes import executor as ex
+    from tests._fakes import FakeMCP, FakeSDK
+
+    mcp = FakeMCP()
+    sdk = FakeSDK(canned_reply="Backbrief body")
+    state = {"mission_id": "mis_abc", "brain_strategy": "do the thing"}
+    ex.backbrief_draft(state, sdk, mcp)
+    guard_calls = [c for c in mcp.calls if c["op"] == "rka_mission_guard"]
+    assert guard_calls and guard_calls[0]["mission_id"] == "mis_abc"
+
+
+def test_backbrief_prompt_includes_guard_warnings():
+    from orchestrator.nodes import executor as ex
+
+    guard = {"warnings": [
+        {"kind": "retracted", "excerpt": "the wool carder identification was wrong",
+         "guidance": "retracted; do not rely on this finding"},
+        {"kind": "contradicted", "excerpt": "green roofs contribute little",
+         "guidance": "unresolved contradiction; verify before relying"},
+    ]}
+    prompt = ex._build_backbrief_prompt({"mission_id": "mis_x"}, None, guard)
+    assert "Negative knowledge" in prompt
+    assert "[retracted]" in prompt and "wool carder" in prompt
+    assert "[contradicted]" in prompt
+
+
+def test_backbrief_prompt_guard_none_shows_explicit_clean_line():
+    from orchestrator.nodes import executor as ex
+    prompt = ex._build_backbrief_prompt({"mission_id": "mis_x"}, None, None)
+    assert "(none —" in prompt or "(none -" in prompt

--- a/orchestrator/tests/test_mcp_client.py
+++ b/orchestrator/tests/test_mcp_client.py
@@ -954,3 +954,61 @@ def test_rka_submit_checkpoint_brain_data_dict_serializes_to_context():
     assert "T2" in ctx
     assert "T3" in ctx
     assert "llm_spend_usd" in ctx
+
+
+# ---------------------------------------------------------------------------
+# v2.8.0 KB-wide verification + temporal currency reads (eval-v3)
+# ---------------------------------------------------------------------------
+
+
+def test_rka_mission_guard_gets_guard_endpoint():
+    http = FakeHttp(canned=FakeResp(_json={"warnings": [{"kind": "retracted"}]}))
+    c = _client(http)
+    out = c.rka_mission_guard("mis_123")
+    call = http.calls[-1]
+    assert call["method"] == "GET" and call["path"] == "/api/missions/mis_123/guard"
+    assert out["warnings"][0]["kind"] == "retracted"
+
+
+def test_rka_collect_report_context_posts_description_and_angles():
+    http = FakeHttp(canned=FakeResp(_json={"nodes": [], "seed_count": 0}))
+    c = _client(http)
+    c.rka_collect_report_context("a report on X", angle_queries=["x", "y"], max_nodes=40)
+    call = http.calls[-1]
+    assert call["method"] == "POST" and call["path"] == "/api/graph/report-context"
+    assert call["json"]["description"] == "a report on X"
+    assert call["json"]["angle_queries"] == ["x", "y"]
+    assert call["json"]["max_nodes"] == 40
+
+
+def test_rka_collect_report_context_drops_none_angles():
+    http = FakeHttp(canned=FakeResp(_json={"nodes": []}))
+    c = _client(http)
+    c.rka_collect_report_context("desc")
+    assert "angle_queries" not in http.calls[-1]["json"]
+
+
+def test_rka_staleness_impact_gets_with_max_depth_param():
+    http = FakeHttp(canned=FakeResp(_json={"impacted": []}))
+    c = _client(http)
+    c.rka_staleness_impact("dec_9", max_depth=2)
+    call = http.calls[-1]
+    assert call["method"] == "GET"
+    assert call["path"] == "/api/graph/staleness-impact/dec_9"
+    assert call["params"] == {"max_depth": 2}
+
+
+def test_rka_belief_as_of_gets_with_date_param():
+    http = FakeHttp(canned=FakeResp(_json={"then_current": {"decisions": []}}))
+    c = _client(http)
+    c.rka_belief_as_of("2026-03-15")
+    call = http.calls[-1]
+    assert call["method"] == "GET" and call["path"] == "/api/graph/as-of"
+    assert call["params"] == {"date": "2026-03-15"}
+
+
+def test_v280_methods_on_protocol_surface():
+    c = _client()
+    for name in ("rka_collect_report_context", "rka_mission_guard",
+                 "rka_staleness_impact", "rka_belief_as_of"):
+        assert hasattr(c, name), f"RestMCPClient missing {name}"

--- a/orchestrator/tests/test_rka_enum_drift.py
+++ b/orchestrator/tests/test_rka_enum_drift.py
@@ -1,0 +1,62 @@
+"""Drift test: orchestrator enum mirror vs RKA's canonical Literal source.
+
+Makes the hand-maintained mirror in rka_enums.py a CI-enforced contract
+against rka/mcp/_enums.py. Reads the RKA source by FILE PATH (no import rka),
+so it stays inside the grep-gate. Skips gracefully when the RKA source tree
+is absent (orchestrator-only install).
+
+See orchestrator/scripts/rka_enum_drift.py for the comparison logic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_DRIFT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "rka_enum_drift.py"
+_spec = importlib.util.spec_from_file_location("rka_enum_drift", _DRIFT_PATH)
+drift_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(drift_mod)
+
+
+def test_rka_enum_mirror_in_sync_with_rka_source():
+    if drift_mod.find_rka_enums_source() is None:
+        pytest.skip("rka/mcp/_enums.py not present (orchestrator-only install)")
+    drift = drift_mod.compute_drift()
+    assert drift == [], (
+        "orchestrator/orchestrator/rka_enums.py has drifted from "
+        "rka/mcp/_enums.py. Run `python orchestrator/scripts/rka_enum_drift.py` "
+        "and update the named frozenset(s):\n" + "\n".join(drift))
+
+
+def test_every_equality_pair_resolves_on_both_sides():
+    # Guards the mapping table itself: a typo'd Literal/frozenset name would
+    # otherwise make the drift check silently vacuous.
+    if drift_mod.find_rka_enums_source() is None:
+        pytest.skip("rka/mcp/_enums.py not present")
+    canonical = drift_mod.extract_literals(drift_mod.find_rka_enums_source())
+    from orchestrator import rka_enums
+    for lit_name, fs_name in drift_mod.EQUALITY_MAP.items():
+        assert lit_name in canonical, f"{lit_name} not found in rka/mcp/_enums.py"
+        assert hasattr(rka_enums, fs_name), f"rka_enums.{fs_name} missing"
+
+
+def test_extractor_parses_literal_forms():
+    # Sanity-check the AST extractor against both tuple and single-element
+    # Literal forms, independent of the live RKA source.
+    import ast
+    import tempfile
+    src = 'from typing import Literal\nA = Literal["x", "y"]\nB = Literal["only"]\nC = 1\n'
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write(src)
+        path = Path(fh.name)
+    try:
+        out = drift_mod.extract_literals(path)
+        assert out["A"] == frozenset({"x", "y"})
+        assert out["B"] == frozenset({"only"})
+        assert "C" not in out
+    finally:
+        path.unlink()
+        del ast  # silence unused in some linters


### PR DESCRIPTION
Implements items 2–4 from the eval-v3 architecture review. Item 1 (the `$HOME` mount guard) turned out to be already implemented in `server.py` — the deferred list was stale, which is itself part of the problem this PR addresses.

## The review's central finding: the docs lag the code

Four "open" items in CLAUDE.md's deferred list were actually **already closed** in the code. For a provenance-first project, the orchestrator's own docs contradicting its code is the exact failure class the KB exists to prevent. Corrected with evidence:

| Deferred item said | Reality |
|---|---|
| `loop_iterations`/`usd_spent` never written → caps unreachable | `_accrue_cost()` writes `usd_spent` from every LLM node; `consensus_check` writes `loop_iterations`; both caps escalate |
| `$HOME` bind-mount needs a refusal-to-start | `server.py` `WorkspaceMountUnsafeError` already refuses `/`, exact `$HOME`, and credential-path ancestors (escape hatch `ORCHESTRATOR_ALLOW_HOME_MOUNT=1`) |
| `pi_decision_select` redirect dead-ends at escalation_router | v0.6.12 `mission_redraft` already routes correct → revise `proposed_actions` → back to `decision_present` (bounded 3) |
| `WebFetch`/`WebSearch` un-policed, no egress allowlist | v0.6.11 audits every call + `WEBHOOK_BLOCKLIST` floor + opt-in `ORCHESTRATOR_EGRESS_ALLOWLIST` |

Also corrected the two `RKA_LEGACY_TOOLS=1` claims (grep confirms it's **not** wired in `orchestrator/docker-compose.yml`; the subprocess uses the default v2.7.0+ surface), and the `graph.py` topology header (node count 18→19; the `pi_decision_select` redirect now shows the `mission_redraft` back-edge).

## Item 3 — schema-mirror drift detector (kills the treadmill)

`orchestrator/orchestrator/rka_enums.py` is a hand-maintained mirror of RKA's enums that historically drifted silently until a live 422. Now:
- `orchestrator/scripts/rka_enum_drift.py` AST-parses `rka/mcp/_enums.py` **by file path** (no `import rka` — grep-gate safe) and compares all 13 canonical `Literal` sets against the vendored frozensets.
- `orchestrator/tests/test_rka_enum_drift.py` fails CI on divergence, naming the exact frozenset to fix; skips gracefully when the RKA source tree is absent. Proven to catch a real injected divergence; all 13 in sync today.

Kept the grep-gate green (reads source as text, never imports) and kept the orchestrator-specific mapping tables (`TOOL_ARG_ENUMS`/`TOOL_REQUIRED_FIELDS`, which encode *adapter* knowledge) hand-owned, as they should be.

## Item 4 — wire the v2.8.0 ops into the orchestrator

The four new v2.8.0 reads were invisible to the orchestrator. Now:
- `MCPClient` Protocol + `RestMCPClient` methods for `rka_collect_report_context`, `rka_mission_guard`, `rka_staleness_impact`, `rka_belief_as_of` (+ `FakeMCP` doubles).
- **`backbrief_draft` deterministically calls `rka_mission_guard` at pickup** and injects retracted/superseded/contradicted warnings into the Backbrief prompt — parent-side, not LLM-discretionary, so a falsified approach can't slip through just because the Executor didn't think to query for it. This is the Vending-Bench repeated-mistake failure mode, which is most dangerous precisely in autonomous mode — and `mission_guard` was designed for exactly this step.
- `EXECUTOR_SYSTEM` gains a "Negative knowledge" section; `BRAIN_SYSTEM` gains a `collect_report_context` note for report-scoped assembly.

## Invariants & testing

- **Bookkeeper invariant intact**: `git diff main -- rka/` empty (touched only `orchestrator/` + root `CLAUDE.md`).
- **Grep-gate intact**: drift checker reads RKA source by path, never imports.
- **Full orchestrator suite: 1352 passed, 2 skipped** (+12 new tests: 6 client-method, 3 guard-injection, 3 drift). Pre-existing ruff findings unchanged (orchestrator CI runs pytest, not ruff). orchestrator 0.6.12 → 0.6.13.

Deliberately **not** done here (the review flagged these as larger design passes): structured-resume payloads to replace sentinel/substring routing, persistent SDK sessions, and "gates as graph, thought as loop."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv

---
_Generated by [Claude Code](https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv)_