### PR TITLE
test: stabilize lifespan and CI timeout

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/test_api/test_app_lifespan.py
+++ b/tests/test_api/test_app_lifespan.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from pathlib import Path
 
 import pytest
@@ -18,12 +17,15 @@ from rka.infra.llm import LLMClient
 
 @pytest.mark.asyncio
 async def test_lifespan_does_not_block_on_llm_startup_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    # Probe sleeps 1.0s; lifespan must return well before the probe completes.
-    # Earlier threshold of 0.15s was flaky on slower/shared CI runners — a 0.5s
-    # threshold still catches a blocking regression (would be >=1.0s) while
-    # tolerating CI scheduling noise.
+    # Hold the probe behind an event so the assertion checks behavior instead
+    # of scheduler speed. If lifespan awaits the probe, __aenter__ times out;
+    # if it schedules the probe in the background, startup completes normally.
+    probe_started = asyncio.Event()
+    release_probe = asyncio.Event()
+
     async def fake_is_available(self: LLMClient) -> bool:
-        await asyncio.sleep(1.0)
+        probe_started.set()
+        await release_probe.wait()
         self._available = False
         return False
 
@@ -43,14 +45,16 @@ async def test_lifespan_does_not_block_on_llm_startup_probe(tmp_path: Path, monk
     app = create_app(config)
     lifespan = app.router.lifespan_context(app)
 
-    start = time.perf_counter()
-    await lifespan.__aenter__()
-    elapsed = time.perf_counter() - start
+    entered = False
 
     try:
-        assert elapsed < 0.5
+        await asyncio.wait_for(lifespan.__aenter__(), timeout=5.0)
+        entered = True
+        await asyncio.wait_for(probe_started.wait(), timeout=5.0)
     finally:
-        await lifespan.__aexit__(None, None, None)
+        release_probe.set()
+        if entered:
+            await lifespan.__aexit__(None, None, None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- replace the LLM startup nonblocking test's wall-clock threshold with event-based synchronization
- increase the full-suite Actions timeout from 10 to 20 minutes

## Why

A docs-only PR exposed two pre-existing CI reliability problems: the timing assertion failed under runner contention, and pytest was canceled at 85% by the 10-minute job cap. The same base had passed immediately before, confirming the behavior was resource-sensitive rather than branch-specific.

The revised test still fails if application startup awaits the LLM probe, but no longer depends on shared-runner scheduling speed. The larger cap accommodates the current 2,700+ test suite without weakening any assertions.

## Validation

- focused lifespan module: 2 passed
- Ruff: passed
- diff check: passed
- prior full local run on the same base: 2,747 passed, 21 skipped; 11 macOS-only failures were due to the local Python build disabling SQLite extension loading
- GitHub Actions on Linux is the authoritative full-suite check