### PR TITLE
feat(writer): advisory pre-submission review + old-vs-new revision-check (v2.5.0)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-writer-review-revision.md
+++ b/docs/superpowers/plans/2026-07-06-writer-review-revision.md
@@ -1,0 +1,656 @@
+# Writer "Review & Revision" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an advisory, reviewer-lens pre-submission review and an old-vs-new revision-check to the RKA writer skill, plus a WARN-only overclaim linter, without gating on LLM judgment.
+
+**Architecture:** Two new reference checklists (`manuscript_review.md`, `revision_check.md`), one new WARN-only script (`overclaim_lint.py`) mirroring `ai_tic_lint.py`, and SKILL.md wiring (new "Pre-Submission Review" section + revision-check subsection + `writer-review` mission path). Source of truth is `rka/skills/writer/`; mirrored to `plugin/skills/writer/`.
+
+**Tech Stack:** Python 3.11 stdlib (argparse, re, json, dataclasses), pytest (module-loaded via conftest `_load_module`), Markdown.
+
+## Global Constraints
+
+- Skill files live under `rka/skills/writer/` ONLY (+ `tests/skills/writer/`) — bookkeeper invariant; never add RKA orchestration elsewhere.
+- **Advisory-only:** the review never BLOCKs compile/submit. `overclaim_lint.py` emits WARN, never BLOCK; exit code is 0 (no hits) or 1 (WARN), never 2.
+- No LLM-reviewer score, no accept/reject verdict, no numeric quality gate.
+- **Dogfood:** no em-dash (U+2014) or en-dash (U+2013) in any SKILL.md or reference `.md` prose. `test_skill_loads.py::test_em_dash_absolute_ban_dogfooded` enforces it for SKILL.md.
+- SKILL.md must stay within 200-700 lines (`test_skill_md_within_line_budget`).
+- Every `references/*.md` named in SKILL.md must exist (`test_supplementary_references_all_discoverable`).
+- Skill frontmatter version bumps `2.4.0 -> 2.5.0` (content version, local to the skill; distinct from the RKA release version).
+- After edits: mirror to `plugin/skills/writer/` and keep `tests/test_skills_packaging.py` (parity + package-data coverage) green.
+- Entity-id shape for tests: `(jrn|dec|lit|mis|clm|ecl)_` + 26 chars of `[0-9A-Z]` (per `verify_provenance.py` `_ID_RE`). Use `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`.
+
+---
+
+### Task 1: `overclaim_lint.py` — lexical detector + report + CLI
+
+**Files:**
+- Create: `rka/skills/writer/scripts/overclaim_lint.py`
+- Modify: `tests/skills/writer/conftest.py` (add `overclaim_lint` fixture)
+- Test: `tests/skills/writer/test_overclaim_lint.py`
+
+**Interfaces:**
+- Produces: `lint_file(path, *, resolver=None, config=None) -> OverclaimReport`; `main(argv=None) -> int`; dataclasses `OverclaimHit(term, category, file, line, sentence, severity="WARN", priority="normal", backing_entity=None, backing_confidence=None)` and `OverclaimReport(hits: list, verdict: str)`. `resolver` is consumed by Task 2.
+
+- [ ] **Step 1: Add the conftest fixture**
+
+Add to `tests/skills/writer/conftest.py` after the `verify_citations` fixture (around line 68):
+
+```python
+@pytest.fixture
+def overclaim_lint():
+    return _load_module("overclaim_lint")
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/skills/writer/test_overclaim_lint.py`:
+
+```python
+"""Tests for overclaim_lint.py (advisory calibration/overclaim linter).
+
+WARN-only: this linter never BLOCKs. It surfaces absolute/overclaim wording
+for the pre-submission review, and (Task 2) ranks a hit higher when the
+backing RKA evidence is weak-confidence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestLexicalDetection:
+    def test_flags_guarantee_word(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Our system guarantees no data leakage.")
+        rep = overclaim_lint.lint_file(f)
+        assert any(h.term.lower() == "guarantees" for h in rep.hits)
+        assert rep.verdict == "WARN"
+
+    def test_flags_multiple_categories(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "It eliminates the attack and is model-agnostic.")
+        rep = overclaim_lint.lint_file(f)
+        cats = {h.category for h in rep.hits}
+        assert "elimination" in cats and "generality" in cats
+
+    def test_clean_prose_passes(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "We observe a 12 percent reduction on the controlled benchmark. "
+            "The external benchmark shows a smaller, mixed effect."
+        )
+        rep = overclaim_lint.lint_file(f)
+        assert rep.verdict == "PASS"
+        assert not rep.hits
+
+
+class TestNeverBlocks:
+    def test_never_blocks_even_on_many_hits(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "verified guaranteed eliminates model-agnostic dominant fundamental"
+        )
+        rep = overclaim_lint.lint_file(f)
+        assert rep.verdict == "WARN"
+        assert rep.verdict != "BLOCK"
+
+
+class TestPerProjectOverride:
+    def test_config_disable_drops_term(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "The evaluation is complete.")
+        cfg = {"complete": {"verdict": "disable"}}
+        assert any("complete" in h.term.lower() for h in overclaim_lint.lint_file(f).hits)
+        assert not overclaim_lint.lint_file(f, config=cfg).hits
+
+
+class TestEntryPoint:
+    def test_main_writes_report_and_returns_warn_code(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Our approach eliminates the attack surface.")
+        out = tmp_path / "r.json"
+        rc = overclaim_lint.main([str(f), "--output", str(out)])
+        assert rc == 1
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["verdict"] == "WARN"
+
+    def test_main_returns_zero_on_clean_file(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "We report a partial improvement on one benchmark.")
+        rc = overclaim_lint.main([str(f), "--output", str(tmp_path / "r.json")])
+        assert rc == 0
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `RKA_DATA_DIR=/private/tmp/rka-test-data .venv/bin/python -m pytest tests/skills/writer/test_overclaim_lint.py -q`
+Expected: FAIL (module `overclaim_lint` not found by the fixture loader).
+
+- [ ] **Step 4: Write the implementation**
+
+Create `rka/skills/writer/scripts/overclaim_lint.py`:
+
+```python
+#!/usr/bin/env python3
+"""overclaim_lint.py: advisory calibration/overclaim detector for the Writer skill.
+
+Advisory-only (WARN, never BLOCK) per the 2026-07-06 Review and Revision design.
+Flags absolute/overclaim wording ("verified", "guaranteed", "eliminates",
+"model-agnostic", ...) so the pre-submission review
+(references/manuscript_review.md) can surface claim-calibration gaps. Mirrors
+ai_tic_lint.py's CLI and report shape.
+
+RKA-confidence ranking (Task 2): when a `% provenance:` comment precedes the
+overclaiming line, an injected `resolver(entity_id) -> dict|None` is consulted;
+a claim backed by hypothesis/tested (not verified) evidence is ranked
+priority="high". No live RKA call is made when no resolver is given.
+
+CLI:
+    python overclaim_lint.py <files>...
+    python overclaim_lint.py --config /path/to/overclaim_config.yaml <files>...
+    python overclaim_lint.py --output report.json <files>...
+
+Exit codes:
+    0: no hits (PASS)
+    1: WARN hits present
+Never returns 2. This linter does not BLOCK.
+
+See references/manuscript_review.md for how the review consumes this report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Callable, Optional
+
+# Calibration / overclaim terms -> category. Authored from the PI manuscript
+# revision prompt template (2026-07-06); extensible per-project via a config
+# mapping {term: {"verdict": "disable"}} (mirrors ai_tic_config.yaml).
+OVERCLAIM_PATTERNS: dict[str, str] = {
+    r"\bverified\b": "guarantee",
+    r"\bguarantees?\b": "guarantee",
+    r"\bguaranteed\b": "guarantee",
+    r"\bprovably\b": "guarantee",
+    r"\bcompletely\b": "completeness",
+    r"\beliminates?\b": "elimination",
+    r"\beliminated\b": "elimination",
+    r"\bmodel-agnostic\b": "generality",
+    r"\bfully general\b": "generality",
+    r"\bgeneralizes?\b": "generality",
+    r"\bdominant\b": "superiority",
+    r"\bdominates?\b": "superiority",
+    r"\bfundamentally\b": "superiority",
+    r"\brobust to adaptive\b": "robustness",
+    r"\bfull recall\b": "metric-absolute",
+    r"\bno false positives?\b": "metric-absolute",
+    r"\bzero false positives?\b": "metric-absolute",
+    r"\bnever fails?\b": "absolute",
+}
+
+_PROV_RE = re.compile(r"^\s*%\s*provenance:\s*(.+)$", re.IGNORECASE)
+_ID_RE = re.compile(r"(jrn|dec|lit|mis|clm|ecl)_[0-9A-Z]{26}")
+# Backing confidences that make an absolute claim a high-priority gap.
+_WEAK_CONFIDENCE = {"hypothesis", "tested"}
+_PROV_WINDOW = 4  # lines to look back for a governing provenance comment
+
+Resolver = Callable[[str], Optional[dict]]
+
+
+@dataclass
+class OverclaimHit:
+    term: str
+    category: str
+    file: str
+    line: int
+    sentence: str
+    severity: str = "WARN"
+    priority: str = "normal"
+    backing_entity: Optional[str] = None
+    backing_confidence: Optional[str] = None
+
+
+@dataclass
+class OverclaimReport:
+    hits: list = field(default_factory=list)
+    verdict: str = "PASS"
+
+    def to_dict(self) -> dict:
+        return {"verdict": self.verdict, "hits": [asdict(h) for h in self.hits]}
+
+
+def _nearest_provenance(lines: list, idx: int, resolver: Resolver):
+    """Return (entity_id, confidence) for the nearest `% provenance:` comment
+    within _PROV_WINDOW lines above `idx`, or (None, None)."""
+    lo = max(-1, idx - _PROV_WINDOW - 1)
+    for j in range(idx, lo, -1):
+        m = _PROV_RE.match(lines[j])
+        if m:
+            id_match = _ID_RE.search(m.group(1))
+            if not id_match:
+                return None, None
+            ent = id_match.group(0)
+            resolved = resolver(ent)
+            conf = (resolved or {}).get("confidence")
+            return ent, (conf.lower() if isinstance(conf, str) else None)
+    return None, None
+
+
+def lint_file(path, *, resolver: Optional[Resolver] = None,
+              config: Optional[dict] = None) -> OverclaimReport:
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    disabled = set()
+    if config:
+        for term, spec in config.items():
+            if isinstance(spec, dict) and spec.get("verdict") == "disable":
+                disabled.add(term.lower())
+    report = OverclaimReport()
+    for i, line in enumerate(lines):
+        for pat, category in OVERCLAIM_PATTERNS.items():
+            for m in re.finditer(pat, line, re.IGNORECASE):
+                term = m.group(0)
+                if term.lower() in disabled:
+                    continue
+                hit = OverclaimHit(
+                    term=term, category=category, file=str(path),
+                    line=i + 1, sentence=line.strip(),
+                )
+                if resolver is not None:
+                    ent, conf = _nearest_provenance(lines, i, resolver)
+                    if ent is not None:
+                        hit.backing_entity = ent
+                        hit.backing_confidence = conf
+                        if conf in _WEAK_CONFIDENCE:
+                            hit.priority = "high"
+                report.hits.append(hit)
+    report.verdict = "WARN" if report.hits else "PASS"
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Advisory overclaim/calibration linter (WARN-only)."
+    )
+    ap.add_argument("files", nargs="+")
+    ap.add_argument("--output", help="write JSON report to this path")
+    ap.add_argument("--config", help="per-project overclaim_config.yaml")
+    args = ap.parse_args(argv)
+
+    config = None
+    if args.config:
+        import yaml  # optional; only needed with --config
+        config = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
+
+    all_hits = []
+    verdict = "PASS"
+    for f in args.files:
+        rep = lint_file(f, config=config)
+        all_hits.extend(rep.hits)
+        if rep.verdict == "WARN":
+            verdict = "WARN"
+
+    out = {"verdict": verdict, "hits": [asdict(h) for h in all_hits]}
+    if args.output:
+        Path(args.output).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    else:
+        print(json.dumps(out, indent=2))
+    return 1 if verdict == "WARN" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `RKA_DATA_DIR=/private/tmp/rka-test-data .venv/bin/python -m pytest tests/skills/writer/test_overclaim_lint.py -q`
+Expected: PASS (all tests in `TestLexicalDetection`, `TestNeverBlocks`, `TestPerProjectOverride`, `TestEntryPoint`).
+
+- [ ] **Step 6: Make the script executable and commit**
+
+```bash
+chmod +x rka/skills/writer/scripts/overclaim_lint.py
+git add rka/skills/writer/scripts/overclaim_lint.py tests/skills/writer/conftest.py tests/skills/writer/test_overclaim_lint.py
+git commit -m "feat(writer): overclaim_lint.py — advisory calibration linter (WARN-only)"
+```
+
+---
+
+### Task 2: `overclaim_lint.py` — RKA-confidence priority ranking
+
+**Files:**
+- Modify: `tests/skills/writer/test_overclaim_lint.py` (add `TestConfidenceRanking`)
+- Test: same file
+
+**Interfaces:**
+- Consumes: `lint_file(path, *, resolver, config)` and `OverclaimHit.priority/backing_entity/backing_confidence` from Task 1. The ranking logic (`_nearest_provenance`, `_WEAK_CONFIDENCE`) already shipped in Task 1's implementation; this task proves it with the resolver-injection tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/skills/writer/test_overclaim_lint.py`:
+
+```python
+_EID = "jrn_01KS0AVZRDA0KPXK61MN9PV5DE"
+
+
+class TestConfidenceRanking:
+    def test_weak_confidence_backing_ranks_high(self, overclaim_lint, tmp_path: Path) -> None:
+        content = (
+            f"% provenance: {_EID} supports paragraph below\n"
+            "Our method guarantees correctness.\n"
+        )
+        f = _write(tmp_path, "s.tex", content)
+        rep = overclaim_lint.lint_file(f, resolver=lambda eid: {"confidence": "tested"})
+        hit = next(h for h in rep.hits if h.term.lower() == "guarantees")
+        assert hit.priority == "high"
+        assert hit.backing_entity == _EID
+        assert hit.backing_confidence == "tested"
+
+    def test_verified_confidence_backing_stays_normal(self, overclaim_lint, tmp_path: Path) -> None:
+        content = (
+            f"% provenance: {_EID} supports paragraph below\n"
+            "Our method guarantees correctness.\n"
+        )
+        f = _write(tmp_path, "s.tex", content)
+        rep = overclaim_lint.lint_file(f, resolver=lambda eid: {"confidence": "verified"})
+        hit = next(h for h in rep.hits if h.term.lower() == "guarantees")
+        assert hit.priority == "normal"
+
+    def test_no_provenance_comment_skips_resolver(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Our method guarantees correctness.")
+        called = []
+
+        def resolver(eid):
+            called.append(eid)
+            return {"confidence": "tested"}
+
+        rep = overclaim_lint.lint_file(f, resolver=resolver)
+        hit = next(h for h in rep.hits if h.term.lower() == "guarantees")
+        assert hit.priority == "normal"
+        assert called == []
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `RKA_DATA_DIR=/private/tmp/rka-test-data .venv/bin/python -m pytest tests/skills/writer/test_overclaim_lint.py::TestConfidenceRanking -q`
+Expected: PASS (the ranking logic from Task 1 satisfies these; if any fail, fix `_nearest_provenance`/`lint_file` in the script, not the tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/skills/writer/test_overclaim_lint.py
+git commit -m "test(writer): overclaim_lint RKA-confidence priority ranking"
+```
+
+---
+
+### Task 3: `references/manuscript_review.md` (Prompt 1 reviewer checklist)
+
+**Files:**
+- Create: `rka/skills/writer/references/manuscript_review.md`
+
+**Interfaces:**
+- Produces: a reference file SKILL.md will link (Task 5). No code contract.
+
+- [ ] **Step 1: Write the reference doc**
+
+Create `rka/skills/writer/references/manuscript_review.md` with this exact structure. It is a PI-facing checklist, not an autograder; open with that framing, then the 15 dimensions. Use no em/en dashes. Required concrete elements per section:
+
+- Title `# Pre-Submission Manuscript Review (advisory)` and a first paragraph stating: this is a PI-facing gap surfacer, it never gates compile or submit, and the only blocking gates remain `verify_provenance.py` / `verify_citations.py` / `layout_audit.py` and the reference-validation statuses. Cross-link `quality_review.md` as the complementary RKA-evidence rubric.
+- `## 0. Source, venue, and evidence discipline` — state assumptions (venue family from `venue/<venue>.md`, paper type, strongest evidence, most fragile evidence); the strict evidence rule (a claim is not safe because it sounds plausible; check manuscript support); point to exact sections/figures/tables.
+- `## 1. Overall assessment and top reviewer-facing risks` — central-story clarity, title/abstract/intro/contribution/results alignment, submission-vs-tech-report read, calibration, strongest-evidence placement, top 3 to 5 reviewer risks.
+- `## 2. Claim-calibration table` — a Markdown table `| Claim | Problem | Safer wording |`; then the calibration word list (verified, guaranteed, complete, eliminates, model-agnostic, dominant, fundamental, robust to adaptive adversaries, generalizes across benchmarks, full recall, no false positives); state the RKA-confidence hook and that `scripts/overclaim_lint.py` surfaces these mechanically (WARN-only, priority=high when backing is hypothesis/tested).
+- `## 3. Abstract review` — first-sentence problem, motivation specificity, arithmetic/ratio correctness, strongest-evidence centrality, honest mixed/preliminary framing, no cherry-picking; ends with "provide remaining problems + a revised abstract draft."
+- `## 4. Introduction review` — motivation, gap statement fair to prior work, key-insight clarity, results paragraph matches evaluation, contribution list is not a second abstract.
+- `## 5. Structure and organization` — logical order; background / threat model / design / implementation / evaluation / discussion / related work / limitations separated; limitations early enough; roadmap clarity; movement suggestions.
+- `## 6. Evaluation-presentation credibility` — denominators explained, arithmetic checked, controlled-vs-external-vs-model-specific-vs-ablation-vs-preliminary separated, trial counts verifiable, outcome categories separated from defense mechanisms, statistics not overstating independence, per-benchmark limitations stated; the hook that every number should trace to a `mis_` report or `jrn_`/`clm_` result.
+- `## 7. Figures, tables, and layout` — caption/denominator clarity, two-column readability, no hidden mixed results, appendix candidates; note this complements (does not duplicate) `layout_audit.py`.
+- `## 8. Terminology normalization` — table `| Current variants | Recommended term | Notes |` across system name, threat-model terms, metric/model/benchmark names, section/figure/table references.
+- `## 9. Writing style` — defer to `ai_tic_lint.py` + `bridge_repetition_check.py`; add only the reviewer-perception framing, no second lexical list.
+- `## 10. Reference and citation integrity` — credibility lens; defer mechanical checks to `verify_provenance.py` / `verify_citations.py` and the reference pipeline; never invent citations, name the source kind needed.
+- `## 11. Venue fit` — read `venue/<venue>.md` (tone, required sections, forbidden constructions).
+- `## 12. Reviewer-risk analysis` — table `| Criticism | Why raised | Severity | How to preempt | Suggested wording |`.
+- `## 13. Concrete rewrite package` — revised title options, abstract, key-insight paragraph, contribution list, limitation paragraph, evaluation-roadmap paragraph, related-work positioning.
+- `## 14. Systems, security, and AI-agent add-on (venue-conditional)` — threat-model vs attack-taxonomy consistency, direct vs indirect attack separation, design-guarantee vs implementation-heuristic distinction, conditional formal properties, baseline fairness (policy-only / filtering-only / taint-only / full-system), CIA + usability claims each backed by the right evidence.
+- `## Output` — write `.planning/REVIEW.md`: one table per dimension plus an explicit Gaps list drawn from the mechanical inputs and RKA evidence. State plainly: no numeric score, no accept/reject verdict.
+- `## Fast pass` — the top-10-issues mode runs sections 1, 2, 6, 7, 8, 12 only.
+- `## Anti-patterns` — DON'T compute an accept/reject or numeric quality score; DON'T treat this as a gate; DON'T assert a review claim without pointing at the manuscript location or RKA evidence.
+
+- [ ] **Step 2: Verify no em/en dashes**
+
+Run: `python3 -c "t=open('rka/skills/writer/references/manuscript_review.md',encoding='utf-8').read(); assert chr(0x2014) not in t and chr(0x2013) not in t, 'dash found'; print('clean')"`
+Expected: `clean`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rka/skills/writer/references/manuscript_review.md
+git commit -m "docs(writer): manuscript_review.md — advisory pre-submission review checklist"
+```
+
+---
+
+### Task 4: `references/revision_check.md` (Prompt 2 old-vs-new)
+
+**Files:**
+- Create: `rka/skills/writer/references/revision_check.md`
+
+**Interfaces:**
+- Produces: a reference file SKILL.md will link (Task 5).
+
+- [ ] **Step 1: Write the reference doc**
+
+Create `rka/skills/writer/references/revision_check.md`. No em/en dashes. Structure:
+
+- Title `# Revision Check (old vs new, advisory)` and a first paragraph: this compares a revised draft against prior review comments and is advisory input to the Revision Loop, not a gate.
+- `## 0. Comparison setup` — identify old vs new draft; the prior-comments baseline source (the spawning `writer-review`/`writer-revision` mission `context`, the prior `.planning/REVIEW.md`, or PI-supplied comments); classify the run as full / new-only-guided-by-prior / limited.
+- `## 1. Executive revision diagnosis` — better / somewhat better / unchanged / worse; most successful revisions; remaining problems; regressions; an advisory readiness judgment (minor-edit / focused-revision / major-restructure / not-ready), explicitly framed as advice not a gate.
+- `## 2. Revision-status tracker` — table `| Prior issue | Status | Evidence in new draft | Remaining problem | Recommended next edit |`; status vocabulary exactly: Fixed, Mostly fixed, Partially fixed, Not fixed, Regressed, New issue, Cannot verify. Track the same dimensions as `manuscript_review.md`.
+- `## 3. Per-dimension re-checks` — abstract, title/contribution alignment, claim calibration (re-run `overclaim_lint.py` and diff), intro story, evaluation, figures/tables, terminology, style (diff `ai_tic_lint.py`), citations; each compared against the prior issue.
+- `## 4. Revision-comment classification` — map each remaining issue to R1-R4 (`handle_factual_r1`, `handle_style_r2`, `handle_inconsistency_r3`, `handle_logical_r4` in `scripts/revision_handler.py`) so the existing Revision Loop applies; note `bridge_repetition_check.py` for cross-section diffs and the `REVIEW_STATE.md` iteration cap of 3.
+- `## 5. Remaining reviewer risks and action plan` — must-fix vs optional lists; exact wording to add/soften/move.
+- `## Output` — write `.planning/REVISION_CHECK.md` (the tracker). No numeric score.
+- `## Anti-patterns` — DON'T re-litigate a Fixed item; DON'T gate on the diagnosis; DON'T mark Cannot-verify items as Fixed.
+
+- [ ] **Step 2: Verify no em/en dashes**
+
+Run: `python3 -c "t=open('rka/skills/writer/references/revision_check.md',encoding='utf-8').read(); assert chr(0x2014) not in t and chr(0x2013) not in t; print('clean')"`
+Expected: `clean`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rka/skills/writer/references/revision_check.md
+git commit -m "docs(writer): revision_check.md — old-vs-new revision tracker"
+```
+
+---
+
+### Task 5: SKILL.md wiring + `test_skill_loads.py` update
+
+**Files:**
+- Modify: `rka/skills/writer/SKILL.md`
+- Modify: `tests/skills/writer/test_skill_loads.py`
+
+**Interfaces:**
+- Consumes: `references/manuscript_review.md` (Task 3), `references/revision_check.md` (Task 4), `scripts/overclaim_lint.py` (Task 1).
+
+- [ ] **Step 1: Update the section-list + version test FIRST (failing)**
+
+In `tests/skills/writer/test_skill_loads.py`: bump the version assertion and insert the new section into `EXPECTED_SECTIONS`.
+
+Change line 43 from:
+```python
+    assert re.search(r"^version:\s*2\.4\.0\s*$", fm, re.MULTILINE)
+```
+to:
+```python
+    assert re.search(r"^version:\s*2\.5\.0\s*$", fm, re.MULTILINE)
+```
+
+In `EXPECTED_SECTIONS`, insert `"## Pre-Submission Review"` immediately before `"## Revision Loop"` (the review pass is advisory input that precedes revision), so the list reads `..., "## Local Rendering", "## Pre-Submission Review", "## Revision Loop", "## Anti-Patterns", "## Related"`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `RKA_DATA_DIR=/private/tmp/rka-test-data .venv/bin/python -m pytest tests/skills/writer/test_skill_loads.py -q`
+Expected: FAIL (SKILL.md still `2.4.0`; `## Pre-Submission Review` section missing).
+
+- [ ] **Step 3: Edit SKILL.md**
+
+Make these edits to `rka/skills/writer/SKILL.md`:
+
+1. Frontmatter: `version: 2.4.0` -> `version: 2.5.0`.
+
+2. In `## Supplementary references (load on demand)`, add two bullets:
+```markdown
+- [`references/manuscript_review.md`](references/manuscript_review.md): advisory pre-submission reviewer checklist (claim calibration, reviewer-risk, evaluation credibility, terminology, venue fit, systems/security add-on). PI-facing gap surfacer, never a gate.
+- [`references/revision_check.md`](references/revision_check.md): old-vs-new revision-status tracker (Fixed / Partial / Not fixed / Regressed), feeding the R1-R4 handlers.
+```
+
+3. In the `## Tool Surface` Scripts list, add:
+```markdown
+`overclaim_lint.py` scans drafts for calibration/overclaim wording ("verified", "guaranteed", "eliminates", "model-agnostic", ...) and emits `overclaim_report.json`. WARN-only, never BLOCK; ranks a hit higher when its backing `jrn_`/`clm_` is at `hypothesis`/`tested` confidence. Advisory input to the pre-submission review.
+```
+
+4. Add a new section `## Pre-Submission Review` immediately before `## Revision Loop`:
+```markdown
+## Pre-Submission Review
+
+Before the Final Layout checkpoint (or on demand), run an advisory reviewer-lens
+pass over the draft. It is a PI-facing gap surfacer, not a gate and not a score:
+it never blocks compile or submit. Only the mechanical gates block
+(`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, the
+reference-validation statuses).
+
+Two entry modes (mirroring the fresh-start vs. midpoint pattern):
+
+- **Fresh review**: run the full checklist in [`references/manuscript_review.md`](references/manuscript_review.md) and write `.planning/REVIEW.md`.
+- **Midpoint re-entry**: resume from an existing `.planning/REVIEW.md`, re-checking only the dimensions whose sections changed.
+
+Mechanical inputs the review aggregates (no new LLM judgment): the
+`verify_provenance.py` / `verify_citations.py` / `layout_audit.py` reports,
+`ai_tic_report.json`, and `overclaim_report.json` (calibration words, ranked by
+backing RKA confidence). The claim-calibration and evaluation-credibility
+dimensions hook into the same provenance and currency the Iron Law already
+enforces.
+
+**Mission-spawned review (Phase 3).** The Brain may commission a review with
+`rka_execute(args={"operation": "create_mission", "project_id": "prj_...", "objective": "...", "motivated_by_decision": "dec_...", "tags": ["writer-review", "manuscript:<jrn_id>"]})`.
+A fresh subagent runs the checklist and reports via
+`rka_execute(args={"operation": "submit_report", ...})`. This parallels the
+existing `writer-revision` path (see Session Start path b).
+
+This complements [`references/quality_review.md`](references/quality_review.md):
+that reports RKA evidence per rubric dimension; this adds the reviewer-facing
+presentation and claim-calibration checks. Neither assigns a score.
+```
+
+5. At the end of `## Revision Loop`, add a subsection:
+```markdown
+### Revision-check (old vs new)
+
+When a revised draft is available, compare it against the prior review comments
+(the spawning mission `context`, a prior `.planning/REVIEW.md`, or PI-supplied
+comments) and produce a revision-status tracker via
+[`references/revision_check.md`](references/revision_check.md). Output is
+`.planning/REVISION_CHECK.md`; each remaining issue maps to an R1-R4 class and
+routes through the handlers above, capped by `REVIEW_STATE.md` at three
+iterations. Advisory only: the readiness diagnosis informs the PI, it does not
+gate.
+```
+
+6. In `## Anti-Patterns`, add two numbered items (continue the numbering):
+```markdown
+16. **DON'T** gate on the pre-submission review or the revision-check. Both are advisory: they surface gaps to the PI, and only the mechanical gates (provenance, citations, layout, reference-validation) block.
+17. **DON'T** compute or report an accept/reject or numeric quality score. `overclaim_lint.py` is WARN-only; the review writes a gaps list, not a grade (see `quality_review.md` for why LLM-reviewer scores are not gates).
+```
+
+7. In `## Related`, add:
+```markdown
+- Pre-submission reviewer checklist: [`references/manuscript_review.md`](references/manuscript_review.md).
+- Revision-status tracker: [`references/revision_check.md`](references/revision_check.md).
+```
+
+- [ ] **Step 4: Verify no em/en dashes and run the section test**
+
+Run: `RKA_DATA_DIR=/private/tmp/rka-test-data .venv/bin/python -m pytest tests/skills/writer/test_skill_loads.py -q`
+Expected: PASS (frontmatter 2.5.0; new section present in order; all referenced files exist; no dashes; within line budget).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rka/skills/writer/SKILL.md tests/skills/writer/test_skill_loads.py
+git commit -m "feat(writer): wire pre-submission review + revision-check into SKILL.md (v2.5.0)"
+```
+
+---
+
+### Task 6: Mirror to plugin, full test, reinstall + refresh cache
+
+**Files:**
+- Modify: `plugin/skills/writer/**` (rsync mirror of `rka/skills/writer/`)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+
+- [ ] **Step 1: Mirror rka/skills/writer -> plugin/skills/writer**
+
+```bash
+rsync -rc --exclude='._*' --exclude='__pycache__' --exclude='__init__.py' \
+  rka/skills/writer/ plugin/skills/writer/
+```
+
+- [ ] **Step 2: Run the writer suite + packaging parity**
+
+Run:
+```bash
+RKA_DATA_DIR=/private/tmp/rka-test-data .venv/bin/python -m pytest \
+  tests/skills/writer/ tests/test_skills_packaging.py -q
+```
+Expected: PASS (writer suite green; `test_plugin_skills_match_packaged_skills` confirms parity; `test_all_packaged_skill_files_covered_by_package_data` confirms the new script + refs ship).
+
+- [ ] **Step 3: Reinstall the wheel and refresh the plugin cache**
+
+```bash
+find . -name '._*' -not -path './.git/*' -delete
+rsync -rc --exclude='._*' --exclude='__pycache__' rka/ /tmp/rka-build/rka/ >/dev/null
+( cd /tmp/rka-build && find . -name '._*' -not -path './.git/*' -delete \
+  && COPYFILE_DISABLE=1 UV_CACHE_DIR=/tmp/uv-cache uv tool install --force --no-cache . ) | tail -2
+claude plugin uninstall rka@rka && claude plugin install rka@rka
+```
+Expected: wheel installs; plugin reinstalls. Confirm the new files ship:
+```bash
+SP=/Users/ceron/.local/share/uv/tools/rka/lib/python3.11/site-packages/rka/skills/writer
+ls "$SP/references/manuscript_review.md" "$SP/references/revision_check.md" "$SP/scripts/overclaim_lint.py"
+```
+Expected: all three paths listed.
+
+- [ ] **Step 4: Commit the plugin mirror + spec/plan docs**
+
+```bash
+git add plugin/skills/writer docs/superpowers/specs/2026-07-06-writer-review-revision-design.md docs/superpowers/plans/2026-07-06-writer-review-revision.md
+git commit -m "chore(writer): mirror review/revision skill to plugin + add spec/plan"
+```
+
+- [ ] **Step 5: (PI-gated) push**
+
+Do NOT push without explicit PI request (repo discipline). When authorized:
+```bash
+git push origin main
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** manuscript_review.md (Task 3) = spec §2.1; revision_check.md (Task 4) = §2.2; overclaim_lint.py (Tasks 1-2) = §2.3; SKILL.md wiring + edwinhu patterns + anti-patterns + version bump (Task 5) = §2.4; testing = §5 (Tasks 1-2, 6); consistency/rollout = §6 (Task 6). Non-goals (§3) enforced by Global Constraints. All spec sections map to a task.
+- **Placeholder scan:** script + test code is complete; doc tasks specify exact headers, tables, and word lists (content is authored prose, structure is fully pinned).
+- **Type consistency:** `OverclaimHit`/`OverclaimReport` fields and `lint_file`/`main`/`_nearest_provenance` signatures are identical across Tasks 1-2; `resolver` contract (`entity_id -> dict|None` with `"confidence"`) matches the test doubles and `verify_provenance.py`'s resolver shape.

--- a/docs/superpowers/specs/2026-07-06-writer-review-revision-design.md
+++ b/docs/superpowers/specs/2026-07-06-writer-review-revision-design.md
@@ -1,0 +1,239 @@
+# Design — Writer skill "Review & Revision" capability
+
+Date: 2026-07-06
+Status: approved design (pending user spec review)
+Scope: `rka/skills/writer/` (mirrored to `plugin/skills/writer/`)
+Skill version: `2.4.0 → 2.5.0`
+
+## 1. Problem & motivation
+
+The RKA writer skill is drafting-forward. It enforces the Iron Law
+(draft-but-don't-assert, every claim provenance-anchored), Knowledge Currency
+(superseded / retracted / contradicted handling), six PI checkpoints, a
+reference-validation pipeline, anti-AI-tic enforcement, LaTeX render + layout
+audit, and a reactive Revision Loop that classifies PI comments into four
+shapes (R1–R4).
+
+What it lacks: a **proactive, reviewer-lens pre-submission review** (claim
+calibration, reviewer-risk preemption, evaluation-presentation credibility,
+terminology normalization, abstract/intro-specific checks) and an
+**old-vs-new revision-checking** pass (compare a revised draft against prior
+review comments and report what got Fixed / Partial / Not fixed / Regressed).
+
+Two inputs shape this design:
+
+- **The PI's manuscript-revision prompt template** (`Prompt 1` = pre-submission
+  reviewer review; `Prompt 2` = old-vs-new revision checking; plus a fast-pass
+  mini-prompt and a systems/security/AI-agent add-on). This is the capability
+  content.
+- **edwinhu/workflows** — a phase-based Claude Code workflow system
+  (`/writing` + `/writing-revise`, internal `writing-review`/`writing-validate`
+  phases, reviewer sub-passes, `.planning/` state). We borrow three *portable*
+  patterns, not its paradigm.
+
+### The load-bearing constraint (non-negotiable)
+
+The writer skill deliberately **does not gate on LLM-reviewer judgment**.
+`references/quality_review.md` documents why: LLM reviewers correlate only
+~r=0.48 with humans, disagree sharply with each other, and carry
+length / positivity / self-preference biases and injection weakness. So this
+capability is **advisory only**: it surfaces concrete, evidence-anchored gaps
+to the PI and never blocks compile or submit on its own judgment. The only
+gates that block remain the existing mechanical ones (`verify_provenance.py`,
+`verify_citations.py`, `layout_audit.py`, the reference-validation statuses).
+
+## 2. What we build
+
+### 2.1 New reference — `references/manuscript_review.md` (Prompt 1)
+
+A PI-facing pre-submission review **checklist** (not an autograder). Runs as
+an advisory pass before Checkpoint 6 (Final Layout), or on demand. Sections:
+
+1. **Source, venue & evidence discipline.** State assumptions: target venue
+   family (from `venue/<venue>.md` if known), paper type, strongest evidence,
+   most fragile evidence. Strict evidence rule: a claim is not safe because it
+   sounds plausible — check whether the manuscript itself supports it
+   (experiment / citation / limitation text). Point to exact sections /
+   figures / tables.
+2. **Overall assessment + top 3–5 reviewer-facing risks.**
+3. **Claim-calibration table** — `original/likely claim | problem | safer
+   revised wording`. Targets absolute wording (`verified`, `guaranteed`,
+   `complete`, `eliminates`, `model-agnostic`, `dominant`, `fundamental`,
+   `robust to adaptive adversaries`, `generalizes across benchmarks`, `full
+   recall`, `no false positives`). **Hook:** cross-reference RKA confidence —
+   an absolute claim whose backing `jrn_`/`clm_` is at `hypothesis`/`tested`
+   confidence (not `verified`) is a high-priority calibration gap, and this is
+   exactly what `scripts/overclaim_lint.py` (§2.3) surfaces mechanically.
+4. **Abstract review** — first-sentence problem framing, motivation
+   specificity, arithmetic/ratio correctness, strongest-evidence centrality,
+   honest framing of mixed/preliminary results, no cherry-picking.
+5. **Introduction review** — motivation, gap statement (fair to prior work),
+   key-insight clarity, results paragraph matches evaluation, contribution
+   list not a second abstract.
+6. **Structure & organization** — logical section order; background / threat
+   model / design / implementation / evaluation / discussion / related work /
+   limitations cleanly separated; limitations early enough; roadmap clarity.
+7. **Evaluation-presentation credibility** — denominators explained,
+   arithmetic checked, controlled-benchmark vs external-benchmark vs
+   model-specific vs ablation vs preliminary results separated, trial counts
+   verifiable, outcome categories separated from defense mechanisms,
+   statistical claims not overstating independence, per-benchmark limitations
+   stated. **Hook:** every reported number should trace to a `mis_` report or
+   `jrn_`/`clm_` result (same provenance the Iron Law already requires).
+8. **Figures, tables & layout** — caption/denominator clarity, two-column
+   readability, no hidden mixed results, move-to-appendix candidates.
+   Complements (does not duplicate) `layout_audit.py`, which handles the
+   mechanical layout gates.
+9. **Terminology-normalization table** — `current variants | recommended term
+   | notes` across system name, threat-model terms, metric names, model names,
+   benchmark names, section/figure/table references.
+10. **Writing style** — defers to the existing anti-AI-tic machinery
+    (`ai_tic_lint.py`, `bridge_repetition_check.py`); this section only adds
+    the reviewer-perception framing, not a second lexical list.
+11. **Reference & citation integrity** — from a credibility lens; defers
+    mechanical checks to `verify_provenance.py` / `verify_citations.py` and the
+    reference-validation pipeline. Never invent citations — name the kind of
+    source needed.
+12. **Venue fit** — reads `venue/<venue>.md` (tone, required sections,
+    forbidden constructions).
+13. **Reviewer-risk analysis** — `criticism | why a reviewer raises it |
+    severity | how to preempt | suggested wording`.
+14. **Concrete rewrite package** — revised title options, abstract, key-insight
+    paragraph, contribution list, limitation paragraph, evaluation-roadmap
+    paragraph, related-work positioning.
+15. **Systems/security/AI-agent add-on** (venue-conditional lens): threat-model
+    ↔ attack-taxonomy consistency, direct vs indirect attack separation,
+    design-guarantee vs implementation-heuristic distinction, conditional
+    formal properties, baseline fairness (policy-only / filtering-only /
+    taint-only / full-system), CIA + usability claims each backed by the right
+    evidence.
+
+**Output artifact:** `.planning/REVIEW.md` — one table per dimension with an
+explicit **Gaps** list drawn from the mechanical inputs and RKA evidence. No
+numeric score, no accept/reject verdict, no gate.
+
+**Fast pass:** a short "top-10-issues" mode (the PI's mini-prompt) documented as
+a lightweight entry that runs sections 2, 3, 7, 8, 9, 13 only.
+
+### 2.2 New reference — `references/revision_check.md` (Prompt 2)
+
+Old-vs-new revision checking. Steps:
+
+1. **Comparison setup** — identify old vs new draft, the prior review comments
+   being used as baseline (from the spawning mission's `context`, the prior
+   `.planning/REVIEW.md`, or PI-supplied comments), and whether the comparison
+   is full / new-only-guided-by-prior / limited.
+2. **Executive revision diagnosis** — better / somewhat better / unchanged /
+   worse; most successful revisions; remaining problems; regressions; a
+   readiness judgment (minor-edit / focused-revision / major-restructure /
+   not-ready) framed as advisory input, not a gate.
+3. **Revision-status tracker** — `prior issue | status | evidence in new draft
+   | remaining problem | recommended next edit`, status ∈ {Fixed, Mostly
+   fixed, Partially fixed, Not fixed, Regressed, New issue, Cannot verify}.
+   Covers the same dimensions as §2.1.
+4. **Per-dimension re-checks** (abstract, title/contribution alignment, claim
+   calibration, intro story, evaluation, figures/tables, terminology, style,
+   citations) — each compared against the prior issue.
+5. **Revision-comment classification** — map each remaining issue to the
+   existing **R1–R4** classes so the current Revision Loop handlers apply
+   (`handle_factual_r1`, `handle_style_r2`, `handle_inconsistency_r3`,
+   `handle_logical_r4`).
+6. **Remaining reviewer risks + action plan** — must-fix vs optional.
+
+**Reuses:** `REVIEW_STATE.md`'s `iteration / max:3 / verdict` cap;
+`bridge_repetition_check.py` and `ai_tic_lint.py` for old-vs-new diffs.
+
+**Output artifact:** `.planning/REVISION_CHECK.md` — the tracker table.
+
+### 2.3 New script — `scripts/overclaim_lint.py`
+
+A lexical overclaim/calibration detector, in the shape of `ai_tic_lint.py`:
+
+- Scans `sections/*.tex` for calibration words (the §2.1(3) list; extensible
+  per-project like the AI-tic config).
+- **WARN-only, never BLOCK** (advisory-only decision). Emits
+  `overclaim_report.json` (term, file, line, sentence, severity=WARN).
+- **RKA-confidence ranking:** when an overclaim word sits in a sentence with a
+  nearby `% provenance:` comment, resolve the cited `jrn_`/`clm_` confidence;
+  `hypothesis`/`tested` backing raises the flag's priority (an absolute claim
+  on non-`verified` evidence). Falls back to plain lexical WARN when no
+  provenance comment is adjacent (no RKA call needed).
+- Mirrors `ai_tic_lint.py`'s CLI + report shape so the Writer treats it as one
+  more mechanical input to `.planning/REVIEW.md`.
+
+### 2.4 SKILL.md changes
+
+- New **"Pre-Submission Review"** section: advisory input to Checkpoint 6 (not
+  a new gating checkpoint); points to `manuscript_review.md`; lists
+  `overclaim_lint.py` among the mechanical inputs; states the advisory-only
+  rule.
+- Extend **"Revision Loop"** with a "Revision-check (old-vs-new)" subsection
+  pointing to `revision_check.md` and wiring its output to R1–R4.
+- **edwinhu patterns folded in:** (a) fresh-review vs. midpoint re-entry
+  (mirror `/writing` vs `/writing-revise`) documented as two entry modes; (b)
+  the `.planning/REVIEW.md` + `.planning/REVISION_CHECK.md` state artifacts
+  added to the `.planning/` convention; (c) a **mission-spawned `writer-review`**
+  path parallel to today's `writer-revision`, threaded through Session Start
+  path (b): Brain spawns `rka_create_mission(..., tags=["writer-review",
+  "manuscript:<jrn_id>"], motivated_by_decision="dec_...")`; the subagent runs
+  the review and reports via `rka_submit_report`.
+- Housekeeping: update the Supplementary-references list, the Scripts list, the
+  Related section, and add two Anti-Patterns: "DON'T gate on the reviewer pass
+  — advisory only"; "DON'T compute an accept/reject or numeric quality score
+  (see quality_review.md)." Bump frontmatter `version: 2.4.0 → 2.5.0`.
+- Cross-link `quality_review.md` (the RKA-evidence rubric) and
+  `manuscript_review.md` (the reviewer-perception lens) as complementary — the
+  former reports RKA evidence per dimension, the latter adds the reviewer-facing
+  presentation/claim-calibration checks. Neither scores.
+
+## 3. Non-goals (YAGNI / principle preservation)
+
+- No LLM-reviewer score, accept/reject verdict, or gate on reviewer judgment.
+- No new PI checkpoint (review is advisory input to Checkpoint 6).
+- No phase restructure of the skill (that was rejected approach D; edwinhu is a
+  standalone-workflow paradigm, not RKA's skill-in-a-knowledge-graph paradigm).
+- No new RKA orchestration beyond the `writer-review` mission tag — bookkeeper
+  invariant holds: new files only under `rka/skills/writer/` and
+  `tests/skills/writer/`.
+- No third-party content vendored; the calibration word list is authored from
+  the PI's prompt, consistent with the Phase-1 posture in
+  `dec_01KS12H9KT1T03DHX2Q6FKTXHH`.
+
+## 4. Integration & data flow
+
+```
+Pre-submission review (advisory)                 Revision-check (advisory)
+  trigger: before Checkpoint 6, or on demand,      trigger: new draft vs prior
+           or Brain-spawned writer-review mission           comments/old draft
+  reads:  sections/*.tex, venue/<venue>.md,        reads: old + new drafts,
+          verify_provenance/citations/layout              prior REVIEW.md or
+          reports, ai_tic_report.json,                    mission context
+          overclaim_report.json, RKA confidence
+  writes: .planning/REVIEW.md (gaps, no score)     writes: .planning/REVISION_CHECK.md
+  next:   PI reads gaps → Checkpoint 6 decision    next:  remaining issues → R1–R4
+                                                           handlers → REVIEW_STATE cap
+```
+
+## 5. Testing
+
+- `tests/skills/writer/test_overclaim_lint.py`: fixture `.tex` with known
+  overclaim words → expected WARN report; a sentence with a `% provenance:`
+  comment pointing at a `tested`-confidence entity ranks higher than a bare
+  lexical hit (RKA confidence mocked, no live call).
+- Doc-consistency is already covered: `tests/test_skills_packaging.py` enforces
+  `plugin/skills/` == `rka/skills/` parity and package-data coverage, so the two
+  new references + script ship on a fresh install.
+
+## 6. Consistency & rollout
+
+`rka/skills/writer/` is the source of truth. After edits: mirror to
+`plugin/skills/writer/` via the documented rsync, run the packaging tests,
+reinstall the wheel + refresh the plugin cache (per
+`project_skill_tool_consistency`). Ship behind the same commit discipline as
+the rest of the repo (no push without explicit PI request).
+
+## 7. Open questions
+
+None blocking. The skill-version bump (2.4.0 → 2.5.0) is a content-version bump
+local to the skill frontmatter, distinct from the RKA release version; called
+out here for visibility.

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rka-writer
-description: Manuscript-drafting AI for RKA-managed research projects. Runs as a Claude Code skill in VSCode per dec_01KS0AWYDV752AWQRF40CQBRFZ. Drafts but does not assert: every prose claim carries provenance to a lit_, jrn_, or dec_ entity in the research graph. Load when starting a manuscript session in a manuscripts/<project>/<venue>/ working directory, when picking up a revision mission from the Brain, or when reasoning about venue, references, layout, or anti-AI-tic enforcement.
-version: 2.4.0
+description: Manuscript-drafting AI for RKA-managed research projects. Runs as a Claude Code skill in VSCode per dec_01KS0AWYDV752AWQRF40CQBRFZ. Drafts but does not assert: every prose claim carries provenance to a lit_, jrn_, or dec_ entity in the research graph. Load when starting a manuscript session in a manuscripts/<project>/<venue>/ working directory, when picking up a revision mission from the Brain, when running a pre-submission review, or when reasoning about venue, references, layout, or anti-AI-tic enforcement.
+version: 2.5.0
 ---
 
 # Writer Skill
@@ -23,6 +23,8 @@ Iron Law: **draft but do not assert.** If you find yourself wanting to state a f
 - [`references/latex_audit.md`](references/latex_audit.md): twelve-field layout checklist used by `scripts/layout_audit.py`.
 - [`references/examples.md`](references/examples.md): worked outline ratification and AI-tic catch examples.
 - [`references/quality_review.md`](references/quality_review.md): the pre-submit quality self-review checklist (rubric dimensions tied to RKA evidence; explicitly not an LLM-reviewer autograder).
+- [`references/manuscript_review.md`](references/manuscript_review.md): advisory pre-submission reviewer checklist (claim calibration, reviewer-risk, evaluation credibility, terminology, venue fit, systems/security add-on). PI-facing gap surfacer, never a gate.
+- [`references/revision_check.md`](references/revision_check.md): old-vs-new revision-status tracker (Fixed / Partial / Not fixed / Regressed), feeding the R1-R4 handlers.
 
 ---
 
@@ -50,7 +52,7 @@ Full worked walkthrough: [`references/workflows.md`](references/workflows.md) se
 
 ## Tool Surface
 
-> **v2.7.0 dispatch translation.** The legacy `rka_*` tool names used throughout this skill (`rka_get_status`, `rka_get_mission`, `rka_get_changelog`, `rka_get_research_map`, `rka_add_decision`, `rka_record_pi_selection`, `rka_submit_report`, `rka_get_literature`, `rka_create_mission`, `rka_get_manuscript`, etc.) are synonyms for the v2.7.0+ typed-arg surface: reads are `rka_query(args={"operation": ...})` and writes are `rka_execute(args={"operation": ...})` (e.g. `rka_get_status` -> operation `status`, `rka_add_decision` -> operation `record_decision`, `rka_create_mission` -> operation `create_mission`). Only `rka_query` / `rka_execute` / `rka_describe` / `rka_load_tools` / `rka_help` broadcast; the legacy names are deferred and must be registered via `rka_load_tools` first. The discipline (`project_id` on every call, `source="pi"` + `verbatim_input`, `related_journal=[...]` on decisions) carries over verbatim — only the call shape changes. See `rka_describe(operation="<name>")` for per-operation signatures.
+> **v2.7.0 dispatch translation.** The legacy `rka_*` tool names used throughout this skill (`rka_get_status`, `rka_get_mission`, `rka_get_changelog`, `rka_get_research_map`, `rka_add_decision`, `rka_record_pi_selection`, `rka_submit_report`, `rka_get_literature`, `rka_create_mission`, `rka_get_manuscript`, etc.) are synonyms for the v2.7.0+ typed-arg surface: reads are `rka_query(args={"operation": ...})` and writes are `rka_execute(args={"operation": ...})` (e.g. `rka_get_status` -> operation `status`, `rka_add_decision` -> operation `record_decision`, `rka_create_mission` -> operation `create_mission`). Only `rka_query` / `rka_execute` / `rka_describe` / `rka_load_tools` / `rka_help` broadcast; the legacy names are deferred and must be registered via `rka_load_tools` first. The discipline (`project_id` on every call, `source="pi"` + `verbatim_input`, `related_journal=[...]` on decisions) carries over verbatim; only the call shape changes. See `rka_describe(operation="<name>")` for per-operation signatures.
 
 Native Claude Code tools you use directly: `Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, `WebSearch`, `WebFetch`. `Bash` is the workhorse here because manuscript work is fundamentally file-and-shell heavy (latexmk, chktex, biber, the custom audit scripts under `scripts/`).
 
@@ -71,6 +73,7 @@ Scripts invoked via `Bash` (under `scripts/`):
 `layout_audit.py` runs after a successful render and produces `audit.json` over twelve fields.
 `chart_render.py` is a skeleton with venue presets (tueplots, SciencePlots); the PI fills in per-manuscript chart logic.
 `validate_references.py` is a Phase 1 stub implementing Stage A only; Stages B through G raise `NotImplementedError` with a Phase 2 reference.
+`overclaim_lint.py` scans drafts for calibration/overclaim wording (`verified`, `guaranteed`, `eliminates`, `model-agnostic`, ...) and emits `overclaim_report.json`. WARN-only, never BLOCK; ranks a hit higher when its backing `jrn_`/`clm_` is at `hypothesis`/`tested` confidence. Advisory input to the pre-submission review.
 `fetch_template.py` is a Phase 1 stub for registry lookup; SHA-256 verification and actual fetching land in Phase 2.
 
 ---
@@ -281,6 +284,23 @@ Full checklist with regex patterns: [`references/latex_audit.md`](references/lat
 
 ---
 
+## Pre-Submission Review
+
+Before the Final Layout checkpoint (or on demand), run an advisory reviewer-lens pass over the draft. It is a PI-facing gap surfacer, not a gate and not a score: it never blocks compile or submit. Only the mechanical gates block (`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, the reference-validation statuses).
+
+Two entry modes (mirroring the fresh-start vs. midpoint pattern):
+
+- **Fresh review**: run the full checklist in [`references/manuscript_review.md`](references/manuscript_review.md) and write `.planning/REVIEW.md`.
+- **Midpoint re-entry**: resume from an existing `.planning/REVIEW.md`, re-checking only the dimensions whose sections changed.
+
+Mechanical inputs the review aggregates (no new LLM judgment): the `verify_provenance.py` / `verify_citations.py` / `layout_audit.py` reports, `ai_tic_report.json`, and `overclaim_report.json` (calibration words, ranked by backing RKA confidence). The claim-calibration and evaluation-credibility dimensions hook into the same provenance and currency the Iron Law already enforces.
+
+**Mission-spawned review (Phase 3).** The Brain may commission a review with `rka_execute(args={"operation": "create_mission", "project_id": "prj_...", "objective": "...", "motivated_by_decision": "dec_...", "tags": ["writer-review", "manuscript:<jrn_id>"]})`. A fresh subagent runs the checklist and reports via `rka_execute(args={"operation": "submit_report", ...})`. This parallels the existing `writer-revision` path (see Session Start path b).
+
+This complements [`references/quality_review.md`](references/quality_review.md): that reports RKA evidence per rubric dimension; this adds the reviewer-facing presentation and claim-calibration checks. Neither assigns a score.
+
+---
+
 ## Revision Loop
 
 When the PI returns review comments on a draft section, classify each comment into one of four shapes and apply the matching procedure. The Phase 3 implementation lives in `scripts/revision_handler.py` (per `dec_01KS2WPKMRVSJ2R0PP74722PEH`) and is invoked either directly by the PI (CLI: `python scripts/revision_handler.py --dispatch --comment "..." --section sections/03.tex`) or via a Brain-spawned `writer-revision` mission (see Session Start path b above).
@@ -297,6 +317,10 @@ When the PI returns review comments on a draft section, classify each comment in
 `.planning/REVIEW_STATE.md` tracks `iteration: N / max: 3 / verdict: CONTINUE | ESCALATE | COMPLETE`. The third failed iteration auto-escalates to a PI Style or Logical checkpoint with three resolution options. See `read_review_state` and `advance_review_state` helpers in `scripts/revision_handler.py`.
 
 Venue-aware overrides: per-venue `references/venue/<venue>.md` may carry stricter rules (Forbidden constructions field). The R2 style handler optionally loads these via `load_venue_overrides`.
+
+### Revision-check (old vs new)
+
+When a revised draft is available, compare it against the prior review comments (the spawning mission `context`, a prior `.planning/REVIEW.md`, or PI-supplied comments) and produce a revision-status tracker via [`references/revision_check.md`](references/revision_check.md). Output is `.planning/REVISION_CHECK.md`; each remaining issue maps to an R1-R4 class and routes through the handlers above, capped by `REVIEW_STATE.md` at three iterations. Advisory only: the readiness diagnosis informs the PI, it does not gate.
 
 ---
 
@@ -319,6 +343,8 @@ Venue-aware overrides: per-venue `references/venue/<venue>.md` may carry stricte
 13. **DON'T** loop more than three iterations on a section. ESCALATE on the third failure with three resolution options.
 14. **DON'T** edit a ratified checkpoint Decision. Create a new `dec_` that `supersedes` it.
 15. **DON'T** vendor third-party content without explicit license verification. Algorithm-only reimplementation from primary sources is the Phase 1 posture per `dec_01KS12H9KT1T03DHX2Q6FKTXHH`.
+16. **DON'T** gate on the pre-submission review or the revision-check. Both are advisory: they surface gaps to the PI, and only the mechanical gates (provenance, citations, layout, reference-validation) block.
+17. **DON'T** compute or report an accept/reject or numeric quality score. `overclaim_lint.py` is WARN-only; the review writes a gaps list, not a grade (see `quality_review.md` for why LLM-reviewer scores are not gates).
 
 ---
 
@@ -332,6 +358,8 @@ Venue-aware overrides: per-venue `references/venue/<venue>.md` may carry stricte
 - LaTeX template registry: [`references/template_registry.md`](references/template_registry.md).
 - Layout audit checklist: [`references/latex_audit.md`](references/latex_audit.md).
 - Worked examples: [`references/examples.md`](references/examples.md).
+- Pre-submission reviewer checklist: [`references/manuscript_review.md`](references/manuscript_review.md).
+- Revision-status tracker: [`references/revision_check.md`](references/revision_check.md).
 - Brain counterpart skill: [`../brain/SKILL.md`](../brain/SKILL.md).
 - Executor counterpart skill: [`../executor/SKILL.md`](../executor/SKILL.md).
 - PI counterpart skill: [`../pi/SKILL.md`](../pi/SKILL.md).

--- a/plugin/skills/writer/references/manuscript_review.md
+++ b/plugin/skills/writer/references/manuscript_review.md
@@ -1,0 +1,230 @@
+# Pre-Submission Manuscript Review (advisory)
+
+This is a **PI-facing gap surfacer, not an autograder.** It never gates compile
+or submit. The only blocking gates remain the mechanical ones:
+`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, and the
+reference-validation statuses. This review adds the reviewer-facing
+presentation and claim-calibration checks that those gates do not cover, and it
+reports concrete gaps for the PI to weigh, never a numeric score or an
+accept/reject verdict.
+
+It complements [`quality_review.md`](quality_review.md): that reports the RKA
+evidence behind each rubric dimension; this adds the reviewer-perception lens
+(claim calibration, evaluation credibility, reviewer risk). Neither scores. See
+`quality_review.md` for why gating on an LLM-reviewer score is unsound (LLM
+reviewers correlate only r=0.48 with humans and carry length / positivity /
+self-preference biases).
+
+Run this before the Final Layout checkpoint, or on demand. Point to exact
+sections, pages, paragraphs, figures, and tables throughout. Where a claim
+needs support, name the RKA entity (`lit_`, `jrn_`, `dec_`, `clm_`) or the kind
+of source needed; do not invent one.
+
+## 0. Source, venue, and evidence discipline
+
+Before commenting, state your assumptions:
+
+- Target venue or venue family (read `references/venue/<venue>.md` if the venue
+  is known), and paper type (systems, security, AI, HCI, NLP, empirical, theory).
+- The strongest evidence in the manuscript.
+- The weakest or most fragile evidence in the manuscript.
+
+Strict evidence rule: a claim is not safe because it sounds plausible. Check
+whether the manuscript itself supports it through an experiment, a citation, a
+formal argument, or explicit limitation text. If it is unsupported, ask for
+evidence or suggest softer wording.
+
+## 1. Overall assessment and top reviewer-facing risks
+
+- Is the central story clear?
+- Do the title, abstract, introduction, contribution list, and results align?
+- Does the manuscript read like a polished submission or an expanded technical
+  report?
+- Are claims calibrated to the evidence?
+- Is the strongest evidence placed where a reviewer will see it?
+- What are the top 3 to 5 reviewer-facing risks?
+
+Be direct. If something is strong, say why. If something invites reviewer
+skepticism, name it.
+
+## 2. Claim-calibration table
+
+| Claim (original or likely) | Problem | Safer revised wording |
+|---|---|---|
+
+Target absolute or promotional wording. The calibration word list:
+`verified`, `guaranteed`, `complete`, `completely`, `eliminates`,
+`model-agnostic`, `dominant`, `fundamental`, `robust to adaptive adversaries`,
+`generalizes across benchmarks`, `full recall`, `no false positives`,
+`provably`, `never fails`.
+
+**Hook:** cross-reference RKA confidence. An absolute claim whose backing
+`jrn_`/`clm_` is at `hypothesis` or `tested` confidence (not `verified`) is a
+high-priority calibration gap. `scripts/overclaim_lint.py` surfaces these
+mechanically: it is WARN-only and marks `priority="high"` when a governing
+`% provenance:` comment resolves to weak-confidence evidence. Fold its
+`overclaim_report.json` into this table rather than re-scanning by eye.
+
+The goal is not to weaken the paper. It is to make the claims precise,
+defensible, and reviewer-proof.
+
+## 3. Abstract review
+
+- Does the first sentence establish the problem clearly?
+- Is the motivation specific rather than generic?
+- Are the contributions accurate without overclaiming?
+- Are all numbers, ratios, and percentage-point changes correct?
+- Is the strongest evidence the centerpiece, and are weaker or preliminary
+  results framed honestly (no cherry-picking, no hidden mixed result)?
+
+Provide remaining abstract problems and a revised abstract draft that is
+shorter, clearer, and more credible, with a one-line note on why it is better.
+
+## 4. Introduction review
+
+Check the opening motivation, motivating example, gap statement (fair to prior
+work, not an unfair attack), key insight, why prior work is insufficient, the
+transition from problem to approach, the results paragraph, and the
+contribution list. Flag sentences that are too broad, too absolute, or
+promotional; repetition; missing transitions; and a contribution list that has
+become a second abstract. Provide a revised introduction outline, suggested
+wording for the key-insight paragraph, and a shorter, more defensible
+contribution list.
+
+## 5. Structure and organization
+
+- Are sections in a logical order?
+- Are background, threat model, design, implementation, evaluation, discussion,
+  related work, and limitations cleanly separated (design not tangled with
+  evaluation configuration)?
+- Do limitations appear early enough?
+- Is the evaluation easy to follow, and does the paper need a clearer roadmap?
+
+Provide a proposed section outline and specific movement suggestions (for
+example, "move this table to the appendix" or "move this limitation earlier").
+
+## 6. Evaluation-presentation credibility
+
+- Is the evaluation story easy to understand, and is the main result clearly
+  identified?
+- Are controlled-benchmark, external-benchmark, model-specific, ablation, and
+  preliminary results separated?
+- Are trial counts and denominators easy to verify, and do captions explain the
+  denominators?
+- Are outcome categories separated from defense mechanisms?
+- Are statistical claims presented without overstating independence, and are
+  repeated trials treated appropriately?
+- Are the limitations of each benchmark stated, and are positive results that
+  should read as preliminary framed that way?
+
+Look for arithmetic errors, confusing denominators, and ambiguous terms (trial,
+scenario, attack evaluation, task success, safe tool call, blocked, bypass).
+**Hook:** every reported number should trace to a `mis_` report or a
+`jrn_`/`clm_` result, the same provenance the Iron Law already requires for body
+prose. Provide a clearer evaluation narrative, caption improvements, and a
+numerical-consistency checklist to run before submission.
+
+## 7. Figures, tables, and layout
+
+For each important figure or table: is the caption clear and does it explain the
+denominator; is it readable in two-column format; does it support the main
+argument; is it duplicative; does it overstate the result; is a mixed or
+negative result hidden in a dense table? This complements (does not duplicate)
+`layout_audit.py`, which handles the mechanical layout gates (page limit,
+undefined refs and cites, overfull boxes). Provide better titles and captions,
+visual-simplification suggestions, and move-to-appendix candidates.
+
+## 8. Terminology normalization
+
+| Current variants | Recommended term | Notes |
+|---|---|---|
+
+Check the system name, title phrase, threat-model terms, attack-category names,
+evaluation metrics, model names, dataset and benchmark names, policy names,
+provenance and measurement labels, and section / figure / table references.
+
+## 9. Writing style
+
+Defer to the existing anti-AI-tic machinery: `ai_tic_lint.py` (lexical tiers
+plus structural detectors) and `bridge_repetition_check.py` (near-duplicate
+sentences across sections). This section adds only the reviewer-perception
+framing (does the prose read as hyped, repetitive, or generated) and does not
+introduce a second lexical list.
+
+## 10. Reference and citation integrity
+
+Review citations from a credibility lens: claims about prior work that need
+citations; citations that are too broad or poorly placed; sentences that cite a
+source but make a stronger claim than the source supports; related-work
+comparisons that may not be apples-to-apples; whether the paper distinguishes
+its own results from prior reported numbers. Defer the mechanical checks to
+`verify_provenance.py`, `verify_citations.py`, and the reference-validation
+pipeline. Do not invent citations; where support is missing, name the kind of
+source needed.
+
+## 11. Venue fit
+
+Read `references/venue/<venue>.md`: expected tone, section order, required
+sections (for example Limitations at EMNLP, Ethics at ACL 2024+, Reproducibility
+checklist at NeurIPS), forbidden constructions, and whether math, system detail,
+user-study detail, or benchmark detail is too much or too little for the venue.
+If the venue is unknown, list the venue-dependent checks the PI should make.
+
+## 12. Reviewer-risk analysis
+
+| Criticism | Why a reviewer raises it | Severity | How to preempt | Suggested wording |
+|---|---|---|---|---|
+
+Include risks such as: the paper overclaims; baselines look weak or unfair; the
+strongest result is not emphasized; the abstract hides a mixed result;
+evaluation numbers are hard to reconcile; the threat model is inconsistent with
+the attack taxonomy; the writing is repetitive; figures or tables are too dense;
+limitations appear too late.
+
+## 13. Concrete rewrite package
+
+Provide a focused, submission-ready package: revised title options, a revised
+abstract, a revised key-insight paragraph, a revised contribution list, a
+revised limitation paragraph, a revised evaluation-roadmap paragraph, and a
+revised related-work positioning paragraph.
+
+## 14. Systems, security, and AI-agent add-on (venue-conditional)
+
+Use this lens for tool-using LLM-agent security papers (and similar
+systems/security work):
+
+- Is the threat model consistent with the attack taxonomy?
+- Are direct and indirect attacks clearly separated?
+- Does the paper distinguish design guarantees from implementation heuristics?
+- Are formal properties stated as conditional on clearly-stated assumptions?
+- Are policy-only, filtering-only, taint-only, and full-system baselines framed
+  fairly?
+- Are evaluation outcomes separated from defense mechanisms, external-benchmark
+  results adapted transparently, and controlled-benchmark results not oversold?
+- Are mixed results acknowledged in the main text?
+- Do final claims distinguish architecture-level generality from empirical
+  results on the tested models?
+- Are confidentiality, integrity, availability, and usability claims each
+  supported by the right evidence?
+
+## Output
+
+Write `.planning/REVIEW.md`: one table per dimension above, each with an explicit
+**Gaps** list drawn from the mechanical inputs (`verify_provenance.py`,
+`verify_citations.py`, `ai_tic_report.json`, `overclaim_report.json`,
+`layout_audit.py`) and RKA evidence (confidence levels, `contradicts` edges).
+No numeric score. No accept/reject verdict.
+
+## Fast pass
+
+A quick top-10-issues mode runs sections 1, 2, 6, 7, 8, and 12 only: overall
+risks, claim calibration, evaluation credibility, figures and tables,
+terminology, and reviewer risk. Same advisory posture and same `.planning/REVIEW.md`
+output, abbreviated.
+
+## Anti-patterns
+
+- DON'T compute or report an accept/reject or numeric quality score.
+- DON'T treat this review as a gate; only the mechanical gates block.
+- DON'T assert a review claim without pointing at the manuscript location or the
+  RKA entity that supports it.

--- a/plugin/skills/writer/references/revision_check.md
+++ b/plugin/skills/writer/references/revision_check.md
@@ -1,0 +1,100 @@
+# Revision Check (old vs new, advisory)
+
+Compare a revised draft against the prior review comments and report what the
+revision fixed, left unfixed, or regressed. This is advisory input to the
+Revision Loop, not a gate: the readiness diagnosis informs the PI, it does not
+block compile or submit. Only the mechanical gates
+(`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, the
+reference-validation statuses) block.
+
+## 0. Comparison setup
+
+Identify:
+
+- Which draft is the older version and which is the newer version.
+- The prior-comments baseline: the spawning `writer-review` or `writer-revision`
+  mission `context`, the prior `.planning/REVIEW.md`, or PI-supplied comments.
+- Whether any input is missing for a fair comparison.
+
+Then state the run type: full old-vs-new comparison; new-version-only guided by
+prior comments; or limited comparison because the old version or prior comments
+are incomplete.
+
+## 1. Executive revision diagnosis
+
+- Is the newer manuscript clearly better, somewhat better, unchanged, or worse?
+- What are the most successful revisions?
+- What earlier problems remain, and did the revision introduce new ones?
+
+Give an advisory readiness judgment (ready after minor editing; needs another
+focused revision; needs major restructuring; not ready). Framed as advice for
+the PI, not a gate.
+
+## 2. Revision-status tracker
+
+| Prior issue | Status | Evidence in new draft | Remaining problem | Recommended next edit |
+|---|---|---|---|---|
+
+Status vocabulary, exactly: `Fixed`, `Mostly fixed`, `Partially fixed`,
+`Not fixed`, `Regressed`, `New issue`, `Cannot verify`.
+
+Track the same dimensions as `manuscript_review.md`: title accuracy, abstract
+clarity and arithmetic, claim calibration, introduction story, contribution
+list, evaluation framing (controlled vs external benchmark emphasis, mixed or
+negative result disclosure), table and figure readability, terminology
+consistency, limitation placement, related-work positioning, reference and
+citation integrity, and anti-AI-tic style.
+
+## 3. Per-dimension re-checks
+
+For each dimension, compare the newer draft against the prior issue:
+
+- **Abstract**: arithmetic and ratios corrected; strongest evidence is the
+  centerpiece; no cherry-picking; mixed results disclosed; aligned with the
+  evaluation tables.
+- **Title, framing, contribution alignment**: title not overclaiming;
+  contribution list shorter and each item backed by evidence; design,
+  implementation, benchmark, and evaluation contributions separated.
+- **Claim calibration**: re-run `scripts/overclaim_lint.py` on the new draft and
+  diff its `overclaim_report.json` against the prior run; a resolved hit is
+  progress, a new or higher-priority hit is a regression.
+- **Introduction, evaluation, figures and tables, terminology**: as in
+  `manuscript_review.md`, but scored against the prior issue rather than fresh.
+- **Style**: diff `ai_tic_lint.py` output old vs new; `bridge_repetition_check.py`
+  for cross-section near-duplicates.
+
+## 4. Revision-comment classification
+
+Map each remaining issue to the four Revision Loop classes so the existing
+handlers in `scripts/revision_handler.py` apply:
+
+- R1 factual (sentence-level) -> `handle_factual_r1`.
+- R2 style or AI-tic -> `handle_style_r2`.
+- R3 cross-section inconsistency -> `handle_inconsistency_r3`
+  (`bridge_repetition_check.py`, ratio >= 0.7).
+- R4 logical gap or unsupported claim -> `handle_logical_r4` (escalates a
+  `writer_evidence_gap` mission to the Brain).
+
+For each remaining issue give: class, severity, location, required action, and
+whether the author can fix it by editing text or needs more evidence. The
+`REVIEW_STATE.md` iteration cap of 3 applies; the third failed iteration
+auto-escalates to a PI checkpoint.
+
+## 5. Remaining reviewer risks and action plan
+
+List the reviewer criticisms that still remain after the revision. For each:
+why it may still arise, how severe, how to preempt, and the exact wording to
+add, soften, or move. End with a prioritized action list split into must-fix
+before submission and optional-but-strengthening.
+
+## Output
+
+Write `.planning/REVISION_CHECK.md`: the revision-status tracker table plus the
+remaining-risks action plan. No numeric score.
+
+## Anti-patterns
+
+- DON'T re-litigate an item already marked `Fixed`.
+- DON'T gate on the readiness diagnosis; it is advisory.
+- DON'T mark a `Cannot verify` item as `Fixed`; surface the missing input to the
+  PI instead.

--- a/plugin/skills/writer/scripts/overclaim_lint.py
+++ b/plugin/skills/writer/scripts/overclaim_lint.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""overclaim_lint.py: advisory calibration/overclaim detector for the Writer skill.
+
+Advisory-only (WARN, never BLOCK) per the 2026-07-06 Review and Revision design.
+Flags absolute/overclaim wording ("verified", "guaranteed", "eliminates",
+"model-agnostic", ...) so the pre-submission review
+(references/manuscript_review.md) can surface claim-calibration gaps. Mirrors
+ai_tic_lint.py's CLI and report shape.
+
+RKA-confidence ranking: when a `% provenance:` comment precedes the
+overclaiming line, an injected `resolver(entity_id) -> dict|None` is consulted;
+a claim backed by hypothesis/tested (not verified) evidence is ranked
+priority="high". No live RKA call is made when no resolver is given.
+
+CLI:
+    python overclaim_lint.py <files>...
+    python overclaim_lint.py --config /path/to/overclaim_config.yaml <files>...
+    python overclaim_lint.py --output report.json <files>...
+
+Exit codes:
+    0: no hits (PASS)
+    1: WARN hits present
+Never returns 2. This linter does not BLOCK.
+
+See references/manuscript_review.md for how the review consumes this report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Callable, Optional
+
+# Calibration / overclaim terms -> category. Authored from the PI manuscript
+# revision prompt template (2026-07-06); extensible per-project via a config
+# mapping {term: {"verdict": "disable"}} (mirrors ai_tic_config.yaml).
+OVERCLAIM_PATTERNS: dict[str, str] = {
+    r"\bverified\b": "guarantee",
+    r"\bguarantees?\b": "guarantee",
+    r"\bguaranteed\b": "guarantee",
+    r"\bprovably\b": "guarantee",
+    r"\bcompletely\b": "completeness",
+    r"\beliminates?\b": "elimination",
+    r"\beliminated\b": "elimination",
+    r"\bmodel-agnostic\b": "generality",
+    r"\bfully general\b": "generality",
+    r"\bgeneralizes?\b": "generality",
+    r"\bdominant\b": "superiority",
+    r"\bdominates?\b": "superiority",
+    r"\bfundamentally\b": "superiority",
+    r"\brobust to adaptive\b": "robustness",
+    r"\bfull recall\b": "metric-absolute",
+    r"\bno false positives?\b": "metric-absolute",
+    r"\bzero false positives?\b": "metric-absolute",
+    r"\bnever fails?\b": "absolute",
+}
+
+_PROV_RE = re.compile(r"^\s*%\s*provenance:\s*(.+)$", re.IGNORECASE)
+_ID_RE = re.compile(r"(jrn|dec|lit|mis|clm|ecl)_[0-9A-Z]{26}")
+# Backing confidences that make an absolute claim a high-priority gap.
+_WEAK_CONFIDENCE = {"hypothesis", "tested"}
+_PROV_WINDOW = 4  # lines to look back for a governing provenance comment
+
+Resolver = Callable[[str], Optional[dict]]
+
+
+@dataclass
+class OverclaimHit:
+    term: str
+    category: str
+    file: str
+    line: int
+    sentence: str
+    severity: str = "WARN"
+    priority: str = "normal"
+    backing_entity: Optional[str] = None
+    backing_confidence: Optional[str] = None
+
+
+@dataclass
+class OverclaimReport:
+    hits: list = field(default_factory=list)
+    verdict: str = "PASS"
+
+    def to_dict(self) -> dict:
+        return {"verdict": self.verdict, "hits": [asdict(h) for h in self.hits]}
+
+
+def _nearest_provenance(lines: list, idx: int, resolver: Resolver):
+    """Return (entity_id, confidence) for the nearest `% provenance:` comment
+    within _PROV_WINDOW lines above `idx`, or (None, None)."""
+    lo = max(-1, idx - _PROV_WINDOW - 1)
+    for j in range(idx, lo, -1):
+        m = _PROV_RE.match(lines[j])
+        if m:
+            id_match = _ID_RE.search(m.group(1))
+            if not id_match:
+                return None, None
+            ent = id_match.group(0)
+            resolved = resolver(ent)
+            conf = (resolved or {}).get("confidence")
+            return ent, (conf.lower() if isinstance(conf, str) else None)
+    return None, None
+
+
+def lint_file(path, *, resolver: Optional[Resolver] = None,
+              config: Optional[dict] = None) -> OverclaimReport:
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    disabled = set()
+    if config:
+        for term, spec in config.items():
+            if isinstance(spec, dict) and spec.get("verdict") == "disable":
+                disabled.add(term.lower())
+    report = OverclaimReport()
+    for i, line in enumerate(lines):
+        for pat, category in OVERCLAIM_PATTERNS.items():
+            for m in re.finditer(pat, line, re.IGNORECASE):
+                term = m.group(0)
+                if term.lower() in disabled:
+                    continue
+                hit = OverclaimHit(
+                    term=term, category=category, file=str(path),
+                    line=i + 1, sentence=line.strip(),
+                )
+                if resolver is not None:
+                    ent, conf = _nearest_provenance(lines, i, resolver)
+                    if ent is not None:
+                        hit.backing_entity = ent
+                        hit.backing_confidence = conf
+                        if conf in _WEAK_CONFIDENCE:
+                            hit.priority = "high"
+                report.hits.append(hit)
+    report.verdict = "WARN" if report.hits else "PASS"
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Advisory overclaim/calibration linter (WARN-only)."
+    )
+    ap.add_argument("files", nargs="+")
+    ap.add_argument("--output", help="write JSON report to this path")
+    ap.add_argument("--config", help="per-project overclaim_config.yaml")
+    args = ap.parse_args(argv)
+
+    config = None
+    if args.config:
+        import yaml  # optional; only needed with --config
+        config = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
+
+    all_hits = []
+    verdict = "PASS"
+    for f in args.files:
+        rep = lint_file(f, config=config)
+        all_hits.extend(rep.hits)
+        if rep.verdict == "WARN":
+            verdict = "WARN"
+
+    out = {"verdict": verdict, "hits": [asdict(h) for h in all_hits]}
+    if args.output:
+        Path(args.output).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    else:
+        print(json.dumps(out, indent=2))
+    return 1 if verdict == "WARN" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rka-writer
-description: Manuscript-drafting AI for RKA-managed research projects. Runs as a Claude Code skill in VSCode per dec_01KS0AWYDV752AWQRF40CQBRFZ. Drafts but does not assert: every prose claim carries provenance to a lit_, jrn_, or dec_ entity in the research graph. Load when starting a manuscript session in a manuscripts/<project>/<venue>/ working directory, when picking up a revision mission from the Brain, or when reasoning about venue, references, layout, or anti-AI-tic enforcement.
-version: 2.4.0
+description: Manuscript-drafting AI for RKA-managed research projects. Runs as a Claude Code skill in VSCode per dec_01KS0AWYDV752AWQRF40CQBRFZ. Drafts but does not assert: every prose claim carries provenance to a lit_, jrn_, or dec_ entity in the research graph. Load when starting a manuscript session in a manuscripts/<project>/<venue>/ working directory, when picking up a revision mission from the Brain, when running a pre-submission review, or when reasoning about venue, references, layout, or anti-AI-tic enforcement.
+version: 2.5.0
 ---
 
 # Writer Skill
@@ -23,6 +23,8 @@ Iron Law: **draft but do not assert.** If you find yourself wanting to state a f
 - [`references/latex_audit.md`](references/latex_audit.md): twelve-field layout checklist used by `scripts/layout_audit.py`.
 - [`references/examples.md`](references/examples.md): worked outline ratification and AI-tic catch examples.
 - [`references/quality_review.md`](references/quality_review.md): the pre-submit quality self-review checklist (rubric dimensions tied to RKA evidence; explicitly not an LLM-reviewer autograder).
+- [`references/manuscript_review.md`](references/manuscript_review.md): advisory pre-submission reviewer checklist (claim calibration, reviewer-risk, evaluation credibility, terminology, venue fit, systems/security add-on). PI-facing gap surfacer, never a gate.
+- [`references/revision_check.md`](references/revision_check.md): old-vs-new revision-status tracker (Fixed / Partial / Not fixed / Regressed), feeding the R1-R4 handlers.
 
 ---
 
@@ -50,7 +52,7 @@ Full worked walkthrough: [`references/workflows.md`](references/workflows.md) se
 
 ## Tool Surface
 
-> **v2.7.0 dispatch translation.** The legacy `rka_*` tool names used throughout this skill (`rka_get_status`, `rka_get_mission`, `rka_get_changelog`, `rka_get_research_map`, `rka_add_decision`, `rka_record_pi_selection`, `rka_submit_report`, `rka_get_literature`, `rka_create_mission`, `rka_get_manuscript`, etc.) are synonyms for the v2.7.0+ typed-arg surface: reads are `rka_query(args={"operation": ...})` and writes are `rka_execute(args={"operation": ...})` (e.g. `rka_get_status` -> operation `status`, `rka_add_decision` -> operation `record_decision`, `rka_create_mission` -> operation `create_mission`). Only `rka_query` / `rka_execute` / `rka_describe` / `rka_load_tools` / `rka_help` broadcast; the legacy names are deferred and must be registered via `rka_load_tools` first. The discipline (`project_id` on every call, `source="pi"` + `verbatim_input`, `related_journal=[...]` on decisions) carries over verbatim — only the call shape changes. See `rka_describe(operation="<name>")` for per-operation signatures.
+> **v2.7.0 dispatch translation.** The legacy `rka_*` tool names used throughout this skill (`rka_get_status`, `rka_get_mission`, `rka_get_changelog`, `rka_get_research_map`, `rka_add_decision`, `rka_record_pi_selection`, `rka_submit_report`, `rka_get_literature`, `rka_create_mission`, `rka_get_manuscript`, etc.) are synonyms for the v2.7.0+ typed-arg surface: reads are `rka_query(args={"operation": ...})` and writes are `rka_execute(args={"operation": ...})` (e.g. `rka_get_status` -> operation `status`, `rka_add_decision` -> operation `record_decision`, `rka_create_mission` -> operation `create_mission`). Only `rka_query` / `rka_execute` / `rka_describe` / `rka_load_tools` / `rka_help` broadcast; the legacy names are deferred and must be registered via `rka_load_tools` first. The discipline (`project_id` on every call, `source="pi"` + `verbatim_input`, `related_journal=[...]` on decisions) carries over verbatim; only the call shape changes. See `rka_describe(operation="<name>")` for per-operation signatures.
 
 Native Claude Code tools you use directly: `Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, `WebSearch`, `WebFetch`. `Bash` is the workhorse here because manuscript work is fundamentally file-and-shell heavy (latexmk, chktex, biber, the custom audit scripts under `scripts/`).
 
@@ -71,6 +73,7 @@ Scripts invoked via `Bash` (under `scripts/`):
 `layout_audit.py` runs after a successful render and produces `audit.json` over twelve fields.
 `chart_render.py` is a skeleton with venue presets (tueplots, SciencePlots); the PI fills in per-manuscript chart logic.
 `validate_references.py` is a Phase 1 stub implementing Stage A only; Stages B through G raise `NotImplementedError` with a Phase 2 reference.
+`overclaim_lint.py` scans drafts for calibration/overclaim wording (`verified`, `guaranteed`, `eliminates`, `model-agnostic`, ...) and emits `overclaim_report.json`. WARN-only, never BLOCK; ranks a hit higher when its backing `jrn_`/`clm_` is at `hypothesis`/`tested` confidence. Advisory input to the pre-submission review.
 `fetch_template.py` is a Phase 1 stub for registry lookup; SHA-256 verification and actual fetching land in Phase 2.
 
 ---
@@ -281,6 +284,23 @@ Full checklist with regex patterns: [`references/latex_audit.md`](references/lat
 
 ---
 
+## Pre-Submission Review
+
+Before the Final Layout checkpoint (or on demand), run an advisory reviewer-lens pass over the draft. It is a PI-facing gap surfacer, not a gate and not a score: it never blocks compile or submit. Only the mechanical gates block (`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, the reference-validation statuses).
+
+Two entry modes (mirroring the fresh-start vs. midpoint pattern):
+
+- **Fresh review**: run the full checklist in [`references/manuscript_review.md`](references/manuscript_review.md) and write `.planning/REVIEW.md`.
+- **Midpoint re-entry**: resume from an existing `.planning/REVIEW.md`, re-checking only the dimensions whose sections changed.
+
+Mechanical inputs the review aggregates (no new LLM judgment): the `verify_provenance.py` / `verify_citations.py` / `layout_audit.py` reports, `ai_tic_report.json`, and `overclaim_report.json` (calibration words, ranked by backing RKA confidence). The claim-calibration and evaluation-credibility dimensions hook into the same provenance and currency the Iron Law already enforces.
+
+**Mission-spawned review (Phase 3).** The Brain may commission a review with `rka_execute(args={"operation": "create_mission", "project_id": "prj_...", "objective": "...", "motivated_by_decision": "dec_...", "tags": ["writer-review", "manuscript:<jrn_id>"]})`. A fresh subagent runs the checklist and reports via `rka_execute(args={"operation": "submit_report", ...})`. This parallels the existing `writer-revision` path (see Session Start path b).
+
+This complements [`references/quality_review.md`](references/quality_review.md): that reports RKA evidence per rubric dimension; this adds the reviewer-facing presentation and claim-calibration checks. Neither assigns a score.
+
+---
+
 ## Revision Loop
 
 When the PI returns review comments on a draft section, classify each comment into one of four shapes and apply the matching procedure. The Phase 3 implementation lives in `scripts/revision_handler.py` (per `dec_01KS2WPKMRVSJ2R0PP74722PEH`) and is invoked either directly by the PI (CLI: `python scripts/revision_handler.py --dispatch --comment "..." --section sections/03.tex`) or via a Brain-spawned `writer-revision` mission (see Session Start path b above).
@@ -297,6 +317,10 @@ When the PI returns review comments on a draft section, classify each comment in
 `.planning/REVIEW_STATE.md` tracks `iteration: N / max: 3 / verdict: CONTINUE | ESCALATE | COMPLETE`. The third failed iteration auto-escalates to a PI Style or Logical checkpoint with three resolution options. See `read_review_state` and `advance_review_state` helpers in `scripts/revision_handler.py`.
 
 Venue-aware overrides: per-venue `references/venue/<venue>.md` may carry stricter rules (Forbidden constructions field). The R2 style handler optionally loads these via `load_venue_overrides`.
+
+### Revision-check (old vs new)
+
+When a revised draft is available, compare it against the prior review comments (the spawning mission `context`, a prior `.planning/REVIEW.md`, or PI-supplied comments) and produce a revision-status tracker via [`references/revision_check.md`](references/revision_check.md). Output is `.planning/REVISION_CHECK.md`; each remaining issue maps to an R1-R4 class and routes through the handlers above, capped by `REVIEW_STATE.md` at three iterations. Advisory only: the readiness diagnosis informs the PI, it does not gate.
 
 ---
 
@@ -319,6 +343,8 @@ Venue-aware overrides: per-venue `references/venue/<venue>.md` may carry stricte
 13. **DON'T** loop more than three iterations on a section. ESCALATE on the third failure with three resolution options.
 14. **DON'T** edit a ratified checkpoint Decision. Create a new `dec_` that `supersedes` it.
 15. **DON'T** vendor third-party content without explicit license verification. Algorithm-only reimplementation from primary sources is the Phase 1 posture per `dec_01KS12H9KT1T03DHX2Q6FKTXHH`.
+16. **DON'T** gate on the pre-submission review or the revision-check. Both are advisory: they surface gaps to the PI, and only the mechanical gates (provenance, citations, layout, reference-validation) block.
+17. **DON'T** compute or report an accept/reject or numeric quality score. `overclaim_lint.py` is WARN-only; the review writes a gaps list, not a grade (see `quality_review.md` for why LLM-reviewer scores are not gates).
 
 ---
 
@@ -332,6 +358,8 @@ Venue-aware overrides: per-venue `references/venue/<venue>.md` may carry stricte
 - LaTeX template registry: [`references/template_registry.md`](references/template_registry.md).
 - Layout audit checklist: [`references/latex_audit.md`](references/latex_audit.md).
 - Worked examples: [`references/examples.md`](references/examples.md).
+- Pre-submission reviewer checklist: [`references/manuscript_review.md`](references/manuscript_review.md).
+- Revision-status tracker: [`references/revision_check.md`](references/revision_check.md).
 - Brain counterpart skill: [`../brain/SKILL.md`](../brain/SKILL.md).
 - Executor counterpart skill: [`../executor/SKILL.md`](../executor/SKILL.md).
 - PI counterpart skill: [`../pi/SKILL.md`](../pi/SKILL.md).

--- a/rka/skills/writer/references/manuscript_review.md
+++ b/rka/skills/writer/references/manuscript_review.md
@@ -1,0 +1,230 @@
+# Pre-Submission Manuscript Review (advisory)
+
+This is a **PI-facing gap surfacer, not an autograder.** It never gates compile
+or submit. The only blocking gates remain the mechanical ones:
+`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, and the
+reference-validation statuses. This review adds the reviewer-facing
+presentation and claim-calibration checks that those gates do not cover, and it
+reports concrete gaps for the PI to weigh, never a numeric score or an
+accept/reject verdict.
+
+It complements [`quality_review.md`](quality_review.md): that reports the RKA
+evidence behind each rubric dimension; this adds the reviewer-perception lens
+(claim calibration, evaluation credibility, reviewer risk). Neither scores. See
+`quality_review.md` for why gating on an LLM-reviewer score is unsound (LLM
+reviewers correlate only r=0.48 with humans and carry length / positivity /
+self-preference biases).
+
+Run this before the Final Layout checkpoint, or on demand. Point to exact
+sections, pages, paragraphs, figures, and tables throughout. Where a claim
+needs support, name the RKA entity (`lit_`, `jrn_`, `dec_`, `clm_`) or the kind
+of source needed; do not invent one.
+
+## 0. Source, venue, and evidence discipline
+
+Before commenting, state your assumptions:
+
+- Target venue or venue family (read `references/venue/<venue>.md` if the venue
+  is known), and paper type (systems, security, AI, HCI, NLP, empirical, theory).
+- The strongest evidence in the manuscript.
+- The weakest or most fragile evidence in the manuscript.
+
+Strict evidence rule: a claim is not safe because it sounds plausible. Check
+whether the manuscript itself supports it through an experiment, a citation, a
+formal argument, or explicit limitation text. If it is unsupported, ask for
+evidence or suggest softer wording.
+
+## 1. Overall assessment and top reviewer-facing risks
+
+- Is the central story clear?
+- Do the title, abstract, introduction, contribution list, and results align?
+- Does the manuscript read like a polished submission or an expanded technical
+  report?
+- Are claims calibrated to the evidence?
+- Is the strongest evidence placed where a reviewer will see it?
+- What are the top 3 to 5 reviewer-facing risks?
+
+Be direct. If something is strong, say why. If something invites reviewer
+skepticism, name it.
+
+## 2. Claim-calibration table
+
+| Claim (original or likely) | Problem | Safer revised wording |
+|---|---|---|
+
+Target absolute or promotional wording. The calibration word list:
+`verified`, `guaranteed`, `complete`, `completely`, `eliminates`,
+`model-agnostic`, `dominant`, `fundamental`, `robust to adaptive adversaries`,
+`generalizes across benchmarks`, `full recall`, `no false positives`,
+`provably`, `never fails`.
+
+**Hook:** cross-reference RKA confidence. An absolute claim whose backing
+`jrn_`/`clm_` is at `hypothesis` or `tested` confidence (not `verified`) is a
+high-priority calibration gap. `scripts/overclaim_lint.py` surfaces these
+mechanically: it is WARN-only and marks `priority="high"` when a governing
+`% provenance:` comment resolves to weak-confidence evidence. Fold its
+`overclaim_report.json` into this table rather than re-scanning by eye.
+
+The goal is not to weaken the paper. It is to make the claims precise,
+defensible, and reviewer-proof.
+
+## 3. Abstract review
+
+- Does the first sentence establish the problem clearly?
+- Is the motivation specific rather than generic?
+- Are the contributions accurate without overclaiming?
+- Are all numbers, ratios, and percentage-point changes correct?
+- Is the strongest evidence the centerpiece, and are weaker or preliminary
+  results framed honestly (no cherry-picking, no hidden mixed result)?
+
+Provide remaining abstract problems and a revised abstract draft that is
+shorter, clearer, and more credible, with a one-line note on why it is better.
+
+## 4. Introduction review
+
+Check the opening motivation, motivating example, gap statement (fair to prior
+work, not an unfair attack), key insight, why prior work is insufficient, the
+transition from problem to approach, the results paragraph, and the
+contribution list. Flag sentences that are too broad, too absolute, or
+promotional; repetition; missing transitions; and a contribution list that has
+become a second abstract. Provide a revised introduction outline, suggested
+wording for the key-insight paragraph, and a shorter, more defensible
+contribution list.
+
+## 5. Structure and organization
+
+- Are sections in a logical order?
+- Are background, threat model, design, implementation, evaluation, discussion,
+  related work, and limitations cleanly separated (design not tangled with
+  evaluation configuration)?
+- Do limitations appear early enough?
+- Is the evaluation easy to follow, and does the paper need a clearer roadmap?
+
+Provide a proposed section outline and specific movement suggestions (for
+example, "move this table to the appendix" or "move this limitation earlier").
+
+## 6. Evaluation-presentation credibility
+
+- Is the evaluation story easy to understand, and is the main result clearly
+  identified?
+- Are controlled-benchmark, external-benchmark, model-specific, ablation, and
+  preliminary results separated?
+- Are trial counts and denominators easy to verify, and do captions explain the
+  denominators?
+- Are outcome categories separated from defense mechanisms?
+- Are statistical claims presented without overstating independence, and are
+  repeated trials treated appropriately?
+- Are the limitations of each benchmark stated, and are positive results that
+  should read as preliminary framed that way?
+
+Look for arithmetic errors, confusing denominators, and ambiguous terms (trial,
+scenario, attack evaluation, task success, safe tool call, blocked, bypass).
+**Hook:** every reported number should trace to a `mis_` report or a
+`jrn_`/`clm_` result, the same provenance the Iron Law already requires for body
+prose. Provide a clearer evaluation narrative, caption improvements, and a
+numerical-consistency checklist to run before submission.
+
+## 7. Figures, tables, and layout
+
+For each important figure or table: is the caption clear and does it explain the
+denominator; is it readable in two-column format; does it support the main
+argument; is it duplicative; does it overstate the result; is a mixed or
+negative result hidden in a dense table? This complements (does not duplicate)
+`layout_audit.py`, which handles the mechanical layout gates (page limit,
+undefined refs and cites, overfull boxes). Provide better titles and captions,
+visual-simplification suggestions, and move-to-appendix candidates.
+
+## 8. Terminology normalization
+
+| Current variants | Recommended term | Notes |
+|---|---|---|
+
+Check the system name, title phrase, threat-model terms, attack-category names,
+evaluation metrics, model names, dataset and benchmark names, policy names,
+provenance and measurement labels, and section / figure / table references.
+
+## 9. Writing style
+
+Defer to the existing anti-AI-tic machinery: `ai_tic_lint.py` (lexical tiers
+plus structural detectors) and `bridge_repetition_check.py` (near-duplicate
+sentences across sections). This section adds only the reviewer-perception
+framing (does the prose read as hyped, repetitive, or generated) and does not
+introduce a second lexical list.
+
+## 10. Reference and citation integrity
+
+Review citations from a credibility lens: claims about prior work that need
+citations; citations that are too broad or poorly placed; sentences that cite a
+source but make a stronger claim than the source supports; related-work
+comparisons that may not be apples-to-apples; whether the paper distinguishes
+its own results from prior reported numbers. Defer the mechanical checks to
+`verify_provenance.py`, `verify_citations.py`, and the reference-validation
+pipeline. Do not invent citations; where support is missing, name the kind of
+source needed.
+
+## 11. Venue fit
+
+Read `references/venue/<venue>.md`: expected tone, section order, required
+sections (for example Limitations at EMNLP, Ethics at ACL 2024+, Reproducibility
+checklist at NeurIPS), forbidden constructions, and whether math, system detail,
+user-study detail, or benchmark detail is too much or too little for the venue.
+If the venue is unknown, list the venue-dependent checks the PI should make.
+
+## 12. Reviewer-risk analysis
+
+| Criticism | Why a reviewer raises it | Severity | How to preempt | Suggested wording |
+|---|---|---|---|---|
+
+Include risks such as: the paper overclaims; baselines look weak or unfair; the
+strongest result is not emphasized; the abstract hides a mixed result;
+evaluation numbers are hard to reconcile; the threat model is inconsistent with
+the attack taxonomy; the writing is repetitive; figures or tables are too dense;
+limitations appear too late.
+
+## 13. Concrete rewrite package
+
+Provide a focused, submission-ready package: revised title options, a revised
+abstract, a revised key-insight paragraph, a revised contribution list, a
+revised limitation paragraph, a revised evaluation-roadmap paragraph, and a
+revised related-work positioning paragraph.
+
+## 14. Systems, security, and AI-agent add-on (venue-conditional)
+
+Use this lens for tool-using LLM-agent security papers (and similar
+systems/security work):
+
+- Is the threat model consistent with the attack taxonomy?
+- Are direct and indirect attacks clearly separated?
+- Does the paper distinguish design guarantees from implementation heuristics?
+- Are formal properties stated as conditional on clearly-stated assumptions?
+- Are policy-only, filtering-only, taint-only, and full-system baselines framed
+  fairly?
+- Are evaluation outcomes separated from defense mechanisms, external-benchmark
+  results adapted transparently, and controlled-benchmark results not oversold?
+- Are mixed results acknowledged in the main text?
+- Do final claims distinguish architecture-level generality from empirical
+  results on the tested models?
+- Are confidentiality, integrity, availability, and usability claims each
+  supported by the right evidence?
+
+## Output
+
+Write `.planning/REVIEW.md`: one table per dimension above, each with an explicit
+**Gaps** list drawn from the mechanical inputs (`verify_provenance.py`,
+`verify_citations.py`, `ai_tic_report.json`, `overclaim_report.json`,
+`layout_audit.py`) and RKA evidence (confidence levels, `contradicts` edges).
+No numeric score. No accept/reject verdict.
+
+## Fast pass
+
+A quick top-10-issues mode runs sections 1, 2, 6, 7, 8, and 12 only: overall
+risks, claim calibration, evaluation credibility, figures and tables,
+terminology, and reviewer risk. Same advisory posture and same `.planning/REVIEW.md`
+output, abbreviated.
+
+## Anti-patterns
+
+- DON'T compute or report an accept/reject or numeric quality score.
+- DON'T treat this review as a gate; only the mechanical gates block.
+- DON'T assert a review claim without pointing at the manuscript location or the
+  RKA entity that supports it.

--- a/rka/skills/writer/references/revision_check.md
+++ b/rka/skills/writer/references/revision_check.md
@@ -1,0 +1,100 @@
+# Revision Check (old vs new, advisory)
+
+Compare a revised draft against the prior review comments and report what the
+revision fixed, left unfixed, or regressed. This is advisory input to the
+Revision Loop, not a gate: the readiness diagnosis informs the PI, it does not
+block compile or submit. Only the mechanical gates
+(`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, the
+reference-validation statuses) block.
+
+## 0. Comparison setup
+
+Identify:
+
+- Which draft is the older version and which is the newer version.
+- The prior-comments baseline: the spawning `writer-review` or `writer-revision`
+  mission `context`, the prior `.planning/REVIEW.md`, or PI-supplied comments.
+- Whether any input is missing for a fair comparison.
+
+Then state the run type: full old-vs-new comparison; new-version-only guided by
+prior comments; or limited comparison because the old version or prior comments
+are incomplete.
+
+## 1. Executive revision diagnosis
+
+- Is the newer manuscript clearly better, somewhat better, unchanged, or worse?
+- What are the most successful revisions?
+- What earlier problems remain, and did the revision introduce new ones?
+
+Give an advisory readiness judgment (ready after minor editing; needs another
+focused revision; needs major restructuring; not ready). Framed as advice for
+the PI, not a gate.
+
+## 2. Revision-status tracker
+
+| Prior issue | Status | Evidence in new draft | Remaining problem | Recommended next edit |
+|---|---|---|---|---|
+
+Status vocabulary, exactly: `Fixed`, `Mostly fixed`, `Partially fixed`,
+`Not fixed`, `Regressed`, `New issue`, `Cannot verify`.
+
+Track the same dimensions as `manuscript_review.md`: title accuracy, abstract
+clarity and arithmetic, claim calibration, introduction story, contribution
+list, evaluation framing (controlled vs external benchmark emphasis, mixed or
+negative result disclosure), table and figure readability, terminology
+consistency, limitation placement, related-work positioning, reference and
+citation integrity, and anti-AI-tic style.
+
+## 3. Per-dimension re-checks
+
+For each dimension, compare the newer draft against the prior issue:
+
+- **Abstract**: arithmetic and ratios corrected; strongest evidence is the
+  centerpiece; no cherry-picking; mixed results disclosed; aligned with the
+  evaluation tables.
+- **Title, framing, contribution alignment**: title not overclaiming;
+  contribution list shorter and each item backed by evidence; design,
+  implementation, benchmark, and evaluation contributions separated.
+- **Claim calibration**: re-run `scripts/overclaim_lint.py` on the new draft and
+  diff its `overclaim_report.json` against the prior run; a resolved hit is
+  progress, a new or higher-priority hit is a regression.
+- **Introduction, evaluation, figures and tables, terminology**: as in
+  `manuscript_review.md`, but scored against the prior issue rather than fresh.
+- **Style**: diff `ai_tic_lint.py` output old vs new; `bridge_repetition_check.py`
+  for cross-section near-duplicates.
+
+## 4. Revision-comment classification
+
+Map each remaining issue to the four Revision Loop classes so the existing
+handlers in `scripts/revision_handler.py` apply:
+
+- R1 factual (sentence-level) -> `handle_factual_r1`.
+- R2 style or AI-tic -> `handle_style_r2`.
+- R3 cross-section inconsistency -> `handle_inconsistency_r3`
+  (`bridge_repetition_check.py`, ratio >= 0.7).
+- R4 logical gap or unsupported claim -> `handle_logical_r4` (escalates a
+  `writer_evidence_gap` mission to the Brain).
+
+For each remaining issue give: class, severity, location, required action, and
+whether the author can fix it by editing text or needs more evidence. The
+`REVIEW_STATE.md` iteration cap of 3 applies; the third failed iteration
+auto-escalates to a PI checkpoint.
+
+## 5. Remaining reviewer risks and action plan
+
+List the reviewer criticisms that still remain after the revision. For each:
+why it may still arise, how severe, how to preempt, and the exact wording to
+add, soften, or move. End with a prioritized action list split into must-fix
+before submission and optional-but-strengthening.
+
+## Output
+
+Write `.planning/REVISION_CHECK.md`: the revision-status tracker table plus the
+remaining-risks action plan. No numeric score.
+
+## Anti-patterns
+
+- DON'T re-litigate an item already marked `Fixed`.
+- DON'T gate on the readiness diagnosis; it is advisory.
+- DON'T mark a `Cannot verify` item as `Fixed`; surface the missing input to the
+  PI instead.

--- a/rka/skills/writer/scripts/overclaim_lint.py
+++ b/rka/skills/writer/scripts/overclaim_lint.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""overclaim_lint.py: advisory calibration/overclaim detector for the Writer skill.
+
+Advisory-only (WARN, never BLOCK) per the 2026-07-06 Review and Revision design.
+Flags absolute/overclaim wording ("verified", "guaranteed", "eliminates",
+"model-agnostic", ...) so the pre-submission review
+(references/manuscript_review.md) can surface claim-calibration gaps. Mirrors
+ai_tic_lint.py's CLI and report shape.
+
+RKA-confidence ranking: when a `% provenance:` comment precedes the
+overclaiming line, an injected `resolver(entity_id) -> dict|None` is consulted;
+a claim backed by hypothesis/tested (not verified) evidence is ranked
+priority="high". No live RKA call is made when no resolver is given.
+
+CLI:
+    python overclaim_lint.py <files>...
+    python overclaim_lint.py --config /path/to/overclaim_config.yaml <files>...
+    python overclaim_lint.py --output report.json <files>...
+
+Exit codes:
+    0: no hits (PASS)
+    1: WARN hits present
+Never returns 2. This linter does not BLOCK.
+
+See references/manuscript_review.md for how the review consumes this report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Callable, Optional
+
+# Calibration / overclaim terms -> category. Authored from the PI manuscript
+# revision prompt template (2026-07-06); extensible per-project via a config
+# mapping {term: {"verdict": "disable"}} (mirrors ai_tic_config.yaml).
+OVERCLAIM_PATTERNS: dict[str, str] = {
+    r"\bverified\b": "guarantee",
+    r"\bguarantees?\b": "guarantee",
+    r"\bguaranteed\b": "guarantee",
+    r"\bprovably\b": "guarantee",
+    r"\bcompletely\b": "completeness",
+    r"\beliminates?\b": "elimination",
+    r"\beliminated\b": "elimination",
+    r"\bmodel-agnostic\b": "generality",
+    r"\bfully general\b": "generality",
+    r"\bgeneralizes?\b": "generality",
+    r"\bdominant\b": "superiority",
+    r"\bdominates?\b": "superiority",
+    r"\bfundamentally\b": "superiority",
+    r"\brobust to adaptive\b": "robustness",
+    r"\bfull recall\b": "metric-absolute",
+    r"\bno false positives?\b": "metric-absolute",
+    r"\bzero false positives?\b": "metric-absolute",
+    r"\bnever fails?\b": "absolute",
+}
+
+_PROV_RE = re.compile(r"^\s*%\s*provenance:\s*(.+)$", re.IGNORECASE)
+_ID_RE = re.compile(r"(jrn|dec|lit|mis|clm|ecl)_[0-9A-Z]{26}")
+# Backing confidences that make an absolute claim a high-priority gap.
+_WEAK_CONFIDENCE = {"hypothesis", "tested"}
+_PROV_WINDOW = 4  # lines to look back for a governing provenance comment
+
+Resolver = Callable[[str], Optional[dict]]
+
+
+@dataclass
+class OverclaimHit:
+    term: str
+    category: str
+    file: str
+    line: int
+    sentence: str
+    severity: str = "WARN"
+    priority: str = "normal"
+    backing_entity: Optional[str] = None
+    backing_confidence: Optional[str] = None
+
+
+@dataclass
+class OverclaimReport:
+    hits: list = field(default_factory=list)
+    verdict: str = "PASS"
+
+    def to_dict(self) -> dict:
+        return {"verdict": self.verdict, "hits": [asdict(h) for h in self.hits]}
+
+
+def _nearest_provenance(lines: list, idx: int, resolver: Resolver):
+    """Return (entity_id, confidence) for the nearest `% provenance:` comment
+    within _PROV_WINDOW lines above `idx`, or (None, None)."""
+    lo = max(-1, idx - _PROV_WINDOW - 1)
+    for j in range(idx, lo, -1):
+        m = _PROV_RE.match(lines[j])
+        if m:
+            id_match = _ID_RE.search(m.group(1))
+            if not id_match:
+                return None, None
+            ent = id_match.group(0)
+            resolved = resolver(ent)
+            conf = (resolved or {}).get("confidence")
+            return ent, (conf.lower() if isinstance(conf, str) else None)
+    return None, None
+
+
+def lint_file(path, *, resolver: Optional[Resolver] = None,
+              config: Optional[dict] = None) -> OverclaimReport:
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    disabled = set()
+    if config:
+        for term, spec in config.items():
+            if isinstance(spec, dict) and spec.get("verdict") == "disable":
+                disabled.add(term.lower())
+    report = OverclaimReport()
+    for i, line in enumerate(lines):
+        for pat, category in OVERCLAIM_PATTERNS.items():
+            for m in re.finditer(pat, line, re.IGNORECASE):
+                term = m.group(0)
+                if term.lower() in disabled:
+                    continue
+                hit = OverclaimHit(
+                    term=term, category=category, file=str(path),
+                    line=i + 1, sentence=line.strip(),
+                )
+                if resolver is not None:
+                    ent, conf = _nearest_provenance(lines, i, resolver)
+                    if ent is not None:
+                        hit.backing_entity = ent
+                        hit.backing_confidence = conf
+                        if conf in _WEAK_CONFIDENCE:
+                            hit.priority = "high"
+                report.hits.append(hit)
+    report.verdict = "WARN" if report.hits else "PASS"
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Advisory overclaim/calibration linter (WARN-only)."
+    )
+    ap.add_argument("files", nargs="+")
+    ap.add_argument("--output", help="write JSON report to this path")
+    ap.add_argument("--config", help="per-project overclaim_config.yaml")
+    args = ap.parse_args(argv)
+
+    config = None
+    if args.config:
+        import yaml  # optional; only needed with --config
+        config = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
+
+    all_hits = []
+    verdict = "PASS"
+    for f in args.files:
+        rep = lint_file(f, config=config)
+        all_hits.extend(rep.hits)
+        if rep.verdict == "WARN":
+            verdict = "WARN"
+
+    out = {"verdict": verdict, "hits": [asdict(h) for h in all_hits]}
+    if args.output:
+        Path(args.output).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    else:
+        print(json.dumps(out, indent=2))
+    return 1 if verdict == "WARN" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/writer/conftest.py
+++ b/tests/skills/writer/conftest.py
@@ -68,6 +68,11 @@ def verify_citations():
 
 
 @pytest.fixture
+def overclaim_lint():
+    return _load_module("overclaim_lint")
+
+
+@pytest.fixture
 def fetch_template():
     return _load_module("fetch_template")
 

--- a/tests/skills/writer/test_overclaim_lint.py
+++ b/tests/skills/writer/test_overclaim_lint.py
@@ -74,3 +74,43 @@ class TestEntryPoint:
         f = _write(tmp_path, "s.tex", "We report a partial improvement on one benchmark.")
         rc = overclaim_lint.main([str(f), "--output", str(tmp_path / "r.json")])
         assert rc == 0
+
+
+_EID = "jrn_01KS0AVZRDA0KPXK61MN9PV5DE"
+
+
+class TestConfidenceRanking:
+    def test_weak_confidence_backing_ranks_high(self, overclaim_lint, tmp_path: Path) -> None:
+        content = (
+            f"% provenance: {_EID} supports paragraph below\n"
+            "Our method guarantees correctness.\n"
+        )
+        f = _write(tmp_path, "s.tex", content)
+        rep = overclaim_lint.lint_file(f, resolver=lambda eid: {"confidence": "tested"})
+        hit = next(h for h in rep.hits if h.term.lower() == "guarantees")
+        assert hit.priority == "high"
+        assert hit.backing_entity == _EID
+        assert hit.backing_confidence == "tested"
+
+    def test_verified_confidence_backing_stays_normal(self, overclaim_lint, tmp_path: Path) -> None:
+        content = (
+            f"% provenance: {_EID} supports paragraph below\n"
+            "Our method guarantees correctness.\n"
+        )
+        f = _write(tmp_path, "s.tex", content)
+        rep = overclaim_lint.lint_file(f, resolver=lambda eid: {"confidence": "verified"})
+        hit = next(h for h in rep.hits if h.term.lower() == "guarantees")
+        assert hit.priority == "normal"
+
+    def test_no_provenance_comment_skips_resolver(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Our method guarantees correctness.")
+        called = []
+
+        def resolver(eid):
+            called.append(eid)
+            return {"confidence": "tested"}
+
+        rep = overclaim_lint.lint_file(f, resolver=resolver)
+        hit = next(h for h in rep.hits if h.term.lower() == "guarantees")
+        assert hit.priority == "normal"
+        assert called == []

--- a/tests/skills/writer/test_overclaim_lint.py
+++ b/tests/skills/writer/test_overclaim_lint.py
@@ -1,0 +1,76 @@
+"""Tests for overclaim_lint.py (advisory calibration/overclaim linter).
+
+WARN-only: this linter never BLOCKs. It surfaces absolute/overclaim wording
+for the pre-submission review, and (Task 2) ranks a hit higher when the
+backing RKA evidence is weak-confidence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestLexicalDetection:
+    def test_flags_guarantee_word(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Our system guarantees no data leakage.")
+        rep = overclaim_lint.lint_file(f)
+        assert any(h.term.lower() == "guarantees" for h in rep.hits)
+        assert rep.verdict == "WARN"
+
+    def test_flags_multiple_categories(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "It eliminates the attack and is model-agnostic.")
+        rep = overclaim_lint.lint_file(f)
+        cats = {h.category for h in rep.hits}
+        assert "elimination" in cats and "generality" in cats
+
+    def test_clean_prose_passes(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "We observe a 12 percent reduction on the controlled benchmark. "
+            "The external benchmark shows a smaller, mixed effect."
+        )
+        rep = overclaim_lint.lint_file(f)
+        assert rep.verdict == "PASS"
+        assert not rep.hits
+
+
+class TestNeverBlocks:
+    def test_never_blocks_even_on_many_hits(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path, "s.tex",
+            "verified guaranteed eliminates model-agnostic dominant fundamentally"
+        )
+        rep = overclaim_lint.lint_file(f)
+        assert rep.verdict == "WARN"
+        assert rep.verdict != "BLOCK"
+
+
+class TestPerProjectOverride:
+    def test_config_disable_drops_term(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "The evaluation is completely done.")
+        cfg = {"completely": {"verdict": "disable"}}
+        assert any("completely" in h.term.lower() for h in overclaim_lint.lint_file(f).hits)
+        assert not overclaim_lint.lint_file(f, config=cfg).hits
+
+
+class TestEntryPoint:
+    def test_main_writes_report_and_returns_warn_code(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "Our approach eliminates the attack surface.")
+        out = tmp_path / "r.json"
+        rc = overclaim_lint.main([str(f), "--output", str(out)])
+        assert rc == 1
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["verdict"] == "WARN"
+
+    def test_main_returns_zero_on_clean_file(self, overclaim_lint, tmp_path: Path) -> None:
+        f = _write(tmp_path, "s.tex", "We report a partial improvement on one benchmark.")
+        rc = overclaim_lint.main([str(f), "--output", str(tmp_path / "r.json")])
+        assert rc == 0

--- a/tests/skills/writer/test_skill_loads.py
+++ b/tests/skills/writer/test_skill_loads.py
@@ -1,6 +1,7 @@
-"""Test that SKILL.md loads correctly: frontmatter, 16 sections, references discoverable.
+"""Test that SKILL.md loads correctly: frontmatter, 17 sections, references discoverable.
 
-Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria.
+Per mis_01KS0C3RP04XANCZAB3HTNAG0P T4 acceptance criteria. The "Pre-Submission
+Review" section (v2.5.0) sits between "Local Rendering" and "Revision Loop".
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ EXPECTED_SECTIONS = [
     "## Venue Tone",
     "## LaTeX Template Management",
     "## Local Rendering",
+    "## Pre-Submission Review",
     "## Revision Loop",
     "## Anti-Patterns",
     "## Related",
@@ -40,11 +42,11 @@ def test_frontmatter_has_name_description_version(skill_md_path: Path) -> None:
     assert end > 0, "SKILL.md frontmatter must close with --- delimiter"
     fm = text[4:end]
     assert re.search(r"^name:\s*rka-writer\s*$", fm, re.MULTILINE)
-    assert re.search(r"^version:\s*2\.4\.0\s*$", fm, re.MULTILINE)
+    assert re.search(r"^version:\s*2\.5\.0\s*$", fm, re.MULTILINE)
     assert re.search(r"^description:\s*\S", fm, re.MULTILINE)
 
 
-def test_all_16_sections_present_in_stable_order(skill_md_path: Path) -> None:
+def test_all_17_sections_present_in_stable_order(skill_md_path: Path) -> None:
     text = _read_skill(skill_md_path)
     last_pos = -1
     for section_header in EXPECTED_SECTIONS:


### PR DESCRIPTION
Adds an advisory, reviewer-lens **pre-submission review** and an **old-vs-new revision-check** to the writer skill, plus a WARN-only overclaim linter. Grounded in the PI's manuscript-revision prompt template (Prompt 1 = pre-submission review, Prompt 2 = revision checking) and the portable patterns from edwinhu/workflows (review phase, re-entry modes, `.planning` state, mission-spawned path). Follows the brainstorm → spec → plan → TDD flow; spec and plan are included under `docs/superpowers/`.

## Load-bearing constraint: advisory only
Consistent with `quality_review.md`'s stance against LLM-reviewer scores, this capability **never gates** compile or submit. It surfaces evidence-anchored gaps to the PI. Only the existing mechanical gates (`verify_provenance.py`, `verify_citations.py`, `layout_audit.py`, reference-validation statuses) block. `overclaim_lint.py` is WARN-only (exit 0/1, never 2); no numeric or accept/reject score anywhere.

## What's here
- `scripts/overclaim_lint.py` — WARN-only calibration/overclaim detector (`verified`, `guaranteed`, `eliminates`, `model-agnostic`, …), mirroring `ai_tic_lint.py`. Ranks a hit `priority=high` when a governing `% provenance:` comment resolves to `hypothesis`/`tested` (not `verified`) evidence, via an injected resolver (no live RKA call in tests).
- `references/manuscript_review.md` — Prompt 1 as a PI-facing checklist (claim-calibration table, evaluation credibility, reviewer-risk, terminology, venue fit, systems/security add-on, fast pass). Output: `.planning/REVIEW.md`.
- `references/revision_check.md` — Prompt 2 old-vs-new tracker (Fixed / Partial / Not fixed / Regressed / …) mapped to the existing R1–R4 handlers. Output: `.planning/REVISION_CHECK.md`.
- `SKILL.md` — new "Pre-Submission Review" section, a revision-check subsection, a `writer-review` mission path (parallel to `writer-revision`), 2 anti-patterns, version bump 2.4.0 → 2.5.0. Also fixes a pre-existing em-dash dogfood violation in the dispatch banner.
- `tests/skills/writer/test_overclaim_lint.py` (10 tests) + `test_skill_loads.py`/`conftest.py` updates.
- `plugin/skills/writer/` mirrored byte-for-byte; `docs/superpowers/{specs,plans}/` design + plan.

## Verification
`tests/skills/writer/` + `tests/test_skills_packaging.py`: **232 passed** (parity + package-data coverage confirm the new files ship on a fresh install). Installed wheel verified at writer v2.5.0 with all three new files. Plugin cache updates after merge to main (it tracks the marketplace source).

Design: `docs/superpowers/specs/2026-07-06-writer-review-revision-design.md`
Plan: `docs/superpowers/plans/2026-07-06-writer-review-revision.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)