### PR TITLE
fix(missions): return 400 (not 500) when motivated_by_decision is invalid

### DIFF
--- a/rka/api/routes/missions.py
+++ b/rka/api/routes/missions.py
@@ -17,7 +17,13 @@ async def create_mission(
     actor: str = "brain",
     svc: MissionService = Depends(get_scoped_mission_service),
 ):
-    return await svc.create(data, actor=actor)
+    try:
+        return await svc.create(data, actor=actor)
+    except ValueError as e:
+        # e.g. motivated_by_decision references a non-existent decision —
+        # a client error, not a 500. Without this, the service's FK-validation
+        # ValueError would propagate as an unhandled 500.
+        raise HTTPException(400, str(e))
 
 
 @router.get("/missions", response_model=list[Mission])

--- a/rka/services/missions.py
+++ b/rka/services/missions.py
@@ -38,8 +38,33 @@ class MissionService(BaseService):
         )
 
     async def create(self, data: MissionCreate, actor: str = "brain") -> Mission:
-        """Create a new mission."""
+        """Create a new mission.
+
+        Raises ValueError (mapped to HTTP 400 by the route) when
+        ``motivated_by_decision`` references a decision that does not exist in
+        this project. Validating up front turns what was an opaque
+        ``sqlite3.IntegrityError`` -> 500 (the FK constraint firing inside the
+        INSERT) into a clear client error. An empty/whitespace reference is
+        normalized to NULL ("no motivation") rather than attempting a doomed FK.
+        """
         mis_id = generate_id("mission")
+
+        # Normalize optional FK references: SQLite enforces a FK on any non-NULL
+        # value, so an empty string would trip the constraint. Treat blank as
+        # "unset".
+        motivated_by = (data.motivated_by_decision or "").strip() or None
+        depends_on = (data.depends_on or "").strip() or None
+
+        if motivated_by is not None:
+            dec = await self.db.fetchone(
+                "SELECT id FROM decisions WHERE id = ? AND project_id = ?",
+                [motivated_by, self.project_id],
+            )
+            if not dec:
+                raise ValueError(
+                    f"motivated_by_decision {motivated_by!r} not found in "
+                    f"project {self.project_id}"
+                )
 
         tasks_json = None
         if data.tasks:
@@ -55,16 +80,16 @@ class MissionService(BaseService):
                 mis_id, data.phase, data.objective, tasks_json,
                 data.context, data.acceptance_criteria,
                 data.scope_boundaries, data.checkpoint_triggers,
-                data.depends_on, data.motivated_by_decision,
+                depends_on, motivated_by,
                 self.project_id,
             ],
         )
         await self.db.commit()
 
         # Write entity_link for motivated_by_decision
-        if data.motivated_by_decision:
+        if motivated_by:
             await self.add_link(
-                "decision", data.motivated_by_decision,
+                "decision", motivated_by,
                 "motivated", "mission", mis_id,
                 created_by=actor,
             )

--- a/tests/test_services/test_mission_decision_fk_validation.py
+++ b/tests/test_services/test_mission_decision_fk_validation.py
@@ -1,0 +1,86 @@
+"""Mission creation validates motivated_by_decision instead of 500ing.
+
+Regression for the FK-violation -> 500 bug surfaced by an end-to-end test:
+POST /api/missions (service-layer create) with a non-existent or empty
+motivated_by_decision tripped a raw `sqlite3.IntegrityError: FOREIGN KEY
+constraint failed` inside the INSERT, surfacing as an opaque 500. The service
+now validates the reference up front (clean ValueError -> HTTP 400) and treats a
+blank reference as "unset" (NULL).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rka.infra.database import Database
+from rka.models.decision import DecisionCreate
+from rka.models.mission import MissionCreate
+from rka.models.project import ProjectCreate
+from rka.services.decisions import DecisionService
+from rka.services.missions import MissionService
+from rka.services.project import ProjectService
+
+PROJECT_ID = "proj_test_mission_fk_validation"
+
+
+@pytest.fixture
+async def services(db: Database):
+    psvc = ProjectService(db)
+    await psvc.create_project(
+        ProjectCreate(id=PROJECT_ID, name="Mission FK test", description="t"),
+        actor="system",
+    )
+    return (
+        DecisionService(db, project_id=PROJECT_ID),
+        MissionService(db, project_id=PROJECT_ID),
+    )
+
+
+async def test_nonexistent_decision_raises_valueerror_not_integrityerror(services):
+    _, msvc = services
+    with pytest.raises(ValueError, match="not found"):
+        await msvc.create(
+            MissionCreate(
+                phase="design",
+                objective="mission with a bogus decision link",
+                motivated_by_decision="dec_does_not_exist",
+            ),
+            actor="executor",
+        )
+
+
+async def test_empty_decision_reference_is_treated_as_unset(services):
+    _, msvc = services
+    mission = await msvc.create(
+        MissionCreate(
+            phase="design",
+            objective="mission with blank motivation",
+            motivated_by_decision="   ",  # whitespace -> NULL, no FK attempt
+        ),
+        actor="executor",
+    )
+    assert mission.id
+    assert not (mission.motivated_by_decision or "")  # stored as unset
+
+
+async def test_valid_decision_reference_succeeds_and_links(services):
+    dsvc, msvc = services
+    decision = await dsvc.create(
+        DecisionCreate(question="anchor decision", phase="design", decided_by="executor")
+    )
+    mission = await msvc.create(
+        MissionCreate(
+            phase="design",
+            objective="mission with a real decision link",
+            motivated_by_decision=decision.id,
+        ),
+        actor="executor",
+    )
+    assert mission.motivated_by_decision == decision.id
+    # the 'motivated' entity_link materializes
+    links = await msvc.db.fetchall(
+        """SELECT id FROM entity_links
+           WHERE source_id = ? AND target_id = ? AND link_type = 'motivated'""",
+        [decision.id, mission.id],
+    )
+    assert len(links) == 1


### PR DESCRIPTION
## Bug found by conducting the live end-to-end test

While **conducting** the research-lifecycle test against a real RKA REST server, creating a mission with a bad `motivated_by_decision` produced a **500 Internal Server Error**:

```
File "rka/services/missions.py", line 48, in create
    await self.db.execute(...)
sqlite3.IntegrityError: FOREIGN KEY constraint failed
```

`POST /api/missions` inserts `motivated_by_decision` directly. When the value is an **empty string** (SQLite enforces the FK on any non-NULL value) or a **non-existent decision id**, the FK constraint fires *inside* the INSERT and surfaces as an opaque 500 — the client can't tell what went wrong, and it's a server crash rather than a graceful rejection. This is reachable in production: the orchestrator's Brain proposes `motivated_by_decision`, and a hallucinated or empty id would 500.

## Fix

`MissionService.create` now:
- **normalizes** an empty/whitespace `motivated_by_decision` (and `depends_on`) to `NULL` — a blank reference means "unset", not a doomed FK; and
- **validates** that a non-empty `motivated_by_decision` references an existing decision in the project (mirrors the existing `clusters.py` / `decision_options.py` `fetchone` + `ValueError("… not found")` pattern).

The `create_mission` route maps that `ValueError` to **HTTP 400** with the message — turning the 500 into a clear client error. (There's no global `ValueError` handler, so the route maps it locally, consistent with the route's existing `HTTPException(404, …)` usage.)

## Verified against a live RKA

| Input | Before | After |
|---|---|---|
| empty `motivated_by_decision` | 500 | **201** (treated as unset) |
| non-existent decision id | 500 | **400** `motivated_by_decision 'dec_nope' not found in project …` |
| valid decision id | 201 | 201 (+ `motivated` entity_link, unchanged) |

Three regression tests added (`tests/test_services/test_mission_decision_fk_validation.py`); the targeted mission suite (34 tests) passes; ruff clean.

> This is the RKA-core counterpart to the orchestrator-side fix in #42 (`acceptance_criteria` list→str), both surfaced by the same live end-to-end conduct. Routed to `main` per the branch guardrail since the bug is in `rka/` code.

https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv

---
_Generated by [Claude Code](https://claude.ai/code/session_011rHJNGokmPhAbzPVkAzWzv)_