### PR TITLE
fix(orchestrator): 4 WRITE/READ adapter contract bugs found by live conduct

### DIFF
--- a/orchestrator/orchestrator/mcp_client.py
+++ b/orchestrator/orchestrator/mcp_client.py
@@ -34,7 +34,7 @@ field so the run's RKA artifacts can be recovered via
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Protocol
+from typing import Any, Protocol
 
 
 class CheckpointError(Exception):
@@ -290,6 +290,23 @@ def _merge_workflow_tag(
 def _drop_none(d: dict) -> dict:
     """Skip dict keys whose value is None — keeps REST bodies tidy."""
     return {k: v for k, v in d.items() if v is not None}
+
+
+def _as_text_criteria(value: "list[str] | str | None") -> "str | None":
+    """Coerce acceptance_criteria to the shape RKA's MissionCreate / MissionUpdate
+    models accept (``str | None``).
+
+    The orchestrator's callers (and the Brain proposed_actions convention)
+    express acceptance criteria as a list, but the RKA REST contract stores a
+    single freeform string. Sending the raw list 422s ("Input should be a valid
+    string") — a bug masked by FakeMCP (which records any shape) and surfaced
+    only against a live RKA. Join a list with newlines; pass a str through; keep
+    None as None so _drop_none can elide it on updates."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return "\n".join(str(x) for x in value)
 
 
 class RestMCPClient:
@@ -791,10 +808,11 @@ class RestMCPClient:
         acceptance_criteria) continue to work — the new kwargs default
         to None and are dropped from the JSON body via _drop_none.
 
-        acceptance_criteria is passed as a list per the historical
-        Phase 2.7 convention; the server's MissionCreate model accepts
-        str | None so the list is currently rendered as a one-element
-        JSON array. (Not breaking anything that already shipped.)
+        acceptance_criteria is accepted as a list (the orchestrator /
+        Brain convention) but RKA's MissionCreate model is str | None;
+        _as_text_criteria newline-joins the list so the POST conforms to
+        the contract. Sending a raw list 422s ("Input should be a valid
+        string") — surfaced against a live RKA, masked by FakeMCP.
         """
         merged_tags = list(tags or [])
         if self.workflow_thread_id and self.workflow_thread_id not in merged_tags:
@@ -803,7 +821,7 @@ class RestMCPClient:
             {
                 "objective": objective,
                 "motivated_by_decision": motivated_by_decision,
-                "acceptance_criteria": list(acceptance_criteria),
+                "acceptance_criteria": _as_text_criteria(acceptance_criteria),
                 "phase": phase,
                 "scope_boundaries": scope_boundaries,
                 "depends_on": depends_on,
@@ -971,7 +989,7 @@ class RestMCPClient:
                 "tasks": kw.get("tasks"),
                 "report": kw.get("report"),
                 "context": kw.get("context"),
-                "acceptance_criteria": kw.get("acceptance_criteria"),
+                "acceptance_criteria": _as_text_criteria(kw.get("acceptance_criteria")),
                 "scope_boundaries": kw.get("scope_boundaries"),
                 "checkpoint_triggers": kw.get("checkpoint_triggers"),
                 "depends_on": kw.get("depends_on"),

--- a/orchestrator/orchestrator/mcp_client.py
+++ b/orchestrator/orchestrator/mcp_client.py
@@ -292,6 +292,21 @@ def _drop_none(d: dict) -> dict:
     return {k: v for k, v in d.items() if v is not None}
 
 
+# Entity id type-prefix -> REST collection segment. RKA has no generic
+# /api/entities/{id}; each type is fetched from its own route. (Prefixes per
+# rka/infra/ids.py; journal ids 'jrn_' are served by /api/notes.)
+_GET_ENDPOINT_BY_PREFIX = {
+    "jrn": "notes",
+    "dec": "decisions",
+    "mis": "missions",
+    "chk": "checkpoints",
+    "clm": "claims",
+    "lit": "literature",
+    "ecl": "clusters",
+    "top": "topics",
+}
+
+
 def _as_text_criteria(value: "list[str] | str | None") -> "str | None":
     """Coerce acceptance_criteria to the shape RKA's MissionCreate / MissionUpdate
     models accept (``str | None``).
@@ -449,7 +464,20 @@ class RestMCPClient:
         return self._request("POST", "/api/search", json=body) or []
 
     def rka_get(self, id: str) -> dict:
-        return self._request("GET", f"/api/entities/{id}") or {}
+        """GET an entity by id. RKA has no generic /api/entities/{id} route, so
+        dispatch by the id's type prefix to the per-type collection
+        (/api/notes, /api/decisions, /api/checkpoints, ...). The prior
+        /api/entities/{id} path did not exist, so it fell through to the SPA
+        catch-all and silently returned index.html instead of the entity —
+        surfaced against a live RKA (it's called from nodes/pi.py), masked by
+        FakeMCP. An unrecognized prefix now raises instead of returning HTML."""
+        prefix = id.split("_", 1)[0] if "_" in id else ""
+        endpoint = _GET_ENDPOINT_BY_PREFIX.get(prefix)
+        if endpoint is None:
+            raise ValueError(
+                f"rka_get: unrecognized id prefix {prefix!r} for id {id!r}"
+            )
+        return self._request("GET", f"/api/{endpoint}/{id}") or {}
 
     def rka_trace_provenance(self, id: str) -> dict:
         return self._request("GET", f"/api/provenance/{id}") or {}

--- a/orchestrator/orchestrator/mcp_client.py
+++ b/orchestrator/orchestrator/mcp_client.py
@@ -983,11 +983,16 @@ class RestMCPClient:
         """
         if not id:
             raise ValueError("rka_update_mission_status requires a non-empty mission id")
+        # `report` is NOT a MissionUpdate field — RKA's MissionUpdate model is
+        # extra="forbid", and reports are filed via the dedicated
+        # POST /api/missions/{id}/report endpoint. Forwarding it in the PUT body
+        # 422s ("Extra inputs are not permitted"); surfaced against a live RKA,
+        # masked by FakeMCP. Route it to the report endpoint instead.
+        report = kw.get("report")
         body = _drop_none(
             {
                 "status": kw.get("status"),
                 "tasks": kw.get("tasks"),
-                "report": kw.get("report"),
                 "context": kw.get("context"),
                 "acceptance_criteria": _as_text_criteria(kw.get("acceptance_criteria")),
                 "scope_boundaries": kw.get("scope_boundaries"),
@@ -1001,7 +1006,12 @@ class RestMCPClient:
             }
         )
         result = self._request("PUT", f"/api/missions/{id}", json=body) or {}
-        return result.get("id") or id
+        out_id = result.get("id") or id
+        if report:
+            # File the report through the canonical endpoint so the kwarg works
+            # instead of 422ing.
+            self.rka_submit_report(mission_id=id, content=report)
+        return out_id
 
     def rka_ingest_document(self, content: str, **kw: Any) -> str:
         """POST /api/ingest/document — single-call structured document ingest.
@@ -1042,14 +1052,27 @@ class RestMCPClient:
             }
         )
         result = self._request("POST", "/api/ingest/document", json=body) or {}
-        # Endpoint returns either {"id": "..."} for single or
-        # {"ids": [...]} for split-by-headings. Take the first as the
-        # canonical artifact id for the dispatcher's ArtifactRef.
+        # /api/ingest/document returns
+        #   {"created": [{"id","type","heading","length"}, ...],
+        #    "errors": [{"section","error"}, ...], "total_sections": N}
+        # The prior code looked for {"id"}/{"ids"} — shapes the endpoint never
+        # returns — so it ALWAYS fell through to the sentinel, even on success.
+        # (Surfaced against a live RKA; masked by FakeMCP.) Parse created[].
+        created = result.get("created") or []
+        if created:
+            first = created[0]
+            return first.get("id", "") if isinstance(first, dict) else str(first)
+        # Nothing created — surface the per-section errors instead of a silent
+        # success-looking sentinel.
+        errors = result.get("errors") or []
+        if errors:
+            detail = errors[0].get("error") if isinstance(errors[0], dict) else str(errors[0])
+            raise ValueError(f"rka_ingest_document created no entries: {detail}")
+        # Back-compat: tolerate the legacy {"id"}/{"ids"} shapes if they ever return.
         if "id" in result:
             return result["id"]
-        if "ids" in result and result["ids"]:
+        if result.get("ids"):
             return result["ids"][0]
-        # Fall back to a synthetic marker the dispatcher can store.
         return "ingest_document_no_id_returned"
 
 

--- a/orchestrator/tests/test_mcp_client.py
+++ b/orchestrator/tests/test_mcp_client.py
@@ -360,7 +360,29 @@ def test_rka_create_mission_carries_decision_link():
     assert out == "mis_001"
     body = http.calls[0]["json"]
     assert body["motivated_by_decision"] == "dec_abc"
-    assert body["acceptance_criteria"] == ["A1", "A2"]
+    # RKA's MissionCreate model is `acceptance_criteria: str | None`; a raw list
+    # 422s against a live server. The adapter newline-joins the list to conform.
+    assert body["acceptance_criteria"] == "A1\nA2"
+    assert isinstance(body["acceptance_criteria"], str)
+
+
+def test_rka_create_mission_accepts_prejoined_string():
+    http = FakeHttp(canned=FakeResp(_json={"id": "mis_002"}))
+    c = _client(http)
+    c.rka_create_mission(
+        "objective",
+        motivated_by_decision="dec_abc",
+        acceptance_criteria="already a string",
+    )
+    assert http.calls[0]["json"]["acceptance_criteria"] == "already a string"
+
+
+def test_rka_update_mission_status_coerces_acceptance_criteria_list():
+    http = FakeHttp(canned=FakeResp(_json={"id": "mis_003"}))
+    c = _client(http)
+    c.rka_update_mission_status("mis_003", acceptance_criteria=["C1", "C2"])
+    body = http.calls[0]["json"]
+    assert body["acceptance_criteria"] == "C1\nC2"
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_mcp_client.py
+++ b/orchestrator/tests/test_mcp_client.py
@@ -425,6 +425,25 @@ def test_rka_ingest_document_raises_on_errors_only():
         c.rka_ingest_document("body", source="brain")
 
 
+def test_rka_get_dispatches_by_id_prefix():
+    # There is no /api/entities/{id}; the adapter must route by the id prefix to
+    # the per-type collection. (Hitting a bad path returns the SPA index.html.)
+    http = FakeHttp(canned=FakeResp(_json={"id": "x"}))
+    c = _client(http)
+    c.rka_get("jrn_abc")
+    c.rka_get("chk_abc")
+    c.rka_get("dec_abc")
+    assert [call["path"] for call in http.calls] == [
+        "/api/notes/jrn_abc", "/api/checkpoints/chk_abc", "/api/decisions/dec_abc",
+    ]
+
+
+def test_rka_get_unrecognized_prefix_raises_not_html():
+    c = _client()
+    with pytest.raises(ValueError, match="unrecognized id prefix"):
+        c.rka_get("zzz_abc")
+
+
 # ---------------------------------------------------------------------------
 # project_id propagation
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_mcp_client.py
+++ b/orchestrator/tests/test_mcp_client.py
@@ -385,6 +385,46 @@ def test_rka_update_mission_status_coerces_acceptance_criteria_list():
     assert body["acceptance_criteria"] == "C1\nC2"
 
 
+def test_rka_update_mission_status_routes_report_to_report_endpoint():
+    # MissionUpdate is extra="forbid" and has no `report` field; forwarding it
+    # in the PUT body 422s. The adapter must route it to POST .../report.
+    http = FakeHttp(canned=FakeResp(_json={"id": "mis_x"}))
+    c = _client(http)
+    c.rka_update_mission_status("mis_x", status="complete", report="final report body")
+    put = http.calls[0]
+    assert put["method"] == "PUT" and put["path"] == "/api/missions/mis_x"
+    assert "report" not in put["json"]            # not in the MissionUpdate body
+    rep = http.calls[1]
+    assert rep["method"] == "POST" and rep["path"] == "/api/missions/mis_x/report"
+
+
+def test_rka_update_mission_status_no_report_endpoint_call_when_absent():
+    http = FakeHttp(canned=FakeResp(_json={"id": "mis_x"}))
+    c = _client(http)
+    c.rka_update_mission_status("mis_x", status="active")
+    assert len(http.calls) == 1                   # only the PUT, no report call
+
+
+def test_rka_ingest_document_parses_created_id():
+    # The endpoint returns {"created":[{"id":...}], "errors":[], "total_sections":N}
+    # — not {"id"}/{"ids"}. The adapter must read created[0].id.
+    http = FakeHttp(canned=FakeResp(_json={
+        "created": [{"id": "jrn_new", "type": "finding"}], "errors": [], "total_sections": 1,
+    }))
+    c = _client(http)
+    assert c.rka_ingest_document("a document body", source="brain") == "jrn_new"
+
+
+def test_rka_ingest_document_raises_on_errors_only():
+    http = FakeHttp(canned=FakeResp(_json={
+        "created": [], "errors": [{"section": "S1", "error": "source invalid"}],
+        "total_sections": 1,
+    }))
+    c = _client(http)
+    with pytest.raises(ValueError, match="created no entries"):
+        c.rka_ingest_document("body", source="brain")
+
+
 # ---------------------------------------------------------------------------
 # project_id propagation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bugs found by conducting the live end-to-end test

Conducting the sorting-crossover research lifecycle against a **real local RKA REST server** (v2.8.0, no Docker) surfaced **four** `RestMCPClient` adapters sending shapes/URLs RKA rejects. All four were masked by `FakeMCP` (which records any shape and never round-trips a real contract) — they only appear against a live server. Three are reachable in production.

### 1. `rka_create_mission` — `acceptance_criteria` list → 422
Sent a JSON **list**, but RKA's `MissionCreate` is `acceptance_criteria: str | None`. A test pinned the buggy shape against the fake. **Fix:** `_as_text_criteria()` newline-joins a list (passes `str`, keeps `None`); applied in create (POST) and update (PUT).

### 2. `rka_update_mission_status` — `report` → 422
`MissionUpdate` is `extra="forbid"` with no `report` field; reports go via `POST /api/missions/{id}/report`. **Fix:** drop `report` from the PUT body, route it to the report endpoint so the kwarg works.

### 3. `rka_ingest_document` — response misparse → always a sentinel
Parsed `result["id"]`/`["ids"]`, but the endpoint returns `{"created":[{"id",...}],"errors":[...],"total_sections":N}` — so it **always** returned `"ingest_document_no_id_returned"`, even on success, breaking `{{PA-N.id}}` chaining for a WRITE_TOOL. **Fix:** read `created[0].id`; raise on errors-only instead of a silent success-looking sentinel.

### 4. `rka_get` — silently returned the SPA's `index.html` 🔴
The worst, because it fails silently: `rka_get(id)` hit `GET /api/entities/{id}`, which **isn't a route** — FastAPI's SPA catch-all served `index.html`, and the adapter returned the HTML as the "entity." It's called from `nodes/pi.py` (`rka_get(checkpoint_id)`, `rka_get(plan_journal_id)`), so the PI node received HTML instead of JSON. **Fix:** dispatch by the id's type prefix to the per-type route (`jrn_`→`/api/notes`, `chk_`→`/api/checkpoints`, …); raise on an unrecognized prefix instead of returning HTML.

## Verified against live RKA
mission creates with the joined string; `update_mission_status(report=...)` files the report; `ingest_document` returns a real `jrn_` id; `rka_get(jrn_/chk_/dec_)` returns entity JSON.

These are **orchestrator adapter** bugs (the adapters must conform to RKA's existing contracts), so they're on `agentic`; the RKA models/routes are unchanged.

10 new/updated tests. Full suite: **1397 passed, 2 skipped**; ruff clean; bookkeeper invariant intact (`git diff main -- rka/` empty).

**Latent siblings noted (not bundled):** `rka_trace_provenance` points at the non-existent `/api/provenance/{id}` but is never called parent-side (only named in prompt strings); `rka_get_mission()` with no id builds `/api/missions/active` (404) but every parent-side call passes an explicit id.

> A separate **main-branch** RKA bug from the same conduct — `POST /api/missions` returning 500 (not 4xx) on an invalid `motivated_by_decision` — is filed in #43.

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv