### PR TITLE
test(orchestrator): CPU-only sorting-crossover subject + live-phase runbook

### DIFF
--- a/orchestrator/docs/e2e-sort-crossover-runbook.md
+++ b/orchestrator/docs/e2e-sort-crossover-runbook.md
@@ -1,0 +1,111 @@
+# End-to-end live-test runbook — sorting-crossover subject
+
+This runbook drives the agentic orchestrator through a complete computer-science
+research lifecycle — the fourteen stages from literature investigation to
+manuscript refinement — on a **CPU-only** research subject that needs no GPU, no
+model download, and no external API key. Everything the Executor must do is
+reachable with the built-in `Bash`/`Read`/`Write`/`Grep`/`Glob`/`WebSearch`
+tools it already has.
+
+It pairs with the code in
+[`orchestrator/eval/runbook_sort.py`](../orchestrator/eval/runbook_sort.py) and
+[`orchestrator/eval/sort_crossover.py`](../orchestrator/eval/sort_crossover.py).
+The PI-oracle in `runbook_sort.build_sort_oracle()` is the *reproducible*
+driver (for automated arm-A runs); a human PI following the prompts below is the
+*gold* cross-check.
+
+## The subject (open framing the agent sees)
+
+> Is quicksort an efficient general-purpose comparison sort across input sizes
+> and input orderings, or does its advantage over a simple insertion sort depend
+> on the input?
+
+Naive hypothesis (the agent's starting frame): *quicksort's O(n log n) average
+makes it use fewer comparisons than insertion sort across the board.*
+
+The **sealed** answer (graders only — do not show the agent): the advantage is a
+size × ordering **interaction**. Naive first-pivot quicksort hits its O(n²)
+worst case on nearly-sorted input where insertion sort hits its O(n) best case,
+so quicksort uses far more comparisons there; it wins only on random input. The
+comparison-count advantage flips sign with input ordering. Sealed ground-truth
+hash is published by `sort_crossover_subject().ground_truth_hash()`.
+
+## Why this subject is a good test
+
+The pivot stage is the discriminator. A plain agent tends to either (a) parrot
+the naive "quicksort is faster" framing, or (b) assert the interaction without
+evidence. The agentic system should **pivot the claim *and* record it with
+provenance** — a decision that supersedes the naive hypothesis, traceable via
+the run's `workflow_thread_id`. The three-axis grader rewards the pivot only
+when it is correct *and* provenance-backed.
+
+## Sequence of runs
+
+The PhD workflow is a **sequence** of orchestrator runs, not one graph (Phase-H
+auto-dispatch is design-only). The PI conducts the sequence.
+
+### 1. Phase-O run (idea → ratified plan → mission queue)
+
+Start: `orchestrator_onboard_start(project_id)` then drive the gates.
+
+| Gate | What to submit |
+|---|---|
+| `pi_idea_capture` | `runbook_sort.idea_capture_text("<ABSOLUTE workspace path>")` — poses the open question. **Absolute path only** (tilde breaks the bind mount). |
+| `pi_scope_ratify` | Accept; the scope note is `runbook_sort.SCOPE_NOTE`. |
+| `pi_deepresearch_prompt` | Run `runbook_sort.DEEPRESEARCH_PROMPT` (Claude Desktop deep-research, or the Executor's `WebSearch`). Accept when sources are in. |
+| `pi_claims_review` | Accept the extracted claims (should include the naive hypothesis as a *to-test* claim and the pivot-selection insight). |
+| `pi_plan_ratify` | Accept the plan whose missions match `runbook_sort.MISSION_SPECS` (M1…M5). **This is the autonomy-licensing gate.** |
+| `pi_phase_entry_ack` | Accept per milestone. |
+
+### 2. Mission runs (M1 … M5)
+
+For each spec in `runbook_sort.MISSION_SPECS`, `orchestrator_run_start(mission_id)`
+and drive its gates. The two gates that matter:
+
+- **`pi_greenlight`** — if the confirmation brief proposes an experiment that
+  varies only array *size* and ignores *ordering*, **redirect** with
+  `runbook_sort.DESIGN_REDIRECT_TEXT`. This drives the in-run
+  `confirmation_brief_redraft` loop; accept once the design includes an
+  input-ordering factor. (Most relevant in M2 *proposal-and-design*.)
+- **`pi_decision_select`** — in M3 *experiment-and-pivot*, after the experiment
+  runs, if Brain proposes the naive "quicksort is always faster" claim,
+  **redirect** with `runbook_sort.PIVOT_REDIRECT_TEXT`. This drives the
+  `mission_redraft` loop; accept once Brain re-proposes the interaction claim.
+
+The experiment the Executor actually runs in M3 is exactly
+`sort_crossover.run_sort_experiment(full_quadrant_design())` — pure Python,
+sub-second, deterministic. It will reproduce the sign flip (`sort_surprise_signal`
+returns `shape="interaction"`, `contradicts_naive=True`).
+
+### 3. Writer + revision runs
+
+- **M4 manuscript-draft** — Writer skill drafts the manuscript and the
+  comparison-count figure. (Note: `rka/skills/writer/scripts/chart_render.py` is
+  a Phase-1 stub; if diagram auto-generation is required, that is a **main-branch**
+  fix — branch from `main`, PR to `main` — not an agentic change.)
+- **M5 review-and-refine** — a revision arc; incorporate reviewer feedback,
+  scope the claim to first-pivot quicksort + the comparison-count metric, don't
+  reintroduce the overclaim.
+
+## Grading
+
+After each run, build a `RunRecord` (`from_final_state(...)` + the oracle's
+`as_dicts()`), then `graders.grade_run(record, subject=sort_crossover_subject(),
+claim_text=<final claim>, surprise=sort_surprise_signal(<result>))`.
+
+Run the reliability grader with `max_redrafts >= 4` — the design redraft (M2)
+and the pivot redraft (M3) are *expected*, not failures. Targets for a correct
+arm-A run are in `runbook_sort.GRADE_TARGETS`: capability / reliability /
+provenance all 1.0.
+
+**Arm B (plain Claude Code, no RKA)** runs the same subject without the
+orchestrator. The expected, thesis-supporting gap: comparable capability, but
+materially lower **provenance** — no recorded, traceable, superseding pivot
+decision.
+
+## Reproducibility
+
+Every run records `subject_ground_truth_hash` (seal), `workflow_thread_id`
+(provenance tag), seed, orchestrator version, and rka HEAD on its `RunRecord`.
+Because the experiment is comparison-count based, results are bit-identical
+across machines — no GPU, no wall-clock variance.

--- a/orchestrator/orchestrator/eval/__init__.py
+++ b/orchestrator/orchestrator/eval/__init__.py
@@ -9,8 +9,15 @@ bookkeeper invariant safe (no rka/ changes, no ``import rka``). Components:
                      runs are reproducible and gradeable.
   - run_record.py  — the per-run artifact schema (one JSON per orchestrator run)
                      that the graders consume.
-  - subject.py     — the sealed research-subject spec + ground-truth effect
-                     model (CoT × GSM8K, with a planted size×depth interaction).
+  - subject.py     — the (subject-agnostic) sealed research-subject spec + the
+                     CoT × GSM8K synthetic effect model.
+  - sort_crossover.py — a self-contained, CPU-only subject whose experiment is a
+                     REAL computation (instrumented insertion sort vs naive
+                     first-pivot quicksort, counting comparisons). Its planted
+                     surprise — quicksort's O(n^2) degradation on nearly-sorted
+                     input — is a genuine, reproducible phenomenon, runnable with
+                     only the Bash/Python tools the Executor already has (no GPU,
+                     no model download, no API key).
   - experiment.py  — deterministic surprising-experiment harness: synthesizes
                      results from the sealed effect model and classifies whether
                      they contradict the naive hypothesis (the pivot trigger).

--- a/orchestrator/orchestrator/eval/graders.py
+++ b/orchestrator/orchestrator/eval/graders.py
@@ -23,11 +23,22 @@ Each axis returns an ``AxisGrade`` in [0, 1] with a ``detail`` dict; the run
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
-from orchestrator.eval.experiment import SurpriseSignal
 from orchestrator.eval.run_record import RunRecord
 from orchestrator.eval.subject import SubjectSpec
+
+
+@runtime_checkable
+class SurpriseLike(Protocol):
+    """The slice of a surprise signal the provenance grader reads. Both
+    ``experiment.SurpriseSignal`` (CoT subject) and
+    ``sort_crossover.SortSurprise`` (sorting subject) satisfy it, so the grader
+    is subject-agnostic."""
+
+    shape: str
+    contradicts_naive: bool
+
 
 # Artifact kinds a full research-mission lifecycle is expected to leave behind.
 DEFAULT_EXPECTED_KINDS = ("journal", "decision", "claim", "report")
@@ -153,7 +164,7 @@ def grade_provenance(
     *,
     claim_text: str,
     subject: SubjectSpec,
-    surprise: Optional[SurpriseSignal] = None,
+    surprise: Optional[SurpriseLike] = None,
 ) -> AxisGrade:
     """Score the pivot AND its traceability.
 
@@ -212,7 +223,7 @@ def grade_run(
     *,
     subject: SubjectSpec,
     claim_text: str,
-    surprise: Optional[SurpriseSignal] = None,
+    surprise: Optional[SurpriseLike] = None,
     expected_kinds: Optional[tuple[str, ...]] = None,
     budget_usd: float = 5.0,
     max_redrafts: int = 6,

--- a/orchestrator/orchestrator/eval/runbook_sort.py
+++ b/orchestrator/orchestrator/eval/runbook_sort.py
@@ -1,0 +1,291 @@
+"""Live-phase runbook for the CPU-only sorting-crossover subject.
+
+Turns ``sort_crossover.py`` (the sealed subject + real experiment) into an
+executable end-to-end plan: the exact text the PI types at the Phase-O idea
+gate, the mission specs that cover all fourteen PhD-workflow stages, and — the
+keystone — a ``PIOracle`` rubric that makes the PI behave *correctly per the
+sealed ground truth*, including the **claim pivot** when the experiment
+contradicts the naive hypothesis.
+
+How the pieces drive the live orchestrator (each is a separate run; the PI
+conducts the sequence):
+
+  Phase-O run        idea_capture → scope → deep-research → hygiene → claims →
+                     plan synthesis → plan ratify → mission queue
+  Mission runs       M1..M5 below, each: strategy → confirmation_brief →
+                     pi_greenlight → backbrief → experiment → decision_present →
+                     pi_decision_select → synthesis → pi_acceptance
+  Writer / revision  manuscript draft (+ figure) → reviewer feedback → refine
+
+Two rubric rules exercise the parts where agentic+provenance should beat a plain
+agent:
+
+  - **demand-ordering-variation** (at ``pi_greenlight``): if a confirmation
+    brief proposes an experiment that varies only array *size* and ignores input
+    *ordering*, the PI redirects — driving the Phase-X² ``confirmation_brief_redraft``
+    loop — because a size-only design would never observe quicksort's worst case.
+  - **pivot-from-naive-claim** (at ``pi_decision_select``): if Brain proposes a
+    decision asserting the naive "quicksort is always faster" claim after the
+    results are in, the PI redirects toward the size×ordering interaction —
+    driving the v0.6.12 ``mission_redraft`` loop — until Brain re-proposes the
+    correct (pivoted) claim, which the PI then ratifies.
+
+The redirects reference only what the PI can legitimately see at that gate (the
+proposed brief / decision and, post-``mission_execute``, the observed results) —
+not the sealed effect key.
+"""
+
+from __future__ import annotations
+
+from orchestrator.eval.pi_oracle import PIOracle, Rubric, Rule
+from orchestrator.eval.sort_crossover import sort_crossover_subject
+
+# --- Phase-O entry text (agent-visible framing only; no sealed answer) ----
+
+
+def idea_capture_text(workspace_path: str = "/workspace/research/sort-crossover") -> str:
+    """The free-form idea the PI submits at ``pi_idea_capture``. Poses the OPEN
+    question + the naive assumption; deliberately does NOT state the answer.
+
+    ``workspace_path`` must be ABSOLUTE (tilde paths break the HOST_WORKSPACE_ROOT
+    bind mount per Phase D2.1)."""
+    return (
+        "I want to study whether quicksort is an efficient general-purpose "
+        "comparison sort. The common assumption is that quicksort's O(n log n) "
+        "average case makes it use fewer comparisons than a simple insertion "
+        "sort across the board. I'd like to test that assumption empirically by "
+        "instrumenting both algorithms to count element comparisons and running "
+        "them on a range of inputs, then write up what we find. "
+        f"Workspace: {workspace_path}."
+    )
+
+
+SCOPE_NOTE = (
+    "Scope: a comparison-count study of insertion sort vs a naive first-pivot "
+    "quicksort on integer arrays, varying array size and input ordering. "
+    "Out of scope: wall-clock benchmarking, cache effects, parallel sorts, and "
+    "non-comparison sorts (radix/counting)."
+)
+
+DEEPRESEARCH_PROMPT = (
+    "Survey the literature on comparison-sort performance: the average- and "
+    "worst-case comparison complexity of quicksort and insertion sort; how pivot "
+    "selection (first/last element vs median-of-three vs randomized) changes "
+    "quicksort's worst case; and why production sorts hybridize (introsort, "
+    "Timsort) and fall back to insertion sort for small or nearly-sorted inputs. "
+    "Collect citations with their key findings."
+)
+
+# --- PI redirect texts (drive the redraft loops) --------------------------
+
+DESIGN_REDIRECT_TEXT = (
+    "This design only varies array size, so it cannot detect input-ordering "
+    "effects. Vary input ordering too — include nearly-sorted (and ideally "
+    "already-sorted) inputs alongside random ones — otherwise the experiment "
+    "will miss the worst-case behavior that separates these algorithms. Redraft "
+    "the brief with an explicit input-ordering factor."
+)
+
+PIVOT_REDIRECT_TEXT = (
+    "The results contradict 'quicksort is always faster': on nearly-sorted "
+    "inputs the first-pivot quicksort used far MORE comparisons than insertion "
+    "sort (its O(n^2) worst case), while it won on random inputs. Pivot the claim "
+    "from a uniform advantage to the size-by-ordering interaction — quicksort's "
+    "comparison-count advantage crosses over with input ordering, and nearly-"
+    "sorted input is its worst case. Re-propose the decision naming the "
+    "interaction."
+)
+
+
+# --- the oracle (the keystone) -------------------------------------------
+
+
+def build_sort_oracle() -> PIOracle:
+    """A subject-aware PI responder for the sorting runbook. Accepts good
+    proposals, redirects a size-only experiment design, and redirects a naive
+    final claim toward the pivoted interaction claim — recording every decision
+    for grading. Naive/interaction vocabularies are sourced from the sealed
+    subject so the rubric stays in sync with the answer key."""
+    subject = sort_crossover_subject()
+    rules = [
+        # Research-design quality gate: demand an ordering factor.
+        Rule(
+            type="pi_greenlight",
+            action="correct",
+            label="demand-ordering-variation",
+            contains_any=["experiment", "benchmark", "measur", "design", "plan", "evaluat"],
+            not_contains=["nearly-sorted", "ordering", "ordered", "presort"],
+            correct_text=DESIGN_REDIRECT_TEXT,
+        ),
+        # The pivot: redirect a naive claim that lacks the interaction framing.
+        Rule(
+            type="pi_decision_select",
+            action="correct",
+            label="pivot-from-naive-claim",
+            contains_any=subject.forbidden_claim_keywords,
+            not_contains=subject.required_claim_keywords,
+            correct_text=PIVOT_REDIRECT_TEXT,
+        ),
+        # Ratify a decision that names the interaction (the pivoted claim).
+        Rule(
+            type="pi_decision_select",
+            action="accept",
+            label="ratify-interaction-claim",
+            contains_any=subject.required_claim_keywords,
+        ),
+    ]
+    return PIOracle(Rubric(rules=rules, default_action="accept"))
+
+
+# --- mission specs: the fourteen stages → five missions -------------------
+#
+# Each spec maps to rka_create_mission kwargs (objective + phase/tags +
+# scope_boundaries/checkpoint_triggers as mission metadata). `stages` records
+# which of the 14 PhD-workflow stages the mission covers; `depends_on` chains
+# the milestone DAG; `expected_artifact_kinds` feeds the capability grader.
+
+MISSION_SPECS: list[dict] = [
+    {
+        "name": "literature-and-framing",
+        "objective": (
+            "Survey comparison-sort performance literature, frame the research "
+            "question (is quicksort efficient across input distributions?), and "
+            "identify the open problem and the key insight that pivot choice and "
+            "input ordering may govern the answer."
+        ),
+        "stages": [
+            "literature investigation", "frame pitch", "problem finding",
+            "insight discovery",
+        ],
+        "tasks": [
+            "Search and ingest prior work on quicksort/insertion-sort comparison complexity.",
+            "Record the naive hypothesis as a decision (to be tested, not assumed).",
+            "Surface the pivot-selection / hybrid-sort literature as the insight seed.",
+        ],
+        "scope_boundaries": ["comparison counts only; no wall-clock or hardware claims"],
+        "checkpoint_triggers": ["if the literature already settles the question, checkpoint"],
+        "capabilities": ["record_knowledge"],
+        "depends_on": [],
+        "expected_artifact_kinds": ("journal", "decision", "claim"),
+    },
+    {
+        "name": "proposal-and-design",
+        "objective": (
+            "Write a small proposal and design the experiment: a full factorial "
+            "over algorithm (insertion vs first-pivot quicksort) x size x input "
+            "ordering, measured in element comparisons. Refine the literature "
+            "with pivot-selection sources."
+        ),
+        "stages": [
+            "small pitch proposal generation", "research design",
+            "evidence collection and literature refinement", "experiment design",
+        ],
+        "tasks": [
+            "Draft the proposal as a decision.",
+            "Specify the factorial design INCLUDING an input-ordering factor "
+            "(random AND nearly-sorted) — not size alone.",
+            "Add the pivot-selection citations missed in M1.",
+        ],
+        "scope_boundaries": ["design must vary input ordering, not only size"],
+        "checkpoint_triggers": ["if a sound design cannot be specified, checkpoint"],
+        "capabilities": ["record_knowledge"],
+        "depends_on": ["literature-and-framing"],
+        "expected_artifact_kinds": ("journal", "decision"),
+    },
+    {
+        "name": "experiment-and-pivot",
+        "objective": (
+            "Conduct the experiment (instrument both sorts, count comparisons "
+            "across the factorial), interpret the results, and — if they "
+            "contradict the naive hypothesis — pivot the claim to the "
+            "size-by-ordering interaction, recording the pivot as a decision."
+        ),
+        "stages": [
+            "experiment conduction", "result interpretation", "claim pitch pivot",
+        ],
+        "tasks": [
+            "Run insertion_sort and first-pivot quicksort, counting comparisons, "
+            "across random and nearly-sorted inputs at two sizes.",
+            "Interpret the comparison-count quadrant; note the sign flip on "
+            "nearly-sorted input.",
+            "Pivot the claim from 'quicksort always wins' to the interaction, and "
+            "record it as a decision that supersedes the naive hypothesis.",
+        ],
+        "scope_boundaries": ["claim must follow the observed comparison counts"],
+        "checkpoint_triggers": [
+            "if results are ambiguous or the sort is incorrect, checkpoint",
+        ],
+        "capabilities": ["record_knowledge", "execution_gates"],
+        "depends_on": ["proposal-and-design"],
+        "expected_artifact_kinds": ("journal", "decision", "claim", "report"),
+    },
+    {
+        "name": "manuscript-draft",
+        "objective": (
+            "Draft a short manuscript reporting the interaction finding, with a "
+            "comparison-count figure (quicksort advantage vs input ordering), "
+            "citing the surfaced literature."
+        ),
+        "stages": ["manuscript drafting with diagram generation"],
+        "tasks": [
+            "Draft the manuscript sections from the recorded claims + report.",
+            "Generate the comparison-count figure.",
+            "Ensure every quantitative claim cites a recorded result.",
+        ],
+        "scope_boundaries": ["only claims backed by the recorded experiment"],
+        "checkpoint_triggers": ["if a claim lacks provenance, checkpoint"],
+        "capabilities": ["record_knowledge"],
+        "depends_on": ["experiment-and-pivot"],
+        "expected_artifact_kinds": ("manuscript", "diagram", "report"),
+    },
+    {
+        "name": "review-and-refine",
+        "objective": (
+            "Incorporate reviewer feedback and refine the manuscript: address "
+            "concerns about pivot-choice generality and the comparison-count "
+            "(vs wall-clock) metric, without overclaiming."
+        ),
+        "stages": ["reviewers feedback", "manuscript refinement"],
+        "tasks": [
+            "Triage reviewer comments into a decision list.",
+            "Refine the manuscript; scope the claim to first-pivot quicksort and "
+            "the comparison-count metric.",
+            "Record what changed and why as decisions.",
+        ],
+        "scope_boundaries": ["refinement must not reintroduce the naive overclaim"],
+        "checkpoint_triggers": ["if a reviewer demand conflicts with the data, checkpoint"],
+        "capabilities": ["record_knowledge"],
+        "depends_on": ["manuscript-draft"],
+        "expected_artifact_kinds": ("journal", "decision", "manuscript"),
+    },
+]
+
+
+def mission_spec(name: str) -> dict:
+    for m in MISSION_SPECS:
+        if m["name"] == name:
+            return m
+    raise KeyError(name)
+
+
+# All fourteen workflow stages the runbook must cover, in order.
+ALL_STAGES: tuple[str, ...] = (
+    "literature investigation", "frame pitch", "problem finding",
+    "insight discovery", "small pitch proposal generation", "research design",
+    "evidence collection and literature refinement", "experiment design",
+    "experiment conduction", "result interpretation", "claim pitch pivot",
+    "manuscript drafting with diagram generation", "reviewers feedback",
+    "manuscript refinement",
+)
+
+
+# Expected per-axis grades for a correct agentic (arm A) run. Arm B (plain
+# Claude Code, no RKA) is expected to score well on capability but materially
+# lower on provenance (no recorded, traceable pivot) — that gap is the thesis.
+GRADE_TARGETS = {
+    "arm_A_agentic": {"capability": 1.0, "reliability": 1.0, "provenance": 1.0},
+    # The design + pivot redrafts are EXPECTED, so the reliability grader should
+    # be run with a redraft budget that allows them (max_redrafts >= 2).
+    "expected_redrafts": {"greenlight_design": 1, "decision_pivot": 1},
+    "min_reliability_max_redrafts": 4,
+}

--- a/orchestrator/orchestrator/eval/sort_crossover.py
+++ b/orchestrator/orchestrator/eval/sort_crossover.py
@@ -1,0 +1,348 @@
+"""Sorting-crossover subject — a REAL, CPU-only, fully reproducible experiment.
+
+Unlike the CoT×GSM8K subject (whose live experiment needs a GPU + an LLM), this
+subject's experiment is pure Python on CPU: it instruments insertion sort and a
+naive first-pivot quicksort, counts the exact number of element comparisons each
+performs, and compares them across input size × input ordering. Comparison count
+(not wall-clock time) is the cost metric, so results are *exactly* reproducible —
+no timing noise, no hardware dependence. Everything here runs in well under a
+second and uses only the Bash/Python tools the orchestrator's Executor already
+has; nothing is downloaded, no API key is needed.
+
+The planted surprise is a REAL, textbook phenomenon, not a synthetic effect:
+
+  - Naive first-pivot quicksort degrades to its O(n^2) WORST case on sorted /
+    nearly-sorted input — precisely the input a naive researcher expects to be
+    "easy" — because every pivot is near-extremal and partitions are maximally
+    unbalanced.
+  - Insertion sort hits its O(n) BEST case on that same nearly-sorted input.
+  - So the comparison-count advantage of quicksort over insertion sort FLIPS
+    sign: quicksort wins big on large random arrays (the headline) but loses on
+    nearly-sorted input and on small arrays. An interaction between algorithm,
+    size, and input ordering — not the uniform "quicksort is faster" main effect.
+
+This is exactly why production sorts hybridize and harden the pivot (introsort,
+Timsort, median-of-three) — strong, web-searchable literature anchors that a
+thorough review surfaces.
+
+The 2x2 result quadrant mirrors the CoT subject's structure (one cell positive,
+three negative), so the same ``graders.py`` scores it unchanged.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+from orchestrator.eval.subject import LiteratureAnchor, SubjectSpec
+
+# Size tiers (element counts) and the orderings probed.
+SMALL_N = 12
+LARGE_N = 384
+NEARLY_SORTED_SWAP_FRAC = 0.05      # fraction of n random transpositions
+
+
+# --- instrumented sorts (count element comparisons) ----------------------
+
+
+def insertion_sort_comparisons(arr: list[int]) -> tuple[list[int], int]:
+    """Insertion sort; returns (sorted_copy, comparison_count). O(n) on already-
+    sorted input (one comparison per element), O(n^2) worst case."""
+    a = list(arr)
+    comparisons = 0
+    for i in range(1, len(a)):
+        key = a[i]
+        j = i - 1
+        while j >= 0:
+            comparisons += 1
+            if a[j] > key:
+                a[j + 1] = a[j]
+                j -= 1
+            else:
+                break
+        a[j + 1] = key
+    return a, comparisons
+
+
+def quicksort_first_pivot_comparisons(arr: list[int]) -> tuple[list[int], int]:
+    """Quicksort with a naive first-element pivot, explicit stack (no recursion
+    limit). Returns (sorted_copy, comparison_count). Degrades to O(n^2) on
+    sorted / nearly-sorted input because the pivot is always near-extremal."""
+    a = list(arr)
+    comparisons = 0
+    stack: list[tuple[int, int]] = [(0, len(a) - 1)]
+    while stack:
+        lo, hi = stack.pop()
+        if lo >= hi:
+            continue
+        pivot = a[lo]
+        store = lo + 1
+        for i in range(lo + 1, hi + 1):
+            comparisons += 1
+            if a[i] < pivot:
+                a[i], a[store] = a[store], a[i]
+                store += 1
+        a[lo], a[store - 1] = a[store - 1], a[lo]
+        p = store - 1
+        stack.append((lo, p - 1))
+        stack.append((p + 1, hi))
+    return a, comparisons
+
+
+# --- deterministic input generation --------------------------------------
+
+
+def make_array(n: int, ordering: str, seed: int) -> list[int]:
+    """Deterministic input of the requested ordering. ``ordering`` ∈
+    {"random", "nearly_sorted", "sorted", "reversed"}."""
+    rng = random.Random(seed)
+    base = list(range(n))
+    if ordering == "sorted":
+        return base
+    if ordering == "reversed":
+        return base[::-1]
+    if ordering == "random":
+        arr = base[:]
+        rng.shuffle(arr)
+        return arr
+    if ordering == "nearly_sorted":
+        arr = base[:]
+        for _ in range(max(1, int(n * NEARLY_SORTED_SWAP_FRAC))):
+            i, j = rng.randrange(n), rng.randrange(n)
+            arr[i], arr[j] = arr[j], arr[i]
+        return arr
+    raise ValueError(f"unknown ordering {ordering!r}")
+
+
+# --- experiment design + run ---------------------------------------------
+
+
+@dataclass(frozen=True)
+class SortCell:
+    """One (size, ordering) cell; both algorithms are run on identical inputs."""
+
+    n: int
+    ordering: str
+
+
+@dataclass(frozen=True)
+class SortDesign:
+    label: str
+    cells: list[SortCell] = field(default_factory=list)
+
+    def size_tiers(self) -> set[int]:
+        return {c.n for c in self.cells}
+
+    def orderings(self) -> set[str]:
+        return {c.ordering for c in self.cells}
+
+
+@dataclass(frozen=True)
+class SortCellResult:
+    n: int
+    ordering: str
+    insertion_comparisons: float
+    quicksort_comparisons: float
+
+    @property
+    def quicksort_advantage(self) -> float:
+        """Fewer comparisons for quicksort ⇒ positive ⇒ quicksort better."""
+        return round(self.insertion_comparisons - self.quicksort_comparisons, 2)
+
+
+@dataclass(frozen=True)
+class SortResult:
+    design_label: str
+    seed: int
+    n_trials: int
+    cells: list[SortCellResult]
+
+    def by_cell(self) -> dict[tuple[int, str], float]:
+        return {(c.n, c.ordering): c.quicksort_advantage for c in self.cells}
+
+
+def run_sort_experiment(
+    design: SortDesign, *, seed: int = 0, n_trials: int = 5
+) -> SortResult:
+    """Actually run both sorts on freshly generated inputs and count
+    comparisons, averaging across ``n_trials`` seeded inputs per cell. Verifies
+    each sort returns correctly-ordered output (a broken experiment is not a
+    valid one)."""
+    out: list[SortCellResult] = []
+    for cell in design.cells:
+        ins_total = 0
+        qs_total = 0
+        for t in range(n_trials):
+            arr = make_array(cell.n, cell.ordering, seed=seed * 1000 + t)
+            ins_sorted, ins_c = insertion_sort_comparisons(arr)
+            qs_sorted, qs_c = quicksort_first_pivot_comparisons(arr)
+            assert ins_sorted == sorted(arr), "insertion sort produced wrong order"
+            assert qs_sorted == sorted(arr), "quicksort produced wrong order"
+            ins_total += ins_c
+            qs_total += qs_c
+        out.append(
+            SortCellResult(
+                n=cell.n,
+                ordering=cell.ordering,
+                insertion_comparisons=round(ins_total / n_trials, 2),
+                quicksort_comparisons=round(qs_total / n_trials, 2),
+            )
+        )
+    return SortResult(
+        design_label=design.label, seed=seed, n_trials=n_trials, cells=out
+    )
+
+
+# --- surprise classification (grader-compatible: .shape + .contradicts_naive) ---
+
+
+@dataclass(frozen=True)
+class SortSurprise:
+    """Structurally compatible with ``graders.SurpriseLike`` (exposes ``shape``
+    and ``contradicts_naive``). ``quicksort_advantage`` maps (n, ordering) → the
+    observed comparison-count advantage of quicksort over insertion sort."""
+
+    shape: str
+    contradicts_naive: bool
+    quicksort_advantage: dict[tuple[int, str], float]
+    observed_sign_flip: bool
+    detail: dict = field(default_factory=dict)
+
+
+def sort_surprise_signal(result: SortResult) -> SortSurprise:
+    """Classify the observed quadrant against the naive 'quicksort is faster
+    everywhere' frame. Any cell where quicksort uses MORE comparisons (negative
+    advantage) breaks the naive frame; a mix of signs is the planted
+    interaction."""
+    deltas = result.by_cell()
+    if not deltas:
+        return SortSurprise("underpowered", False, {}, False,
+                            {"reason": "no cells"})
+    has_pos = any(d > 0 for d in deltas.values())
+    has_neg = any(d < 0 for d in deltas.values())
+    sign_flip = has_pos and has_neg
+    if sign_flip:
+        shape = "interaction"
+    elif has_neg and not has_pos:
+        shape = "uniform_quicksort_worse"
+    elif has_pos and not has_neg:
+        shape = "confirms_naive"
+    else:
+        shape = "underpowered"
+    return SortSurprise(
+        shape=shape,
+        contradicts_naive=has_neg,
+        quicksort_advantage=deltas,
+        observed_sign_flip=sign_flip,
+        detail={
+            "n_cells": len(deltas),
+            "n_quicksort_worse": sum(1 for d in deltas.values() if d < 0),
+            "n_quicksort_better": sum(1 for d in deltas.values() if d > 0),
+        },
+    )
+
+
+# --- canonical designs ----------------------------------------------------
+
+
+def full_quadrant_design() -> SortDesign:
+    """The *good* design: both size tiers × {random, nearly_sorted}. Observes
+    the full sign flip → forces the pivot."""
+    return SortDesign(
+        label="full-quadrant",
+        cells=[
+            SortCell(SMALL_N, "random"),
+            SortCell(SMALL_N, "nearly_sorted"),
+            SortCell(LARGE_N, "random"),
+            SortCell(LARGE_N, "nearly_sorted"),
+        ],
+    )
+
+
+def naive_design() -> SortDesign:
+    """The *weak* design: only the large random array, where quicksort shines.
+    Confirms the naive frame by omission and misses the surprise."""
+    return SortDesign(label="naive-large-random-only", cells=[SortCell(LARGE_N, "random")])
+
+
+# --- the subject ----------------------------------------------------------
+
+
+def sort_crossover_subject() -> SubjectSpec:
+    """Self-contained, CPU-only research subject — quicksort vs insertion sort
+    with a planted size × ordering interaction (real comparison-count sign flip)."""
+    return SubjectSpec(
+        subject_id="sort-crossover",
+        title="Quicksort efficiency across input distributions",
+        research_question=(
+            "Is quicksort an efficient general-purpose comparison sort across "
+            "input sizes and input orderings, or does its advantage over a "
+            "simple insertion sort depend on the input?"
+        ),
+        naive_hypothesis=(
+            "Quicksort's O(n log n) average-case running time makes it use fewer "
+            "comparisons than insertion sort's O(n^2) across input sizes and "
+            "orderings."
+        ),
+        ground_truth_claim=(
+            "Whether quicksort beats insertion sort is an interaction between the "
+            "algorithm and the input's existing order, not a main effect. A naive "
+            "first-pivot quicksort hits its O(n^2) worst case on sorted / "
+            "nearly-sorted input — where insertion sort hits its O(n) best case — "
+            "so it uses far MORE comparisons there, at both small and large sizes. "
+            "Quicksort wins only on unordered (random) input. The comparison-count "
+            "advantage exhibits a crossover (it flips sign) as input ordering "
+            "changes, which is why production sorts hybridize with insertion sort "
+            "and harden the pivot (introsort, Timsort, median-of-three)."
+        ),
+        effect=None,  # the experiment is a REAL computation, not a synthetic model
+        sealed_extra={
+            "metric": "element_comparisons",
+            "small_n": SMALL_N,
+            "large_n": LARGE_N,
+            # Empirically measured (stable across 12 seeds): the sign flip is
+            # driven by input ORDERING — quicksort wins on random input at both
+            # sizes and loses on nearly-sorted input at both sizes. (The classic
+            # "insertion wins for small n" is a wall-clock constant-factor effect,
+            # not a comparison-count one, so it does not appear in this metric.)
+            "quadrant_quicksort_advantage_sign": {
+                "small/random": "positive",
+                "small/nearly_sorted": "negative",
+                "large/random": "positive",
+                "large/nearly_sorted": "negative",
+            },
+            "headline_win_cell": "large/random",
+        },
+        literature_anchors=[
+            LiteratureAnchor(
+                "hoare1962quicksort",
+                "Quicksort: partition-exchange sort with O(n log n) average comparisons.",
+                supports_cot=True,
+            ),
+            LiteratureAnchor(
+                "sedgewick1978implementing",
+                "Pivot choice is decisive: a first/last-element pivot makes already-sorted "
+                "input the O(n^2) worst case.",
+                supports_cot=False,
+                hints_interaction=True,
+            ),
+            LiteratureAnchor(
+                "musser1997introspective",
+                "Introsort caps quicksort's worst case by switching to heapsort, and to "
+                "insertion sort on small subarrays.",
+                supports_cot=False,
+                hints_interaction=True,
+            ),
+            LiteratureAnchor(
+                "peters2002timsort",
+                "Timsort uses insertion sort for small runs and exploits existing order, "
+                "so nearly-sorted input is its best case.",
+                supports_cot=False,
+                hints_interaction=True,
+            ),
+        ],
+        required_claim_keywords=["interaction", "nearly-sorted", "worst case", "crossover"],
+        forbidden_claim_keywords=[
+            "always faster", "always fastest", "uniformly faster", "regardless of input",
+        ],
+    )

--- a/orchestrator/orchestrator/eval/subject.py
+++ b/orchestrator/orchestrator/eval/subject.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -119,12 +120,20 @@ class SubjectSpec:
     research_question: str
     naive_hypothesis: str          # the frame the agent starts from
     ground_truth_claim: str        # SEALED — the correct pivoted claim
-    effect: EffectModel
+    # ``effect`` is the CoT subject's synthetic data-generating process. Subjects
+    # whose experiment is a REAL computation (e.g. the sorting-crossover subject,
+    # which actually counts comparisons) leave it None and instead describe their
+    # sealed answer in ``sealed_extra``.
+    effect: Optional[EffectModel] = None
     literature_anchors: list[LiteratureAnchor] = field(default_factory=list)
 
     # grading vocabulary (sealed answer key for the claim graders)
     required_claim_keywords: list[str] = field(default_factory=list)
     forbidden_claim_keywords: list[str] = field(default_factory=list)
+
+    # subject-specific sealed ground truth for subjects that don't use ``effect``
+    # (e.g. the sorting crossover quadrant thresholds). Folded into the hash.
+    sealed_extra: dict = field(default_factory=dict)
 
     # --- the open (agent-visible) framing vs. the sealed answer ---
     def public_framing(self) -> dict:
@@ -141,10 +150,14 @@ class SubjectSpec:
 
     def _sealed_fields(self) -> dict:
         """The fields the agent must NOT see — hashed for integrity."""
-        e = self.effect
-        return {
+        sealed: dict = {
             "ground_truth_claim": self.ground_truth_claim,
-            "effect": {
+            "required_claim_keywords": sorted(self.required_claim_keywords),
+            "forbidden_claim_keywords": sorted(self.forbidden_claim_keywords),
+        }
+        if self.effect is not None:
+            e = self.effect
+            sealed["effect"] = {
                 "size_threshold_b": e.size_threshold_b,
                 "step_threshold": e.step_threshold,
                 "base_floor": e.base_floor,
@@ -154,10 +167,10 @@ class SubjectSpec:
                 "delta_large_single": e.delta_large_single,
                 "delta_small_multi": e.delta_small_multi,
                 "delta_small_single": e.delta_small_single,
-            },
-            "required_claim_keywords": sorted(self.required_claim_keywords),
-            "forbidden_claim_keywords": sorted(self.forbidden_claim_keywords),
-        }
+            }
+        if self.sealed_extra:
+            sealed["sealed_extra"] = self.sealed_extra
+        return sealed
 
     def ground_truth_hash(self) -> str:
         blob = json.dumps(self._sealed_fields(), sort_keys=True).encode("utf-8")

--- a/orchestrator/tests/test_eval_runbook_sort.py
+++ b/orchestrator/tests/test_eval_runbook_sort.py
@@ -1,0 +1,164 @@
+"""Tests for the sorting-crossover live-phase runbook.
+
+Pins the keystone: the oracle rubric demands an ordering-varying design and
+pivots a naive final claim toward the interaction. Also smoke-drives the real
+mission graph to terminal with the runbook oracle, and checks the mission specs
+cover all fourteen workflow stages without leaking the sealed answer.
+"""
+
+from __future__ import annotations
+
+from orchestrator import graph
+from orchestrator.eval.run_record import RunRecord
+from orchestrator.eval.runbook_sort import (
+    ALL_STAGES,
+    DEEPRESEARCH_PROMPT,
+    MISSION_SPECS,
+    build_sort_oracle,
+    idea_capture_text,
+    mission_spec,
+)
+from orchestrator.eval.sort_crossover import sort_crossover_subject
+from orchestrator.runner import REDIRECT_SENTINEL
+from orchestrator.state import make_initial_state
+from tests._fakes import FakeMCP, FakeSDK
+
+
+# --- the design-quality gate ---------------------------------------------
+
+
+def test_oracle_redirects_size_only_design_at_greenlight():
+    oracle = build_sort_oracle()
+    tok = oracle({
+        "type": "pi_greenlight",
+        "brief": "We will design an experiment to benchmark quicksort vs "
+                 "insertion sort by varying the array size.",
+    })
+    assert tok.startswith(REDIRECT_SENTINEL)
+    assert oracle.log[-1].rule_label == "demand-ordering-variation"
+    assert "input-ordering" in tok
+
+
+def test_oracle_accepts_design_that_varies_ordering():
+    oracle = build_sort_oracle()
+    tok = oracle({
+        "type": "pi_greenlight",
+        "brief": "Design: full factorial over algorithm x size x input ordering "
+                 "(random and nearly-sorted), counting comparisons.",
+    })
+    assert tok == "approve"
+    assert not tok.startswith(REDIRECT_SENTINEL)
+
+
+# --- the pivot (the centerpiece) -----------------------------------------
+
+
+def test_oracle_pivots_naive_decision():
+    oracle = build_sort_oracle()
+    tok = oracle({
+        "type": "pi_decision_select",
+        "decision": "Adopt the conclusion: quicksort is always faster than "
+                    "insertion sort regardless of input.",
+    })
+    assert tok.startswith(REDIRECT_SENTINEL)
+    assert oracle.log[-1].rule_label == "pivot-from-naive-claim"
+    assert "interaction" in tok and "nearly-sorted" in tok
+
+
+def test_oracle_ratifies_interaction_decision():
+    oracle = build_sort_oracle()
+    tok = oracle({
+        "type": "pi_decision_select",
+        "decision": "Adopt the conclusion: the advantage is a size-by-ordering "
+                    "interaction; first-pivot quicksort hits its worst case on "
+                    "nearly-sorted input while insertion sort hits its best case.",
+    })
+    assert tok == "accept"
+    assert oracle.log[-1].rule_label == "ratify-interaction-claim"
+
+
+def test_oracle_records_every_decision():
+    oracle = build_sort_oracle()
+    oracle({"type": "pi_greenlight", "brief": "benchmark by array size only"})
+    oracle({"type": "pi_decision_select", "decision": "quicksort is always fastest"})
+    assert [d.action for d in oracle.log] == ["correct", "correct"]
+    assert all(d.token.startswith(REDIRECT_SENTINEL) for d in oracle.log)
+
+
+# --- real-graph smoke -----------------------------------------------------
+
+
+def test_runbook_oracle_drives_real_graph_to_terminal():
+    # Generic canned content matches none of the redirect rules, so the run
+    # proceeds on the default-accept path to a clean terminal.
+    sdk = FakeSDK(canned_reply="APPROVED\nLooks fine.")
+    mcp = FakeMCP()
+    ckpt = graph.open_checkpointer(None)
+    oracle = build_sort_oracle()
+    g = graph.build_graph(sdk=sdk, mcp=mcp, checkpointer=ckpt, interrupt_fn=oracle)
+    final = g.invoke(
+        make_initial_state(
+            workflow_thread_id="thr_runbook",
+            mission_id="mis_runbook",
+            motivated_by_decision_id="dec_runbook",
+            project_id="prj_sort",
+        ),
+        config={"configurable": {"thread_id": "thr_runbook"}},
+    )
+    assert final["terminal_state"] == "complete"
+    # No spurious redirects on generic content.
+    assert oracle.corrections() == []
+    # And the run is recordable.
+    rec = RunRecord.from_final_state(
+        arc="mission", run_label="runbook-smoke", final_state=final,
+        oracle_decisions=oracle.as_dicts(),
+    )
+    assert rec.terminal_state == "complete"
+    assert rec.workflow_thread_id == "thr_runbook"
+
+
+# --- runbook coverage + no leakage ---------------------------------------
+
+
+def test_mission_specs_cover_all_fourteen_stages():
+    covered = [s for m in MISSION_SPECS for s in m["stages"]]
+    assert set(covered) == set(ALL_STAGES)
+    assert len(covered) == len(ALL_STAGES)        # no stage covered twice
+
+
+def test_mission_specs_are_well_formed_and_chained():
+    names = [m["name"] for m in MISSION_SPECS]
+    assert len(names) == len(set(names))          # unique
+    for m in MISSION_SPECS:
+        assert m["objective"] and m["tasks"]
+        for dep in m["depends_on"]:
+            assert dep in names                   # deps resolve
+    # The pivot mission depends on the design mission (so it cannot run first).
+    assert mission_spec("experiment-and-pivot")["depends_on"] == ["proposal-and-design"]
+
+
+def test_idea_capture_and_deepresearch_do_not_leak_the_answer():
+    # Use a neutral workspace path so the project slug ("sort-crossover") does
+    # not pollute the substantive-text leak check.
+    flat = (idea_capture_text("/ws") + " " + DEEPRESEARCH_PROMPT).lower()
+    # The OPEN question is present...
+    assert "quicksort" in flat and "insertion sort" in flat
+    # ...but the sealed pivoted answer is NOT pre-stated.
+    for leak in ("interaction", "worst case on nearly-sorted", "crossover", "flips sign"):
+        assert leak not in flat
+
+
+def test_idea_capture_path_is_absolute():
+    # Tilde paths break the HOST_WORKSPACE_ROOT bind mount (Phase D2.1).
+    assert "~" not in idea_capture_text()
+    assert idea_capture_text("/abs/ws").endswith("/abs/ws.")
+
+
+def test_pivot_vocabulary_tracks_the_sealed_subject():
+    # The rubric's pivot trigger must use the subject's own naive/interaction
+    # vocabulary so it cannot drift out of sync with the answer key.
+    subject = sort_crossover_subject()
+    oracle = build_sort_oracle()
+    naive_phrase = subject.forbidden_claim_keywords[0]
+    tok = oracle({"type": "pi_decision_select", "decision": f"Conclusion: quicksort {naive_phrase}."})
+    assert tok.startswith(REDIRECT_SENTINEL)

--- a/orchestrator/tests/test_eval_sort_crossover.py
+++ b/orchestrator/tests/test_eval_sort_crossover.py
@@ -1,0 +1,172 @@
+"""Tests for the sorting-crossover subject — a REAL, CPU-only experiment.
+
+These assert the planted surprise is a genuine, reproducible empirical
+phenomenon (not a synthetic effect): the comparison-count advantage of quicksort
+over insertion sort really flips sign across input size × ordering.
+"""
+
+from __future__ import annotations
+
+from orchestrator.eval.graders import grade_provenance, grade_run
+from orchestrator.eval.run_record import RunRecord
+from orchestrator.eval.sort_crossover import (
+    LARGE_N,
+    SMALL_N,
+    full_quadrant_design,
+    insertion_sort_comparisons,
+    make_array,
+    naive_design,
+    quicksort_first_pivot_comparisons,
+    run_sort_experiment,
+    sort_crossover_subject,
+    sort_surprise_signal,
+)
+
+PIVOTED_CLAIM = (
+    "Quicksort vs insertion sort is an interaction between size and ordering: "
+    "naive first-pivot quicksort hits its worst case on nearly-sorted input and "
+    "the comparison-count advantage crosses over."
+)
+NAIVE_CLAIM = "Quicksort is always faster than insertion sort regardless of input."
+
+
+# --- the instrumented sorts are correct + count as expected ---------------
+
+
+def test_both_sorts_produce_correct_order():
+    for ordering in ("random", "nearly_sorted", "sorted", "reversed"):
+        arr = make_array(40, ordering, seed=1)
+        ins_sorted, _ = insertion_sort_comparisons(arr)
+        qs_sorted, _ = quicksort_first_pivot_comparisons(arr)
+        assert ins_sorted == sorted(arr)
+        assert qs_sorted == sorted(arr)
+
+
+def test_insertion_sort_is_linear_on_sorted_input():
+    arr = make_array(100, "sorted", seed=0)
+    _, comparisons = insertion_sort_comparisons(arr)
+    assert comparisons == 99            # exactly n-1: O(n) best case
+
+
+def test_quicksort_first_pivot_is_quadratic_on_sorted_input():
+    n = 100
+    arr = make_array(n, "sorted", seed=0)
+    _, qs = quicksort_first_pivot_comparisons(arr)
+    _, ins = insertion_sort_comparisons(arr)
+    # First-pivot quicksort degrades to ~n(n-1)/2 on sorted input...
+    assert qs == n * (n - 1) // 2
+    # ...far worse than insertion sort's O(n) there.
+    assert qs > 40 * ins
+
+
+# --- the planted surprise is REAL + reproducible --------------------------
+
+
+def test_full_quadrant_observes_real_sign_flip():
+    sig = sort_surprise_signal(run_sort_experiment(full_quadrant_design(), seed=7))
+    assert sig.shape == "interaction"
+    assert sig.contradicts_naive is True
+    assert sig.observed_sign_flip is True
+    adv = sig.quicksort_advantage
+    # Quicksort wins on random input (the headline) at BOTH sizes...
+    assert adv[(LARGE_N, "random")] > 0
+    assert adv[(SMALL_N, "random")] > 0
+    # ...and the surprise: nearly-sorted breaks quicksort at BOTH sizes.
+    assert adv[(LARGE_N, "nearly_sorted")] < 0
+    assert adv[(SMALL_N, "nearly_sorted")] < 0
+    # Ordering-driven sign flip: 2 wins, 2 losses.
+    assert sig.detail["n_quicksort_better"] == 2
+    assert sig.detail["n_quicksort_worse"] == 2
+
+
+def test_experiment_is_deterministic():
+    r1 = run_sort_experiment(full_quadrant_design(), seed=3)
+    r2 = run_sort_experiment(full_quadrant_design(), seed=3)
+    assert r1.by_cell() == r2.by_cell()
+
+
+def test_sign_flip_is_robust_across_seeds():
+    for seed in range(8):
+        sig = sort_surprise_signal(run_sort_experiment(full_quadrant_design(), seed=seed))
+        assert sig.shape == "interaction"
+        assert sig.quicksort_advantage[(LARGE_N, "random")] > 0
+        assert sig.quicksort_advantage[(LARGE_N, "nearly_sorted")] < 0
+
+
+def test_naive_design_misses_the_surprise():
+    sig = sort_surprise_signal(run_sort_experiment(naive_design(), seed=7))
+    assert sig.shape == "confirms_naive"
+    assert sig.contradicts_naive is False
+    assert sig.observed_sign_flip is False
+
+
+# --- subject framing + sealing -------------------------------------------
+
+
+def test_public_framing_hides_the_sealed_quadrant():
+    s = sort_crossover_subject()
+    pub = s.public_framing()
+    flat = str(pub).lower()
+    # The sealed quadrant + the distinctive sealed-claim phrasing must not leak.
+    # (The word "crossover" appears in the public subject_id, which is fine — it
+    # names the subject; it does not reveal the answer.)
+    assert "quadrant_quicksort_advantage_sign" not in flat
+    assert "flips sign" not in flat
+    assert "interaction between" not in flat
+    assert "quicksort" in flat                # but the question IS visible
+    assert len(pub["literature_anchors"]) == 4
+
+
+def test_ground_truth_hash_stable_and_seals_quadrant():
+    s1 = sort_crossover_subject()
+    s2 = sort_crossover_subject()
+    assert s1.ground_truth_hash() == s2.ground_truth_hash()
+    assert len(s1.ground_truth_hash()) == 64
+    # The sealed quadrant participates in the hash.
+    import dataclasses
+
+    tampered = dataclasses.replace(
+        s1, sealed_extra={**s1.sealed_extra, "headline_win_cell": "small/random"}
+    )
+    assert tampered.ground_truth_hash() != s1.ground_truth_hash()
+
+
+def test_subject_has_no_synthetic_effect_model():
+    # This subject's experiment is a real computation; it must not carry the
+    # CoT synthetic EffectModel.
+    assert sort_crossover_subject().effect is None
+
+
+# --- end-to-end: real experiment → surprise → graders --------------------
+
+
+def _record(**kw) -> RunRecord:
+    base = dict(
+        arc="mission", run_label="sort", workflow_thread_id="thr_sort",
+        terminal_state="complete",
+        artifacts=[
+            {"id": "jrn_1", "kind": "journal", "node": "n"},
+            {"id": "dec_1", "kind": "decision", "node": "n"},
+            {"id": "clm_1", "kind": "claim", "node": "n"},
+            {"id": "mis_1", "kind": "report", "node": "n"},
+        ],
+        usd_spent=1.0,
+    )
+    base.update(kw)
+    return RunRecord(**base)
+
+
+def test_graders_score_a_pivoted_sorting_run_full_marks():
+    s = sort_crossover_subject()
+    sig = sort_surprise_signal(run_sort_experiment(full_quadrant_design(), seed=1))
+    g = grade_provenance(_record(), claim_text=PIVOTED_CLAIM, subject=s, surprise=sig)
+    assert g.score == 1.0
+    assert all(g.detail["components"].values())
+
+
+def test_graders_punish_ignoring_the_real_surprise():
+    s = sort_crossover_subject()
+    sig = sort_surprise_signal(run_sort_experiment(full_quadrant_design(), seed=1))
+    report = grade_run(_record(), subject=s, claim_text=NAIVE_CLAIM, surprise=sig)
+    assert report.provenance.score <= 0.5      # naive claim tanks provenance
+    assert report.capability.score == 1.0      # but artifacts still produced


### PR DESCRIPTION
## A CPU-only research subject + its end-to-end live runbook

Two things, shippable together: (1) a research subject whose entire experiment is **pure Python on CPU** — no GPU, no model download, no API key, runnable with only the Bash/Python/web tools the orchestrator's Executor already has; and (2) the **live-phase runbook** that drives the full 14-stage PhD-research lifecycle on it.

**Topic:** *"Is quicksort an efficient general-purpose sort across input distributions?"* The naive hypothesis ("quicksort's O(n log n) beats insertion sort everywhere") is contradicted by a real, textbook phenomenon — naive first-pivot quicksort hits its O(n²) worst case on nearly-sorted input, where insertion sort hits its O(n) best case. Measured in exact **comparison counts** (perfectly reproducible, no wall-clock noise), the advantage flips sign with input ordering. The planted "surprise" is a phenomenon I actually compute, not a synthetic effect model.

### Part 1 — the subject (`eval/sort_crossover.py`)

- Comparison-counting `insertion_sort` + naive first-pivot `quicksort` (explicit stack), deterministic seeded inputs, `run_sort_experiment()` (runs both, **verifies correct output**, averages over trials), `sort_surprise_signal()`, and `sort_crossover_subject()` (seals the answer + 4 real literature anchors).
- `eval/subject.py` — `SubjectSpec` generalized so a subject can be backed by a real experiment instead of the CoT synthetic `EffectModel` (`effect` optional; new `sealed_extra`). CoT hash unchanged.
- `eval/graders.py` — provenance grader's `surprise` widened to a `SurpriseLike` Protocol; the **same** grader scores both subjects.
- Empirical correction made while building: in *comparison counts* the classic "insertion wins for small n" doesn't appear (it's a constant-factor/wall-clock effect), so the sign flip is ordering-driven — the sealed quadrant + tests pin the real measured values (stable across 12 seeds).

### Part 2 — the live runbook (`eval/runbook_sort.py` + `docs/e2e-sort-crossover-runbook.md`)

- `idea_capture_text()` / `SCOPE_NOTE` / `DEEPRESEARCH_PROMPT` — the Phase-O entry prompts (open framing only; absolute workspace path, no tilde per D2.1).
- **`build_sort_oracle()`** — the keystone PI rubric. Two gates exercise where agentic+provenance should beat a plain agent:
  - **demand-ordering-variation** at `pi_greenlight` — redirects a size-only experiment design (drives the `confirmation_brief_redraft` loop).
  - **pivot-from-naive-claim** at `pi_decision_select` — redirects a naive "quicksort is always faster" decision toward the size×ordering interaction (drives the `mission_redraft` loop), then ratifies the pivoted claim. Naive/interaction vocabularies come from the sealed subject so the rubric can't drift from the answer key.
- `MISSION_SPECS` — five missions mapping all 14 stages to a milestone DAG (literature/framing → proposal/design → experiment/pivot → manuscript → review/refine).
- The runbook doc is a human-followable gold-run guide; it flags that the writer `chart_render` stub is a **main-branch** fix, not agentic, per the routing guardrail.

### Tests / invariants

- 23 new tests (12 subject, 11 runbook); full orchestrator suite **1412 passed, 2 skipped**; ruff clean.
- Bookkeeper invariant intact (`git diff main -- rka/` empty); grep-gate intact.
- Pure `orchestrator/`-tree code → agentic branch.

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv