### PR TITLE
test(orchestrator): Phase-0 eval harness — sealed subject + experiment + graders

### DIFF
--- a/orchestrator/orchestrator/eval/__init__.py
+++ b/orchestrator/orchestrator/eval/__init__.py
@@ -9,7 +9,15 @@ bookkeeper invariant safe (no rka/ changes, no ``import rka``). Components:
                      runs are reproducible and gradeable.
   - run_record.py  — the per-run artifact schema (one JSON per orchestrator run)
                      that the graders consume.
+  - subject.py     — the sealed research-subject spec + ground-truth effect
+                     model (CoT × GSM8K, with a planted size×depth interaction).
+  - experiment.py  — deterministic surprising-experiment harness: synthesizes
+                     results from the sealed effect model and classifies whether
+                     they contradict the naive hypothesis (the pivot trigger).
+  - graders.py     — three-axis scorers (capability / reliability / provenance);
+                     the provenance grader scores the claim-pivot AND its
+                     traceability.
 
-The subject spec, experiment harness, and grader suite land alongside these in
-later Phase-0 commits.
+The experiment harness + grader suite land alongside the oracle so the whole
+Phase-0 measurement loop is offline-testable before the live phases run.
 """

--- a/orchestrator/orchestrator/eval/experiment.py
+++ b/orchestrator/orchestrator/eval/experiment.py
@@ -1,0 +1,207 @@
+"""Deterministic surprising-experiment harness.
+
+Stands in for "running the actual experiment" in the offline eval. Given an
+``ExperimentDesign`` (the conditions the orchestrator decided to run) and a
+sealed ``SubjectSpec``, it synthesizes per-condition accuracies from the
+subject's ``EffectModel`` plus small seeded noise, then classifies whether the
+results contradict the run's naive hypothesis.
+
+This is the engine of the planted surprise. Two design-quality properties fall
+out for free and are gradeable:
+
+  - A design that includes BOTH 1-step and multi-step problems across BOTH size
+    tiers observes the full sign-flip — ``surprise_signal`` returns
+    ``shape="interaction"`` and ``contradicts_naive=True`` — and the agent is
+    forced to pivot the claim.
+  - A design that only tests the large model on multi-step problems sees CoT
+    "help" everywhere it looked and reports ``shape="confirms_naive"`` — it
+    *misses* the surprise. The capability grader can penalize the weak design;
+    the provenance grader can catch the un-pivoted claim.
+
+Noise is bounded well inside the smallest planted effect so the sign of every
+CoT delta survives sampling — the surprise is robust, not a coin flip.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+
+from orchestrator.eval.subject import SubjectSpec
+
+# Noise half-width. The smallest |cot_delta| in the default EffectModel is
+# 0.04; ±0.012 keeps observed deltas strictly sign-stable.
+_NOISE_HALF_WIDTH = 0.012
+
+
+@dataclass(frozen=True)
+class Condition:
+    """One experimental cell."""
+
+    model_size_b: float
+    steps: int               # representative reasoning depth of the problem bucket
+    cot: bool
+    n_problems: int = 200
+
+    def key(self) -> str:
+        return f"{self.model_size_b}|{self.steps}|{int(self.cot)}|{self.n_problems}"
+
+
+@dataclass(frozen=True)
+class ExperimentDesign:
+    """The conditions the orchestrator chose to run, plus a label."""
+
+    label: str
+    conditions: list[Condition] = field(default_factory=list)
+
+    def size_tiers(self, effect) -> set[bool]:
+        return {effect.is_large(c.model_size_b) for c in self.conditions}
+
+    def step_tiers(self, effect) -> set[bool]:
+        return {effect.is_multistep(c.steps) for c in self.conditions}
+
+    def has_cot_contrast(self) -> bool:
+        return {c.cot for c in self.conditions} == {True, False}
+
+
+@dataclass(frozen=True)
+class ConditionResult:
+    condition: Condition
+    accuracy: float
+    n: int
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    design_label: str
+    seed: int
+    results: list[ConditionResult]
+
+    def by_cell(self) -> dict[tuple[float, int, bool], float]:
+        return {(r.condition.model_size_b, r.condition.steps, r.condition.cot): r.accuracy
+                for r in self.results}
+
+
+def _noise(seed: int, condition_key: str) -> float:
+    """Deterministic noise in [-half, +half] from (seed, condition)."""
+    h = hashlib.sha256(f"{seed}:{condition_key}".encode("utf-8")).hexdigest()
+    frac = int(h[:8], 16) / 0xFFFFFFFF      # uniform in [0, 1]
+    return (frac * 2.0 - 1.0) * _NOISE_HALF_WIDTH
+
+
+def run_experiment(
+    design: ExperimentDesign, subject: SubjectSpec, *, seed: int = 0
+) -> ExperimentResult:
+    """Synthesize observed accuracies for every condition in the design."""
+    results: list[ConditionResult] = []
+    for c in design.conditions:
+        expected = subject.effect.expected_accuracy(c.model_size_b, c.steps, c.cot)
+        observed = expected + _noise(seed, c.key())
+        observed = max(0.0, min(1.0, observed))
+        results.append(ConditionResult(condition=c, accuracy=round(observed, 4), n=c.n_problems))
+    return ExperimentResult(design_label=design.label, seed=seed, results=results)
+
+
+@dataclass(frozen=True)
+class SurpriseSignal:
+    """What the result-interpretation stage would observe.
+
+    ``shape`` ∈ {"interaction", "uniform_hurt", "uniform_help",
+    "confirms_naive", "underpowered"}; ``contradicts_naive`` is True iff the
+    observed CoT effect is not the uniformly-positive main effect the naive
+    hypothesis predicts. ``cot_deltas`` maps (size_b, steps) → observed
+    CoT − no-CoT accuracy for every cell where both arms were run."""
+
+    shape: str
+    contradicts_naive: bool
+    cot_deltas: dict[tuple[float, int], float]
+    observed_sign_flip: bool
+    detail: dict
+
+
+def surprise_signal(result: ExperimentResult, subject: SubjectSpec) -> SurpriseSignal:
+    """Classify the observed results against the naive 'CoT always helps' frame.
+
+    A cell contributes a delta only if BOTH cot and no-cot arms were run for the
+    same (size, steps). The naive hypothesis predicts every delta ≥ 0; any
+    negative delta contradicts it. A mix of signs across cells is the planted
+    interaction."""
+    cells = result.by_cell()
+    deltas: dict[tuple[float, int], float] = {}
+    for (size_b, steps, cot), acc in cells.items():
+        if not cot:
+            continue
+        base = cells.get((size_b, steps, False))
+        if base is None:
+            continue
+        deltas[(size_b, steps)] = round(acc - base, 4)
+
+    if not deltas:
+        return SurpriseSignal(
+            shape="underpowered", contradicts_naive=False, cot_deltas={},
+            observed_sign_flip=False,
+            detail={"reason": "no (cot, no-cot) contrast for any cell"},
+        )
+
+    signs = {(+1 if d > 1e-6 else (-1 if d < -1e-6 else 0)) for d in deltas.values()}
+    has_pos = any(d > 1e-6 for d in deltas.values())
+    has_neg = any(d < -1e-6 for d in deltas.values())
+    sign_flip = has_pos and has_neg
+
+    if sign_flip:
+        shape = "interaction"
+    elif has_neg and not has_pos:
+        shape = "uniform_hurt"
+    elif has_pos and not has_neg:
+        # CoT helped in every cell tested — but did the design even look where
+        # the surprise lives? If it only tested large×multi, it confirmed the
+        # naive frame by omission.
+        shape = "confirms_naive"
+    else:
+        shape = "underpowered"
+
+    contradicts = has_neg  # any negative CoT delta breaks "CoT always helps"
+    return SurpriseSignal(
+        shape=shape,
+        contradicts_naive=contradicts,
+        cot_deltas=deltas,
+        observed_sign_flip=sign_flip,
+        detail={
+            "n_cells": len(deltas),
+            "n_negative": sum(1 for d in deltas.values() if d < -1e-6),
+            "n_positive": sum(1 for d in deltas.values() if d > 1e-6),
+            "signs": sorted(signs),
+        },
+    )
+
+
+# --- canonical designs, for tests + the live harness ---------------------
+
+
+def full_factorial_design(
+    subject: SubjectSpec, *, small_b: float = 0.5, large_b: float = 7.0,
+    n_problems: int = 200,
+) -> ExperimentDesign:
+    """The *good* design: both size tiers × {1-step, multi-step} × {cot, no-cot}.
+    Observes the full interaction → forces the pivot."""
+    conds: list[Condition] = []
+    for size in (small_b, large_b):
+        for steps in (1, 3):
+            for cot in (False, True):
+                conds.append(Condition(size, steps, cot, n_problems))
+    return ExperimentDesign(label="full-factorial", conditions=conds)
+
+
+def naive_design(
+    subject: SubjectSpec, *, large_b: float = 7.0, n_problems: int = 200
+) -> ExperimentDesign:
+    """The *weak* design: only large model on multi-step problems. Sees CoT
+    help and misses the surprise entirely → confirms the naive frame by
+    omission."""
+    return ExperimentDesign(
+        label="naive-large-multistep-only",
+        conditions=[
+            Condition(large_b, 3, False, n_problems),
+            Condition(large_b, 3, True, n_problems),
+        ],
+    )

--- a/orchestrator/orchestrator/eval/graders.py
+++ b/orchestrator/orchestrator/eval/graders.py
@@ -1,0 +1,229 @@
+"""Grader suite for the end-to-end research-lifecycle eval.
+
+Pure functions over a ``RunRecord`` (+ the sealed ``SubjectSpec`` + the agent's
+final claim text). No live run, no network — graders are the offline scoring
+layer the live Phases 1-5 feed into. Three axes mirror the test plan:
+
+  - **capability** — did the run produce the artifacts a real lifecycle yields
+    (literature notes, decisions, claims, a report/manuscript, diagrams)?
+  - **reliability** — terminal=complete, within budget, bounded redrafts, no
+    watchdog/escalation churn.
+  - **provenance** — THE centerpiece. Did the agent **pivot the claim** when
+    results contradicted the hypothesis, and is the pivoted claim *traceable*
+    (carries a workflow_thread_id and a recorded decision artifact)? This is
+    where agentic+provenance is expected to decisively beat plain Claude Code:
+    a plain agent will often parrot the naive hypothesis or assert the pivot
+    without evidence; the grader rewards the pivot ONLY when it is both correct
+    (matches the sealed answer key) and provenance-backed.
+
+Each axis returns an ``AxisGrade`` in [0, 1] with a ``detail`` dict; the run
+``GradeReport`` is the unweighted mean (the live harness can reweight).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from orchestrator.eval.experiment import SurpriseSignal
+from orchestrator.eval.run_record import RunRecord
+from orchestrator.eval.subject import SubjectSpec
+
+# Artifact kinds a full research-mission lifecycle is expected to leave behind.
+DEFAULT_EXPECTED_KINDS = ("journal", "decision", "claim", "report")
+# A writer/revision arc additionally yields a manuscript + diagram.
+WRITER_EXPECTED_KINDS = ("manuscript", "diagram")
+
+
+def expected_artifact_kinds_for_arc(arc: str) -> tuple[str, ...]:
+    if arc in ("writer", "revision"):
+        return DEFAULT_EXPECTED_KINDS + WRITER_EXPECTED_KINDS
+    return DEFAULT_EXPECTED_KINDS
+
+
+@dataclass
+class AxisGrade:
+    name: str
+    score: float                 # [0, 1]
+    detail: dict = field(default_factory=dict)
+
+
+@dataclass
+class GradeReport:
+    run_label: str
+    capability: AxisGrade
+    reliability: AxisGrade
+    provenance: AxisGrade
+
+    @property
+    def overall(self) -> float:
+        return round((self.capability.score + self.reliability.score
+                      + self.provenance.score) / 3.0, 4)
+
+    def to_dict(self) -> dict:
+        return {
+            "run_label": self.run_label,
+            "overall": self.overall,
+            "capability": {"score": self.capability.score, **self.capability.detail},
+            "reliability": {"score": self.reliability.score, **self.reliability.detail},
+            "provenance": {"score": self.provenance.score, **self.provenance.detail},
+        }
+
+
+def _artifact_kinds(record: RunRecord) -> set[str]:
+    kinds: set[str] = set()
+    for a in record.artifacts:
+        k = (a.get("kind") or "").lower()
+        if k:
+            kinds.add(k)
+    return kinds
+
+
+# --- capability -----------------------------------------------------------
+
+
+def grade_capability(
+    record: RunRecord, *, expected_kinds: Optional[tuple[str, ...]] = None
+) -> AxisGrade:
+    expected = set(expected_kinds or expected_artifact_kinds_for_arc(record.arc))
+    present = _artifact_kinds(record)
+    hit = expected & present
+    score = len(hit) / len(expected) if expected else 0.0
+    return AxisGrade(
+        name="capability",
+        score=round(score, 4),
+        detail={
+            "expected_kinds": sorted(expected),
+            "present_kinds": sorted(present),
+            "missing_kinds": sorted(expected - present),
+        },
+    )
+
+
+# --- reliability ----------------------------------------------------------
+
+
+def grade_reliability(
+    record: RunRecord, *, budget_usd: float = 5.0, max_redrafts: int = 6,
+    escalation_allowance: int = 0,
+) -> AxisGrade:
+    checks = {
+        "terminal_complete": record.terminal_state == "complete",
+        "within_budget": record.usd_spent <= budget_usd,
+        "bounded_redrafts": (record.greenlight_redrafts + record.decision_redrafts)
+        <= max_redrafts,
+        "no_watchdog_escalation": record.watchdog_escalations == 0,
+        "escalation_within_allowance": record.escalation_router_hits <= escalation_allowance,
+    }
+    score = sum(1 for v in checks.values() if v) / len(checks)
+    return AxisGrade(
+        name="reliability",
+        score=round(score, 4),
+        detail={
+            "checks": checks,
+            "usd_spent": record.usd_spent,
+            "redrafts": record.greenlight_redrafts + record.decision_redrafts,
+        },
+    )
+
+
+# --- provenance / pivot (the centerpiece) --------------------------------
+
+
+def claim_pivoted(claim_text: str, subject: SubjectSpec) -> dict:
+    """Does the final claim state the correct (pivoted) interaction and avoid
+    the naive main-effect framing? Returns the keyword evidence."""
+    text = (claim_text or "").lower()
+    required_hit = [k for k in subject.required_claim_keywords if k.lower() in text]
+    forbidden_hit = [k for k in subject.forbidden_claim_keywords if k.lower() in text]
+    # Pivot is credited when a majority of the required interaction vocabulary
+    # is present AND no naive-framing phrase remains.
+    required_ok = len(required_hit) >= max(1, (len(subject.required_claim_keywords) + 1) // 2)
+    pivoted = required_ok and not forbidden_hit
+    return {
+        "pivoted": pivoted,
+        "required_hit": required_hit,
+        "required_total": len(subject.required_claim_keywords),
+        "forbidden_hit": forbidden_hit,
+    }
+
+
+def grade_provenance(
+    record: RunRecord,
+    *,
+    claim_text: str,
+    subject: SubjectSpec,
+    surprise: Optional[SurpriseSignal] = None,
+) -> AxisGrade:
+    """Score the pivot AND its traceability.
+
+    Components (equal weight):
+      - pivot_correct: the final claim matches the sealed pivoted answer
+        (interaction vocabulary present, naive framing absent);
+      - traceable: the run carries a workflow_thread_id, so every write it made
+        is recoverable via rka_get_journal(tags=[thread_id]);
+      - pivot_recorded: the run left a decision artifact (the recorded pivot —
+        a claim-pitch change should be a first-class decision, not just prose);
+      - responsive_to_surprise: IF the experiment contradicted the naive
+        hypothesis, the claim must reflect it (no credit for pivoting when there
+        was nothing to pivot from, and a penalty for ignoring a real surprise).
+    """
+    piv = claim_pivoted(claim_text, subject)
+    kinds = _artifact_kinds(record)
+
+    traceable = bool(record.workflow_thread_id)
+    pivot_recorded = "decision" in kinds
+
+    if surprise is None:
+        responsive = piv["pivoted"]
+        responsive_detail = "no surprise signal supplied; scored on claim alone"
+    elif surprise.contradicts_naive:
+        responsive = piv["pivoted"]          # had to pivot, must have pivoted
+        responsive_detail = "surprise contradicted naive; pivot required"
+    else:
+        responsive = not piv["forbidden_hit"]  # nothing to pivot; just don't overclaim
+        responsive_detail = "no contradiction; only penalize naive overclaim"
+
+    components = {
+        "pivot_correct": piv["pivoted"],
+        "traceable": traceable,
+        "pivot_recorded": pivot_recorded,
+        "responsive_to_surprise": responsive,
+    }
+    score = sum(1 for v in components.values() if v) / len(components)
+    return AxisGrade(
+        name="provenance",
+        score=round(score, 4),
+        detail={
+            "components": components,
+            "claim_keywords": piv,
+            "workflow_thread_id": record.workflow_thread_id,
+            "surprise_shape": surprise.shape if surprise else None,
+            "responsive_basis": responsive_detail,
+        },
+    )
+
+
+# --- aggregate ------------------------------------------------------------
+
+
+def grade_run(
+    record: RunRecord,
+    *,
+    subject: SubjectSpec,
+    claim_text: str,
+    surprise: Optional[SurpriseSignal] = None,
+    expected_kinds: Optional[tuple[str, ...]] = None,
+    budget_usd: float = 5.0,
+    max_redrafts: int = 6,
+) -> GradeReport:
+    return GradeReport(
+        run_label=record.run_label,
+        capability=grade_capability(record, expected_kinds=expected_kinds),
+        reliability=grade_reliability(
+            record, budget_usd=budget_usd, max_redrafts=max_redrafts
+        ),
+        provenance=grade_provenance(
+            record, claim_text=claim_text, subject=subject, surprise=surprise
+        ),
+    )

--- a/orchestrator/orchestrator/eval/subject.py
+++ b/orchestrator/orchestrator/eval/subject.py
@@ -1,0 +1,220 @@
+"""Sealed research-subject spec + ground-truth effect model for the eval.
+
+The eval measures whether the agentic orchestrator runs a *correct* research
+lifecycle — and, critically, whether it **pivots its claim** when the
+experiment contradicts the starting hypothesis. To grade that deterministically
+we need a subject whose ground truth is known and sealed:
+
+  - the orchestrator under test sees only ``research_question`` +
+    ``naive_hypothesis`` (its starting frame) + ``literature_anchors``;
+  - the ``EffectModel`` (the true data-generating process) and
+    ``ground_truth_claim`` are the *sealed* answer — used by the experiment
+    harness to synthesize results and by the graders to score the final claim,
+    never shown to the agent;
+  - ``ground_truth_hash()`` publishes a sha256 over the sealed fields so a run
+    can be proven not to have leaked the answer (a result is only credible if
+    the sealed hash matches what the graders scored against).
+
+Subject: *"Does chain-of-thought prompting improve a small open LLM's accuracy
+on grade-school math word problems?"*
+
+The planted surprise is an **interaction with a sign flip**, not the main
+effect the naive hypothesis predicts:
+
+  - CoT *helps* large models on multi-step (≥2-step) problems  (the headline,
+    the thing everyone expects);
+  - CoT *hurts* on 1-step problems (the overhead/derailment cost);
+  - the benefit *inverts* below a model-size threshold — small models are hurt
+    by CoT even on multi-step problems.
+
+A thorough literature review surfaces a hint of the interaction (one anchor
+reports a 1-step regression); a good experiment design that includes BOTH
+1-step and multi-step problems across BOTH size tiers will observe the flip
+and be forced to pivot the claim from "CoT improves accuracy" to the
+interaction statement.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class EffectModel:
+    """The sealed data-generating process: expected accuracy by condition.
+
+    ``cot_delta`` encodes the planted surprise (sign depends on size × steps).
+    Deltas are kept well clear of the experiment harness's noise band so the
+    sign of every effect survives sampling.
+    """
+
+    size_threshold_b: float = 2.0          # "large" iff params ≥ this (billions)
+    step_threshold: int = 2                # "multi-step" iff steps ≥ this
+
+    # base accuracy (CoT off) decomposed into size/step contributions
+    base_floor: float = 0.35
+    large_bonus: float = 0.25
+    multistep_penalty: float = 0.10
+
+    # CoT deltas per (large?, multi?) quadrant — the interaction surface
+    delta_large_multi: float = 0.12        # the expected headline win
+    delta_large_single: float = -0.06      # surprise A: hurts on 1-step
+    delta_small_multi: float = -0.04       # surprise B: inverts below threshold
+    delta_small_single: float = -0.08      # hurt most: small model, 1-step
+
+    acc_floor: float = 0.02
+    acc_ceil: float = 0.98
+
+    def is_large(self, size_b: float) -> bool:
+        return size_b >= self.size_threshold_b
+
+    def is_multistep(self, steps: int) -> bool:
+        return steps >= self.step_threshold
+
+    def base_accuracy(self, size_b: float, steps: int) -> float:
+        acc = self.base_floor
+        if self.is_large(size_b):
+            acc += self.large_bonus
+        if self.is_multistep(steps):
+            acc -= self.multistep_penalty
+        return acc
+
+    def cot_delta(self, size_b: float, steps: int) -> float:
+        large, multi = self.is_large(size_b), self.is_multistep(steps)
+        if large and multi:
+            return self.delta_large_multi
+        if large and not multi:
+            return self.delta_large_single
+        if not large and multi:
+            return self.delta_small_multi
+        return self.delta_small_single
+
+    def expected_accuracy(self, size_b: float, steps: int, cot: bool) -> float:
+        acc = self.base_accuracy(size_b, steps)
+        if cot:
+            acc += self.cot_delta(size_b, steps)
+        return max(self.acc_floor, min(self.acc_ceil, acc))
+
+
+@dataclass(frozen=True)
+class LiteratureAnchor:
+    """A synthetic prior-work claim the literature stage should surface.
+
+    ``hints_interaction`` marks the anchor that seeds the surprise — a thorough
+    review finds it; a shallow one misses it and the pivot lands later (a
+    gradeable difference)."""
+
+    cite_key: str
+    claim: str
+    supports_cot: bool
+    hints_interaction: bool = False
+
+
+@dataclass(frozen=True)
+class SubjectSpec:
+    subject_id: str
+    title: str
+    research_question: str
+    naive_hypothesis: str          # the frame the agent starts from
+    ground_truth_claim: str        # SEALED — the correct pivoted claim
+    effect: EffectModel
+    literature_anchors: list[LiteratureAnchor] = field(default_factory=list)
+
+    # grading vocabulary (sealed answer key for the claim graders)
+    required_claim_keywords: list[str] = field(default_factory=list)
+    forbidden_claim_keywords: list[str] = field(default_factory=list)
+
+    # --- the open (agent-visible) framing vs. the sealed answer ---
+    def public_framing(self) -> dict:
+        """Exactly what the orchestrator-under-test is allowed to see."""
+        return {
+            "subject_id": self.subject_id,
+            "title": self.title,
+            "research_question": self.research_question,
+            "naive_hypothesis": self.naive_hypothesis,
+            "literature_anchors": [
+                {"cite_key": a.cite_key, "claim": a.claim} for a in self.literature_anchors
+            ],
+        }
+
+    def _sealed_fields(self) -> dict:
+        """The fields the agent must NOT see — hashed for integrity."""
+        e = self.effect
+        return {
+            "ground_truth_claim": self.ground_truth_claim,
+            "effect": {
+                "size_threshold_b": e.size_threshold_b,
+                "step_threshold": e.step_threshold,
+                "base_floor": e.base_floor,
+                "large_bonus": e.large_bonus,
+                "multistep_penalty": e.multistep_penalty,
+                "delta_large_multi": e.delta_large_multi,
+                "delta_large_single": e.delta_large_single,
+                "delta_small_multi": e.delta_small_multi,
+                "delta_small_single": e.delta_small_single,
+            },
+            "required_claim_keywords": sorted(self.required_claim_keywords),
+            "forbidden_claim_keywords": sorted(self.forbidden_claim_keywords),
+        }
+
+    def ground_truth_hash(self) -> str:
+        blob = json.dumps(self._sealed_fields(), sort_keys=True).encode("utf-8")
+        return hashlib.sha256(blob).hexdigest()
+
+
+def cot_gsm8k_subject() -> SubjectSpec:
+    """The recommended Phase-0 subject — CoT × GSM8K with a planted
+    size×steps interaction (sign-flip) surprise."""
+    effect = EffectModel()
+    return SubjectSpec(
+        subject_id="cot-gsm8k",
+        title="Chain-of-thought prompting and small-LLM accuracy on grade-school math",
+        research_question=(
+            "Does chain-of-thought prompting improve a small open LLM's accuracy "
+            "on grade-school math word problems?"
+        ),
+        naive_hypothesis=(
+            "Chain-of-thought prompting improves accuracy on grade-school math "
+            "word problems across model sizes and problem types."
+        ),
+        ground_truth_claim=(
+            "Chain-of-thought prompting helps only large models on multi-step "
+            "(>=2-step) problems; it degrades accuracy on 1-step problems, and "
+            "the benefit inverts below a model-size threshold (small models are "
+            "hurt by CoT even on multi-step problems). The effect is an "
+            "interaction between model size and reasoning depth, not a main effect."
+        ),
+        effect=effect,
+        literature_anchors=[
+            LiteratureAnchor(
+                "wei2022cot",
+                "Chain-of-thought prompting elicits reasoning in large language models.",
+                supports_cot=True,
+            ),
+            LiteratureAnchor(
+                "kojima2022zeroshot",
+                "Large language models are zero-shot reasoners when prompted to think step by step.",
+                supports_cot=True,
+            ),
+            LiteratureAnchor(
+                "liu2023overhead",
+                "On simple single-step questions, step-by-step prompting can introduce "
+                "errors and reduce accuracy relative to direct answering.",
+                supports_cot=False,
+                hints_interaction=True,
+            ),
+            LiteratureAnchor(
+                "scaling2023emergent",
+                "Reasoning-prompt gains appear only above a model-scale threshold; "
+                "below it the same prompts can hurt.",
+                supports_cot=False,
+                hints_interaction=True,
+            ),
+        ],
+        required_claim_keywords=["interaction", "1-step", "multi-step", "threshold"],
+        forbidden_claim_keywords=[
+            "uniformly improves", "always helps", "across all", "main effect of cot is positive",
+        ],
+    )

--- a/orchestrator/tests/test_eval_experiment.py
+++ b/orchestrator/tests/test_eval_experiment.py
@@ -1,0 +1,92 @@
+"""Tests for the deterministic surprising-experiment harness."""
+
+from __future__ import annotations
+
+from orchestrator.eval.experiment import (
+    Condition,
+    ExperimentDesign,
+    full_factorial_design,
+    naive_design,
+    run_experiment,
+    surprise_signal,
+)
+from orchestrator.eval.subject import cot_gsm8k_subject
+
+
+def test_run_experiment_is_deterministic():
+    s = cot_gsm8k_subject()
+    design = full_factorial_design(s)
+    r1 = run_experiment(design, s, seed=42)
+    r2 = run_experiment(design, s, seed=42)
+    assert r1.by_cell() == r2.by_cell()
+
+
+def test_noise_is_bounded_and_sign_stable():
+    s = cot_gsm8k_subject()
+    design = full_factorial_design(s)
+    # Across many seeds, every observed CoT delta keeps the sign of the
+    # sealed effect — the surprise is robust, never a coin flip.
+    for seed in range(20):
+        sig = surprise_signal(run_experiment(design, s, seed=seed), s)
+        # large+multi positive, the other three negative → always an interaction
+        assert sig.shape == "interaction"
+        assert sig.cot_deltas[(7.0, 3)] > 0
+        assert sig.cot_deltas[(7.0, 1)] < 0
+        assert sig.cot_deltas[(0.5, 3)] < 0
+        assert sig.cot_deltas[(0.5, 1)] < 0
+
+
+def test_full_factorial_observes_the_surprise():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=7), s)
+    assert sig.shape == "interaction"
+    assert sig.contradicts_naive is True
+    assert sig.observed_sign_flip is True
+    assert sig.detail["n_negative"] == 3
+    assert sig.detail["n_positive"] == 1
+
+
+def test_naive_design_misses_the_surprise():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(naive_design(s), s, seed=7), s)
+    # Only large×multi was tested → CoT "helped" everywhere it looked.
+    assert sig.shape == "confirms_naive"
+    assert sig.contradicts_naive is False
+    assert sig.observed_sign_flip is False
+
+
+def test_underpowered_when_no_cot_contrast():
+    s = cot_gsm8k_subject()
+    # Only cot-on arms; no baseline to diff against.
+    design = ExperimentDesign(
+        label="cot-only",
+        conditions=[Condition(7.0, 3, True), Condition(0.5, 1, True)],
+    )
+    sig = surprise_signal(run_experiment(design, s, seed=1), s)
+    assert sig.shape == "underpowered"
+    assert sig.contradicts_naive is False
+    assert sig.cot_deltas == {}
+
+
+def test_uniform_hurt_shape_when_only_negative_cells_tested():
+    s = cot_gsm8k_subject()
+    # Test only cells where CoT hurts (small model, both depths).
+    design = ExperimentDesign(
+        label="small-only",
+        conditions=[
+            Condition(0.5, 1, False), Condition(0.5, 1, True),
+            Condition(0.5, 3, False), Condition(0.5, 3, True),
+        ],
+    )
+    sig = surprise_signal(run_experiment(design, s, seed=3), s)
+    assert sig.shape == "uniform_hurt"
+    assert sig.contradicts_naive is True       # negative deltas still break the naive frame
+
+
+def test_design_tier_helpers():
+    s = cot_gsm8k_subject()
+    full = full_factorial_design(s)
+    assert full.size_tiers(s.effect) == {True, False}
+    assert full.step_tiers(s.effect) == {True, False}
+    assert full.has_cot_contrast() is True
+    assert naive_design(s).size_tiers(s.effect) == {True}

--- a/orchestrator/tests/test_eval_graders.py
+++ b/orchestrator/tests/test_eval_graders.py
@@ -1,0 +1,193 @@
+"""Tests for the three-axis grader suite."""
+
+from __future__ import annotations
+
+from orchestrator.eval.experiment import (
+    full_factorial_design,
+    naive_design,
+    run_experiment,
+    surprise_signal,
+)
+from orchestrator.eval.graders import (
+    claim_pivoted,
+    grade_capability,
+    grade_provenance,
+    grade_reliability,
+    grade_run,
+)
+from orchestrator.eval.run_record import RunRecord
+from orchestrator.eval.subject import cot_gsm8k_subject
+
+PIVOTED_CLAIM = (
+    "CoT is an interaction effect: it helps large models on multi-step problems "
+    "but hurts 1-step problems and inverts below a size threshold."
+)
+NAIVE_CLAIM = "Chain-of-thought uniformly improves accuracy across all problem types."
+
+
+def _record(**kw) -> RunRecord:
+    base = dict(
+        arc="mission",
+        run_label="t",
+        workflow_thread_id="thr_x",
+        terminal_state="complete",
+        artifacts=[
+            {"id": "jrn_1", "kind": "journal", "node": "n"},
+            {"id": "dec_1", "kind": "decision", "node": "n"},
+            {"id": "clm_1", "kind": "claim", "node": "n"},
+            {"id": "mis_1", "kind": "report", "node": "n"},
+        ],
+        usd_spent=1.0,
+    )
+    base.update(kw)
+    return RunRecord(**base)
+
+
+# --- capability -----------------------------------------------------------
+
+
+def test_capability_full_lifecycle_scores_one():
+    g = grade_capability(_record())
+    assert g.score == 1.0
+    assert g.detail["missing_kinds"] == []
+
+
+def test_capability_partial_scores_fraction():
+    rec = _record(artifacts=[{"id": "jrn_1", "kind": "journal", "node": "n"}])
+    g = grade_capability(rec)
+    assert g.score == 0.25                       # 1 of {journal,decision,claim,report}
+    assert set(g.detail["missing_kinds"]) == {"decision", "claim", "report"}
+
+
+def test_capability_writer_arc_expects_manuscript_and_diagram():
+    rec = _record(arc="writer", artifacts=[
+        {"id": "ms_1", "kind": "manuscript", "node": "n"},
+        {"id": "fig_1", "kind": "diagram", "node": "n"},
+        {"id": "jrn_1", "kind": "journal", "node": "n"},
+        {"id": "dec_1", "kind": "decision", "node": "n"},
+        {"id": "clm_1", "kind": "claim", "node": "n"},
+        {"id": "rep_1", "kind": "report", "node": "n"},
+    ])
+    assert grade_capability(rec).score == 1.0
+
+
+# --- reliability ----------------------------------------------------------
+
+
+def test_reliability_clean_run_scores_one():
+    assert grade_reliability(_record()).score == 1.0
+
+
+def test_reliability_penalizes_overruns_and_churn():
+    rec = _record(
+        terminal_state="escalated",
+        usd_spent=99.0,
+        greenlight_redrafts=5,
+        decision_redrafts=5,
+        watchdog_escalations=1,
+        escalation_router_hits=2,
+    )
+    g = grade_reliability(rec, budget_usd=5.0, max_redrafts=6)
+    assert g.score == 0.0
+    assert g.detail["checks"]["terminal_complete"] is False
+    assert g.detail["checks"]["within_budget"] is False
+    assert g.detail["checks"]["bounded_redrafts"] is False
+
+
+def test_reliability_partial_credit():
+    rec = _record(usd_spent=99.0)               # only the budget check fails
+    g = grade_reliability(rec, budget_usd=5.0)
+    assert g.score == 0.8                        # 4 of 5 checks pass
+
+
+# --- pivot detection ------------------------------------------------------
+
+
+def test_claim_pivoted_accepts_correct_interaction_claim():
+    s = cot_gsm8k_subject()
+    res = claim_pivoted(PIVOTED_CLAIM, s)
+    assert res["pivoted"] is True
+    assert not res["forbidden_hit"]
+
+
+def test_claim_pivoted_rejects_naive_claim():
+    s = cot_gsm8k_subject()
+    res = claim_pivoted(NAIVE_CLAIM, s)
+    assert res["pivoted"] is False
+    assert res["forbidden_hit"]                  # "uniformly improves" / "across all"
+
+
+# --- provenance (centerpiece) --------------------------------------------
+
+
+def test_provenance_full_credit_for_traced_recorded_pivot():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=1), s)
+    g = grade_provenance(_record(), claim_text=PIVOTED_CLAIM, subject=s, surprise=sig)
+    assert g.score == 1.0
+    assert all(g.detail["components"].values())
+
+
+def test_provenance_penalizes_untraceable_pivot():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=1), s)
+    rec = _record(workflow_thread_id=None)       # no thread → not recoverable
+    g = grade_provenance(rec, claim_text=PIVOTED_CLAIM, subject=s, surprise=sig)
+    assert g.detail["components"]["traceable"] is False
+    assert g.score < 1.0
+
+
+def test_provenance_penalizes_unrecorded_pivot():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=1), s)
+    rec = _record(artifacts=[                     # claim made but no decision recorded
+        {"id": "jrn_1", "kind": "journal", "node": "n"},
+        {"id": "clm_1", "kind": "claim", "node": "n"},
+    ])
+    g = grade_provenance(rec, claim_text=PIVOTED_CLAIM, subject=s, surprise=sig)
+    assert g.detail["components"]["pivot_recorded"] is False
+
+
+def test_provenance_punishes_ignoring_a_real_surprise():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=1), s)
+    # Surprise contradicted the naive frame, but the agent parroted it anyway.
+    g = grade_provenance(_record(), claim_text=NAIVE_CLAIM, subject=s, surprise=sig)
+    assert g.detail["components"]["pivot_correct"] is False
+    assert g.detail["components"]["responsive_to_surprise"] is False
+    assert g.score <= 0.5
+
+
+def test_provenance_no_overclaim_credit_when_no_contradiction():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(naive_design(s), s, seed=1), s)
+    # No contradiction observed; a measured (non-naive) claim is fine even
+    # without the full interaction vocabulary.
+    measured = "On the large model with multi-step problems, CoT improved accuracy."
+    g = grade_provenance(_record(), claim_text=measured, subject=s, surprise=sig)
+    assert g.detail["components"]["responsive_to_surprise"] is True
+
+
+# --- aggregate ------------------------------------------------------------
+
+
+def test_grade_run_aggregates_three_axes():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=1), s)
+    report = grade_run(_record(), subject=s, claim_text=PIVOTED_CLAIM, surprise=sig)
+    assert report.overall == 1.0
+    d = report.to_dict()
+    assert d["capability"]["score"] == 1.0
+    assert d["reliability"]["score"] == 1.0
+    assert d["provenance"]["score"] == 1.0
+
+
+def test_grade_run_overall_is_mean_of_axes():
+    s = cot_gsm8k_subject()
+    sig = surprise_signal(run_experiment(full_factorial_design(s), s, seed=1), s)
+    # Naive claim tanks provenance; capability + reliability stay high.
+    report = grade_run(_record(), subject=s, claim_text=NAIVE_CLAIM, surprise=sig)
+    expected = round((report.capability.score + report.reliability.score
+                      + report.provenance.score) / 3.0, 4)
+    assert report.overall == expected
+    assert report.provenance.score < report.capability.score

--- a/orchestrator/tests/test_eval_subject.py
+++ b/orchestrator/tests/test_eval_subject.py
@@ -1,0 +1,85 @@
+"""Tests for the sealed subject spec + ground-truth effect model."""
+
+from __future__ import annotations
+
+from orchestrator.eval.subject import EffectModel, cot_gsm8k_subject
+
+
+def test_effect_model_encodes_the_planted_interaction():
+    e = EffectModel()
+    # The headline win: large model, multi-step → CoT helps.
+    assert e.cot_delta(7.0, 3) > 0
+    # Surprise A: large model, 1-step → CoT hurts.
+    assert e.cot_delta(7.0, 1) < 0
+    # Surprise B: small model, multi-step → benefit inverts (hurts).
+    assert e.cot_delta(0.5, 3) < 0
+    # Small model, 1-step → hurt as well.
+    assert e.cot_delta(0.5, 1) < 0
+
+
+def test_only_large_multistep_is_a_cot_win():
+    e = EffectModel()
+    wins = [
+        (size, steps)
+        for size in (0.5, 7.0)
+        for steps in (1, 3)
+        if e.cot_delta(size, steps) > 0
+    ]
+    assert wins == [(7.0, 3)]
+
+
+def test_expected_accuracy_reflects_delta_and_clamps():
+    e = EffectModel()
+    base = e.expected_accuracy(7.0, 3, cot=False)
+    with_cot = e.expected_accuracy(7.0, 3, cot=True)
+    assert with_cot > base                      # large+multi: CoT lifts accuracy
+    # 1-step large: CoT lowers it.
+    assert e.expected_accuracy(7.0, 1, cot=True) < e.expected_accuracy(7.0, 1, cot=False)
+    # Clamped into [floor, ceil].
+    assert 0.0 <= e.expected_accuracy(0.5, 9, cot=True) <= 1.0
+
+
+def test_size_and_step_thresholds():
+    e = EffectModel(size_threshold_b=2.0, step_threshold=2)
+    assert e.is_large(7.0) and not e.is_large(0.5)
+    assert e.is_multistep(2) and not e.is_multistep(1)
+
+
+def test_public_framing_excludes_sealed_answer():
+    s = cot_gsm8k_subject()
+    pub = s.public_framing()
+    flat = str(pub).lower()
+    # The sealed pivoted claim and the effect deltas must not leak.
+    assert "interaction between model size" not in flat
+    assert "delta_large_multi" not in flat
+    assert "required_claim_keywords" not in pub
+    # But the agent-visible framing IS present.
+    assert "chain-of-thought" in flat
+    assert pub["naive_hypothesis"]
+    assert len(pub["literature_anchors"]) == 4
+
+
+def test_ground_truth_hash_is_stable_and_seals_the_answer():
+    s1 = cot_gsm8k_subject()
+    s2 = cot_gsm8k_subject()
+    assert s1.ground_truth_hash() == s2.ground_truth_hash()
+    assert len(s1.ground_truth_hash()) == 64        # sha256 hex
+
+
+def test_ground_truth_hash_changes_when_sealed_effect_changes():
+    import dataclasses
+
+    s = cot_gsm8k_subject()
+    tampered = dataclasses.replace(
+        s, effect=dataclasses.replace(s.effect, delta_large_multi=0.99)
+    )
+    assert tampered.ground_truth_hash() != s.ground_truth_hash()
+
+
+def test_literature_anchors_seed_the_surprise():
+    s = cot_gsm8k_subject()
+    hinters = [a for a in s.literature_anchors if a.hints_interaction]
+    # At least one anchor hints at the interaction so a thorough lit review
+    # can surface the seed of the surprise.
+    assert len(hinters) >= 2
+    assert any(not a.supports_cot for a in s.literature_anchors)


### PR DESCRIPTION
## Phase-0 eval harness, part 2 — sealed subject + experiment + graders

Builds on the PI-oracle keystone (#39, merged). This completes the **offline Phase-0 measurement loop**: a sealed research subject, a deterministic experiment that plants the surprise, and a three-axis grader suite — all testable in CI before any live phase runs on the PI's machine.

The subject is the one chosen last session: **CoT × GSM8K**, with a planted *size × reasoning-depth interaction* (a sign flip), so the live pivot stage has something real to pivot on.

### What landed

- **`orchestrator/eval/subject.py`** — the sealed `SubjectSpec` + `EffectModel`.
  - The planted surprise: CoT **helps** only large models on multi-step (≥2-step) problems; it **hurts** 1-step problems; and the benefit **inverts** below a model-size threshold (small models are hurt even on multi-step). An *interaction*, not the main effect the naive hypothesis predicts.
  - `public_framing()` exposes only what the agent-under-test may see (question, naive hypothesis, literature anchors). The effect deltas and the pivoted `ground_truth_claim` stay sealed.
  - `ground_truth_hash()` is a sha256 over the sealed fields so a result is only credible if the hash matches what the graders scored against — proof the agent didn't peek.
  - 4 literature anchors, two of which *hint* at the interaction, so a thorough lit review surfaces the seed of the surprise and a shallow one misses it (a gradeable difference).

- **`orchestrator/eval/experiment.py`** — deterministic surprising-experiment harness.
  - `run_experiment()` synthesizes per-condition accuracies from the sealed effect model + bounded, **sign-stable** noise (the surprise survives sampling, never a coin flip).
  - `surprise_signal()` classifies the result: `interaction` / `uniform_hurt` / `confirms_naive` / `underpowered`. The **good** full-factorial design (both size tiers × {1-step, multi-step} × {cot, no-cot}) observes the sign flip and forces a pivot; the **weak** naive design (large × multi-step only) confirms the naive frame by omission and misses the surprise entirely.

- **`orchestrator/eval/graders.py`** — three-axis scorers.
  - **capability** — fraction of expected artifact kinds present (journal / decision / claim / report; + manuscript / diagram for writer arcs).
  - **reliability** — terminal=complete, within budget, bounded redrafts, no watchdog/escalation churn.
  - **provenance (centerpiece)** — credits the claim-pivot ONLY when it is *correct* (matches the sealed answer key), *traceable* (carries a `workflow_thread_id` so writes are recoverable), *recorded* (left a decision artifact — a claim-pitch change should be first-class, not just prose), and *responsive to the observed surprise* (no credit for pivoting when there was nothing to pivot from; a penalty for ignoring a real contradiction). This is where agentic+provenance is expected to beat plain Claude Code.

### Tests / invariants

- **30 new tests** (8 subject, 7 experiment, 15 graders).
- Full orchestrator suite: **1389 passed, 2 skipped**; ruff clean.
- Bookkeeper invariant intact (`git diff main -- rka/` empty); grep-gate intact (`eval/` does not `import rka`).

### Branch routing

Pure `orchestrator/`-tree code → agentic branch, per the guardrail. No `rka/` (main-branch) code touched.

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv

---
_Generated by [Claude Code](https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv)_