### PR TITLE
fix(mcp): accept dict tasks in rka_create_mission / rka_update_mission_status

### DIFF
--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -1625,7 +1625,13 @@ async def rka_create_mission(
         body = {
             "phase": phase,
             "objective": objective,
-            "tasks": [task.model_dump() for task in tasks] if tasks else None,
+            # Coerce each task to a plain dict. Via the v2.7.0+ `rka_execute`
+            # dispatch path (verb_dispatch -> _legacy("rka_create_mission")),
+            # `tasks` arrive as plain dicts (CreateMissionArgs.tasks: list[dict]),
+            # NOT MissionTask models — so a bare `task.model_dump()` raised
+            # `'dict' object has no attribute 'model_dump'`. Accept both shapes.
+            "tasks": [t.model_dump() if hasattr(t, "model_dump") else t
+                      for t in tasks] if tasks else None,
             "context": context, "acceptance_criteria": acceptance_criteria,
             "scope_boundaries": scope_boundaries,
             "checkpoint_triggers": checkpoint_triggers,
@@ -1694,7 +1700,10 @@ async def rka_update_mission_status(
     async with _client(project_id) as c:
         body = {"status": status}
         if tasks:
-            body["tasks"] = [task.model_dump() for task in tasks]
+            # Accept both MissionTask models and plain dicts (the v2.7.0+
+            # rka_execute dispatch passes dicts; see rka_create_mission).
+            body["tasks"] = [t.model_dump() if hasattr(t, "model_dump") else t
+                             for t in tasks]
         r = await c.put(f"/api/missions/{id}", json=body)
         _raise_with_detail(r)
         return f"Mission {id} → {status}"

--- a/tests/test_mcp/test_v270_legacy_parity.py
+++ b/tests/test_mcp/test_v270_legacy_parity.py
@@ -457,3 +457,54 @@ async def test_parity_submit_checkpoint_content_alias(captured_calls):
     assert L["body"] == V["body"], (
         f"content-alias drift: legacy={L['body']!r} verb={V['body']!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: create_mission with tasks as plain DICTS (v2.7.0 rka_execute path)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_mission_tasks_as_dicts_does_not_crash(captured_calls):
+    """Regression (2026-06-15): rka_execute(create_mission) routes through
+    verb_dispatch -> _legacy('rka_create_mission') passing tasks as PLAIN DICTS
+    (CreateMissionArgs.tasks: list[dict]). The legacy tool built the body with
+    `[task.model_dump() for task in tasks]`, raising
+    `'dict' object has no attribute 'model_dump'`. Both the verb path and the
+    legacy tool must accept dict tasks (passed through) AND MissionTask models
+    (model_dump'd)."""
+    leg, ver, set_factory, switch_to = captured_calls
+    set_factory(lambda m, p: (200, {"id": "mis_1", "phase": "execution",
+                                     "objective": "x", "status": "pending"}))
+    dict_tasks = [{"id": "T1", "description": "do the thing", "status": "pending"}]
+
+    # v2.7.0 verb path (rka_mission action=create) — delivers dicts to the tool.
+    switch_to(ver)
+    await mcp_mod.rka_mission(
+        action="create", project_id="prj_t", phase="execution",
+        objective="x", motivated_by_decision="dec_root", tasks=dict_tasks,
+    )
+    assert ver.requests[0]["body"]["tasks"] == dict_tasks  # dicts passed through
+
+    # legacy tool path directly with dict tasks (same coercion site).
+    switch_to(leg)
+    await mcp_mod.rka_create_mission(
+        phase="execution", objective="x", motivated_by_decision="dec_root",
+        project_id="prj_t", tasks=dict_tasks,
+    )
+    assert leg.requests[0]["body"]["tasks"] == dict_tasks
+
+
+async def test_create_mission_tasks_as_models_still_model_dumped(captured_calls):
+    """The pre-existing MissionTask-model path must still work (model_dump)."""
+    from rka.models.mission import MissionTask
+    leg, ver, set_factory, switch_to = captured_calls
+    set_factory(lambda m, p: (200, {"id": "mis_1", "phase": "execution",
+                                     "objective": "x", "status": "pending"}))
+    mt = MissionTask(description="modelled task")
+    switch_to(leg)
+    await mcp_mod.rka_create_mission(
+        phase="execution", objective="x", motivated_by_decision="dec_root",
+        project_id="prj_t", tasks=[mt],
+    )
+    sent = leg.requests[0]["body"]["tasks"]
+    assert isinstance(sent[0], dict) and sent[0].get("description") == "modelled task"


### PR DESCRIPTION
## Summary
`rka_execute(create_mission)` (and `update_mission_status`) raised `'dict' object has no attribute 'model_dump'` when tasks were supplied. The v2.7.0+ dispatch routes `rka_execute` → `verb_dispatch.dispatch_mission` → `_legacy('rka_create_mission')`, passing `tasks` as **plain dicts** (`CreateMissionArgs.tasks: list[dict]`), but the legacy tool built the request body with `[task.model_dump() for task in tasks]` — assuming `MissionTask` models.

(The REST→service path is unaffected: `MissionCreate.tasks` is `list[MissionTask]`, so Pydantic coerces dicts at parse time.)

## Fix
Coerce defensively at both server-side body sites (`rka_create_mission`, `rka_update_mission_status`):
```python
[t.model_dump() if hasattr(t, "model_dump") else t for t in tasks]
```
Accepts both `MissionTask` models (legacy behavior preserved) and plain dicts.

## Tests
- `tests/test_mcp/test_v270_legacy_parity.py`: `test_create_mission_tasks_as_dicts_does_not_crash` (verb path + legacy tool with dict tasks pass through) and `test_create_mission_tasks_as_models_still_model_dumped` (model path still `model_dump`'d).
- Targeted mission/dispatch suites green (82 passed).

## Live verification
Against a running RKA v2.8.0, the fixed `rka_create_mission(..., tasks=[{...dict...}])`:
```
POST /api/missions → 201 Created
MISSION CREATED  …  Tasks: 2
```
(Before the fix the identical call raised the AttributeError.)

## Provenance
Surfaced conducting an end-to-end research-lifecycle eval of the agentic orchestrator — creating a mission with a `tasks` list via `rka_execute` tripped the bug; worked around at the time by folding tasks into the objective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
