### PR TITLE
feat(writer): add read-only manuscript workbench

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,22 +5,27 @@ plan](docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-wo
 into implementation milestones. It combines the ARA-inspired research-artifact
 substrate with a researcher-facing manuscript drafting workbench.
 
+The M0 authority, stage, proposal, and provider decisions are recorded in
+[ADR 0001](docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md).
+
 The roadmap is ordered by dependency, not by invented delivery dates. Every
 milestone must satisfy its exit gate before dependent work is treated as ready.
 
 ## Now
 
-**M0 / PR 0A — Reconcile the choice-first Writer workflow onto current
-`main`.**
+**M0 / PR 0A and PR 0B are implemented and technically validated on the
+workbench feature branch.** The choice-first Writer delta is reconciled, the
+authority and AI boundary is recorded in ADR 0001, and the read-only workbench
+has been walked through with DelaySteer and a full-manuscript control.
 
-This is the next implementation step because the installed Writer behavior and
-the repository implementation have diverged. Resolve that delta and prove that
-the packaged and repository Writer bundles match before freezing new workbench
-contracts.
-
-After PR 0A, complete PR 0B: document the authority and schema decisions, build
-a read-only clickable workbench prototype, and walk the DelaySteer project
-through it. Do not begin database migrations before this walkthrough.
+The walkthrough and its design revisions are recorded in
+[`2026-08-14-delaysteer-workbench-walkthrough.md`](docs/superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md).
+The authority and stage contracts have researcher approval. The remaining M0
+gate is review and merge of this feature slice. After merge, the immediate
+implementation target is **M1 / PR 1 Interpretation Staging and
+experiment-contract schema design**. M2 / PR 4 may expand the read-only
+workbench in parallel, but no migration should land before the M1 schema ADR is
+approved.
 
 ## Dependency map
 

--- a/docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md
+++ b/docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md
@@ -1,0 +1,255 @@
+# ADR 0001: Manuscript Workbench Authority, Stage, and AI Boundary
+
+- Status: accepted for M0 prototype; M1 schema details remain provisional
+  pending researcher review of the completed walkthrough
+- Date: 2026-08-14
+- Scope: roadmap issues #50 and #51
+- Related plan:
+  [`2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md`](../superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md)
+
+## Context
+
+RKA already has a native manuscript aggregate, exact claim versions, typed
+evidence roles, PI ratifications, manuscript units, checkpoints, readiness,
+and semantic change impact. The proposed workbench must reduce the cognitive
+load of turning research history into a paper without becoming a second source
+of truth.
+
+The interface also needs AI assistance. The researcher may use a ChatGPT
+subscription through Codex, a Claude subscription through the Claude Agent
+SDK, or a local model in LM Studio. These are different runtime and
+authentication boundaries. Re-enabling RKA's removed server-side LLM client
+would couple semantic storage to one provider and would invite raw model output
+to bypass proposal review.
+
+M0 therefore freezes the authority and interaction contracts before any
+planning-artifact database migration.
+
+## Decision 1: Four authority layers
+
+The workbench uses four distinct layers.
+
+| Layer | Authority | Examples | Mutation rule |
+|---|---|---|---|
+| Research evidence | canonical RKA | `jrn_`, `lit_`, grounded `clm_`, `ecl_`, RQs, decisions, artifacts | existing typed RKA services |
+| Manuscript semantics | canonical RKA | `man_`, immutable `mcl_` versions, evidence bindings, `mun_`, ratifications, checkpoints | revision-guarded native manuscript commands |
+| Deliberation | provisional and versioned in a future schema | seeds, paragraph spines, gap maps, alternatives, evaluation plans, branches | append a version; explicit promotion only |
+| Authoring files | editable external artifacts | Markdown, LaTeX, Word, figures, tables | expected content hash and atomic replacement |
+
+The M0 web prototype reads only the first two layers. Stage guidance shown by
+the interface is explicitly marked as an interface projection. It is not
+evidence, a decision, a claim, or a checkpoint.
+
+Generated Writer YAML and Markdown files remain deterministic review
+projections. They never authorize a semantic transition.
+
+The DelaySteer walkthrough established that project-only exploration is a
+first-class state: a researcher may inspect and shape an argument before a
+canonical `man_` exists. Manuscript registration is a later explicit promotion
+step, not a prerequisite for seed, landscape, gap, or RQ work.
+
+## Decision 2: Planning artifacts and branches
+
+The future deliberation layer will use generic, typed planning artifacts rather
+than a table per screen and rather than one unconstrained JSON document.
+
+The minimum logical contract is:
+
+- a project-scoped manuscript planning branch with a parent and base manuscript
+  revision;
+- a stable planning artifact identity with a closed stage type;
+- immutable artifact versions containing schema-validated stage payloads;
+- exact evidence/context bindings with role and locator;
+- origin labels: `user`, `ai_suggested`, `imported`, or `user_revised`;
+- unresolved items and categorical readiness findings;
+- promotion lineage to any resulting `dec_`, `mcl_`, or `mun_`;
+- selected, archived, and superseded states without destructive deletion.
+
+The precise table split remains open until the M0 walkthrough. The contract
+does not permit a planning artifact to act as empirical evidence or exact PI
+ratification.
+
+## Decision 3: One patch path for human and AI edits
+
+Direct editing and AI-assisted editing will produce the same structured patch
+proposal. Neither gets a privileged mutation route.
+
+A proposal must contain:
+
+- project, manuscript, branch, stage, and proposal identity;
+- base manuscript revision and planning-artifact version;
+- typed operations with before and after values;
+- rationale and evidence bindings by role;
+- affected claims, units, files, and public/private treatment boundaries;
+- claim-strength and scope-change classification;
+- context-manifest hash and provider/model metadata when AI-generated;
+- validation findings and proposed/applied/rejected/expired/superseded state.
+
+Application is a separate, explicit action. A revision conflict opens a
+compare/rebase flow. Ratified wording is never overwritten; a semantic change
+appends a version and follows the exact decision and ratification path.
+
+## Decision 4: Guided but non-linear stage contract
+
+The stage rail is guidance, not a mandatory wizard. A researcher may jump
+between stages. Each stage shows its structured output, derivation, blockers,
+and a categorical state: `Ready`, `Needs review`, `Blocked`, or `Exploratory`.
+
+M0 renders these read-only stages:
+
+| Stage | M0 source | Honest M0 output |
+|---|---|---|
+| Seed insight | project status, RQs, eligible cluster candidates | inspiration only; never a stored claim |
+| Paper spine | native claims or server-attested candidates | exact current wording or provisional candidate wording |
+| Problem and scope | allowed and prohibited wording | visible scope gaps; no inferred boundary |
+| Literature and SOTA | research map RQs and clusters | evidence organization, not an established novelty claim |
+| Gap and motivation | gap, contradiction, and candidate blocker signals | review targets, not automatic gap assertions |
+| Insight and response | methodological/theoretical claims and eligible clusters | current or provisional response candidates |
+| Research questions | current RKA RQ decisions | navigation structure, not empirical evidence |
+| Contributions | native claims, ratifications, candidates, readiness | current versus provisional contribution boundary |
+| Evaluation contract | current result units and artifact/evidence bindings | explicit notice that first-class experiments/runs/results are not yet modeled |
+| Outline | native manuscript units and claim links | read-only claim-sized unit sequence |
+
+Every displayed card must disclose its endpoint or design source, derivation,
+record IDs, and status. A partial impact page is labeled partial and cannot be
+shown as clean.
+
+Project and manuscript identity form a UI authority boundary. The request
+header must change before project-scoped query keys are published, and local
+selection state such as the evidence inspector must be scoped to the exact
+project/manuscript context. A context switch cannot retain an unvalidated card
+from the previous project.
+
+## Decision 5: Context Capsules are reproducible manifests
+
+An AI request receives a compact Context Capsule selected for one stage and
+intent. The persisted audit object is a reproducible manifest plus content
+hash, not an opaque prose dump.
+
+The manifest records:
+
+- explicit project, manuscript, branch, stage, and base revisions;
+- selected RKA record IDs, roles, exact source locators, and content hashes;
+- short retrieval angles and `included_via` derivations;
+- current qualifiers, counterevidence, contradictions, and stale items;
+- venue, audience, and public/private treatment constraints;
+- omitted categories and truncation or pagination state;
+- requested provider/model and outbound disclosure class;
+- canonical serialized manifest hash.
+
+The UI previews the manifest before an external disclosure boundary expands.
+The provider response never becomes evidence merely because it used an
+evidence-linked capsule.
+
+## Decision 6: Provider-neutral local AI broker
+
+AI orchestration lives in a separate, loopback-only workbench broker. It does
+not run inside an RKA database transaction and does not restore the old
+`/api/llm/*` feature as semantic authority.
+
+The broker exposes a small provider-neutral contract:
+
+```text
+propose(stage, intent, context_manifest, output_schema, provider_policy)
+-> streamed discussion or validated proposal candidate
+```
+
+Adapters are:
+
+1. **Codex App Server.** Preferred when the researcher wants subscription-backed
+   OpenAI reasoning. Codex owns ChatGPT authentication and conversation/approval
+   behavior; the broker uses the official App Server protocol. It does not
+   translate a ChatGPT subscription into an OpenAI API key.
+2. **Claude Agent SDK.** Optional when the researcher chooses Claude. The SDK
+   owns Claude authentication. Subscription eligibility is treated as a
+   provider capability that may change, not as an RKA guarantee.
+3. **LM Studio.** Local adapter over LM Studio's native v1 or compatible HTTP
+   endpoint. It is preferred when the selected context is local-only or the
+   user requests offline inference.
+4. **Direct API-key adapters.** Optional and explicit. They use separate
+   provider billing and credentials; they are never implied by a ChatGPT or
+   Claude chat subscription.
+
+Provider selection is visible and task-aware, not a fixed “LM Studio first”
+rule. The broker considers disclosure policy, user choice, model capability,
+availability, latency, and cost. A local-only context cannot silently fall back
+to an external provider.
+
+Credentials remain with the official runtime, OS keychain, or RKA credential
+vault as appropriate. They are never written to the RKA database, planning
+artifacts, browser local storage, Context Capsule, proposal, logs, or Git.
+
+The browser talks to the local broker through RKA's authenticated/local web
+boundary. The broker uses stdio or loopback transports for local runtimes and
+streams normalized events to the UI. Codex WebSocket transport remains
+experimental and is not the production default.
+
+Official capability references:
+
+- [Codex App Server](https://learn.chatgpt.com/docs/app-server)
+- [Codex authentication](https://learn.chatgpt.com/docs/auth)
+- [Claude Agent SDK with a Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+- [LM Studio local API server](https://lmstudio.ai/docs/developer/core/server)
+- [LM Studio server security settings](https://lmstudio.ai/docs/developer/core/server/settings)
+
+## Decision 7: AI outputs cannot write directly
+
+The broker may return:
+
+1. ephemeral discussion;
+2. a provisional planning-artifact candidate; or
+3. a typed semantic patch proposal.
+
+It cannot call canonical write operations as part of generation. Tool-capable
+provider runtimes receive only the read bundle and proposal schema required for
+the turn. Applying a proposal uses the same RKA service used for a human edit
+and requires explicit user action.
+
+If a provider fails, the workbench retains its deterministic read-only views
+and the unsent user text. It reports the provider and failed layer. It does not
+silently switch providers when that would cross a disclosure boundary.
+
+## Security and privacy consequences
+
+- Bind broker and provider runtimes to loopback by default.
+- Validate Origin/Host and use CSRF protection for browser mutations.
+- Treat all imported text as untrusted data and never as instructions.
+- Restrict model context to the manifest; do not expose database files or
+  arbitrary workspace roots.
+- Disable arbitrary provider tool calls in proposal generation.
+- Redact credentials and likely secrets before manifest preview and dispatch.
+- Record provider, model, manifest hash, timing, and output class, but not raw
+  hidden credentials or unselected project data.
+
+## M0 implementation and test gate
+
+M0 intentionally introduces no database migration and no workbench write API.
+It is acceptable only when:
+
+- repository and plugin Writer bundles remain byte-identical;
+- the framing session template is packaged and resumable;
+- the web build and changed-file lint pass;
+- project-only and canonical-manuscript modes render without AI;
+- every card exposes origin, derivation, and IDs;
+- a missing or foreign `man_` fails without querying dependent projections;
+- missing experiment semantics are visible in the Evaluation stage;
+- the DelaySteer walkthrough records blockers instead of promoting unsupported
+  material;
+- the design is revised from the walkthrough before migrations are frozen.
+
+## Consequences
+
+This design adds one local process boundary later, but preserves RKA's semantic
+integrity and lets the researcher choose Codex, Claude, LM Studio, or an API
+without rewriting the manuscript model. The M0 UI is useful as a navigation
+and validation instrument even when every model provider is unavailable.
+
+## M0 walkthrough resolution
+
+The 2026-08-14 walkthrough used DelaySteer in project-only mode and CPSEval as
+a full-manuscript control. It verified the deterministic read path, exposed an
+unsupported DelaySteer composability RQ with zero clusters and claims, and
+kept CPSEval's missing active claims, checkpoints, result units, and experiment
+semantics blocked. The two cross-project UI provenance defects found during the
+walkthrough were corrected and retested. Detailed evidence is in
+[`2026-08-14-delaysteer-workbench-walkthrough.md`](../superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md).

--- a/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
+++ b/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
@@ -1,12 +1,18 @@
 # RKA Epistemic Pipeline and Manuscript Drafting Workbench
 
-Status: roadmap design source; no implementation has started.
+Status: roadmap design source; M0 implementation technically validated and
+researcher-approved, feature review and merge pending.
 
 Date: 2026-08-14
 
 Roadmap: [`ROADMAP.md`](../../../ROADMAP.md). The roadmap defines milestone
 order and the immediate implementation target; this document remains the
 normative detailed design and acceptance-criteria source.
+
+M0 authority, stage, proposal, and AI-provider decisions are frozen in
+[`ADR 0001`](../../adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md).
+The real-project validation and resulting design revisions are recorded in the
+[`M0 walkthrough`](../specs/2026-08-14-delaysteer-workbench-walkthrough.md).
 
 ## 1. Baseline and source snapshots
 
@@ -18,17 +24,17 @@ This plan targets the clean default RKA branch at:
 - RKA package version: `2.9.0`
 - latest migration: `039`
 
-The Writer behavior also has a relevant, not-yet-merged delta:
+The Writer behavior had a relevant delta that the M0 implementation now
+reconciles onto the current baseline:
 
 - remote branch: `origin/codex/writer-framing-elicitation`
 - commit: `a00bc8b77511d7dae3676cbcc3cf5e04b78eee5a`
 - installed personal Writer metadata: `2.7.2`
 - key addition: choice-first framing and resumable `FRAMING_SESSION.yaml`
 
-The feature branch and `main` have diverged by one commit each. The workbench
-must therefore be implemented on `main`, with an explicit reconciliation or
-port of the choice-first Writer behavior. It must not assume that the installed
-plugin is already part of RKA `main`.
+The implementation ports the choice-first behavior rather than assuming that
+the installed plugin is part of RKA `main`. Repository and plugin mirrors are
+tested together.
 
 External design inputs inspected for this plan:
 
@@ -601,8 +607,9 @@ Record:
 - Ignore common secret, credential, cache, model, binary, and dependency
   directories by default.
 - Preview exactly which snippets will be sent to a model.
-- Default to the configured local LM Studio model when practical. For an
-  external model, require an explicit context-disclosure confirmation.
+- Keep provider selection visible and task-aware. Require local inference for
+  local-only material, and require an explicit context-disclosure confirmation
+  before an external provider receives a new data scope.
 - Do not automatically promote an extracted sentence into a supported claim.
 
 ## 11. AI interaction contract
@@ -1012,7 +1019,8 @@ PR 6 - Unified human/AI patch proposals
 - semantic diff;
 - apply/reject/supersede;
 - optimistic conflict handling;
-- configured local LM Studio adapter plus host-agent MCP path;
+- provider-neutral loopback broker with Codex App Server, Claude Agent SDK, LM
+  Studio, and optional direct API-key adapters;
 - context manifest and outbound-data boundary.
 
 ### Phase 4: spine, RQ, contribution, and evaluation editing
@@ -1161,7 +1169,7 @@ These are evaluation measures, not automated manuscript-quality scores.
 | Guided vs free-form | Guided entry, freely navigable afterward | lowers blank-page load without trapping expert users |
 | Planning persistence | generic typed, versioned planning artifacts | supports all stages without a parallel claim system |
 | Raw chat persistence | ephemeral; explicit capture only | prevents conversational noise from entering research history |
-| AI provider | configured local LM Studio first; pluggable host/external adapters | privacy, availability, and user choice |
+| AI provider | visible task/disclosure-aware broker; LM Studio for local-only context; Codex, Claude, or direct API adapters by explicit policy | privacy, capability, availability, and user choice |
 | AI mutation | proposal only; separate explicit apply | preserves authority and makes diffs reviewable |
 | Canonical spine | native RKA manuscript aggregate | avoids projection drift |
 | Draft editor MVP | structured cards plus Markdown/LaTeX split view | lower synchronization risk than full WYSIWYG |

--- a/docs/superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md
+++ b/docs/superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md
@@ -1,0 +1,143 @@
+# M0 Manuscript Workbench Walkthrough
+
+- Date: 2026-08-14
+- Build under test: RKA `2.9.0` from `main` baseline `9db7bd8` plus the
+  local M0 changes
+- Primary project: DelaySteer (`prj_01KZVF35ESDGKZKTG1D1J59TCF`)
+- Full-manuscript control: CPSEval (`prj_01KPVB7NHJ0N33C024TD0E6CZ6`),
+  manuscript `man_01M00D9BPMA60CN3FXTE86C4W1`
+- Data safety: the browser test used a SQLite-consistent backup in a disposable
+  Docker volume. The live RKA `2.8.1` containers and `rka_rka-data` volume were
+  not restarted or modified.
+
+## Purpose
+
+Validate the M0 authority and stage contracts against real RKA state before
+introducing planning-artifact or experiment-schema migrations. The walkthrough
+must expose unsupported or incomplete material rather than filling gaps with
+generated prose.
+
+## DelaySteer: project-only path
+
+DelaySteer has no canonical `man_` record in the snapshot. That is a normal and
+important pre-manuscript state, not an error. The workbench therefore opened in
+project-only mode and rendered:
+
+- 5 active research questions;
+- 13 evidence clusters;
+- 69 grounded claims;
+- no manuscript claim, unit, readiness, or impact aggregate.
+
+The stage rail correctly treated the early project state as:
+
+| Stage | Verdict | Reason |
+|---|---|---|
+| Seed insight | Exploratory | author intent is not yet a canonical record |
+| Paper spine | Exploratory | no native claim or eligible manuscript candidate |
+| Problem and scope | Blocked | no manuscript claim scope contract |
+| Literature and SOTA | Ready | active RQs and clusters are navigable |
+| Gap and motivation | Exploratory | no explicit gap signal is promoted automatically |
+| Insight and response | Exploratory | project evidence is inspiration, not a manuscript claim |
+| Research questions | Ready | five active RQ decisions are visible |
+| Contributions | Blocked | no native or admissible contribution claim |
+| Evaluation contract | Blocked | no native result units or experiment contract |
+| Outline | Blocked | no manuscript units |
+
+The strongest diagnostic was RQ
+`dec_01KZVQ7N0G5FHRKGFP7GGFY2BE`, concerning compositional temporal
+programmability. The workbench showed **0 clusters and 0 claims** for this RQ,
+while the other four RQs retained their own cluster and claim counts. It did
+not reinterpret the unsupported RQ as a validated novelty claim.
+
+## Full-manuscript control path
+
+The CPSEval control exercised all five manuscript read projections:
+
+- `/api/manuscripts/:id/context`
+- `/api/manuscripts/:id/spine`
+- `/api/manuscripts/:id/writing-candidates`
+- `/api/manuscripts/:id/readiness?target_phase=drafting`
+- `/api/manuscripts/:id/impact?since_cursor=0&limit=100`
+
+Every request returned HTTP 200. The context capsule showed 2 RQs, 6 clusters,
+and 81 claims for CPSEval. The native drafting gate remained `BLOCK` with three
+specific findings:
+
+1. `NO_ACTIVE_CLAIMS`: the argument spine has no active claims;
+2. `CHECKPOINT_REQUIRED`: the venue checkpoint is unresolved;
+3. `CHECKPOINT_REQUIRED`: the outline checkpoint is unresolved.
+
+The Evaluation stage also stated that the current schema has no first-class
+experiment, run, measurement, baseline, metric, or condition objects and that
+no result units exist for this manuscript. It did not infer experiments from
+journal prose or repository execution.
+
+## Defects found and corrected
+
+### Project-switch request race
+
+On the first pass, React published the new project query keys before the API
+client's project header was updated. The first DelaySteer fetch therefore
+cached Default Project data under the DelaySteer query key. The provider now
+updates the API request boundary synchronously before publishing the new
+project state. A repeated DelaySteer load showed the correct name and the
+5/13/69 RQ-cluster-claim counts.
+
+### Stale inspector selection across projects
+
+The first full-manuscript switch retained a previously selected DelaySteer RQ
+in the CPSEval evidence inspector. Inspector selections are now scoped to the
+exact `(project_id, manuscript_id-or-project-only)` context. The regression
+walkthrough confirmed that switching to CPSEval resets the inspector to the
+current CPSEval stage contract.
+
+### MCP dependency-major drift
+
+A clean Docker build resolved `mcp` 2.0.0, which removed the
+`mcp.server.fastmcp` import used by RKA and caused six Writer MCP-wrapper tests
+to error. `pyproject.toml` now declares `mcp>=1.26.0,<2.0.0` until RKA is
+deliberately migrated to the 2.x API. The rebuilt image resolved `mcp` 1.29.0,
+and `rka mcp --help` succeeded.
+
+## Verification evidence
+
+- Web TypeScript/Vite build: pass.
+- Changed-file ESLint set: pass.
+- Writer, Writer packaging, native manuscript API, and change-tracking API
+  suites: **397 passed**.
+- Docker image smoke test: `rka mcp --help` pass.
+- Browser walkthrough: DelaySteer project-only path and CPSEval full-manuscript
+  path pass; all observed workbench API calls returned HTTP 200.
+- Desktop visual inspection: stage rail, context capsule, stage canvas, and
+  evidence inspector remained legible and navigable in dark mode.
+
+The repository-wide web lint command still reports 8 errors and 2 warnings in
+pre-existing files (`FirstRunBanner`, shared UI variants, `useTheme`, Journal,
+ResearchMap, and Settings). No reported error is in the changed M0 file set.
+The production bundle also retains the existing large-chunk warning. These are
+baseline cleanup items, not evidence that the M0 workflow semantics failed.
+
+## Design revisions from the walkthrough
+
+1. **Project-only mode is first-class.** A researcher must be able to begin
+   with an insight and inspect RQs/clusters/claims before registering a
+   manuscript. Creating `man_` is an explicit promotion step, not an entry
+   requirement.
+2. **The context key is an authority boundary.** Project and manuscript
+   changes must invalidate request and selection state synchronously. No card
+   may survive a context-key change unless its trace is revalidated.
+3. **Zero coverage is actionable information.** An active RQ with zero
+   clusters/claims is shown as unsupported even when adjacent RQs are rich.
+4. **M1 experiment semantics remain necessary.** Result-like prose and generic
+   claims cannot substitute for planned experiment/run/result entities.
+5. **No migration is justified by UI fluency alone.** The next schema work must
+   start with the interpretation-staging and experiment-contract ADRs and
+   preserve this project-only path.
+
+## Exit decision
+
+The M0 implementation is technically validated and suitable for researcher
+review. The remaining M0 gate is explicit approval of the authority and stage
+contracts. After that approval, M1 Interpretation Staging/schema design and M2
+read-only workbench expansion may proceed in parallel. No canonical data was
+created or modified during this walkthrough.

--- a/plugin/skills/writer/README.md
+++ b/plugin/skills/writer/README.md
@@ -24,7 +24,9 @@ The command writes a complete, portable workspace only after RKA returns a
 canonical native `man_` manuscript. It stores the explicit binding in
 `.rka/manuscript.json` and leaves no unresolved core placeholders. Then:
 
-- Edit `.planning/PRECIS.md`: PI authors the title and abstract.
+- Run the choice-first framing session. The Writer proposes evidence-bounded
+  options with pros and cons; the PI selects or edits the final title,
+  abstract, claims, and paper spine recorded in `.planning/PRECIS.md`.
 - Edit `main.tex` after the Venue checkpoint resolves: replace
   `\documentclass{article}` with the venue class.
 
@@ -45,7 +47,8 @@ Start procedure runs:
 3. `rka writer sync` refreshes the read-only v2 spine and generated views.
 4. `rka_query(args={"operation": "research_map", ...})` provides retrieval
    orientation.
-5. `.planning/ACTIVE_WORKFLOW.md` carries disposable local resume state.
+5. `.planning/FRAMING_SESSION.yaml` resumes the advisory author/researcher
+   interview; `.planning/ACTIVE_WORKFLOW.md` carries disposable local state.
 6. `rka writer readiness --target-phase ...` asks RKA for the authoritative
    mechanical gate.
 7. The Writer greets the PI with the inferred next action.
@@ -75,7 +78,7 @@ python3 rka/skills/writer/scripts/layout_audit.py --venue CHI --output audit.jso
 
 | Component | Status |
 |---|---|
-| `SKILL.md` | v2.7.0 server-authoritative role contract, checkpoints, provenance, and review workflow |
+| `SKILL.md` | v2.7.2 server-authoritative role contract, choice-first framing, checkpoints, provenance, and review workflow |
 | `references/` | architecture, evidence and citation rules, review guidance, and venue registry |
 | `scripts/` | deterministic provenance, citation, venue, reference, layout, and claim-spine checks |
 | `mcp_tools/` | reference-metadata and discovery backends for Writer workflows |

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: rka-writer
-description: "Manuscript-drafting AI for RKA-managed research projects. Produces persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
-version: 2.7.1
+description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, then produces persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
+metadata:
+  version: "2.7.2"
 ---
 
 # Writer Skill
@@ -19,6 +20,15 @@ channel, then use materiality triage for public prose. Disclose material or
 venue-required limitations accurately; frame ordinary scope boundaries
 neutrally; do not volunteer speculative or irrelevant imperfections. Follow
 [`references/persuasive_framing.md`](references/persuasive_framing.md).
+
+Interaction Law: **propose choices before requesting composition.** During
+framing and spine work, ask one decision at a time and normally offer two to
+four evidence-bounded options with concrete pros, cons, evidence, risks, and
+paper-level consequences. State whether each question is single-select or
+multi-select and mark a recommendation when justified. Use focused free text
+only for custom alternatives, missing evidence, disagreements not covered by
+the choices, or exact wording corrections. Follow
+[`references/framing_elicitation.md`](references/framing_elicitation.md).
 
 The native claim spine is part of RKA's manuscript aggregate, not a second
 knowledge base or orchestrator. RKA is authoritative for manuscript identity,
@@ -45,6 +55,9 @@ commands.
 - [`references/persuasive_framing.md`](references/persuasive_framing.md):
   two-channel author/manuscript discipline, limitation materiality triage,
   strength-first defense patterns, and the quick-reader path.
+- [`references/framing_elicitation.md`](references/framing_elicitation.md):
+  choice-first author/researcher interview, adaptive framing rounds,
+  disagreement handling, and final spine confirmation.
 - [`references/reference_pipeline.md`](references/reference_pipeline.md): implemented seven-stage validation pipeline, categorical verdicts, retraction checks, and explicit backend degradation.
 - [`references/ai_tics.md`](references/ai_tics.md): banned-term tiers with primary-source citations (PI verbatim list, Kobak et al. 2025, Matsui 2025), replacement table, structural detectors, per-project override mechanism. Sources cited directly per `dec_01KS12H9KT1T03DHX2Q6FKTXHH`; no third-party content vendored in Phase 1.
 - [`references/venue/CHI.md`](references/venue/CHI.md) and [`references/venue/EMNLP.md`](references/venue/EMNLP.md): seed venue files for HCI and NLP (Phase 1 scope per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q3).
@@ -89,7 +102,9 @@ writer readiness` asks RKA for the authoritative target-phase gate.
 4. Run `rka writer sync` to refresh the `rka-claim-spine/v2` projection and
    generated planning views from RKA. The projection is read-only.
 5. Call `rka_query(args={"operation": "research_map", "project_id": "prj_..."})` for a structural overview,
-   then read `.planning/ACTIVE_WORKFLOW.md` and resume its `next_action`.
+   then read `.planning/ACTIVE_WORKFLOW.md` and resume its `next_action`. If
+   `.planning/FRAMING_SESSION.yaml` is incomplete, resume the first unresolved
+   choice round instead of restarting the interview.
 6. Verify `.mcp.json` lists `rka` plus `rka-writer-tools`. Pass `project_id` on
    every operation. Native manuscript work uses `manuscript_context`,
    `manuscript_spine`, `manuscript_readiness`, `upsert_argument_spine`,
@@ -220,6 +235,14 @@ mechanism, not the authority for a native manuscript.
 
 Before any prose is written, you co-author an outline with the PI as a Decision (`rka_add_decision`). The Iron Law is **no prose before outline ratification.** The `main.tex` stays skeleton-only until the Outline checkpoint passes: `\documentclass{...}`, `\begin{document}`, `\input{sections/...}`, `\end{document}` and nothing in `sections/*.tex` yet.
 
+Before generating the final outline options, run the choice-first framing
+session in [`references/framing_elicitation.md`](references/framing_elicitation.md).
+The Writer proposes options; the author supplies narrative intent; the
+researcher supplies evidence and scope judgment; the PI confirms final
+authority. One person may hold all roles. Record micro-selections in
+`.planning/FRAMING_SESSION.yaml`, not as RKA decisions. They remain advisory
+until the final framing and exact contribution wording are ratified.
+
 The outline brief uses the strip-then-re-inject pattern that Brain uses for any multi-choice decision (see `../brain/decision_ux.md`):
 
 1. Generate three candidate outline framings (results-led, method-led, motivation-led) with PI preference stripped from context.
@@ -276,7 +299,17 @@ Full procedure with checkpoint UX: [`references/workflows.md`](references/workfl
 
 ## PI Checkpoints
 
-Six in-session checkpoints. All use the strip-then-re-inject pattern. Each produces a `dec_` with three ratified options, opposing-critique ranking, and the PI's selection.
+Six in-session checkpoints. All use the strip-then-re-inject pattern. Each
+produces a `dec_` with bounded options, opposing-critique ranking, and the PI's
+selection. Formal checkpoint resolution is normally single-select. Preparatory
+questions may be multi-select when choices can coexist, but remain advisory
+until the checkpoint is ratified.
+
+Use structured choice controls when the host provides them. Otherwise show
+option IDs and ask the PI to reply with one ID or an allowed set. Every option
+must show concrete pros and cons, evidence status, material risk, and the
+effect on the manuscript. Do not force exactly three options when only two are
+credible, and do not invent a weak option to fill the menu.
 
 | Number | Checkpoint | Fires when | What is at stake |
 |---|---|---|---|
@@ -518,6 +551,11 @@ When a revised draft is available, compare it against the prior review comments 
 22. **DON'T** paste the private reviewer-risk register into manuscript prose. Triage each concern by materiality and public relevance first.
 23. **DON'T** use persuasive framing to conceal claim-relevant negative results, unresolved contradictions, material validity or security issues, or venue-required disclosures.
 24. **DON'T** weaken every defensible claim with generic caveats. Preserve semantic qualifiers, then lead with the bounded contribution, evidence, and defense.
+25. **DON'T** ask the author to invent a framing from a blank page when current
+   evidence supports bounded choices. Propose options with pros and cons first.
+26. **DON'T** record a framing micro-selection as evidence, claim ratification,
+   or a formal PI decision. Persist it in `FRAMING_SESSION.yaml` until final
+   confirmation.
 
 ---
 
@@ -527,6 +565,8 @@ When a revised draft is available, compare it against the prior review comments 
 - Server-authoritative sync, impact, readiness, update, and migration loop:
   [`references/server_authoritative_workflow.md`](references/server_authoritative_workflow.md).
 - Session-start walkthrough, sub-procedures, checkpoint UX: [`references/workflows.md`](references/workflows.md).
+- Choice-first author/researcher interview and framing-session schema:
+  [`references/framing_elicitation.md`](references/framing_elicitation.md).
 - Persuasive framing, limitation triage, and quick-reader guidance:
   [`references/persuasive_framing.md`](references/persuasive_framing.md).
 - Implemented reference validation pipeline: [`references/reference_pipeline.md`](references/reference_pipeline.md).

--- a/plugin/skills/writer/docs/phase-1-mvp.md
+++ b/plugin/skills/writer/docs/phase-1-mvp.md
@@ -86,8 +86,8 @@ PATCH 2).
 `manuscripts/<project-id>/<venue>/`:
 
 - `.mcp.json`, `.latexmkrc`, `ai_tic_config.yaml`, `main.tex`, `refs.bib`.
-- `.planning/`: `ACTIVE_WORKFLOW.md`, `PRECIS.md`, `OUTLINE.md`,
-  `REVIEW_STATE.md`.
+- `.planning/`: `ACTIVE_WORKFLOW.md`, `FRAMING_SESSION.yaml`, `PRECIS.md`,
+  `OUTLINE.md`, `REVIEW_STATE.md`.
 - Directory placeholders: `sections/`, `figures/`, `tables/`, `charts/`,
   `styles/`.
 

--- a/plugin/skills/writer/references/architecture.md
+++ b/plugin/skills/writer/references/architecture.md
@@ -21,6 +21,7 @@ Writer session
         +-- .planning/CONTRIBUTION_CONTRACT.md   generated
         +-- .planning/ARGUMENT_SPINE.md          generated
         +-- .planning/RESULTS_TRACE.md            generated
+        +-- .planning/FRAMING_SESSION.yaml        advisory interaction state
         +-- .planning/ACTIVE_WORKFLOW.md          local session state
         +-- sections/, figures/, tables/, charts/
         +-- refs.bib, main.tex, styles/

--- a/plugin/skills/writer/references/claim_spine.md
+++ b/plugin/skills/writer/references/claim_spine.md
@@ -140,7 +140,14 @@ authorize drafting.
 
 ### 2. Assemble candidates
 
-Use multi-angle RKA retrieval. For each candidate identify:
+Use multi-angle RKA retrieval and the choice-first session in
+[`framing_elicitation.md`](framing_elicitation.md). The Writer proposes
+evidence-bounded alternatives with pros and cons; the author supplies narrative
+intent; the researcher supplies scientific scope judgment. Record provisional
+selections in `.planning/FRAMING_SESSION.yaml`. They do not modify the native
+manuscript aggregate and do not count as evidence or ratification.
+
+For each candidate identify:
 
 1. the prior limitation or open problem;
 2. the project's response;
@@ -151,7 +158,10 @@ Use multi-angle RKA retrieval. For each candidate identify:
 7. the result and non-result units that will carry the claim.
 
 `rka writer assist` may accelerate discovery but returns unratified candidates
-only.
+only. Present contribution inclusion as a multi-select choice, claim
+calibration as a single-select choice per contribution, and the final whole
+paper spine as a single-select choice. Offer revise/combine and defer/gather
+evidence paths where appropriate.
 
 ### 3. Dry-run and apply
 
@@ -181,8 +191,10 @@ decision, or creates PI authority.
 
 ### 4. Ratify exact wording
 
-Present bounded alternatives during the existing Outline checkpoint. For each
-selected contribution:
+Present the surviving alternatives with concrete pros, cons, evidence coverage,
+missing evidence, scope boundaries, and outline consequences during the
+existing Outline checkpoint. Obtain one explicit final PI confirmation after
+the advisory framing session. For each selected contribution:
 
 1. record an active PI decision whose `chosen` text exactly matches the claim
    version;

--- a/plugin/skills/writer/references/framing_elicitation.md
+++ b/plugin/skills/writer/references/framing_elicitation.md
@@ -1,0 +1,310 @@
+# Framing and Spine Elicitation
+
+Use this workflow before the Outline checkpoint when the manuscript framing is
+new, disputed, weakly specified, or materially affected by new research. Its
+purpose is to help the author and researcher discover a defensible paper spine
+without asking them to compose that spine from a blank page.
+
+The Writer proposes bounded choices from current RKA evidence. The people make
+the selections. The interaction is deliberative, but the resulting session
+artifact is advisory until the PI ratifies exact claim wording and the Outline
+checkpoint.
+
+## Authority boundary
+
+- RKA remains authoritative for research records, manuscript claims, evidence
+  roles, decisions, ratifications, units, and checkpoints.
+- `.planning/FRAMING_SESSION.yaml` is resumable working state. It is not
+  evidence, a PI decision, or a substitute for the native claim spine.
+- A user selection expresses preference or intent. It does not verify an
+  empirical claim or resolve a contradiction.
+- Only an explicit final PI selection may be recorded as a decision. Exact
+  contribution wording still requires claim-scope ratification.
+- Keep author intent and researcher evidence judgment distinct even when the
+  same person supplies both.
+
+## Choice-first interaction contract
+
+Default to structured choices for framing and spine work.
+
+1. Ask one decision per turn.
+2. Offer two to four evidence-bounded options. Use fewer than three when the
+   evidence does not support three genuine alternatives.
+3. State whether the decision is `single-select` or `multi-select`. For a
+   multi-select question, state the maximum number of selections when a limit
+   is useful.
+4. Give every option a short ID and label, followed by:
+   - what the option means;
+   - concrete pros;
+   - concrete cons or tradeoffs;
+   - the strongest supporting RKA evidence;
+   - missing evidence or material risk;
+   - how the option changes the claim, audience, or outline.
+5. Mark one option `Recommended` when the evidence supports a recommendation.
+   Explain why. Do not manufacture a recommendation when the alternatives are
+   genuinely tied.
+6. Include `Revise or combine these options` whenever a hybrid is coherent.
+   Include `Defer and gather evidence` when the evidence boundary is the real
+   blocker.
+7. Use the host's structured choice UI when available. Otherwise present
+   numbered or lettered options and ask the user to reply with IDs.
+8. After a selection, restate the chosen interpretation in one sentence and
+   update the session artifact before asking the next decision.
+
+Do not present a false menu. Options must differ on a material decision axis,
+not merely wording. Do not hide a required disclosure, unsupported extension,
+or contradiction in an option's fine print.
+
+### Free-text exceptions
+
+Use a focused free-text question only when:
+
+- the user wants an option that the Writer cannot infer;
+- exact title, abstract, author order, or claim wording needs correction;
+- relevant evidence or context is absent from RKA;
+- the author and researcher disagree in a way the proposed reconciliation
+  choices do not cover; or
+- the user explicitly asks to discuss an issue without a menu.
+
+After receiving free text, summarize it and return to choices. New empirical
+information must enter RKA and pass the normal evidence checks before it
+supports a manuscript claim.
+
+## Option card
+
+Use this compact shape. Keep each option scannable.
+
+```text
+Decision F4 - Primary novelty axis [single-select]
+
+A. Mechanism-first [Recommended]
+Meaning: The paper leads with the new control mechanism.
+Pros: Clearest technical novelty; strongest match to the verified ablation.
+Cons: Requires a concise explanation of the deployment assumptions.
+Evidence: clm_... supported by jrn_...
+Risk: Cross-platform evidence is currently narrow.
+Effect: Method-led claim and outline.
+
+B. Outcome-first
+Meaning: The paper leads with the measured operational improvement.
+Pros: Fastest reader payoff; strongest headline result.
+Cons: Novelty may look incremental without the mechanism explanation.
+Evidence: clm_... supported by jrn_...
+Risk: Baseline comparability needs a visible defense.
+Effect: Results-led claim and outline.
+
+Select A or B, or choose "Revise or combine."
+```
+
+For multi-select rounds, give each option independent consequences and ask for
+IDs such as `C1, C3`. Never use multi-select when the choices are mutually
+exclusive.
+
+## Participant handling
+
+At the first round, identify who is answering:
+
+- `Author voice`: intended audience, desired takeaway, narrative emphasis, and
+  terminology.
+- `Researcher judgment`: scientific novelty, evidence strength, conditions,
+  counterevidence, and defensible scope.
+- `PI authority`: final scope, exact claim wording, and checkpoint decisions.
+
+One person may hold all three roles. When different people participate, attach
+each selection to its role. If their selections conflict, do not silently
+average them. Present two to four reconciliation choices with pros, cons, and
+the effect on the paper. Escalate unresolved authority conflicts to the PI.
+
+## Elicitation rounds
+
+Run only the rounds needed for the current manuscript. Resume from the first
+unresolved round in `.planning/FRAMING_SESSION.yaml`.
+
+### F0. Session posture
+
+Confirm the participants and the task:
+
+- frame a new paper;
+- repair an existing but weak spine;
+- reframe for a different venue or audience; or
+- revisit a spine after material evidence changed.
+
+This may be a multi-select when more than one purpose applies.
+
+### F1. Reader and outcome
+
+Propose two to four target-reader outcomes, such as:
+
+- understand a new mechanism;
+- trust a new empirical finding;
+- adopt a practical system or method;
+- revise an assumption or threat model.
+
+Mode: usually single-select. Capture secondary audiences separately rather than
+merging incompatible primary outcomes.
+
+### F2. Central problem or gap
+
+Propose bounded problem statements based on current literature, research
+questions, decisions, and verified claims. For each option show:
+
+- what prior limitation it asserts;
+- what evidence supports that characterization;
+- what it does not claim about prior work; and
+- which venue audience would care.
+
+Mode: single-select, with a hybrid allowed only when the combined gap remains
+coherent.
+
+### F3. Contribution portfolio
+
+Propose candidate contributions after `rka writer assist` and evidence
+triage. Each candidate must identify:
+
+- contribution type;
+- exact provisional wording;
+- positive evidence;
+- qualifiers and counterevidence;
+- tested conditions;
+- allowed and prohibited extension;
+- likely manuscript unit.
+
+Mode: multi-select. Recommend the smallest coherent set, normally two to four
+contributions. Mark decorative, redundant, or unsupported candidates for
+defer/remove rather than inflating the list.
+
+### F4. Primary novelty axis
+
+Propose the strongest defensible novelty thesis, for example:
+
+- mechanism or method novelty;
+- empirical discovery;
+- system integration or operational capability;
+- theory, model, or conceptual reframing;
+- dataset, benchmark, or measurement contribution.
+
+Mode: single-select. A secondary novelty axis may be selected only when it has
+independent evidence and a distinct role.
+
+### F5. Evidence anchor and result priority
+
+Propose which verified results should carry the quick-reader path. Compare
+effect size or qualitative importance, evidence quality, baseline fairness,
+scope, uncertainty, and venue relevance.
+
+Mode: multi-select, normally one primary result and up to two supporting
+results. Do not select a result solely because it is visually impressive.
+
+### F6. Claim calibration
+
+For each candidate contribution, propose bounded wording levels such as:
+
+- strongest wording supported by current evidence;
+- narrower wording with lower reviewer risk;
+- defer pending an evidence mission.
+
+Mode: single-select per claim. State the tested conditions and prohibited
+interpretation for every option. A preference for stronger language cannot
+override current evidence.
+
+### F7. Narrative architecture
+
+Generate two to four whole-paper spines. Results-led, method-led, and
+motivation-led are defaults, not mandatory labels. Add a hybrid only when it
+has a distinct and coherent reading path.
+
+For each candidate spine show:
+
+- one-sentence paper thesis;
+- ordered contribution claims;
+- primary evidence path;
+- five to eight section purposes;
+- main reviewer advantage;
+- main reviewer risk;
+- venue fit;
+- what is intentionally not central.
+
+Mode: single-select. Mark one recommendation after opposing-critique review.
+
+### F8. Boundaries and reviewer defense
+
+Use the materiality policy in `persuasive_framing.md`. Propose treatments for
+the material assumptions, mixed results, counterevidence, and likely reviewer
+attacks:
+
+- lead with an evidence-backed defense;
+- state a neutral scope boundary;
+- disclose a material limitation;
+- repair before submission;
+- commission an evidence mission;
+- keep internal only when truly M4 or speculative.
+
+Mode: multi-select across independent concerns, then single-select for the
+treatment of each concern. An M1/M2 issue cannot be assigned `internal only`.
+
+### F9. Final spine selection
+
+Present the surviving candidate spines side by side. Every candidate must
+include exact provisional claims, pros, cons, evidence coverage, missing
+evidence, public boundaries, outline effect, and venue fit.
+
+Mode: single-select:
+
+- select one candidate;
+- combine named parts of two candidates;
+- revise the options;
+- defer and gather evidence.
+
+After selection, show the complete proposed contribution contract and outline.
+Ask for one explicit final confirmation before dry-running the native spine
+import and recording any RKA decision.
+
+## Triage rules
+
+- **Duplicate choices:** merge them and explain the lost distinction.
+- **Dominated choices:** prune when another option is at least as strong on
+  evidence coverage, scope accuracy, venue fit, and narrative clarity without
+  a material disadvantage.
+- **Unsupported but interesting choices:** label them hypotheses or evidence
+  missions, not contribution claims.
+- **Contradicted choices:** present the contradiction and resolution paths.
+  Do not recommend strong wording while the contradiction is unresolved.
+- **Author/researcher conflict:** present reconciliation options and attach the
+  final selection to PI authority.
+- **Too many contributions:** propose a coherent core, an optional secondary
+  set, and a defer-to-future-work set.
+- **No credible spine:** say so and offer evidence-gathering, scope reduction,
+  or a different paper objective. Do not fill the menu with weak alternatives.
+
+## Session artifact
+
+`.planning/FRAMING_SESSION.yaml` records:
+
+- session status, purpose, participants, and roles;
+- each choice round, mode, options, recommendation, selection, and rationale;
+- RKA evidence IDs and unresolved evidence needs;
+- author/researcher disagreements and their resolution status;
+- candidate spines and the final provisional selection;
+- links to resulting PI decisions after ratification.
+
+Append a new round revision instead of silently replacing a prior selection.
+The artifact may summarize pros and cons, but it must not contain secrets or
+credentials. Synchronizing the native claim spine does not overwrite it.
+
+## Completion criteria
+
+The elicitation stage is complete only when:
+
+1. the primary reader outcome and central problem are selected;
+2. the contribution portfolio and novelty axis are selected;
+3. every contribution has evidence, conditions, allowed wording, and
+   prohibited wording, or is explicitly deferred;
+4. the primary results and reviewer-sensitive boundaries are triaged;
+5. one coherent candidate spine and outline is provisionally selected;
+6. author/researcher disagreements are resolved or escalated;
+7. the PI explicitly confirms the complete proposal; and
+8. no micro-selection has been misrepresented as evidence or ratification.
+
+Then dry-run `rka writer import-spine`, present the authoritative diff, apply
+with an expected revision only after approval, ratify exact claim wording, and
+resolve the existing Outline checkpoint.

--- a/plugin/skills/writer/references/workflows.md
+++ b/plugin/skills/writer/references/workflows.md
@@ -97,7 +97,10 @@ last_session: 2026-04-11
 If `ACTIVE_WORKFLOW.md` is absent, infer from the working directory:
 
 - `.planning/PRECIS.md` absent: phase = venue selection.
-- `PRECIS.md` present, claim spine not ratified: phase = contribution and outline.
+- Venue ratified and `FRAMING_SESSION.yaml` absent or incomplete: phase =
+  framing elicitation.
+- Framing session complete, claim spine not ratified: phase = contribution and
+  outline.
 - Claim spine ratified, `OUTLINE.md` absent: phase = outline completion.
 - `OUTLINE.md` present, `sections/` empty: phase = table and figure planning.
 - `sections/` populated: phase = drafting; next section is the first one with status `outlined` rather than `drafted`.
@@ -127,6 +130,12 @@ Greet the PI with the inferred state and the next action. Example:
 ## The Seven Sub-Procedures
 
 The seven sub-procedures map to the six PI checkpoints plus the Revision Loop.
+Most PI exchanges inside them use the choice-first interaction contract in
+[`framing_elicitation.md`](framing_elicitation.md): one decision per turn, two
+to four bounded options, concrete pros and cons, explicit single-select or
+multi-select mode, and a recommendation when justified. Use free text only for
+a custom alternative, missing evidence, unresolved disagreement, or exact
+wording correction.
 
 ### 1. Venue handler
 
@@ -154,14 +163,28 @@ Procedure:
    questions. Select which research questions are in manuscript scope.
 2. Resolve every cluster blocker through Brain. Do not promote journal prose,
    an LLM-only synthesis, stale claims, or unresolved counterevidence.
-3. Read the selected cluster lineage and assemble evidence from several short
+3. Start or resume `.planning/FRAMING_SESSION.yaml` using
+   [`framing_elicitation.md`](framing_elicitation.md). Identify whether each
+   participant is supplying author voice, researcher judgment, PI authority,
+   or more than one role. Ask one choice at a time and update the artifact
+   after each selection.
+4. Run the needed elicitation rounds for reader outcome, problem or gap,
+   contribution portfolio, novelty axis, evidence anchors, claim calibration,
+   narrative architecture, and reviewer-sensitive boundaries. Use
+   single-select for mutually exclusive choices and multi-select for compatible
+   contribution, result, or defense choices. Every option shows pros, cons,
+   evidence, missing evidence, and its effect on the paper.
+5. If author and researcher selections conflict, propose two to four
+   reconciliation paths. Do not silently average their positions. Escalate an
+   unresolved authority conflict to the PI.
+6. Read the selected cluster lineage and assemble evidence from several short
    retrieval angles. For each contribution candidate, resolve positive
    evidence, qualifiers, counterevidence, terminal source records, current
    design decisions, and relevant superseded choices that explain the design's
    evolution. Superseded choices may inform lineage but are not current
    support. An `ecl_` guides synthesis but does not count as terminal empirical
    support; a `dec_` ratifies wording but does not prove it.
-4. Build a contribution contract and candidate proposal with exact claim text,
+7. Build a contribution contract and candidate proposal with exact claim text,
    source-backed evidence, missing evidence, novelty/significance risks,
    allowed wording, prohibited wording, and planned manuscript units. The
    assist result seeds this work but cannot write or ratify it. Treat risks,
@@ -169,36 +192,43 @@ Procedure:
    record, not as text that must all appear in the public manuscript. Classify
    their public treatment through
    [`persuasive_framing.md`](persuasive_framing.md).
-5. Generate three bounded claim-and-outline framings with PI preference stripped from context:
+8. Generate two to four bounded claim-and-outline framings with PI preference
+   stripped from context. Use these defaults when they are genuinely distinct:
    - Results-led: section ordering driven by the most novel finding.
    - Method-led: section ordering driven by the methodological contribution.
    - Motivation-led: section ordering driven by the problem framing.
-6. For each framing, show the exact contribution wording, its evidence path,
+   Add a hybrid only when it has a coherent reading path that the defaults do
+   not represent.
+9. For each framing, show the exact contribution wording, its evidence path,
    conditions, known counterevidence, missing evidence, and a 5-to-8-section
-   outline with one-sentence section purposes.
-7. Prune any framing dominated on evidence coverage, scope accuracy,
+   outline with one-sentence section purposes. Include concrete pros, cons,
+   reviewer advantage, reviewer risk, and venue fit.
+10. Prune any framing dominated on evidence coverage, scope accuracy,
    novelty-positioning, venue fit, quick-reader comprehension, strongest-
    evidence visibility, and narrative momentum. Do not compute an aggregate
    paper score or acceptance prediction.
-8. Re-inject PI preference as opposing-critique; rank surviving framings.
-9. Present three (or fewer if pruned) options to the PI; one carries
-   `is_recommended`. The PI may retain, narrow, or defer a claim and commission
-   an evidence-gap mission.
-10. Dry-run `rka writer import-spine`. Review the evidence roles, result
+11. Re-inject PI preference as opposing-critique; rank surviving framings.
+12. Present the surviving options as the final F9 single-select choice; one
+   carries `is_recommended` when justified. The PI may select one, combine
+   named parts, request revised options, or defer and commission an evidence
+   mission. Show the complete proposed contribution contract and outline, then
+   obtain explicit final confirmation.
+13. Dry-run `rka writer import-spine`. Review the evidence roles, result
    coverage, and proposed revision; apply only with an explicit expected
    revision. Import never creates ratifications.
-11. Record the PI's selected framing and one child claim-scope `dec_` per
+14. Record the PI's selected framing and one child claim-scope `dec_` per
    selected contribution. Set `chosen` to the exact claim text,
    `decided_by: pi`, and connect the decision to its evidence and Outline
    lineage. Bind each exact native claim version through
    `ratify_manuscript_claim`. A later material edit requires a new version and
    a superseding PI decision.
-12. Resolve the native Outline checkpoint, run `rka writer sync`, and require
+15. Resolve the native Outline checkpoint, run `rka writer sync`, and require
     server readiness. The generated `CONTRIBUTION_CONTRACT.md`,
     `ARGUMENT_SPINE.md`, and `RESULTS_TRACE.md` are read-only views.
 
 Output: Outline Decision (`dec_`), one exact-wording claim-scope `dec_` per
 contribution with evidence provenance,
+`.planning/FRAMING_SESSION.yaml`,
 `.planning/RKA_CLAIM_SPINE.yaml`, its three generated views,
 `.planning/OUTLINE.md`, and `.planning/sketches/<section-id>.md` per section.
 
@@ -379,11 +409,23 @@ remain outside this workflow.
 
 ## Checkpoint UX patterns
 
-All six PI checkpoints use the strip-then-re-inject decision UX inherited from Brain (`../brain/decision_ux.md` is the canonical reference). Three ratified options per checkpoint; opposing-critique ranking; PI selection via `rka_record_pi_selection`.
+All six PI checkpoints use the strip-then-re-inject decision UX inherited from
+Brain (`../brain/decision_ux.md` is the canonical reference). Present two to
+four credible options, use opposing-critique ranking, and identify one
+recommendation when justified. Every option includes concrete pros, cons,
+evidence status, material risk, and manuscript consequence. Formal checkpoint
+resolution is single-select via `rka_record_pi_selection`.
+
+Preparatory decisions default to the choice-first contract in
+[`framing_elicitation.md`](framing_elicitation.md). Use multi-select only when
+the options can coexist, such as contribution inclusion, primary/supporting
+results, or independent reviewer defenses. Record those micro-selections in
+the framing session, not as RKA decisions. Use the host's structured selector
+when available; otherwise ask for option IDs.
 
 Per-checkpoint specifics:
 
-| Checkpoint | Three option framings | Pareto axes |
+| Checkpoint | Typical option framings | Pareto axes |
 |---|---|---|
 | Venue | venue A / venue B / venue C | venue fit, deadline, audience reach |
 | Outline | results-led / method-led / motivation-led, each with bounded claim wording | evidence coverage, claim boundary, novelty positioning, venue fit |

--- a/plugin/skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md
+++ b/plugin/skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md
@@ -13,6 +13,7 @@ last_session: (initial bootstrap)
 | Phase | Trigger to advance |
 |---|---|
 | venue_selection | Venue checkpoint ratified; .planning/PRECIS.md authored |
+| framing_elicitation | Choice rounds complete; PI confirms one provisional spine |
 | evidence_synthesis | In-scope RQs selected; cluster blockers and counterevidence resolved |
 | contribution_contract | Exact allowed/prohibited contribution boundary accepted for spine import |
 | outline | Outline checkpoint ratified; .planning/OUTLINE.md ratified |

--- a/plugin/skills/writer/workspace-template/.planning/FRAMING_SESSION.yaml
+++ b/plugin/skills/writer/workspace-template/.planning/FRAMING_SESSION.yaml
@@ -1,0 +1,12 @@
+schema: rka-framing-session/v1
+status: not_started
+purpose: null
+participants: []
+rounds: []
+candidate_spines: []
+selected_spine: null
+unresolved_questions: []
+rka_decision_links: []
+
+# Advisory, resumable interaction state only.
+# This file is not evidence, a PI decision, or a claim ratification.

--- a/plugin/skills/writer/workspace-template/.planning/PRECIS.md
+++ b/plugin/skills/writer/workspace-template/.planning/PRECIS.md
@@ -1,15 +1,18 @@
 # PRECIS
 
-PI-authored. The title and abstract are the manuscript's verbatim_input in
-the RKA manuscript manifest (Option 2 per dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q1).
+PI-confirmed. The Writer may propose bounded title, abstract, and claim options
+during framing elicitation, but the PI's selected or edited final text becomes
+the manuscript's verbatim_input in the RKA manuscript manifest (Option 2 per
+dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q1).
 
 ## Title
 
-(PI fills in.)
+(Writer proposes options; PI selects, edits if needed, and confirms verbatim.)
 
 ## Abstract
 
-(PI fills in. ~150 to 250 words depending on venue.)
+(Writer proposes bounded alternatives after spine selection; PI selects, edits
+if needed, and confirms verbatim. Use ~150 to 250 words depending on venue.)
 
 ## Target venue
 
@@ -22,8 +25,9 @@ dec_ ID once the checkpoint resolves.)
 
 ## Key claims
 
-(PI fills in 3 to 5 bullet points stating the contribution claims. These
-are the targets that prose must support via provenance edges.)
+(Populate from the PI-confirmed framing session and exact claim-scope
+ratifications. Use 3 to 5 bullets stating the contribution claims. These are
+the targets that prose must support via provenance edges.)
 
 ## Notes for the Writer
 

--- a/rka/skills/writer/README.md
+++ b/rka/skills/writer/README.md
@@ -24,7 +24,9 @@ The command writes a complete, portable workspace only after RKA returns a
 canonical native `man_` manuscript. It stores the explicit binding in
 `.rka/manuscript.json` and leaves no unresolved core placeholders. Then:
 
-- Edit `.planning/PRECIS.md`: PI authors the title and abstract.
+- Run the choice-first framing session. The Writer proposes evidence-bounded
+  options with pros and cons; the PI selects or edits the final title,
+  abstract, claims, and paper spine recorded in `.planning/PRECIS.md`.
 - Edit `main.tex` after the Venue checkpoint resolves: replace
   `\documentclass{article}` with the venue class.
 
@@ -45,7 +47,8 @@ Start procedure runs:
 3. `rka writer sync` refreshes the read-only v2 spine and generated views.
 4. `rka_query(args={"operation": "research_map", ...})` provides retrieval
    orientation.
-5. `.planning/ACTIVE_WORKFLOW.md` carries disposable local resume state.
+5. `.planning/FRAMING_SESSION.yaml` resumes the advisory author/researcher
+   interview; `.planning/ACTIVE_WORKFLOW.md` carries disposable local state.
 6. `rka writer readiness --target-phase ...` asks RKA for the authoritative
    mechanical gate.
 7. The Writer greets the PI with the inferred next action.
@@ -75,7 +78,7 @@ python3 rka/skills/writer/scripts/layout_audit.py --venue CHI --output audit.jso
 
 | Component | Status |
 |---|---|
-| `SKILL.md` | v2.7.0 server-authoritative role contract, checkpoints, provenance, and review workflow |
+| `SKILL.md` | v2.7.2 server-authoritative role contract, choice-first framing, checkpoints, provenance, and review workflow |
 | `references/` | architecture, evidence and citation rules, review guidance, and venue registry |
 | `scripts/` | deterministic provenance, citation, venue, reference, layout, and claim-spine checks |
 | `mcp_tools/` | reference-metadata and discovery backends for Writer workflows |

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: rka-writer
-description: "Manuscript-drafting AI for RKA-managed research projects. Produces persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
-version: 2.7.1
+description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, then produces persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
+metadata:
+  version: "2.7.2"
 ---
 
 # Writer Skill
@@ -19,6 +20,15 @@ channel, then use materiality triage for public prose. Disclose material or
 venue-required limitations accurately; frame ordinary scope boundaries
 neutrally; do not volunteer speculative or irrelevant imperfections. Follow
 [`references/persuasive_framing.md`](references/persuasive_framing.md).
+
+Interaction Law: **propose choices before requesting composition.** During
+framing and spine work, ask one decision at a time and normally offer two to
+four evidence-bounded options with concrete pros, cons, evidence, risks, and
+paper-level consequences. State whether each question is single-select or
+multi-select and mark a recommendation when justified. Use focused free text
+only for custom alternatives, missing evidence, disagreements not covered by
+the choices, or exact wording corrections. Follow
+[`references/framing_elicitation.md`](references/framing_elicitation.md).
 
 The native claim spine is part of RKA's manuscript aggregate, not a second
 knowledge base or orchestrator. RKA is authoritative for manuscript identity,
@@ -45,6 +55,9 @@ commands.
 - [`references/persuasive_framing.md`](references/persuasive_framing.md):
   two-channel author/manuscript discipline, limitation materiality triage,
   strength-first defense patterns, and the quick-reader path.
+- [`references/framing_elicitation.md`](references/framing_elicitation.md):
+  choice-first author/researcher interview, adaptive framing rounds,
+  disagreement handling, and final spine confirmation.
 - [`references/reference_pipeline.md`](references/reference_pipeline.md): implemented seven-stage validation pipeline, categorical verdicts, retraction checks, and explicit backend degradation.
 - [`references/ai_tics.md`](references/ai_tics.md): banned-term tiers with primary-source citations (PI verbatim list, Kobak et al. 2025, Matsui 2025), replacement table, structural detectors, per-project override mechanism. Sources cited directly per `dec_01KS12H9KT1T03DHX2Q6FKTXHH`; no third-party content vendored in Phase 1.
 - [`references/venue/CHI.md`](references/venue/CHI.md) and [`references/venue/EMNLP.md`](references/venue/EMNLP.md): seed venue files for HCI and NLP (Phase 1 scope per `dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D` Q3).
@@ -89,7 +102,9 @@ writer readiness` asks RKA for the authoritative target-phase gate.
 4. Run `rka writer sync` to refresh the `rka-claim-spine/v2` projection and
    generated planning views from RKA. The projection is read-only.
 5. Call `rka_query(args={"operation": "research_map", "project_id": "prj_..."})` for a structural overview,
-   then read `.planning/ACTIVE_WORKFLOW.md` and resume its `next_action`.
+   then read `.planning/ACTIVE_WORKFLOW.md` and resume its `next_action`. If
+   `.planning/FRAMING_SESSION.yaml` is incomplete, resume the first unresolved
+   choice round instead of restarting the interview.
 6. Verify `.mcp.json` lists `rka` plus `rka-writer-tools`. Pass `project_id` on
    every operation. Native manuscript work uses `manuscript_context`,
    `manuscript_spine`, `manuscript_readiness`, `upsert_argument_spine`,
@@ -220,6 +235,14 @@ mechanism, not the authority for a native manuscript.
 
 Before any prose is written, you co-author an outline with the PI as a Decision (`rka_add_decision`). The Iron Law is **no prose before outline ratification.** The `main.tex` stays skeleton-only until the Outline checkpoint passes: `\documentclass{...}`, `\begin{document}`, `\input{sections/...}`, `\end{document}` and nothing in `sections/*.tex` yet.
 
+Before generating the final outline options, run the choice-first framing
+session in [`references/framing_elicitation.md`](references/framing_elicitation.md).
+The Writer proposes options; the author supplies narrative intent; the
+researcher supplies evidence and scope judgment; the PI confirms final
+authority. One person may hold all roles. Record micro-selections in
+`.planning/FRAMING_SESSION.yaml`, not as RKA decisions. They remain advisory
+until the final framing and exact contribution wording are ratified.
+
 The outline brief uses the strip-then-re-inject pattern that Brain uses for any multi-choice decision (see `../brain/decision_ux.md`):
 
 1. Generate three candidate outline framings (results-led, method-led, motivation-led) with PI preference stripped from context.
@@ -276,7 +299,17 @@ Full procedure with checkpoint UX: [`references/workflows.md`](references/workfl
 
 ## PI Checkpoints
 
-Six in-session checkpoints. All use the strip-then-re-inject pattern. Each produces a `dec_` with three ratified options, opposing-critique ranking, and the PI's selection.
+Six in-session checkpoints. All use the strip-then-re-inject pattern. Each
+produces a `dec_` with bounded options, opposing-critique ranking, and the PI's
+selection. Formal checkpoint resolution is normally single-select. Preparatory
+questions may be multi-select when choices can coexist, but remain advisory
+until the checkpoint is ratified.
+
+Use structured choice controls when the host provides them. Otherwise show
+option IDs and ask the PI to reply with one ID or an allowed set. Every option
+must show concrete pros and cons, evidence status, material risk, and the
+effect on the manuscript. Do not force exactly three options when only two are
+credible, and do not invent a weak option to fill the menu.
 
 | Number | Checkpoint | Fires when | What is at stake |
 |---|---|---|---|
@@ -518,6 +551,11 @@ When a revised draft is available, compare it against the prior review comments 
 22. **DON'T** paste the private reviewer-risk register into manuscript prose. Triage each concern by materiality and public relevance first.
 23. **DON'T** use persuasive framing to conceal claim-relevant negative results, unresolved contradictions, material validity or security issues, or venue-required disclosures.
 24. **DON'T** weaken every defensible claim with generic caveats. Preserve semantic qualifiers, then lead with the bounded contribution, evidence, and defense.
+25. **DON'T** ask the author to invent a framing from a blank page when current
+   evidence supports bounded choices. Propose options with pros and cons first.
+26. **DON'T** record a framing micro-selection as evidence, claim ratification,
+   or a formal PI decision. Persist it in `FRAMING_SESSION.yaml` until final
+   confirmation.
 
 ---
 
@@ -527,6 +565,8 @@ When a revised draft is available, compare it against the prior review comments 
 - Server-authoritative sync, impact, readiness, update, and migration loop:
   [`references/server_authoritative_workflow.md`](references/server_authoritative_workflow.md).
 - Session-start walkthrough, sub-procedures, checkpoint UX: [`references/workflows.md`](references/workflows.md).
+- Choice-first author/researcher interview and framing-session schema:
+  [`references/framing_elicitation.md`](references/framing_elicitation.md).
 - Persuasive framing, limitation triage, and quick-reader guidance:
   [`references/persuasive_framing.md`](references/persuasive_framing.md).
 - Implemented reference validation pipeline: [`references/reference_pipeline.md`](references/reference_pipeline.md).

--- a/rka/skills/writer/docs/phase-1-mvp.md
+++ b/rka/skills/writer/docs/phase-1-mvp.md
@@ -86,8 +86,8 @@ PATCH 2).
 `manuscripts/<project-id>/<venue>/`:
 
 - `.mcp.json`, `.latexmkrc`, `ai_tic_config.yaml`, `main.tex`, `refs.bib`.
-- `.planning/`: `ACTIVE_WORKFLOW.md`, `PRECIS.md`, `OUTLINE.md`,
-  `REVIEW_STATE.md`.
+- `.planning/`: `ACTIVE_WORKFLOW.md`, `FRAMING_SESSION.yaml`, `PRECIS.md`,
+  `OUTLINE.md`, `REVIEW_STATE.md`.
 - Directory placeholders: `sections/`, `figures/`, `tables/`, `charts/`,
   `styles/`.
 

--- a/rka/skills/writer/references/architecture.md
+++ b/rka/skills/writer/references/architecture.md
@@ -21,6 +21,7 @@ Writer session
         +-- .planning/CONTRIBUTION_CONTRACT.md   generated
         +-- .planning/ARGUMENT_SPINE.md          generated
         +-- .planning/RESULTS_TRACE.md            generated
+        +-- .planning/FRAMING_SESSION.yaml        advisory interaction state
         +-- .planning/ACTIVE_WORKFLOW.md          local session state
         +-- sections/, figures/, tables/, charts/
         +-- refs.bib, main.tex, styles/

--- a/rka/skills/writer/references/claim_spine.md
+++ b/rka/skills/writer/references/claim_spine.md
@@ -140,7 +140,14 @@ authorize drafting.
 
 ### 2. Assemble candidates
 
-Use multi-angle RKA retrieval. For each candidate identify:
+Use multi-angle RKA retrieval and the choice-first session in
+[`framing_elicitation.md`](framing_elicitation.md). The Writer proposes
+evidence-bounded alternatives with pros and cons; the author supplies narrative
+intent; the researcher supplies scientific scope judgment. Record provisional
+selections in `.planning/FRAMING_SESSION.yaml`. They do not modify the native
+manuscript aggregate and do not count as evidence or ratification.
+
+For each candidate identify:
 
 1. the prior limitation or open problem;
 2. the project's response;
@@ -151,7 +158,10 @@ Use multi-angle RKA retrieval. For each candidate identify:
 7. the result and non-result units that will carry the claim.
 
 `rka writer assist` may accelerate discovery but returns unratified candidates
-only.
+only. Present contribution inclusion as a multi-select choice, claim
+calibration as a single-select choice per contribution, and the final whole
+paper spine as a single-select choice. Offer revise/combine and defer/gather
+evidence paths where appropriate.
 
 ### 3. Dry-run and apply
 
@@ -181,8 +191,10 @@ decision, or creates PI authority.
 
 ### 4. Ratify exact wording
 
-Present bounded alternatives during the existing Outline checkpoint. For each
-selected contribution:
+Present the surviving alternatives with concrete pros, cons, evidence coverage,
+missing evidence, scope boundaries, and outline consequences during the
+existing Outline checkpoint. Obtain one explicit final PI confirmation after
+the advisory framing session. For each selected contribution:
 
 1. record an active PI decision whose `chosen` text exactly matches the claim
    version;

--- a/rka/skills/writer/references/framing_elicitation.md
+++ b/rka/skills/writer/references/framing_elicitation.md
@@ -1,0 +1,310 @@
+# Framing and Spine Elicitation
+
+Use this workflow before the Outline checkpoint when the manuscript framing is
+new, disputed, weakly specified, or materially affected by new research. Its
+purpose is to help the author and researcher discover a defensible paper spine
+without asking them to compose that spine from a blank page.
+
+The Writer proposes bounded choices from current RKA evidence. The people make
+the selections. The interaction is deliberative, but the resulting session
+artifact is advisory until the PI ratifies exact claim wording and the Outline
+checkpoint.
+
+## Authority boundary
+
+- RKA remains authoritative for research records, manuscript claims, evidence
+  roles, decisions, ratifications, units, and checkpoints.
+- `.planning/FRAMING_SESSION.yaml` is resumable working state. It is not
+  evidence, a PI decision, or a substitute for the native claim spine.
+- A user selection expresses preference or intent. It does not verify an
+  empirical claim or resolve a contradiction.
+- Only an explicit final PI selection may be recorded as a decision. Exact
+  contribution wording still requires claim-scope ratification.
+- Keep author intent and researcher evidence judgment distinct even when the
+  same person supplies both.
+
+## Choice-first interaction contract
+
+Default to structured choices for framing and spine work.
+
+1. Ask one decision per turn.
+2. Offer two to four evidence-bounded options. Use fewer than three when the
+   evidence does not support three genuine alternatives.
+3. State whether the decision is `single-select` or `multi-select`. For a
+   multi-select question, state the maximum number of selections when a limit
+   is useful.
+4. Give every option a short ID and label, followed by:
+   - what the option means;
+   - concrete pros;
+   - concrete cons or tradeoffs;
+   - the strongest supporting RKA evidence;
+   - missing evidence or material risk;
+   - how the option changes the claim, audience, or outline.
+5. Mark one option `Recommended` when the evidence supports a recommendation.
+   Explain why. Do not manufacture a recommendation when the alternatives are
+   genuinely tied.
+6. Include `Revise or combine these options` whenever a hybrid is coherent.
+   Include `Defer and gather evidence` when the evidence boundary is the real
+   blocker.
+7. Use the host's structured choice UI when available. Otherwise present
+   numbered or lettered options and ask the user to reply with IDs.
+8. After a selection, restate the chosen interpretation in one sentence and
+   update the session artifact before asking the next decision.
+
+Do not present a false menu. Options must differ on a material decision axis,
+not merely wording. Do not hide a required disclosure, unsupported extension,
+or contradiction in an option's fine print.
+
+### Free-text exceptions
+
+Use a focused free-text question only when:
+
+- the user wants an option that the Writer cannot infer;
+- exact title, abstract, author order, or claim wording needs correction;
+- relevant evidence or context is absent from RKA;
+- the author and researcher disagree in a way the proposed reconciliation
+  choices do not cover; or
+- the user explicitly asks to discuss an issue without a menu.
+
+After receiving free text, summarize it and return to choices. New empirical
+information must enter RKA and pass the normal evidence checks before it
+supports a manuscript claim.
+
+## Option card
+
+Use this compact shape. Keep each option scannable.
+
+```text
+Decision F4 - Primary novelty axis [single-select]
+
+A. Mechanism-first [Recommended]
+Meaning: The paper leads with the new control mechanism.
+Pros: Clearest technical novelty; strongest match to the verified ablation.
+Cons: Requires a concise explanation of the deployment assumptions.
+Evidence: clm_... supported by jrn_...
+Risk: Cross-platform evidence is currently narrow.
+Effect: Method-led claim and outline.
+
+B. Outcome-first
+Meaning: The paper leads with the measured operational improvement.
+Pros: Fastest reader payoff; strongest headline result.
+Cons: Novelty may look incremental without the mechanism explanation.
+Evidence: clm_... supported by jrn_...
+Risk: Baseline comparability needs a visible defense.
+Effect: Results-led claim and outline.
+
+Select A or B, or choose "Revise or combine."
+```
+
+For multi-select rounds, give each option independent consequences and ask for
+IDs such as `C1, C3`. Never use multi-select when the choices are mutually
+exclusive.
+
+## Participant handling
+
+At the first round, identify who is answering:
+
+- `Author voice`: intended audience, desired takeaway, narrative emphasis, and
+  terminology.
+- `Researcher judgment`: scientific novelty, evidence strength, conditions,
+  counterevidence, and defensible scope.
+- `PI authority`: final scope, exact claim wording, and checkpoint decisions.
+
+One person may hold all three roles. When different people participate, attach
+each selection to its role. If their selections conflict, do not silently
+average them. Present two to four reconciliation choices with pros, cons, and
+the effect on the paper. Escalate unresolved authority conflicts to the PI.
+
+## Elicitation rounds
+
+Run only the rounds needed for the current manuscript. Resume from the first
+unresolved round in `.planning/FRAMING_SESSION.yaml`.
+
+### F0. Session posture
+
+Confirm the participants and the task:
+
+- frame a new paper;
+- repair an existing but weak spine;
+- reframe for a different venue or audience; or
+- revisit a spine after material evidence changed.
+
+This may be a multi-select when more than one purpose applies.
+
+### F1. Reader and outcome
+
+Propose two to four target-reader outcomes, such as:
+
+- understand a new mechanism;
+- trust a new empirical finding;
+- adopt a practical system or method;
+- revise an assumption or threat model.
+
+Mode: usually single-select. Capture secondary audiences separately rather than
+merging incompatible primary outcomes.
+
+### F2. Central problem or gap
+
+Propose bounded problem statements based on current literature, research
+questions, decisions, and verified claims. For each option show:
+
+- what prior limitation it asserts;
+- what evidence supports that characterization;
+- what it does not claim about prior work; and
+- which venue audience would care.
+
+Mode: single-select, with a hybrid allowed only when the combined gap remains
+coherent.
+
+### F3. Contribution portfolio
+
+Propose candidate contributions after `rka writer assist` and evidence
+triage. Each candidate must identify:
+
+- contribution type;
+- exact provisional wording;
+- positive evidence;
+- qualifiers and counterevidence;
+- tested conditions;
+- allowed and prohibited extension;
+- likely manuscript unit.
+
+Mode: multi-select. Recommend the smallest coherent set, normally two to four
+contributions. Mark decorative, redundant, or unsupported candidates for
+defer/remove rather than inflating the list.
+
+### F4. Primary novelty axis
+
+Propose the strongest defensible novelty thesis, for example:
+
+- mechanism or method novelty;
+- empirical discovery;
+- system integration or operational capability;
+- theory, model, or conceptual reframing;
+- dataset, benchmark, or measurement contribution.
+
+Mode: single-select. A secondary novelty axis may be selected only when it has
+independent evidence and a distinct role.
+
+### F5. Evidence anchor and result priority
+
+Propose which verified results should carry the quick-reader path. Compare
+effect size or qualitative importance, evidence quality, baseline fairness,
+scope, uncertainty, and venue relevance.
+
+Mode: multi-select, normally one primary result and up to two supporting
+results. Do not select a result solely because it is visually impressive.
+
+### F6. Claim calibration
+
+For each candidate contribution, propose bounded wording levels such as:
+
+- strongest wording supported by current evidence;
+- narrower wording with lower reviewer risk;
+- defer pending an evidence mission.
+
+Mode: single-select per claim. State the tested conditions and prohibited
+interpretation for every option. A preference for stronger language cannot
+override current evidence.
+
+### F7. Narrative architecture
+
+Generate two to four whole-paper spines. Results-led, method-led, and
+motivation-led are defaults, not mandatory labels. Add a hybrid only when it
+has a distinct and coherent reading path.
+
+For each candidate spine show:
+
+- one-sentence paper thesis;
+- ordered contribution claims;
+- primary evidence path;
+- five to eight section purposes;
+- main reviewer advantage;
+- main reviewer risk;
+- venue fit;
+- what is intentionally not central.
+
+Mode: single-select. Mark one recommendation after opposing-critique review.
+
+### F8. Boundaries and reviewer defense
+
+Use the materiality policy in `persuasive_framing.md`. Propose treatments for
+the material assumptions, mixed results, counterevidence, and likely reviewer
+attacks:
+
+- lead with an evidence-backed defense;
+- state a neutral scope boundary;
+- disclose a material limitation;
+- repair before submission;
+- commission an evidence mission;
+- keep internal only when truly M4 or speculative.
+
+Mode: multi-select across independent concerns, then single-select for the
+treatment of each concern. An M1/M2 issue cannot be assigned `internal only`.
+
+### F9. Final spine selection
+
+Present the surviving candidate spines side by side. Every candidate must
+include exact provisional claims, pros, cons, evidence coverage, missing
+evidence, public boundaries, outline effect, and venue fit.
+
+Mode: single-select:
+
+- select one candidate;
+- combine named parts of two candidates;
+- revise the options;
+- defer and gather evidence.
+
+After selection, show the complete proposed contribution contract and outline.
+Ask for one explicit final confirmation before dry-running the native spine
+import and recording any RKA decision.
+
+## Triage rules
+
+- **Duplicate choices:** merge them and explain the lost distinction.
+- **Dominated choices:** prune when another option is at least as strong on
+  evidence coverage, scope accuracy, venue fit, and narrative clarity without
+  a material disadvantage.
+- **Unsupported but interesting choices:** label them hypotheses or evidence
+  missions, not contribution claims.
+- **Contradicted choices:** present the contradiction and resolution paths.
+  Do not recommend strong wording while the contradiction is unresolved.
+- **Author/researcher conflict:** present reconciliation options and attach the
+  final selection to PI authority.
+- **Too many contributions:** propose a coherent core, an optional secondary
+  set, and a defer-to-future-work set.
+- **No credible spine:** say so and offer evidence-gathering, scope reduction,
+  or a different paper objective. Do not fill the menu with weak alternatives.
+
+## Session artifact
+
+`.planning/FRAMING_SESSION.yaml` records:
+
+- session status, purpose, participants, and roles;
+- each choice round, mode, options, recommendation, selection, and rationale;
+- RKA evidence IDs and unresolved evidence needs;
+- author/researcher disagreements and their resolution status;
+- candidate spines and the final provisional selection;
+- links to resulting PI decisions after ratification.
+
+Append a new round revision instead of silently replacing a prior selection.
+The artifact may summarize pros and cons, but it must not contain secrets or
+credentials. Synchronizing the native claim spine does not overwrite it.
+
+## Completion criteria
+
+The elicitation stage is complete only when:
+
+1. the primary reader outcome and central problem are selected;
+2. the contribution portfolio and novelty axis are selected;
+3. every contribution has evidence, conditions, allowed wording, and
+   prohibited wording, or is explicitly deferred;
+4. the primary results and reviewer-sensitive boundaries are triaged;
+5. one coherent candidate spine and outline is provisionally selected;
+6. author/researcher disagreements are resolved or escalated;
+7. the PI explicitly confirms the complete proposal; and
+8. no micro-selection has been misrepresented as evidence or ratification.
+
+Then dry-run `rka writer import-spine`, present the authoritative diff, apply
+with an expected revision only after approval, ratify exact claim wording, and
+resolve the existing Outline checkpoint.

--- a/rka/skills/writer/references/workflows.md
+++ b/rka/skills/writer/references/workflows.md
@@ -97,7 +97,10 @@ last_session: 2026-04-11
 If `ACTIVE_WORKFLOW.md` is absent, infer from the working directory:
 
 - `.planning/PRECIS.md` absent: phase = venue selection.
-- `PRECIS.md` present, claim spine not ratified: phase = contribution and outline.
+- Venue ratified and `FRAMING_SESSION.yaml` absent or incomplete: phase =
+  framing elicitation.
+- Framing session complete, claim spine not ratified: phase = contribution and
+  outline.
 - Claim spine ratified, `OUTLINE.md` absent: phase = outline completion.
 - `OUTLINE.md` present, `sections/` empty: phase = table and figure planning.
 - `sections/` populated: phase = drafting; next section is the first one with status `outlined` rather than `drafted`.
@@ -127,6 +130,12 @@ Greet the PI with the inferred state and the next action. Example:
 ## The Seven Sub-Procedures
 
 The seven sub-procedures map to the six PI checkpoints plus the Revision Loop.
+Most PI exchanges inside them use the choice-first interaction contract in
+[`framing_elicitation.md`](framing_elicitation.md): one decision per turn, two
+to four bounded options, concrete pros and cons, explicit single-select or
+multi-select mode, and a recommendation when justified. Use free text only for
+a custom alternative, missing evidence, unresolved disagreement, or exact
+wording correction.
 
 ### 1. Venue handler
 
@@ -154,14 +163,28 @@ Procedure:
    questions. Select which research questions are in manuscript scope.
 2. Resolve every cluster blocker through Brain. Do not promote journal prose,
    an LLM-only synthesis, stale claims, or unresolved counterevidence.
-3. Read the selected cluster lineage and assemble evidence from several short
+3. Start or resume `.planning/FRAMING_SESSION.yaml` using
+   [`framing_elicitation.md`](framing_elicitation.md). Identify whether each
+   participant is supplying author voice, researcher judgment, PI authority,
+   or more than one role. Ask one choice at a time and update the artifact
+   after each selection.
+4. Run the needed elicitation rounds for reader outcome, problem or gap,
+   contribution portfolio, novelty axis, evidence anchors, claim calibration,
+   narrative architecture, and reviewer-sensitive boundaries. Use
+   single-select for mutually exclusive choices and multi-select for compatible
+   contribution, result, or defense choices. Every option shows pros, cons,
+   evidence, missing evidence, and its effect on the paper.
+5. If author and researcher selections conflict, propose two to four
+   reconciliation paths. Do not silently average their positions. Escalate an
+   unresolved authority conflict to the PI.
+6. Read the selected cluster lineage and assemble evidence from several short
    retrieval angles. For each contribution candidate, resolve positive
    evidence, qualifiers, counterevidence, terminal source records, current
    design decisions, and relevant superseded choices that explain the design's
    evolution. Superseded choices may inform lineage but are not current
    support. An `ecl_` guides synthesis but does not count as terminal empirical
    support; a `dec_` ratifies wording but does not prove it.
-4. Build a contribution contract and candidate proposal with exact claim text,
+7. Build a contribution contract and candidate proposal with exact claim text,
    source-backed evidence, missing evidence, novelty/significance risks,
    allowed wording, prohibited wording, and planned manuscript units. The
    assist result seeds this work but cannot write or ratify it. Treat risks,
@@ -169,36 +192,43 @@ Procedure:
    record, not as text that must all appear in the public manuscript. Classify
    their public treatment through
    [`persuasive_framing.md`](persuasive_framing.md).
-5. Generate three bounded claim-and-outline framings with PI preference stripped from context:
+8. Generate two to four bounded claim-and-outline framings with PI preference
+   stripped from context. Use these defaults when they are genuinely distinct:
    - Results-led: section ordering driven by the most novel finding.
    - Method-led: section ordering driven by the methodological contribution.
    - Motivation-led: section ordering driven by the problem framing.
-6. For each framing, show the exact contribution wording, its evidence path,
+   Add a hybrid only when it has a coherent reading path that the defaults do
+   not represent.
+9. For each framing, show the exact contribution wording, its evidence path,
    conditions, known counterevidence, missing evidence, and a 5-to-8-section
-   outline with one-sentence section purposes.
-7. Prune any framing dominated on evidence coverage, scope accuracy,
+   outline with one-sentence section purposes. Include concrete pros, cons,
+   reviewer advantage, reviewer risk, and venue fit.
+10. Prune any framing dominated on evidence coverage, scope accuracy,
    novelty-positioning, venue fit, quick-reader comprehension, strongest-
    evidence visibility, and narrative momentum. Do not compute an aggregate
    paper score or acceptance prediction.
-8. Re-inject PI preference as opposing-critique; rank surviving framings.
-9. Present three (or fewer if pruned) options to the PI; one carries
-   `is_recommended`. The PI may retain, narrow, or defer a claim and commission
-   an evidence-gap mission.
-10. Dry-run `rka writer import-spine`. Review the evidence roles, result
+11. Re-inject PI preference as opposing-critique; rank surviving framings.
+12. Present the surviving options as the final F9 single-select choice; one
+   carries `is_recommended` when justified. The PI may select one, combine
+   named parts, request revised options, or defer and commission an evidence
+   mission. Show the complete proposed contribution contract and outline, then
+   obtain explicit final confirmation.
+13. Dry-run `rka writer import-spine`. Review the evidence roles, result
    coverage, and proposed revision; apply only with an explicit expected
    revision. Import never creates ratifications.
-11. Record the PI's selected framing and one child claim-scope `dec_` per
+14. Record the PI's selected framing and one child claim-scope `dec_` per
    selected contribution. Set `chosen` to the exact claim text,
    `decided_by: pi`, and connect the decision to its evidence and Outline
    lineage. Bind each exact native claim version through
    `ratify_manuscript_claim`. A later material edit requires a new version and
    a superseding PI decision.
-12. Resolve the native Outline checkpoint, run `rka writer sync`, and require
+15. Resolve the native Outline checkpoint, run `rka writer sync`, and require
     server readiness. The generated `CONTRIBUTION_CONTRACT.md`,
     `ARGUMENT_SPINE.md`, and `RESULTS_TRACE.md` are read-only views.
 
 Output: Outline Decision (`dec_`), one exact-wording claim-scope `dec_` per
 contribution with evidence provenance,
+`.planning/FRAMING_SESSION.yaml`,
 `.planning/RKA_CLAIM_SPINE.yaml`, its three generated views,
 `.planning/OUTLINE.md`, and `.planning/sketches/<section-id>.md` per section.
 
@@ -379,11 +409,23 @@ remain outside this workflow.
 
 ## Checkpoint UX patterns
 
-All six PI checkpoints use the strip-then-re-inject decision UX inherited from Brain (`../brain/decision_ux.md` is the canonical reference). Three ratified options per checkpoint; opposing-critique ranking; PI selection via `rka_record_pi_selection`.
+All six PI checkpoints use the strip-then-re-inject decision UX inherited from
+Brain (`../brain/decision_ux.md` is the canonical reference). Present two to
+four credible options, use opposing-critique ranking, and identify one
+recommendation when justified. Every option includes concrete pros, cons,
+evidence status, material risk, and manuscript consequence. Formal checkpoint
+resolution is single-select via `rka_record_pi_selection`.
+
+Preparatory decisions default to the choice-first contract in
+[`framing_elicitation.md`](framing_elicitation.md). Use multi-select only when
+the options can coexist, such as contribution inclusion, primary/supporting
+results, or independent reviewer defenses. Record those micro-selections in
+the framing session, not as RKA decisions. Use the host's structured selector
+when available; otherwise ask for option IDs.
 
 Per-checkpoint specifics:
 
-| Checkpoint | Three option framings | Pareto axes |
+| Checkpoint | Typical option framings | Pareto axes |
 |---|---|---|
 | Venue | venue A / venue B / venue C | venue fit, deadline, audience reach |
 | Outline | results-led / method-led / motivation-led, each with bounded claim wording | evidence coverage, claim boundary, novelty positioning, venue fit |

--- a/rka/skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md
+++ b/rka/skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md
@@ -13,6 +13,7 @@ last_session: (initial bootstrap)
 | Phase | Trigger to advance |
 |---|---|
 | venue_selection | Venue checkpoint ratified; .planning/PRECIS.md authored |
+| framing_elicitation | Choice rounds complete; PI confirms one provisional spine |
 | evidence_synthesis | In-scope RQs selected; cluster blockers and counterevidence resolved |
 | contribution_contract | Exact allowed/prohibited contribution boundary accepted for spine import |
 | outline | Outline checkpoint ratified; .planning/OUTLINE.md ratified |

--- a/rka/skills/writer/workspace-template/.planning/FRAMING_SESSION.yaml
+++ b/rka/skills/writer/workspace-template/.planning/FRAMING_SESSION.yaml
@@ -1,0 +1,12 @@
+schema: rka-framing-session/v1
+status: not_started
+purpose: null
+participants: []
+rounds: []
+candidate_spines: []
+selected_spine: null
+unresolved_questions: []
+rka_decision_links: []
+
+# Advisory, resumable interaction state only.
+# This file is not evidence, a PI decision, or a claim ratification.

--- a/rka/skills/writer/workspace-template/.planning/PRECIS.md
+++ b/rka/skills/writer/workspace-template/.planning/PRECIS.md
@@ -1,15 +1,18 @@
 # PRECIS
 
-PI-authored. The title and abstract are the manuscript's verbatim_input in
-the RKA manuscript manifest (Option 2 per dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q1).
+PI-confirmed. The Writer may propose bounded title, abstract, and claim options
+during framing elicitation, but the PI's selected or edited final text becomes
+the manuscript's verbatim_input in the RKA manuscript manifest (Option 2 per
+dec_01KS0BKJ5ZJKJ4R19GYAK3QN9D Q1).
 
 ## Title
 
-(PI fills in.)
+(Writer proposes options; PI selects, edits if needed, and confirms verbatim.)
 
 ## Abstract
 
-(PI fills in. ~150 to 250 words depending on venue.)
+(Writer proposes bounded alternatives after spine selection; PI selects, edits
+if needed, and confirms verbatim. Use ~150 to 250 words depending on venue.)
 
 ## Target venue
 
@@ -22,8 +25,9 @@ dec_ ID once the checkpoint resolves.)
 
 ## Key claims
 
-(PI fills in 3 to 5 bullet points stating the contribution claims. These
-are the targets that prose must support via provenance edges.)
+(Populate from the PI-confirmed framing session and exact claim-scope
+ratifications. Use 3 to 5 bullets stating the contribution claims. These are
+the targets that prose must support via provenance edges.)
 
 ## Notes for the Writer
 

--- a/tests/skills/writer/test_framing_elicitation.py
+++ b/tests/skills/writer/test_framing_elicitation.py
@@ -1,0 +1,62 @@
+"""Contract tests for the choice-first framing and spine interview."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WRITER_DIR = REPO_ROOT / "rka" / "skills" / "writer"
+REFERENCE = WRITER_DIR / "references" / "framing_elicitation.md"
+SESSION_TEMPLATE = (
+    WRITER_DIR
+    / "workspace-template"
+    / ".planning"
+    / "FRAMING_SESSION.yaml"
+)
+
+
+def test_choice_first_contract_is_explicit() -> None:
+    text = REFERENCE.read_text(encoding="utf-8")
+
+    required = [
+        "Ask one decision per turn.",
+        "Offer two to four evidence-bounded options.",
+        "`single-select` or `multi-select`",
+        "concrete pros",
+        "concrete cons",
+        "Mark one option `Recommended`",
+        "Use the host's structured choice UI when available.",
+        "Revise or combine these options",
+        "Defer and gather evidence",
+    ]
+    for phrase in required:
+        assert phrase in text
+
+
+def test_elicitation_covers_framing_spine_and_disagreement() -> None:
+    text = REFERENCE.read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+
+    for round_id in range(10):
+        assert f"### F{round_id}." in text
+    assert "Author voice" in text
+    assert "Researcher judgment" in text
+    assert "PI authority" in text
+    assert "do not silently average" in normalized.lower()
+    assert "not evidence, a PI decision, or a substitute" in normalized
+
+
+def test_framing_session_template_is_advisory_and_resumable() -> None:
+    data = yaml.safe_load(SESSION_TEMPLATE.read_text(encoding="utf-8"))
+
+    assert data["schema"] == "rka-framing-session/v1"
+    assert data["status"] == "not_started"
+    assert data["participants"] == []
+    assert data["rounds"] == []
+    assert data["candidate_spines"] == []
+    assert data["selected_spine"] is None
+    assert data["unresolved_questions"] == []
+    assert data["rka_decision_links"] == []

--- a/tests/skills/writer/test_package_data.py
+++ b/tests/skills/writer/test_package_data.py
@@ -35,6 +35,7 @@ def test_package_data_includes_hidden_writer_planning_templates() -> None:
 
     expected = {
         "skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md",
+        "skills/writer/workspace-template/.planning/FRAMING_SESSION.yaml",
         "skills/writer/workspace-template/.planning/OUTLINE.md",
         "skills/writer/workspace-template/.planning/PRECIS.md",
         "skills/writer/workspace-template/.planning/REVIEW_STATE.md",

--- a/tests/skills/writer/test_skill_loads.py
+++ b/tests/skills/writer/test_skill_loads.py
@@ -42,7 +42,8 @@ def test_frontmatter_has_name_description_version(skill_md_path: Path) -> None:
     assert end > 0, "SKILL.md frontmatter must close with --- delimiter"
     fm = text[4:end]
     assert re.search(r"^name:\s*rka-writer\s*$", fm, re.MULTILINE)
-    assert re.search(r"^version:\s*2\.7\.1\s*$", fm, re.MULTILINE)
+    assert re.search(r"^metadata:\s*$", fm, re.MULTILINE)
+    assert re.search(r'^\s+version:\s*"2\.7\.2"\s*$', fm, re.MULTILINE)
     assert re.search(r"^description:\s*\S", fm, re.MULTILINE)
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { Toaster } from "@/components/ui/sonner"
 import { AppLayout } from "@/components/layout/AppLayout"
-import { ProjectSelectionProvider } from "@/hooks/useProjectSelection"
+import { ProjectSelectionProvider } from "@/components/providers/ProjectSelectionProvider"
 import { ThemeProvider } from "@/hooks/useTheme"
 
 // Pages
@@ -19,6 +19,7 @@ import Settings from "@/pages/Settings"
 import ResearchMap from "@/pages/ResearchMap"
 import ResearchHealth from "@/pages/ResearchHealth"
 import ReportContext from "@/pages/ReportContext"
+import ManuscriptWorkbench from "@/pages/ManuscriptWorkbench"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -48,6 +49,8 @@ export default function App() {
               <Route path="research-map" element={<ResearchMap />} />
               <Route path="health" element={<ResearchHealth />} />
               <Route path="report-context" element={<ReportContext />} />
+              <Route path="workbench" element={<ManuscriptWorkbench />} />
+              <Route path="manuscripts/:manuscriptId/workbench" element={<ManuscriptWorkbench />} />
               <Route path="audit" element={<AuditLog />} />
               <Route path="context" element={<ContextInspector />} />
               <Route path="settings" element={<Settings />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -54,7 +54,7 @@ async function parseApiError(res: Response): Promise<never> {
 
 function getFilenameFromDisposition(disposition: string | null, fallback: string): string {
   if (!disposition) return fallback
-  const match = disposition.match(/filename=\"?([^\";]+)\"?/)
+  const match = disposition.match(/filename="?([^";]+)"?/)
   return match?.[1] ?? fallback
 }
 
@@ -148,6 +148,11 @@ import type {
   ReportContextResult,
   StalenessReviewFiling,
   LinkSupportAudit,
+  ManuscriptContext,
+  ManuscriptImpact,
+  ManuscriptReadiness,
+  ManuscriptSpine,
+  ManuscriptWritingCandidates,
 } from "./types"
 
 export const api = {
@@ -425,6 +430,25 @@ export const api = {
     post<StalenessReviewFiling>("/verification/file-staleness-reviews"),
   auditLinkSupport: (limit = 200) =>
     get<LinkSupportAudit>(`/verification/link-support?limit=${limit}`),
+
+  // Native manuscript workbench reads. These endpoints are projections over
+  // RKA's canonical aggregate; the prototype intentionally exposes no writes.
+  getManuscriptContext: (manuscriptId: string) =>
+    get<ManuscriptContext>(`/manuscripts/${encodeURIComponent(manuscriptId)}/context`),
+  getManuscriptSpine: (manuscriptId: string) =>
+    get<ManuscriptSpine>(`/manuscripts/${encodeURIComponent(manuscriptId)}/spine`),
+  getManuscriptWritingCandidates: (manuscriptId: string) =>
+    get<ManuscriptWritingCandidates>(
+      `/manuscripts/${encodeURIComponent(manuscriptId)}/writing-candidates`,
+    ),
+  getManuscriptReadiness: (manuscriptId: string, targetPhase = "drafting") =>
+    get<ManuscriptReadiness>(
+      `/manuscripts/${encodeURIComponent(manuscriptId)}/readiness?target_phase=${encodeURIComponent(targetPhase)}`,
+    ),
+  getManuscriptImpact: (manuscriptId: string, sinceCursor = 0, limit = 100) =>
+    get<ManuscriptImpact>(
+      `/manuscripts/${encodeURIComponent(manuscriptId)}/impact?since_cursor=${sinceCursor}&limit=${limit}`,
+    ),
 }
 
 export { ApiError }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -636,6 +636,13 @@ export interface ResearchQuestion {
   gap_count: number
   contradiction_count: number
   created_at: string | null
+  clusters?: Array<{
+    id: string
+    label: string
+    confidence: string
+    claim_count: number
+    staleness: string
+  }>
 }
 
 export interface ResearchMapData {
@@ -654,6 +661,232 @@ export interface ResearchMapData {
     total_contradictions: number
     pending_review: number
   }
+}
+
+// ---- Native manuscript workbench (read-only prototype) ----
+
+export interface NativeManuscript {
+  id: string
+  project_id: string
+  title: string
+  abstract: string | null
+  venue: string | null
+  phase: string
+  state: string
+  workspace_ref: string | null
+  revision: number
+  legacy_journal_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ManuscriptEvidenceBinding {
+  role: "support" | "qualifier" | "counterevidence"
+  evidence_claim_id: string
+  content?: string | null
+  source_entry_id?: string | null
+  confidence?: number | null
+  verified?: number | boolean | null
+  evidence_status?: string | null
+  stale?: number | boolean | null
+  staleness?: string | null
+  contradicted?: number | boolean | null
+  source_current?: number | boolean | null
+  source_is_manuscript?: number | boolean | null
+}
+
+export interface ManuscriptClaimContext {
+  id: string
+  local_key: string
+  kind: string
+  state: string
+  version: number | null
+  exact_wording: string | null
+  allowed_wording: string | null
+  prohibited_wording: string[]
+  evidence: ManuscriptEvidenceBinding[]
+  ratifications: Array<{
+    decision_id: string
+    claim_version: number
+    decision_status: string
+    decided_by: string
+    chosen: string | null
+    superseded_by: string | null
+  }>
+  unit_links: Array<{
+    unit_id: string
+    unit_local_key: string
+    unit_kind: string
+    unit_location: string
+    relationship: string
+  }>
+}
+
+export interface ManuscriptUnitContext {
+  id: string
+  local_key: string
+  kind: string
+  location: string
+  title: string | null
+  artifact_ref: string | null
+  allowed_interpretation: string | null
+  prohibited_interpretation: string | null
+  sequence: number
+  status: string
+  evidence: ManuscriptEvidenceBinding[]
+  artifact_binding?: Record<string, unknown>
+}
+
+export interface ManuscriptContext {
+  schema_version: "rka.manuscript-context/v1"
+  project_id: string
+  manuscript: NativeManuscript
+  claims: ManuscriptClaimContext[]
+  units: ManuscriptUnitContext[]
+  checkpoints: Array<Record<string, unknown>>
+  verification_attestations: Array<Record<string, unknown>>
+  reference_validations: Array<Record<string, unknown>>
+  reference_manifest: Record<string, unknown>
+  authoritative_source: "rka"
+}
+
+export interface ManuscriptSpineClaim {
+  claim_id: string
+  rka_manuscript_claim_id: string
+  version: number | null
+  claim_type: string
+  status: string
+  text: string | null
+  allowed_wording: string | null
+  prohibited_wording: string[]
+  ratified_by: string | null
+  evidence_ids: string[]
+  qualifier_ids: string[]
+  counterevidence_ids: string[]
+  manuscript_units: string[]
+}
+
+export interface ManuscriptSpineUnit {
+  unit_id: string
+  rka_manuscript_unit_id: string
+  kind: string
+  location: string
+  artifact_ref: string | null
+  allowed_interpretation: string | null
+  prohibited_interpretation: string | null
+  status: string
+  evidence_ids: string[]
+  claim_ids: string[]
+}
+
+export interface ManuscriptSpine {
+  schema_version: "rka-claim-spine/v2"
+  authoritative_source: "rka"
+  project_id: string
+  manuscript_id: string
+  manuscript_revision: number
+  claims: ManuscriptSpineClaim[]
+  units: ManuscriptSpineUnit[]
+  reference_manifest: Record<string, unknown>
+}
+
+export interface WritingCandidateClaim {
+  claim_id: string
+  claim_type: string
+  status: "candidate"
+  text: string
+  allowed_wording: string
+  prohibited_wording: string[]
+  ratified_by: null
+  evidence_ids: string[]
+  qualifier_ids: string[]
+  counterevidence_ids: string[]
+  manuscript_units: string[]
+}
+
+export interface WritingCandidateCluster {
+  cluster_id: string
+  research_question_id: string | null
+  research_question: string | null
+  rq_lifecycle: string | null
+  label: string
+  synthesis: string | null
+  confidence: string
+  synthesized_by: string
+  support_claim_ids: string[]
+  representative_claim_ids: string[]
+  qualifier_claim_ids: string[]
+  counterevidence_claim_ids: string[]
+  duplicate_support_groups: string[][]
+  disposition: "eligible" | "needs_review"
+  blockers: string[]
+}
+
+export interface ManuscriptWritingCandidates {
+  schema_version: "rka.writing-evidence-candidates/v1"
+  project_id: string
+  manuscript_id: string
+  manuscript_revision: number
+  policy: Record<string, unknown>
+  clusters: WritingCandidateCluster[]
+  excluded_claims: Array<{
+    claim_id: string
+    cluster_id: string
+    reasons: string[]
+  }>
+  candidate_spine: {
+    claims: WritingCandidateClaim[]
+    units: unknown[]
+  }
+  candidate_lineage: Record<
+    string,
+    {
+      cluster_id: string
+      research_question_id: string | null
+      representative_claim_ids: string[]
+    }
+  >
+  summary: {
+    clusters_total: number
+    clusters_eligible: number
+    clusters_needing_review: number
+    claims_excluded: number
+  }
+  required_human_actions: string[]
+  mode: "server_attested_read_only_proposal"
+}
+
+export interface ManuscriptReadinessFinding {
+  verdict: "PASS" | "WARN" | "BLOCK" | "ERROR"
+  code: string
+  message: string
+  claim_id?: string
+  unit_id?: string
+  citation_key?: string
+  literature_id?: string
+}
+
+export interface ManuscriptReadiness {
+  schema_version?: string
+  project_id: string
+  manuscript_id: string
+  target_phase: string
+  ready: boolean
+  verdict: "PASS" | "WARN" | "BLOCK" | "ERROR"
+  findings: ManuscriptReadinessFinding[]
+}
+
+export interface ManuscriptImpact {
+  project_id: string
+  manuscript_id: string
+  requested_since_cursor: number
+  next_cursor: number
+  has_more: boolean
+  relevant_changes: Array<Record<string, unknown>>
+  affected_claims: Array<Record<string, unknown>>
+  affected_units: Array<Record<string, unknown>>
+  changed_sources: Array<Record<string, unknown>>
+  [key: string]: unknown
 }
 
 export interface ClusterContradiction {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Sun,
   Moon,
   Monitor,
+  PanelsTopLeft,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useTheme } from "@/hooks/useTheme"
@@ -57,6 +58,7 @@ const navItems = [
   { to: "/research-map", icon: Map, label: "Research Map" },
   { to: "/health", icon: Activity, label: "Research Health" },
   { to: "/report-context", icon: FileSearch, label: "Report Context" },
+  { to: "/workbench", icon: PanelsTopLeft, label: "Manuscript Workbench" },
   { to: "/audit", icon: Shield, label: "Audit Log" },
   { to: "/context", icon: Telescope, label: "Context" },
   { to: "/settings", icon: Settings, label: "Settings" },

--- a/web/src/components/providers/ProjectSelectionProvider.tsx
+++ b/web/src/components/providers/ProjectSelectionProvider.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState, type ReactNode } from "react"
+import { setApiProjectId } from "@/api/client"
+import {
+  PROJECT_SELECTION_STORAGE_KEY,
+  ProjectSelectionContext,
+} from "@/contexts/projectSelection"
+
+export function ProjectSelectionProvider({ children }: { children: ReactNode }) {
+  const [projectId, setProjectIdState] = useState(() => {
+    if (typeof window === "undefined") return "proj_default"
+    return window.localStorage.getItem(PROJECT_SELECTION_STORAGE_KEY) || "proj_default"
+  })
+
+  useEffect(() => {
+    setApiProjectId(projectId)
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(PROJECT_SELECTION_STORAGE_KEY, projectId)
+    }
+  }, [projectId])
+
+  return (
+    <ProjectSelectionContext.Provider
+      value={{
+        projectId,
+        setProjectId: (nextProjectId: string | null) => {
+          const normalizedProjectId = nextProjectId?.trim() || "proj_default"
+
+          // Publish the request boundary before React publishes new query
+          // keys. Otherwise the first refetch can cache the previous
+          // project's response under the newly selected project id.
+          setApiProjectId(normalizedProjectId)
+          setProjectIdState(normalizedProjectId)
+        },
+      }}
+    >
+      {children}
+    </ProjectSelectionContext.Provider>
+  )
+}

--- a/web/src/components/workbench/ContextCapsule.tsx
+++ b/web/src/components/workbench/ContextCapsule.tsx
@@ -1,0 +1,113 @@
+import { AlertTriangle, Database, FileText, GitCommitHorizontal, ShieldCheck } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import type { ManuscriptContext, ManuscriptReadiness, ResearchMapData } from "@/api/types"
+
+function CapsuleFact({
+  label,
+  value,
+  source,
+}: {
+  label: string
+  value: string
+  source: string
+}) {
+  return (
+    <div className="min-w-0 rounded-md border bg-background/70 px-3 py-2">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-0.5 truncate text-sm font-medium" title={value}>{value}</p>
+      <p className="mt-1 truncate text-[10px] text-muted-foreground" title={source}>Source: {source}</p>
+    </div>
+  )
+}
+
+export function ContextCapsule({
+  projectId,
+  projectName,
+  context,
+  readiness,
+  map,
+  impactCount,
+  impactPartial,
+}: {
+  projectId: string
+  projectName: string
+  context?: ManuscriptContext
+  readiness?: ManuscriptReadiness
+  map?: ResearchMapData
+  impactCount: number
+  impactPartial: boolean
+}) {
+  const manuscript = context?.manuscript
+  const readinessLabel = readiness
+    ? readiness.ready
+      ? "Ready for drafting"
+      : `${readiness.verdict}: ${readiness.findings.length} finding${readiness.findings.length === 1 ? "" : "s"}`
+    : manuscript
+      ? "Readiness loading"
+      : "Pre-manuscript exploration"
+
+  return (
+    <Card className="border-primary/20 bg-gradient-to-r from-primary/[0.04] via-background to-background">
+      <CardContent className="space-y-3 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-primary" />
+            <div>
+              <h2 className="text-sm font-semibold">Context Capsule</h2>
+              <p className="text-xs text-muted-foreground">
+                Compact, inspectable context only. No AI call is made by this view.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            <Badge variant="outline"><Database className="mr-1 h-3 w-3" />RKA authoritative</Badge>
+            <Badge variant="outline"><FileText className="mr-1 h-3 w-3" />Read-only prototype</Badge>
+          </div>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+          <CapsuleFact label="Project" value={projectName} source={`/api/status · ${projectId}`} />
+          <CapsuleFact
+            label="Manuscript"
+            value={manuscript ? manuscript.title : "Not selected"}
+            source={manuscript ? `/api/manuscripts/${manuscript.id}/context` : "No canonical man_ aggregate"}
+          />
+          <CapsuleFact
+            label="Venue and phase"
+            value={manuscript ? `${manuscript.venue ?? "Venue unset"} · ${manuscript.phase}` : "Planning not registered"}
+            source={manuscript ? `man_ revision ${manuscript.revision}` : "Workbench stage contract"}
+          />
+          <CapsuleFact
+            label="Research map"
+            value={map ? `${map.summary.total_rqs} RQs · ${map.summary.total_clusters} clusters · ${map.summary.total_claims} claims` : "Loading"}
+            source="/api/research-map"
+          />
+          <CapsuleFact label="Readiness" value={readinessLabel} source="/api/manuscripts/:id/readiness?target_phase=drafting" />
+        </div>
+
+        {(impactCount > 0 || impactPartial) && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="text-xs">
+              <p className="font-medium">
+                {impactCount} relevant semantic change{impactCount === 1 ? "" : "s"} found since cursor 0.
+              </p>
+              <p className="mt-0.5 opacity-80">
+                Derived from <code>/api/manuscripts/:id/impact</code>.
+                {impactPartial ? " The first page is partial; this is not a clean impact result." : ""}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {manuscript && (
+          <p className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <GitCommitHorizontal className="h-3 w-3" />
+            Canonical identity {manuscript.id}; workspace {manuscript.workspace_ref ?? "not registered"}; state {manuscript.state}.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/components/workbench/EvidenceInspector.tsx
+++ b/web/src/components/workbench/EvidenceInspector.tsx
@@ -1,0 +1,67 @@
+import { ArrowRight, Eye, Fingerprint } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export interface WorkbenchTraceItem {
+  title: string
+  summary: string
+  kind: string
+  origin: string
+  derivation: string
+  ids: string[]
+  status?: string
+  trace?: string[]
+}
+
+export function EvidenceInspector({ item }: { item: WorkbenchTraceItem }) {
+  return (
+    <Card className="min-h-40">
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <Eye className="h-4 w-4" /> Evidence and derivation
+          </CardTitle>
+          <Badge variant="outline">{item.kind}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <div className="space-y-2">
+          <div>
+            <h3 className="text-sm font-semibold">{item.title}</h3>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">{item.summary}</p>
+          </div>
+          <div className="rounded-md border bg-muted/30 p-2.5 text-xs">
+            <p><span className="font-medium">Origin:</span> {item.origin}</p>
+            <p className="mt-1"><span className="font-medium">Derivation:</span> {item.derivation}</p>
+            {item.status && <p className="mt-1"><span className="font-medium">Status:</span> {item.status}</p>}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5 text-xs font-medium">
+            <Fingerprint className="h-3.5 w-3.5" /> Record identifiers
+          </div>
+          {item.ids.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {item.ids.map((id) => (
+                <code key={id} className="rounded bg-muted px-1.5 py-1 text-[10px]">{id}</code>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">No canonical record yet. This item is an interface-stage projection.</p>
+          )}
+          {item.trace && item.trace.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+              {item.trace.map((node, index) => (
+                <span key={`${node}-${index}`} className="flex items-center gap-1">
+                  {index > 0 && <ArrowRight className="h-3 w-3" />}
+                  <span className="rounded border px-1.5 py-0.5">{node}</span>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/components/workbench/StageRail.tsx
+++ b/web/src/components/workbench/StageRail.tsx
@@ -1,0 +1,65 @@
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import {
+  WORKBENCH_STAGES,
+  type StageVerdict,
+  type WorkbenchStageId,
+} from "@/components/workbench/stages"
+
+const verdictStyles: Record<StageVerdict, string> = {
+  Ready: "border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200",
+  "Needs review": "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200",
+  Blocked: "border-red-300 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200",
+  Exploratory: "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200",
+}
+
+export function StageRail({
+  selected,
+  verdicts,
+  onSelect,
+}: {
+  selected: WorkbenchStageId
+  verdicts: Record<WorkbenchStageId, StageVerdict>
+  onSelect: (stage: WorkbenchStageId) => void
+}) {
+  return (
+    <nav aria-label="Manuscript stages" className="space-y-1.5">
+      {WORKBENCH_STAGES.map((stage, index) => {
+        const Icon = stage.icon
+        const verdict = verdicts[stage.id]
+        return (
+          <button
+            key={stage.id}
+            type="button"
+            onClick={() => onSelect(stage.id)}
+            className={cn(
+              "w-full rounded-lg border px-3 py-2.5 text-left transition-colors",
+              selected === stage.id
+                ? "border-primary bg-primary/5 shadow-sm"
+                : "border-transparent hover:border-border hover:bg-muted/60",
+            )}
+            aria-current={selected === stage.id ? "step" : undefined}
+          >
+            <div className="flex items-start gap-2.5">
+              <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground">
+                {index + 1}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <Icon className="h-3.5 w-3.5 shrink-0" />
+                  <span className="truncate text-sm font-medium">{stage.label}</span>
+                </div>
+                <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+                  {stage.question}
+                </p>
+                <Badge variant="outline" className={cn("mt-2 text-[10px]", verdictStyles[verdict])}>
+                  {verdict}
+                </Badge>
+              </div>
+            </div>
+          </button>
+        )
+      })}
+    </nav>
+  )
+}

--- a/web/src/components/workbench/stages.ts
+++ b/web/src/components/workbench/stages.ts
@@ -1,0 +1,47 @@
+import {
+  BookOpenText,
+  Box,
+  CircleHelp,
+  FlaskConical,
+  Focus,
+  GitPullRequestArrow,
+  Lightbulb,
+  ListTree,
+  Map,
+  ScanSearch,
+} from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+
+export type WorkbenchStageId =
+  | "seed"
+  | "spine"
+  | "scope"
+  | "landscape"
+  | "gap"
+  | "response"
+  | "rqs"
+  | "contributions"
+  | "evaluation"
+  | "outline"
+
+export type StageVerdict = "Ready" | "Needs review" | "Blocked" | "Exploratory"
+
+export interface WorkbenchStage {
+  id: WorkbenchStageId
+  label: string
+  question: string
+  icon: LucideIcon
+}
+
+export const WORKBENCH_STAGES: WorkbenchStage[] = [
+  { id: "seed", label: "Seed insight", question: "What is the smallest non-obvious idea?", icon: Lightbulb },
+  { id: "spine", label: "Paper spine", question: "Can the argument be read as one paragraph?", icon: GitPullRequestArrow },
+  { id: "scope", label: "Problem and scope", question: "What exactly is in and out of scope?", icon: Focus },
+  { id: "landscape", label: "Literature and SOTA", question: "What exists and on which comparison axes?", icon: Map },
+  { id: "gap", label: "Gap and motivation", question: "Which gap is real, material, and supported?", icon: ScanSearch },
+  { id: "response", label: "Insight and response", question: "How does the mechanism address the gap?", icon: Box },
+  { id: "rqs", label: "Research questions", question: "What questions organize the evidence?", icon: CircleHelp },
+  { id: "contributions", label: "Contributions", question: "What bounded claims will the paper defend?", icon: BookOpenText },
+  { id: "evaluation", label: "Evaluation contract", question: "What evidence would make each claim credible?", icon: FlaskConical },
+  { id: "outline", label: "Outline", question: "What sequence makes the promise easy to verify?", icon: ListTree },
+]

--- a/web/src/contexts/projectSelection.ts
+++ b/web/src/contexts/projectSelection.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react"
+
+export const PROJECT_SELECTION_STORAGE_KEY = "rka.activeProjectId"
+
+export type ProjectSelectionValue = {
+  projectId: string
+  setProjectId: (projectId: string | null) => void
+}
+
+export const ProjectSelectionContext = createContext<ProjectSelectionValue | null>(null)

--- a/web/src/hooks/useManuscriptWorkbench.ts
+++ b/web/src/hooks/useManuscriptWorkbench.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/api/client"
+import { useActiveProjectId } from "@/hooks/useProjectSelection"
+
+/**
+ * Read-only manuscript workbench data.
+ *
+ * Context is the gate query: dependent projections are fetched only after the
+ * manuscript is proven to belong to the active project. This avoids a burst of
+ * redundant 404s for a mistyped or foreign manuscript id.
+ */
+export function useManuscriptWorkbench(manuscriptId: string | null) {
+  const projectId = useActiveProjectId()
+  const enabled = Boolean(manuscriptId)
+
+  const context = useQuery({
+    queryKey: ["manuscript-workbench", projectId, manuscriptId, "context"],
+    queryFn: () => api.getManuscriptContext(manuscriptId!),
+    enabled,
+  })
+
+  const aggregateReady = enabled && context.isSuccess
+
+  const spine = useQuery({
+    queryKey: ["manuscript-workbench", projectId, manuscriptId, "spine"],
+    queryFn: () => api.getManuscriptSpine(manuscriptId!),
+    enabled: aggregateReady,
+  })
+
+  const candidates = useQuery({
+    queryKey: ["manuscript-workbench", projectId, manuscriptId, "candidates"],
+    queryFn: () => api.getManuscriptWritingCandidates(manuscriptId!),
+    enabled: aggregateReady,
+  })
+
+  const readiness = useQuery({
+    queryKey: ["manuscript-workbench", projectId, manuscriptId, "readiness", "drafting"],
+    queryFn: () => api.getManuscriptReadiness(manuscriptId!, "drafting"),
+    enabled: aggregateReady,
+  })
+
+  const impact = useQuery({
+    queryKey: ["manuscript-workbench", projectId, manuscriptId, "impact", 0],
+    queryFn: () => api.getManuscriptImpact(manuscriptId!, 0, 100),
+    enabled: aggregateReady,
+  })
+
+  return { context, spine, candidates, readiness, impact }
+}

--- a/web/src/hooks/useProjectSelection.tsx
+++ b/web/src/hooks/useProjectSelection.tsx
@@ -1,41 +1,5 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react"
-import { setApiProjectId } from "@/api/client"
-
-const STORAGE_KEY = "rka.activeProjectId"
-
-type ProjectSelectionValue = {
-  projectId: string
-  setProjectId: (projectId: string | null) => void
-}
-
-const ProjectSelectionContext = createContext<ProjectSelectionValue | null>(null)
-
-export function ProjectSelectionProvider({ children }: { children: ReactNode }) {
-  const [projectId, setProjectIdState] = useState(() => {
-    if (typeof window === "undefined") return "proj_default"
-    return window.localStorage.getItem(STORAGE_KEY) || "proj_default"
-  })
-
-  useEffect(() => {
-    setApiProjectId(projectId)
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(STORAGE_KEY, projectId)
-    }
-  }, [projectId])
-
-  return (
-    <ProjectSelectionContext.Provider
-      value={{
-        projectId,
-        setProjectId: (nextProjectId: string | null) => {
-          setProjectIdState(nextProjectId?.trim() || "proj_default")
-        },
-      }}
-    >
-      {children}
-    </ProjectSelectionContext.Provider>
-  )
-}
+import { useContext } from "react"
+import { ProjectSelectionContext } from "@/contexts/projectSelection"
 
 export function useProjectSelection() {
   const context = useContext(ProjectSelectionContext)

--- a/web/src/pages/ManuscriptWorkbench.tsx
+++ b/web/src/pages/ManuscriptWorkbench.tsx
@@ -1,0 +1,816 @@
+import { useMemo, useState } from "react"
+import type { FormEvent, ReactNode } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import {
+  AlertCircle,
+  ArrowRight,
+  Braces,
+  Database,
+  FlaskConical,
+  Info,
+  Loader2,
+  Search,
+} from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { ContextCapsule } from "@/components/workbench/ContextCapsule"
+import {
+  EvidenceInspector,
+  type WorkbenchTraceItem,
+} from "@/components/workbench/EvidenceInspector"
+import {
+  StageRail,
+} from "@/components/workbench/StageRail"
+import {
+  WORKBENCH_STAGES,
+  type StageVerdict,
+  type WorkbenchStageId,
+} from "@/components/workbench/stages"
+import { useManuscriptWorkbench } from "@/hooks/useManuscriptWorkbench"
+import { useProjectStatus } from "@/hooks/useProject"
+import { useActiveProjectId } from "@/hooks/useProjectSelection"
+import { useResearchMap } from "@/hooks/useResearchMap"
+import type {
+  ManuscriptClaimContext,
+  ManuscriptContext,
+  ManuscriptReadiness,
+  ManuscriptSpine,
+  ManuscriptUnitContext,
+  ManuscriptWritingCandidates,
+  ResearchMapData,
+  ResearchQuestion,
+  WritingCandidateClaim,
+  WritingCandidateCluster,
+} from "@/api/types"
+
+type WorkbenchParams = { manuscriptId?: string }
+
+type ScopedTraceSelection = {
+  scopeKey: string
+  item: WorkbenchTraceItem
+}
+
+const stageDescriptions: Record<WorkbenchStageId, string> = {
+  seed: "Author intent and candidate inspiration. A seed is not evidence and is not stored by this prototype.",
+  spine: "Current ratified claims first, then server-attested candidate claims. No prose is generated here.",
+  scope: "Allowed and prohibited wording make the claim boundary visible before drafting.",
+  landscape: "Research questions and their cluster coverage organize the evidence landscape.",
+  gap: "Gaps and blocked clusters remain explicit; absence of support is never converted into novelty.",
+  response: "Method and mechanism candidates are shown only with their review state and lineage.",
+  rqs: "Active research questions are navigational structure, not empirical support.",
+  contributions: "Contribution candidates remain provisional until native versioning and exact PI ratification.",
+  evaluation: "Current RKA result units are visible, while missing first-class experiment semantics are labeled.",
+  outline: "Claim-sized manuscript units form the read-only outline and preserve file and evidence anchors.",
+}
+
+function statusForClaim(claim: ManuscriptClaimContext): string {
+  const currentRatification = claim.ratifications.some(
+    (item) =>
+      item.claim_version === claim.version &&
+      item.decision_status === "active" &&
+      item.decided_by === "pi" &&
+      !item.superseded_by &&
+      item.chosen === claim.exact_wording,
+  )
+  return currentRatification ? "Ratified" : "Provisional or stale ratification"
+}
+
+function makeStageVerdicts(
+  map: ResearchMapData | undefined,
+  context: ManuscriptContext | undefined,
+  candidates: ManuscriptWritingCandidates | undefined,
+  readiness: ManuscriptReadiness | undefined,
+): Record<WorkbenchStageId, StageVerdict> {
+  const activeClaims = context?.claims.filter((claim) => claim.state === "active") ?? []
+  const candidateClaims = candidates?.candidate_spine.claims ?? []
+  const units = context?.units.filter((unit) => unit.status !== "removed") ?? []
+  const resultUnits = units.filter((unit) => unit.kind === "result")
+  const rqs = map?.research_questions ?? []
+  const hasBoundedScope = activeClaims.length > 0 && activeClaims.every(
+    (claim) => claim.allowed_wording?.trim() && claim.prohibited_wording.length > 0,
+  )
+
+  return {
+    seed: "Exploratory",
+    spine: activeClaims.length > 0 ? "Ready" : candidateClaims.length > 0 ? "Needs review" : "Exploratory",
+    scope: hasBoundedScope ? "Ready" : activeClaims.length > 0 || candidateClaims.length > 0 ? "Needs review" : "Blocked",
+    landscape: rqs.length > 0 ? "Ready" : "Blocked",
+    gap: (map?.summary.total_gaps ?? 0) > 0 ? "Needs review" : rqs.length > 0 ? "Exploratory" : "Blocked",
+    response: (candidates?.summary.clusters_eligible ?? 0) > 0 || activeClaims.some((claim) => claim.kind === "methodological")
+      ? "Needs review"
+      : "Exploratory",
+    rqs: rqs.length > 0 ? "Ready" : "Blocked",
+    contributions: activeClaims.length > 0 ? (readiness?.ready ? "Ready" : "Needs review") : candidateClaims.length > 0 ? "Needs review" : "Blocked",
+    evaluation: resultUnits.length > 0 ? "Needs review" : "Blocked",
+    outline: units.length > 0 ? "Needs review" : "Blocked",
+  }
+}
+
+export default function ManuscriptWorkbench() {
+  const { manuscriptId: routeManuscriptId } = useParams<WorkbenchParams>()
+  const manuscriptId = routeManuscriptId?.trim() || null
+  const navigate = useNavigate()
+  const projectId = useActiveProjectId()
+  const [idInput, setIdInput] = useState(manuscriptId ?? "")
+  const [stage, setStage] = useState<WorkbenchStageId>("seed")
+  const [selectedTrace, setSelectedTrace] = useState<ScopedTraceSelection | null>(null)
+
+  const project = useProjectStatus()
+  const researchMap = useResearchMap()
+  const workbench = useManuscriptWorkbench(manuscriptId)
+  const traceScopeKey = `${projectId}:${manuscriptId ?? "project-only"}`
+
+  const context = workbench.context.data
+  const spine = workbench.spine.data
+  const candidates = workbench.candidates.data
+  const readiness = workbench.readiness.data
+  const impact = workbench.impact.data
+  const verdicts = useMemo(
+    () => makeStageVerdicts(researchMap.data, context, candidates, readiness),
+    [researchMap.data, context, candidates, readiness],
+  )
+
+  const handleLoad = (event: FormEvent) => {
+    event.preventDefault()
+    const next = idInput.trim()
+    navigate(next ? `/manuscripts/${encodeURIComponent(next)}/workbench` : "/workbench")
+  }
+
+  const stageMeta = WORKBENCH_STAGES.find((item) => item.id === stage)!
+  const defaultTrace: WorkbenchTraceItem = {
+    title: stageMeta.label,
+    summary: stageDescriptions[stage],
+    kind: "stage contract",
+    origin: "M0 workbench architecture decision",
+    derivation: "Interface-only projection; it creates no RKA record and performs no LLM call.",
+    ids: manuscriptId ? [projectId, manuscriptId] : [projectId],
+    status: verdicts[stage],
+    trace: manuscriptId ? [projectId, manuscriptId, stage] : [projectId, stage],
+  }
+
+  const impactCount = impact?.relevant_changes?.length ?? 0
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">Manuscript Workbench</h1>
+            <Badge variant="outline">M0 read-only</Badge>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Navigate the argument from seed to outline while preserving the distinction between RKA evidence,
+            manuscript semantics, and provisional interface guidance.
+          </p>
+        </div>
+
+        <form onSubmit={handleLoad} className="flex w-full gap-2 lg:w-[34rem]">
+          <Input
+            value={idInput}
+            onChange={(event) => setIdInput(event.target.value)}
+            placeholder="Canonical manuscript id (man_...)"
+            aria-label="Canonical manuscript id"
+          />
+          <Button type="submit" variant="outline">
+            <Search className="mr-2 h-4 w-4" /> Load
+          </Button>
+          {manuscriptId && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setIdInput("")
+                navigate("/workbench")
+              }}
+            >
+              Project only
+            </Button>
+          )}
+        </form>
+      </div>
+
+      {manuscriptId && workbench.context.isLoading && (
+        <div className="flex h-36 items-center justify-center rounded-lg border">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading canonical manuscript context
+        </div>
+      )}
+
+      {workbench.context.error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <p className="font-medium">The manuscript could not be loaded in the selected project.</p>
+            <p className="mt-1 text-xs opacity-80">{workbench.context.error.message}</p>
+          </div>
+        </div>
+      )}
+
+      <ContextCapsule
+        projectId={projectId}
+        projectName={project.data?.project_name ?? "Loading project"}
+        context={context}
+        readiness={readiness}
+        map={researchMap.data}
+        impactCount={impactCount}
+        impactPartial={Boolean(impact?.has_more)}
+      />
+
+      <div className="grid gap-4 xl:grid-cols-[17rem_minmax(0,1fr)]">
+        <Card className="h-fit">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Guided stage rail</CardTitle>
+            <p className="text-xs text-muted-foreground">Freely navigable; status is categorical, never a score.</p>
+          </CardHeader>
+          <CardContent>
+            <StageRail
+              selected={stage}
+              verdicts={verdicts}
+              onSelect={(next) => {
+                setStage(next)
+                setSelectedTrace(null)
+              }}
+            />
+          </CardContent>
+        </Card>
+
+        <div className="min-w-0 space-y-4">
+          <StageCanvas
+            stage={stage}
+            map={researchMap.data}
+            context={context}
+            spine={spine}
+            candidates={candidates}
+            readiness={readiness}
+            onInspect={(item) => setSelectedTrace({ scopeKey: traceScopeKey, item })}
+          />
+          <EvidenceInspector
+            item={selectedTrace?.scopeKey === traceScopeKey ? selectedTrace.item : defaultTrace}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StageCanvas({
+  stage,
+  map,
+  context,
+  spine,
+  candidates,
+  readiness,
+  onInspect,
+}: {
+  stage: WorkbenchStageId
+  map?: ResearchMapData
+  context?: ManuscriptContext
+  spine?: ManuscriptSpine
+  candidates?: ManuscriptWritingCandidates
+  readiness?: ManuscriptReadiness
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const stageMeta = WORKBENCH_STAGES.find((item) => item.id === stage)!
+  const activeClaims = context?.claims.filter((claim) => claim.state === "active") ?? []
+  const units = context?.units.filter((unit) => unit.status !== "removed") ?? []
+  const candidateClaims = candidates?.candidate_spine.claims ?? []
+  const candidateClusters = candidates?.clusters ?? []
+  const rqs = map?.research_questions ?? []
+
+  return (
+    <Card>
+      <CardHeader className="border-b pb-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-lg">{stageMeta.label}</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">{stageMeta.question}</p>
+          </div>
+          <Badge variant="secondary">Read-only</Badge>
+        </div>
+        <p className="rounded-md bg-muted/50 px-3 py-2 text-xs leading-5 text-muted-foreground">
+          {stageDescriptions[stage]}
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3 p-4">
+        {stage === "seed" && (
+          <SeedView map={map} candidates={candidates} onInspect={onInspect} />
+        )}
+        {stage === "spine" && (
+          <SpineView activeClaims={activeClaims} candidateClaims={candidateClaims} candidates={candidates} onInspect={onInspect} />
+        )}
+        {stage === "scope" && (
+          <ScopeView activeClaims={activeClaims} candidateClaims={candidateClaims} onInspect={onInspect} />
+        )}
+        {stage === "landscape" && <ResearchQuestionsView rqs={rqs} mode="landscape" onInspect={onInspect} />}
+        {stage === "gap" && (
+          <GapView rqs={rqs} clusters={candidateClusters} onInspect={onInspect} />
+        )}
+        {stage === "response" && (
+          <ResponseView activeClaims={activeClaims} clusters={candidateClusters} onInspect={onInspect} />
+        )}
+        {stage === "rqs" && <ResearchQuestionsView rqs={rqs} mode="rqs" onInspect={onInspect} />}
+        {stage === "contributions" && (
+          <ContributionView
+            activeClaims={activeClaims}
+            candidateClaims={candidateClaims}
+            readiness={readiness}
+            onInspect={onInspect}
+          />
+        )}
+        {stage === "evaluation" && <EvaluationView units={units} onInspect={onInspect} />}
+        {stage === "outline" && <OutlineView units={units} spine={spine} onInspect={onInspect} />}
+      </CardContent>
+    </Card>
+  )
+}
+
+function TraceCard({
+  title,
+  children,
+  trace,
+  onInspect,
+}: {
+  title: string
+  children: ReactNode
+  trace: WorkbenchTraceItem
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onInspect(trace)}
+      className="group w-full rounded-lg border bg-card p-3 text-left transition-colors hover:border-primary/40 hover:bg-muted/25"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </div>
+      <div className="mt-2 text-xs leading-5 text-muted-foreground">{children}</div>
+      <div className="mt-3 flex flex-wrap items-center gap-1.5 border-t pt-2 text-[10px] text-muted-foreground">
+        <Database className="h-3 w-3" />
+        <span>{trace.origin}</span>
+        {trace.ids.slice(0, 3).map((id) => <code key={id} className="rounded bg-muted px-1 py-0.5">{id}</code>)}
+      </div>
+    </button>
+  )
+}
+
+function EmptyState({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="rounded-lg border border-dashed p-6 text-center">
+      <Info className="mx-auto h-5 w-5 text-muted-foreground" />
+      <h3 className="mt-2 text-sm font-medium">{title}</h3>
+      <p className="mx-auto mt-1 max-w-xl text-xs leading-5 text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function SeedView({
+  map,
+  candidates,
+  onInspect,
+}: {
+  map?: ResearchMapData
+  candidates?: ManuscriptWritingCandidates
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const inspirations = (candidates?.clusters ?? []).slice(0, 4)
+  if (inspirations.length === 0) {
+    return (
+      <>
+        <EmptyState
+          title="No canonical seed exists by design"
+          detail="The seed is author intent. Current RKA supplies research-map context, but the M0 prototype does not persist or promote a seed."
+        />
+        {map && (
+          <TraceCard
+            title="Research-map inspiration boundary"
+            trace={{
+              title: "Research-map inspiration boundary",
+              summary: "The project map may inspire a seed, but neither an RQ nor a cluster becomes author intent automatically.",
+              kind: "derived guidance",
+              origin: "/api/research-map",
+              derivation: "Counts only; no claim promotion and no LLM synthesis.",
+              ids: map.research_questions.map((rq) => rq.id),
+              trace: ["research map", "author review", "seed (not persisted)"],
+            }}
+            onInspect={onInspect}
+          >
+            {map.summary.total_rqs} research questions and {map.summary.total_clusters} clusters are available as inspectable inspiration.
+          </TraceCard>
+        )}
+      </>
+    )
+  }
+  return <>{inspirations.map((cluster) => <ClusterCard key={cluster.cluster_id} cluster={cluster} prefix="Possible seed inspiration" onInspect={onInspect} />)}</>
+}
+
+function SpineView({
+  activeClaims,
+  candidateClaims,
+  candidates,
+  onInspect,
+}: {
+  activeClaims: ManuscriptClaimContext[]
+  candidateClaims: WritingCandidateClaim[]
+  candidates?: ManuscriptWritingCandidates
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  if (activeClaims.length > 0) {
+    return <>{activeClaims.map((claim) => <ClaimCard key={claim.id} claim={claim} label="Canonical spine claim" onInspect={onInspect} />)}</>
+  }
+  if (candidateClaims.length > 0) {
+    return <>{candidateClaims.map((claim) => <CandidateClaimCard key={claim.claim_id} claim={claim} candidates={candidates} onInspect={onInspect} />)}</>
+  }
+  return <EmptyState title="No paper spine yet" detail="No active native claim or eligible server-attested candidate is available. Review clusters or narrow the manuscript scope before drafting." />
+}
+
+function ScopeView({
+  activeClaims,
+  candidateClaims,
+  onInspect,
+}: {
+  activeClaims: ManuscriptClaimContext[]
+  candidateClaims: WritingCandidateClaim[]
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  if (activeClaims.length === 0 && candidateClaims.length === 0) {
+    return <EmptyState title="Scope cannot be inferred" detail="A project description or research question does not supply an allowed/prohibited claim boundary. Select a candidate claim first." />
+  }
+  return (
+    <>
+      {activeClaims.map((claim) => (
+        <TraceCard
+          key={claim.id}
+          title={`${claim.local_key} · ${claim.kind}`}
+          trace={{
+            title: claim.exact_wording ?? claim.local_key,
+            summary: claim.allowed_wording ?? "Allowed wording missing",
+            kind: "native claim scope",
+            origin: "/api/manuscripts/:id/context",
+            derivation: "Latest immutable wording version on the active manuscript claim.",
+            ids: [claim.id, ...claim.evidence.map((item) => item.evidence_claim_id)],
+            status: statusForClaim(claim),
+            trace: ["mcl_ version", "scope boundary", "manuscript units"],
+          }}
+          onInspect={onInspect}
+        >
+          <p><span className="font-medium text-foreground">Allowed:</span> {claim.allowed_wording ?? "Missing"}</p>
+          <p className="mt-1"><span className="font-medium text-foreground">Prohibited:</span> {claim.prohibited_wording.length > 0 ? claim.prohibited_wording.join(" · ") : "Missing, so scope is not ready"}</p>
+        </TraceCard>
+      ))}
+      {activeClaims.length === 0 && candidateClaims.map((claim) => (
+        <TraceCard
+          key={claim.claim_id}
+          title={`${claim.claim_id} · provisional scope`}
+          trace={{
+            title: claim.text,
+            summary: claim.allowed_wording,
+            kind: "candidate scope",
+            origin: "/api/manuscripts/:id/writing-candidates",
+            derivation: "Brain-reviewed cluster synthesis; not a native claim or PI ratification.",
+            ids: claim.evidence_ids,
+            status: claim.prohibited_wording.length ? "Bounded candidate" : "Needs prohibited wording",
+          }}
+          onInspect={onInspect}
+        >
+          <p><span className="font-medium text-foreground">Allowed:</span> {claim.allowed_wording}</p>
+          <p className="mt-1"><span className="font-medium text-foreground">Prohibited:</span> {claim.prohibited_wording.length ? claim.prohibited_wording.join(" · ") : "Not yet bounded"}</p>
+        </TraceCard>
+      ))}
+    </>
+  )
+}
+
+function ResearchQuestionsView({
+  rqs,
+  mode,
+  onInspect,
+}: {
+  rqs: ResearchQuestion[]
+  mode: "landscape" | "rqs"
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  if (rqs.length === 0) return <EmptyState title="No active research questions" detail="Create and review research-question decisions before treating the project map as a paper landscape." />
+  return (
+    <>{rqs.map((rq) => (
+      <TraceCard
+        key={rq.id}
+        title={rq.question}
+        trace={{
+          title: rq.question,
+          summary: `${rq.cluster_count} clusters, ${rq.total_claims} claims, ${rq.gap_count} gaps, ${rq.contradiction_count} contradictions.`,
+          kind: mode === "rqs" ? "research question" : "landscape axis",
+          origin: "/api/research-map",
+          derivation: mode === "rqs" ? "Active RKA research-question decision." : "Workbench groups current clusters under their RKA research question.",
+          ids: [rq.id, ...(rq.clusters ?? []).map((cluster) => cluster.id)],
+          status: rq.status,
+          trace: [rq.id, "ecl_ clusters", "clm_ claims"],
+        }}
+        onInspect={onInspect}
+      >
+        {rq.cluster_count} clusters · {rq.total_claims} claims · {rq.gap_count} gaps · {rq.contradiction_count} contradictions
+      </TraceCard>
+    ))}</>
+  )
+}
+
+function GapView({
+  rqs,
+  clusters,
+  onInspect,
+}: {
+  rqs: ResearchQuestion[]
+  clusters: WritingCandidateCluster[]
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const gapRqs = rqs.filter((rq) => rq.gap_count > 0 || rq.contradiction_count > 0)
+  const blocked = clusters.filter((cluster) => cluster.blockers.length > 0)
+  if (gapRqs.length === 0 && blocked.length === 0) {
+    return <EmptyState title="No established gap is exposed" detail="This does not prove that the literature has no gap. It means current RKA reads do not expose a reviewed gap or blocker for this manuscript." />
+  }
+  return (
+    <>
+      {gapRqs.map((rq) => (
+        <TraceCard
+          key={rq.id}
+          title={rq.question}
+          trace={{
+            title: rq.question,
+            summary: `${rq.gap_count} gap signals and ${rq.contradiction_count} contradictions are recorded under this RQ.`,
+            kind: "gap signal",
+            origin: "/api/research-map",
+            derivation: "Aggregated review-queue and contradiction counts; not an automatically established novelty claim.",
+            ids: [rq.id],
+            status: "Needs review",
+          }}
+          onInspect={onInspect}
+        >
+          {rq.gap_count} gap signals · {rq.contradiction_count} contradictions. Inspect sources before using this as motivation.
+        </TraceCard>
+      ))}
+      {blocked.slice(0, 8).map((cluster) => <ClusterCard key={cluster.cluster_id} cluster={cluster} prefix="Blocked candidate" onInspect={onInspect} />)}
+    </>
+  )
+}
+
+function ResponseView({
+  activeClaims,
+  clusters,
+  onInspect,
+}: {
+  activeClaims: ManuscriptClaimContext[]
+  clusters: WritingCandidateCluster[]
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const methods = activeClaims.filter((claim) => ["methodological", "theoretical"].includes(claim.kind))
+  const eligible = clusters.filter((cluster) => cluster.disposition === "eligible")
+  if (methods.length === 0 && eligible.length === 0) {
+    return <EmptyState title="No reviewed response candidate" detail="Current clusters are missing review, current support, or a research-question binding. The interface does not invent a mechanism from raw journals." />
+  }
+  return (
+    <>
+      {methods.map((claim) => <ClaimCard key={claim.id} claim={claim} label="Canonical response claim" onInspect={onInspect} />)}
+      {methods.length === 0 && eligible.map((cluster) => <ClusterCard key={cluster.cluster_id} cluster={cluster} prefix="Provisional response" onInspect={onInspect} />)}
+    </>
+  )
+}
+
+function ContributionView({
+  activeClaims,
+  candidateClaims,
+  readiness,
+  onInspect,
+}: {
+  activeClaims: ManuscriptClaimContext[]
+  candidateClaims: WritingCandidateClaim[]
+  readiness?: ManuscriptReadiness
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  return (
+    <>
+      {readiness && readiness.findings.length > 0 && (
+        <TraceCard
+          title={`${readiness.verdict}: drafting gate has ${readiness.findings.length} finding${readiness.findings.length === 1 ? "" : "s"}`}
+          trace={{
+            title: "Authoritative drafting readiness",
+            summary: readiness.findings.map((item) => `${item.code}: ${item.message}`).join(" "),
+            kind: "readiness gate",
+            origin: "/api/manuscripts/:id/readiness?target_phase=drafting",
+            derivation: "Deterministic RKA service findings over current claims, evidence, units, references, and checkpoints.",
+            ids: readiness.findings.flatMap((item) => [item.claim_id, item.unit_id, item.literature_id].filter(Boolean) as string[]),
+            status: readiness.verdict,
+          }}
+          onInspect={onInspect}
+        >
+          {readiness.findings.slice(0, 4).map((item) => <p key={`${item.code}-${item.claim_id ?? item.unit_id ?? "all"}`}>{item.code}: {item.message}</p>)}
+        </TraceCard>
+      )}
+      {activeClaims.map((claim) => <ClaimCard key={claim.id} claim={claim} label="Native contribution" onInspect={onInspect} />)}
+      {activeClaims.length === 0 && candidateClaims.map((claim) => <CandidateClaimCard key={claim.claim_id} claim={claim} onInspect={onInspect} />)}
+      {activeClaims.length === 0 && candidateClaims.length === 0 && (
+        <EmptyState title="No contribution candidate is admissible" detail="Review cluster blockers, resolve contradictions, or gather evidence. A fluent synthesis is not promoted automatically." />
+      )}
+    </>
+  )
+}
+
+function EvaluationView({
+  units,
+  onInspect,
+}: {
+  units: ManuscriptUnitContext[]
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const results = units.filter((unit) => unit.kind === "result")
+  return (
+    <>
+      <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+        <FlaskConical className="mt-0.5 h-4 w-4 shrink-0" />
+        <div>
+          <p className="font-medium">Missing experiment semantics are explicit.</p>
+          <p className="mt-1 opacity-80">
+            Current native reads expose result units, artifacts, evidence claims, and interpretation boundaries, but not the planned first-class experiment, run, measurement, baseline, metric, and condition objects from M1.
+          </p>
+          <p className="mt-1 opacity-70">Derivation: current API/schema audit plus the M0 stage contract.</p>
+        </div>
+      </div>
+      {results.map((unit) => <UnitCard key={unit.id} unit={unit} label="Result unit" onInspect={onInspect} />)}
+      {results.length === 0 && (
+        <EmptyState title="No result units" detail="The evaluation view remains blocked. The prototype will not infer experiments from journal prose or treat repository execution as support for a manuscript claim." />
+      )}
+    </>
+  )
+}
+
+function OutlineView({
+  units,
+  spine,
+  onInspect,
+}: {
+  units: ManuscriptUnitContext[]
+  spine?: ManuscriptSpine
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const ordered = [...units].sort((left, right) => left.sequence - right.sequence || left.local_key.localeCompare(right.local_key))
+  if (ordered.length === 0) return <EmptyState title="No native manuscript units" detail="A section-name list alone is not accepted as the argument outline. Create claim-sized units and their claim/evidence links through the future proposal path." />
+  return (
+    <>
+      {ordered.map((unit) => <UnitCard key={unit.id} unit={unit} label={`Unit ${unit.sequence}`} onInspect={onInspect} />)}
+      {spine && (
+        <p className="flex items-center gap-1.5 rounded-md bg-muted/50 px-3 py-2 text-[10px] text-muted-foreground">
+          <Braces className="h-3 w-3" /> Derived from deterministic {spine.schema_version} at manuscript revision {spine.manuscript_revision}.
+        </p>
+      )}
+    </>
+  )
+}
+
+function ClaimCard({
+  claim,
+  label,
+  onInspect,
+}: {
+  claim: ManuscriptClaimContext
+  label: string
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const evidenceIds = claim.evidence.map((item) => item.evidence_claim_id)
+  return (
+    <TraceCard
+      title={`${claim.local_key} · ${label}`}
+      trace={{
+        title: claim.exact_wording ?? claim.local_key,
+        summary: claim.allowed_wording ?? "Allowed wording missing",
+        kind: `native ${claim.kind} claim`,
+        origin: "/api/manuscripts/:id/context",
+        derivation: "Latest immutable mcl_ wording version with typed evidence and unit bindings.",
+        ids: [claim.id, ...evidenceIds, ...claim.unit_links.map((link) => link.unit_id)],
+        status: statusForClaim(claim),
+        trace: ["terminal source", "clm_", claim.id, "mun_", "prose"],
+      }}
+      onInspect={onInspect}
+    >
+      <p className="text-foreground">{claim.exact_wording ?? "Wording missing"}</p>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <Badge variant="outline">{claim.kind}</Badge>
+        <Badge variant="outline">{statusForClaim(claim)}</Badge>
+        <Badge variant="outline">{evidenceIds.length} evidence bindings</Badge>
+        <Badge variant="outline">{claim.unit_links.length} unit links</Badge>
+      </div>
+    </TraceCard>
+  )
+}
+
+function CandidateClaimCard({
+  claim,
+  candidates,
+  onInspect,
+}: {
+  claim: WritingCandidateClaim
+  candidates?: ManuscriptWritingCandidates
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  const lineage = candidates?.candidate_lineage[claim.claim_id]
+  const lineageIds = lineage
+    ? [lineage.cluster_id, ...(lineage.research_question_id ? [lineage.research_question_id] : []), ...lineage.representative_claim_ids]
+    : []
+  return (
+    <TraceCard
+      title={`${claim.claim_id} · server-attested candidate`}
+      trace={{
+        title: claim.text,
+        summary: "Eligible cluster synthesis proposed for manuscript scoping; not a native claim and not PI-ratified.",
+        kind: "writing candidate",
+        origin: "/api/manuscripts/:id/writing-candidates",
+        derivation: "Current Brain-reviewed cluster bound to an active RQ, with duplicate grouping and admission checks.",
+        ids: [...lineageIds, ...claim.evidence_ids],
+        status: "Provisional",
+        trace: ["jrn_", "clm_", lineage?.cluster_id ?? "ecl_", lineage?.research_question_id ?? "RQ", "candidate"],
+      }}
+      onInspect={onInspect}
+    >
+      <p className="text-foreground">{claim.text}</p>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <Badge variant="outline">{claim.claim_type}</Badge>
+        <Badge variant="outline">{claim.evidence_ids.length} admitted claims</Badge>
+        <Badge variant="outline">not ratified</Badge>
+      </div>
+    </TraceCard>
+  )
+}
+
+function ClusterCard({
+  cluster,
+  prefix,
+  onInspect,
+}: {
+  cluster: WritingCandidateCluster
+  prefix: string
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  return (
+    <TraceCard
+      title={`${prefix}: ${cluster.label}`}
+      trace={{
+        title: cluster.label,
+        summary: cluster.synthesis ?? "Cluster synthesis missing",
+        kind: "evidence cluster projection",
+        origin: "/api/manuscripts/:id/writing-candidates",
+        derivation: "Server evaluates RQ binding, Brain review, currency, support admission, duplicates, and contradictions.",
+        ids: [cluster.cluster_id, ...(cluster.research_question_id ? [cluster.research_question_id] : []), ...cluster.support_claim_ids],
+        status: cluster.blockers.length ? `Blocked: ${cluster.blockers.join(", ")}` : "Eligible, still provisional",
+        trace: ["clm_ support", cluster.cluster_id, cluster.research_question_id ?? "RQ missing", "candidate"],
+      }}
+      onInspect={onInspect}
+    >
+      <p>{cluster.synthesis ?? "No reviewed synthesis"}</p>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <Badge variant="outline">{cluster.confidence}</Badge>
+        <Badge variant="outline">{cluster.synthesized_by}</Badge>
+        {cluster.blockers.map((blocker) => <Badge key={blocker} variant="destructive">{blocker}</Badge>)}
+      </div>
+    </TraceCard>
+  )
+}
+
+function UnitCard({
+  unit,
+  label,
+  onInspect,
+}: {
+  unit: ManuscriptUnitContext
+  label: string
+  onInspect: (item: WorkbenchTraceItem) => void
+}) {
+  return (
+    <TraceCard
+      title={`${unit.local_key} · ${unit.title ?? unit.kind}`}
+      trace={{
+        title: unit.title ?? unit.local_key,
+        summary: `${unit.kind} at ${unit.location}`,
+        kind: "native manuscript unit",
+        origin: "/api/manuscripts/:id/context",
+        derivation: "Current mun_ record with evidence bindings and optional result interpretation boundary.",
+        ids: [unit.id, ...unit.evidence.map((item) => item.evidence_claim_id), ...(unit.artifact_ref ? [unit.artifact_ref] : [])],
+        status: unit.status,
+        trace: ["mcl_", unit.id, unit.location],
+      }}
+      onInspect={onInspect}
+    >
+      <div className="flex flex-wrap gap-1.5">
+        <Badge variant="outline">{label}</Badge>
+        <Badge variant="outline">{unit.kind}</Badge>
+        <Badge variant="outline">{unit.status}</Badge>
+      </div>
+      <p className="mt-2"><span className="font-medium text-foreground">Location:</span> {unit.location}</p>
+      {unit.kind === "result" && (
+        <>
+          <p className="mt-1"><span className="font-medium text-foreground">Allowed:</span> {unit.allowed_interpretation ?? "Missing"}</p>
+          <p className="mt-1"><span className="font-medium text-foreground">Prohibited:</span> {unit.prohibited_interpretation ?? "Missing"}</p>
+        </>
+      )}
+    </TraceCard>
+  )
+}


### PR DESCRIPTION
## What changed

- reconcile the choice-first Writer workflow into the current `main` Writer and plugin mirrors
- add the read-only manuscript workbench shell, stage rail, Context Capsule, and evidence inspector
- preserve project-only entry before manuscript registration and invalidate selections across project/manuscript context changes
- record the M0 authority, stage, proposal, and AI-provider boundary in ADR 0001
- update the roadmap and detailed plan with the approved M0 status and DelaySteer walkthrough evidence

## Why

RKA already held claims, evidence, decisions, research maps, and a native manuscript aggregate, but researchers had no single surface for navigating those records as a developing paper argument. The installed Writer also contained a choice-first framing workflow that had not been reconciled into the repository. This slice aligns the Writer bundles and introduces a read-only workbench before any new epistemic schema or mutation path is added.

## User and developer impact

- researchers can enter with a project alone, inspect the current sentence/paragraph spine and its source records, and move between argument stages without changing canonical state
- all displayed knowledge remains a projection over native RKA objects; the workbench does not create claims, evidence, or manuscript revisions
- repository and packaged Writer mirrors remain synchronized and tested
- the newly merged public README, architecture reference, MCP dependency pin, and CI stabilization remain intact

## Validation

- `git diff --check origin/main...HEAD`
- `npm run build` in `web/`
- fresh Docker image build: `docker compose build rka`
- focused Writer suite: `385 passed`
- full Python suite: `2782 passed`
- disposable fresh-database container smoke: `/api/health` returned `status=ok`, version `2.9.0`, vector service available

The production bundle retains the existing large-chunk warning; no new build failure or changed runtime warning was introduced.

## Scope boundary

This PR intentionally does not add Interpretation Staging, claim-scope contracts, experiment/run/result semantics, or canonical workbench writes. Those remain separate dependency-ordered slices in the roadmap.
