### PR TITLE
test(orchestrator): Phase-0 eval harness — rubric PI-oracle + run record

### DIFF
--- a/orchestrator/orchestrator/eval/__init__.py
+++ b/orchestrator/orchestrator/eval/__init__.py
@@ -1,0 +1,15 @@
+"""End-to-end research-lifecycle evaluation harness for the agentic orchestrator.
+
+Lives in the orchestrator package (importable as ``orchestrator.eval``) so the
+test suite and live drivers share one harness. Agentic-branch code only —
+bookkeeper invariant safe (no rka/ changes, no ``import rka``). Components:
+
+  - pi_oracle.py   — rubric-driven, subject-parameterized PI responder that
+                     replaces driver.py's stdin / pilot's happy-path, so live
+                     runs are reproducible and gradeable.
+  - run_record.py  — the per-run artifact schema (one JSON per orchestrator run)
+                     that the graders consume.
+
+The subject spec, experiment harness, and grader suite land alongside these in
+later Phase-0 commits.
+"""

--- a/orchestrator/orchestrator/eval/pi_oracle.py
+++ b/orchestrator/orchestrator/eval/pi_oracle.py
@@ -1,0 +1,177 @@
+"""Rubric-driven PI-oracle for reproducible end-to-end orchestrator runs.
+
+The mission / Phase-O / onboarding graphs call an in-process
+``interrupt_fn(payload) -> str`` at every PI gate to obtain the PI's response
+(``pilot_t12.pilot_interrupt`` returns a hardcoded happy path;
+``driver.py`` reads stdin). For a reproducible, gradeable end-to-end test we
+need a PI that decides *correctly per the research subject's ground truth* —
+ratifying good proposals, redirecting deviations with verbatim pushback, and
+rejecting fundamentally-wrong ones — and that **records every decision** so the
+grader can later check "did the system surface the right options and respond
+to redirects."
+
+This oracle is exactly that: a subject-parameterized ``interrupt_fn``. It
+returns contract-correct tokens via ``runner.resume_token`` (accept →
+type-specific token; correct → ``REDIRECT_SENTINEL`` + text; reject →
+``"reject"``), so it plugs into ``graph.build_graph(interrupt_fn=oracle)`` with
+the real SDK + ``RestMCPClient`` unchanged.
+
+Design:
+  - A ``Rubric`` is an ordered list of ``Rule``s. The first rule whose
+    ``matches(payload)`` is True decides the action; if none match, the
+    ``default_action`` applies (``accept`` → happy path, mirroring the pilot).
+  - A ``Rule`` matches on interrupt ``type`` (+ optional ``node``) and an
+    optional content predicate over the payload — ``contains_any`` /
+    ``not_contains`` for JSON-spec'd rubrics, or a free ``predicate`` callable
+    for richer logic (e.g. "does the proposed decision name the pivoted claim
+    rather than the falsified original?").
+  - Every call appends a ``Decision`` to ``oracle.log`` (type, node, action,
+    token, matched-rule label, payload digest) — the grading substrate.
+
+The oracle is the ground truth for the "did the PI gate behave correctly"
+axis; the human-PI gold run (driver.py stdin) cross-checks that the oracle
+isn't flattering the system.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal, Optional
+
+from orchestrator.runner import resume_token
+
+Action = Literal["accept", "reject", "correct"]
+
+
+def _payload_text(payload: dict) -> str:
+    """Flatten the human-readable fields of an interrupt payload to one
+    lowercased string for content matching. Interrupt payloads vary by gate;
+    we scan the common rendered fields plus a JSON fallback."""
+    parts: list[str] = []
+    for key in ("summary", "brief", "text", "rendered", "decision", "options",
+                "proposal", "question", "description", "body", "content"):
+        v = payload.get(key)
+        if isinstance(v, str):
+            parts.append(v)
+        elif v is not None:
+            parts.append(str(v))
+    if not parts:
+        # fall back to the whole payload minus the type discriminator
+        parts.append(str({k: v for k, v in payload.items() if k != "type"}))
+    return " ".join(parts).lower()
+
+
+@dataclass
+class Rule:
+    """One rubric rule. ``type`` is the interrupt type it applies to (or "*"
+    for any). At most one content matcher should be set; if several are, all
+    must hold (AND)."""
+
+    type: str
+    action: Action
+    label: str
+    node: Optional[str] = None
+    contains_any: Optional[list[str]] = None
+    not_contains: Optional[list[str]] = None
+    predicate: Optional[Callable[[dict], bool]] = None
+    correct_text: Optional[str] = None  # required when action == "correct"
+
+    def matches(self, payload: dict) -> bool:
+        if self.type != "*" and payload.get("type") != self.type:
+            return False
+        if self.node is not None and payload.get("node") != self.node:
+            return False
+        text = _payload_text(payload)
+        if self.contains_any is not None and not any(
+            t.lower() in text for t in self.contains_any
+        ):
+            return False
+        if self.not_contains is not None and any(
+            t.lower() in text for t in self.not_contains
+        ):
+            return False
+        if self.predicate is not None and not self.predicate(payload):
+            return False
+        return True
+
+
+@dataclass
+class Decision:
+    interrupt_type: str
+    node: Optional[str]
+    action: Action
+    token: str
+    rule_label: str
+    payload_digest: str
+
+
+@dataclass
+class Rubric:
+    rules: list[Rule] = field(default_factory=list)
+    default_action: Action = "accept"
+    default_label: str = "default-accept"
+
+    def decide(self, payload: dict) -> tuple[Action, str, Optional[str]]:
+        """Return (action, rule_label, correct_text|None) for a payload."""
+        for rule in self.rules:
+            if rule.matches(payload):
+                if rule.action == "correct" and not rule.correct_text:
+                    raise ValueError(
+                        f"rule {rule.label!r} is action=correct but has no correct_text")
+                return rule.action, rule.label, rule.correct_text
+        if self.default_action == "correct":
+            raise ValueError("default_action cannot be 'correct' (no text)")
+        return self.default_action, self.default_label, None
+
+
+class PIOracle:
+    """Callable PI responder: ``oracle(payload) -> token``.
+
+    Pass ``oracle.interrupt_fn`` (or the instance itself — it is callable) to
+    ``graph.build_graph(interrupt_fn=...)``.
+    """
+
+    def __init__(self, rubric: Optional[Rubric] = None):
+        self.rubric = rubric or Rubric()
+        self.log: list[Decision] = []
+
+    def __call__(self, payload: dict) -> str:
+        itype = payload.get("type", "")
+        node = payload.get("node")
+        action, label, correct_text = self.rubric.decide(payload)
+        token = resume_token(
+            interrupt_type=itype, action=action, response_text=correct_text
+        )
+        digest = re.sub(r"\s+", " ", _payload_text(payload))[:160]
+        self.log.append(Decision(itype, node, action, token, label, digest))
+        return token
+
+    # convenience alias for readers who prefer an explicit attribute
+    @property
+    def interrupt_fn(self) -> Callable[[dict], str]:
+        return self
+
+    # --- grading helpers ---
+    def decisions_of_type(self, interrupt_type: str) -> list[Decision]:
+        return [d for d in self.log if d.interrupt_type == interrupt_type]
+
+    def corrections(self) -> list[Decision]:
+        return [d for d in self.log if d.action == "correct"]
+
+    def as_dicts(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "interrupt_type": d.interrupt_type, "node": d.node,
+                "action": d.action, "rule_label": d.rule_label,
+                "payload_digest": d.payload_digest,
+            }
+            for d in self.log
+        ]
+
+
+def happy_path_oracle() -> PIOracle:
+    """An oracle that accepts every gate — equivalent to pilot_t12's
+    happy path, but with a decision log. Useful as the Phase-0 smoke baseline
+    before subject rubrics are layered on."""
+    return PIOracle(Rubric(default_action="accept"))

--- a/orchestrator/orchestrator/eval/run_record.py
+++ b/orchestrator/orchestrator/eval/run_record.py
@@ -1,0 +1,104 @@
+"""Per-run record schema for the end-to-end research-lifecycle eval.
+
+One ``RunRecord`` is written (as JSON) per orchestrator run (a Phase-O run, a
+mission run, a writer/revision pass). The grader suite consumes these plus the
+RKA knowledge-graph state and the sealed subject ground truth.
+
+Captures the three measurement axes from the test plan:
+  - capability:  artifacts produced (artifact ids by kind)
+  - reliability: terminal_state, segments, watchdog/escalation signals,
+                 PI-interventions (oracle decisions), redraft-loop usage, cost
+  - provenance:  the workflow_thread_id that tags every RKA write this run made,
+                 so a run's artifacts are recoverable via
+                 rka_get_journal(tags=[workflow_thread_id]).
+
+Reproducibility provenance (corpus hash / rka HEAD / orchestrator version /
+seed) lives on the record so a result is reconstructable.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass
+class RunRecord:
+    # identity / reproducibility
+    arc: str                       # "phase_o" | "mission" | "writer" | "revision"
+    run_label: str                 # human label, e.g. "mission-3-experiment"
+    workflow_thread_id: Optional[str] = None
+    project_id: Optional[str] = None
+    mission_id: Optional[str] = None
+    seed: Optional[int] = None
+    orchestrator_version: Optional[str] = None
+    rka_head: Optional[str] = None
+    subject_id: Optional[str] = None
+    subject_ground_truth_hash: Optional[str] = None
+    arm: str = "A"                 # "A" agentic | "B" plain-claude | "C" human
+
+    # capability
+    terminal_state: Optional[str] = None   # complete | escalated | failed | cancelled
+    artifacts: list[dict[str, Any]] = field(default_factory=list)  # [{id, kind, node}]
+
+    # reliability telemetry
+    segments: int = 0
+    watchdog_escalations: int = 0
+    escalation_router_hits: int = 0
+    greenlight_redrafts: int = 0
+    decision_redrafts: int = 0
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    usd_spent: float = 0.0
+    wall_clock_s: Optional[float] = None
+
+    # PI interaction (oracle decision log, or human-PI transcript summary)
+    pi_decisions: list[dict[str, Any]] = field(default_factory=list)
+    pi_intervention_count: int = 0     # corrections + rejects (not bare accepts)
+
+    # free-form notes (e.g. "mission_guard surfaced 2 warnings at pickup")
+    notes: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_final_state(
+        cls,
+        *,
+        arc: str,
+        run_label: str,
+        final_state: dict,
+        oracle_decisions: Optional[list[dict]] = None,
+        **kw: Any,
+    ) -> "RunRecord":
+        """Build a record from a LangGraph terminal state + oracle log."""
+        decisions = oracle_decisions or []
+        interventions = sum(1 for d in decisions if d.get("action") in ("correct", "reject"))
+        return cls(
+            arc=arc,
+            run_label=run_label,
+            workflow_thread_id=final_state.get("workflow_thread_id"),
+            project_id=final_state.get("project_id"),
+            mission_id=final_state.get("mission_id"),
+            terminal_state=final_state.get("terminal_state"),
+            artifacts=list(final_state.get("artifacts", []) or []),
+            greenlight_redrafts=int(final_state.get("greenlight_redrafts", 0) or 0),
+            decision_redrafts=int(final_state.get("decision_redrafts", 0) or 0),
+            errors=list(final_state.get("errors", []) or []),
+            usd_spent=float(final_state.get("usd_spent", 0.0) or 0.0),
+            escalation_router_hits=sum(
+                1 for e in (final_state.get("errors") or [])
+                if (e.get("node_name") == "escalation_router")
+            ),
+            pi_decisions=decisions,
+            pi_intervention_count=interventions,
+            **kw,
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, default=str)
+
+    def write(self, path: str | Path) -> Path:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(self.to_json(), encoding="utf-8")
+        return p

--- a/orchestrator/tests/test_eval_pi_oracle.py
+++ b/orchestrator/tests/test_eval_pi_oracle.py
@@ -1,0 +1,239 @@
+"""Phase-0 dry-run for the end-to-end research-lifecycle eval harness.
+
+Proves the eval scaffolding (`orchestrator/eval/`) drives the REAL mission
+graph with in-process fakes — no live SDK, no REST, no network — so the
+harness itself is testable in CI before any of the live Phases 1-5 run on
+the PI's machine.
+
+Three things are asserted:
+  1. ``happy_path_oracle()`` (accept-every-gate) takes the real 19-node
+     graph to ``terminal_state == "complete"`` and records a decision per
+     PI gate visited — i.e. the oracle is a drop-in for the pilot's
+     hardcoded ``interrupt_fn`` but with an auditable log.
+  2. A rubric whose ``correct`` rule fires on the first ``pi_greenlight``
+     drives the Phase-X² in-run redraft loop exactly once
+     (``greenlight_redrafts == 1``) and still reaches ``complete`` — the
+     redirect path the live pivot stage exercises.
+  3. ``RunRecord.from_final_state`` lifts the terminal state + oracle log
+     into the gradeable per-run record (telemetry axes + JSON round-trip).
+
+These use the same ``FakeSDK(canned_reply="APPROVED…")`` + ``FakeMCP``
+doubles as ``tests/test_graph.py::test_happy_path_runs_to_completion`` so
+the graph routes deterministically to terminal.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator import graph
+from orchestrator.eval.pi_oracle import PIOracle, Rubric, Rule, happy_path_oracle
+from orchestrator.eval.run_record import RunRecord
+from orchestrator.runner import REDIRECT_SENTINEL
+from orchestrator.state import make_initial_state
+from tests._fakes import FakeMCP, FakeSDK
+
+
+@pytest.fixture
+def sdk():
+    # "APPROVED" first line → gate1 routes to mission_execute (same as the
+    # canonical happy-path smoke in test_graph.py).
+    return FakeSDK(canned_reply="APPROVED\nLooks fine.")
+
+
+@pytest.fixture
+def mcp():
+    return FakeMCP()
+
+
+def _run(sdk, mcp, oracle, thread="thr_eval_dryrun"):
+    ckpt = graph.open_checkpointer(None)
+    g = graph.build_graph(sdk=sdk, mcp=mcp, checkpointer=ckpt, interrupt_fn=oracle)
+    initial = make_initial_state(
+        workflow_thread_id=thread,
+        mission_id="mis_eval",
+        motivated_by_decision_id="dec_eval",
+        project_id="prj_eval",
+    )
+    return g.invoke(initial, config={"configurable": {"thread_id": thread}})
+
+
+# ---------------------------------------------------------------------------
+# 1. happy-path oracle == pilot interrupt_fn, but logged
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_oracle_drives_graph_to_complete(sdk, mcp):
+    oracle = happy_path_oracle()
+    final = _run(sdk, mcp, oracle)
+
+    assert final["terminal_state"] == "complete"
+    # Every PI gate visit recorded a Decision.
+    types = {d.interrupt_type for d in oracle.log}
+    assert "pi_greenlight" in types
+    assert "pi_acceptance" in types
+    # No redirect on the happy path.
+    assert oracle.corrections() == []
+    # Accept tokens are the bare type-specific tokens (no sentinel).
+    for d in oracle.log:
+        assert not d.token.startswith(REDIRECT_SENTINEL)
+    assert {d.token for d in oracle.decisions_of_type("pi_greenlight")} == {"approve"}
+    assert {d.token for d in oracle.decisions_of_type("pi_acceptance")} == {"accept"}
+
+
+# ---------------------------------------------------------------------------
+# 2. correct rule drives the Phase-X² in-run greenlight redraft loop once
+# ---------------------------------------------------------------------------
+
+
+def test_correct_rule_triggers_single_greenlight_redraft(sdk, mcp):
+    # Stateful matcher: correct the FIRST pi_greenlight, approve the rest.
+    # (Rules are stateless by design; the predicate closes over a counter so
+    # the loop redrafts exactly once instead of cycling to the cap.)
+    seen = {"n": 0}
+
+    def first_greenlight_only(payload: dict) -> bool:
+        if payload.get("type") != "pi_greenlight":
+            return False
+        seen["n"] += 1
+        return seen["n"] == 1
+
+    rubric = Rubric(
+        rules=[
+            Rule(
+                type="pi_greenlight",
+                action="correct",
+                label="redirect-framing-once",
+                predicate=first_greenlight_only,
+                correct_text="Reframe around the falsified hypothesis, not the original.",
+            )
+        ],
+        default_action="accept",
+    )
+    oracle = PIOracle(rubric)
+    final = _run(sdk, mcp, oracle, thread="thr_eval_redraft")
+
+    assert final["terminal_state"] == "complete"
+    assert final["greenlight_redrafts"] == 1
+    corr = oracle.corrections()
+    assert len(corr) == 1
+    # The correction token carries the sentinel + verbatim PI text.
+    assert corr[0].token.startswith(REDIRECT_SENTINEL)
+    assert corr[0].token[len(REDIRECT_SENTINEL):].startswith("Reframe around")
+    # The loop re-parked at pi_greenlight: at least two greenlight visits.
+    assert len(oracle.decisions_of_type("pi_greenlight")) >= 2
+
+
+# ---------------------------------------------------------------------------
+# 3. RunRecord lifts terminal state + oracle log into the gradeable record
+# ---------------------------------------------------------------------------
+
+
+def test_run_record_from_final_state_round_trips(sdk, mcp):
+    oracle = happy_path_oracle()
+    final = _run(sdk, mcp, oracle)
+
+    rec = RunRecord.from_final_state(
+        arc="mission",
+        run_label="phase0-dryrun",
+        final_state=final,
+        oracle_decisions=oracle.as_dicts(),
+        seed=7,
+        subject_id="cot-gsm8k",
+        arm="A",
+    )
+
+    assert rec.terminal_state == "complete"
+    assert rec.workflow_thread_id == "thr_eval_dryrun"
+    assert rec.project_id == "prj_eval"
+    assert rec.arm == "A"
+    assert rec.seed == 7
+    # happy path: no interventions, no redrafts.
+    assert rec.pi_intervention_count == 0
+    assert rec.greenlight_redrafts == 0
+    assert rec.pi_decisions  # non-empty decision log carried through
+    # JSON round-trips (default=str covers any non-primitive).
+    parsed = json.loads(rec.to_json())
+    assert parsed["terminal_state"] == "complete"
+    assert parsed["arc"] == "mission"
+
+
+def test_run_record_counts_interventions_from_oracle_log(sdk, mcp):
+    # A record built off a correcting oracle counts the correction as an
+    # intervention (corrections + rejects, not bare accepts).
+    seen = {"n": 0}
+
+    def first_greenlight_only(payload: dict) -> bool:
+        if payload.get("type") != "pi_greenlight":
+            return False
+        seen["n"] += 1
+        return seen["n"] == 1
+
+    rubric = Rubric(
+        rules=[
+            Rule(
+                type="pi_greenlight",
+                action="correct",
+                label="redirect-once",
+                predicate=first_greenlight_only,
+                correct_text="Tighten the scope to the 2-step subset.",
+            )
+        ],
+        default_action="accept",
+    )
+    oracle = PIOracle(rubric)
+    final = _run(sdk, mcp, oracle, thread="thr_eval_intervene")
+
+    rec = RunRecord.from_final_state(
+        arc="mission",
+        run_label="phase0-intervene",
+        final_state=final,
+        oracle_decisions=oracle.as_dicts(),
+    )
+    assert rec.pi_intervention_count == 1
+    assert rec.greenlight_redrafts == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. oracle token-contract unit checks (no graph)
+# ---------------------------------------------------------------------------
+
+
+def test_oracle_emits_contract_correct_tokens():
+    rubric = Rubric(
+        rules=[
+            Rule(type="pi_acceptance", action="reject", label="reject-it"),
+            Rule(
+                type="pi_decision_select",
+                action="correct",
+                label="redirect-decision",
+                correct_text="Pick the pivoted-claim option, not the original.",
+            ),
+        ],
+        default_action="accept",
+    )
+    oracle = PIOracle(rubric)
+
+    assert oracle({"type": "pi_greenlight"}) == "approve"        # default accept
+    assert oracle({"type": "pi_acceptance"}) == "reject"          # explicit reject
+    tok = oracle({"type": "pi_decision_select", "decision": "..."})
+    assert tok.startswith(REDIRECT_SENTINEL)                      # correct → sentinel
+    # log captured all three with right actions
+    assert [d.action for d in oracle.log] == ["accept", "reject", "correct"]
+
+
+def test_correct_rule_without_text_raises():
+    rubric = Rubric(
+        rules=[Rule(type="pi_greenlight", action="correct", label="no-text")]
+    )
+    oracle = PIOracle(rubric)
+    with pytest.raises(ValueError, match="no correct_text"):
+        oracle({"type": "pi_greenlight"})
+
+
+def test_unknown_interrupt_type_raises():
+    oracle = happy_path_oracle()
+    with pytest.raises(ValueError, match="unknown interrupt_type"):
+        oracle({"type": "pi_not_a_real_gate"})


### PR DESCRIPTION
## Phase-0 of the end-to-end research-lifecycle eval

This is the first, self-contained unit of the comprehensive end-to-end test plan for the agentic branch — the **reproducibility keystone**. It replaces the pilot's hardcoded `interrupt_fn` (and `driver.py`'s stdin) with a rubric-driven PI that decides *correctly per a research subject's ground truth* and records every decision, so a live run becomes reproducible and gradeable.

Everything here runs offline with fakes — no live SDK, no REST, no network — so the harness itself is CI-testable before any of the live Phases 1–5 run on the PI's machine.

### What landed

- **`orchestrator/eval/pi_oracle.py`** — `Rubric` / `Rule` / `Decision` / `PIOracle`. A subject-parameterized, in-process `interrupt_fn(payload) -> str` that:
  - decides `accept` / `reject` / `correct` per an ordered rubric (first matching rule wins; `default_action` otherwise),
  - emits **contract-correct** tokens via `runner.resume_token` (accept → type-specific token, `correct` → `REDIRECT_SENTINEL` + verbatim text, `reject` → `"reject"`), so it plugs straight into `graph.build_graph(interrupt_fn=oracle)` with the real SDK + `RestMCPClient` unchanged,
  - logs every gate decision (type, node, action, token, matched-rule label, payload digest) — the grading substrate.
  - `happy_path_oracle()` is the accept-everything baseline (equivalent to the pilot's happy path, but with an auditable log).

- **`orchestrator/eval/run_record.py`** — `RunRecord`, the per-run JSON schema capturing the three measurement axes (capability / reliability / provenance), with `from_final_state()` to lift a LangGraph terminal state + oracle log into a gradeable record.

- **`orchestrator/tests/test_eval_pi_oracle.py`** (7 tests) — drives the **real 19-node mission graph** with `FakeSDK`/`FakeMCP`:
  - happy-path oracle reaches `terminal_state == "complete"` and records a decision per PI gate;
  - a `correct` rule fires the Phase-X² in-run greenlight redraft loop **exactly once** (`greenlight_redrafts == 1`) and still completes;
  - `RunRecord` round-trips through JSON and counts interventions (corrections + rejects, not bare accepts);
  - token-contract + error-path unit checks (sentinel prefix, missing `correct_text`, unknown interrupt type).

### Invariants

- **Bookkeeper** — `git diff main -- rka/` empty; this PR touches `orchestrator/` only.
- **Grep-gate** — `eval/` does not `import rka` (verified by `test_invariants.py`).
- Full orchestrator suite: **1359 passed, 2 skipped**; ruff clean.

### Why agentic, not main

Per the branch-routing guardrail: this is pure `orchestrator/`-tree code, so it belongs on the agentic branch. No main-branch (`rka/`) code is touched. The next Phase-0 commits (subject spec + sealed ground truth, surprising-experiment harness, grader suite) land alongside these.

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv

---
_Generated by [Claude Code](https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv)_