### PR TITLE
fix(ci): constrain MCP to compatible v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.9.0"
 description = "Research Knowledge Agent — MCP server + REST API for AI-assisted research orchestration"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "aiosqlite>=0.22",


### PR DESCRIPTION
## What changed

- constrain the `mcp` dependency to `>=1.26.0,<2`

## Why

MCP 2.0 removed `mcp.server.fastmcp`, while RKA still imports and targets the MCP 1.x FastMCP API. Fresh CI environments began resolving 2.0 and failed during collection with 19 import errors.

This is a compatibility bound, not a downgrade: a deliberate MCP 2 migration can be handled separately.

## Validation

- fresh isolated install resolved `mcp 1.29.0`
- `from mcp.server.fastmcp import FastMCP` succeeds
- full local suite collected and ran: 2,747 passed, 21 skipped; 11 embedding tests were blocked only because this macOS Python build disables SQLite extension loading, which is independent of the dependency change
- GitHub Actions on Linux is the authoritative full-suite check