### PR TITLE
feat(research): add canonical claim scope contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ flowchart LR
     Journal["Journal<br/>observations · procedures · directives"]
     Candidates["Interpretation candidates<br/>source locator · uncertainty · falsifier"]
     Claims["Claims<br/>typed assertions with source spans"]
+    Scope["Claim scope versions<br/>conditions · extension policy · falsifier"]
     Clusters["Evidence clusters<br/>related claims + synthesis"]
     Questions["Research map<br/>questions · gaps · contradictions"]
     Writing["Claim spine<br/>argument · contribution · evaluation"]
 
-    Journal --> Candidates --> Claims --> Clusters --> Questions --> Writing
+    Journal --> Candidates --> Claims --> Scope --> Clusters --> Questions --> Writing
 ```
 
 Raw records remain available even when later interpretations change. Candidate
@@ -78,6 +79,12 @@ interpretations must be reviewed explicitly before promotion; they can be
 deferred, rejected, merged, or classified without silently becoming scientific
 claims. Derived claims and clusters can be reviewed, superseded, or rebuilt
 without rewriting history.
+
+Each canonical claim has a separate, immutable applicability contract. Scope
+reviews record typed conditions, uncertainty, allowed and prohibited
+extensions, and falsifiers. Missing or stale scope stays visible rather than
+being inferred, and manuscript admission also continues to check grounding,
+scientific evidence status, contradictions, and freshness independently.
 
 ### Provenance by construction
 
@@ -112,6 +119,7 @@ Zotero, repositories, notebooks, and experimental platforms remain important sou
 
 - **Persistent, multi-project research records** for journals, literature, decisions, missions, reports, checkpoints, and artifacts.
 - **Interpretation staging** with exact source locators, uncertainty, falsifiers, immutable review history, and explicit promotion or revocation.
+- **Canonical claim-scope contracts** with immutable revisions, typed applicability conditions, extension policy, falsifiers, and fail-closed manuscript readiness.
 - **Claims and evidence clusters** with source-span provenance, confidence states, contradictions, and review workflows.
 - **Research maps** connecting research questions to clusters and individual claims.
 - **Decision and freshness lifecycles** with supersession, staleness propagation, assumption tracking, and historical belief queries.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,17 +9,19 @@ The M0 authority, stage, proposal, and provider decisions are recorded in
 [ADR 0001](docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md).
 The M1 interpretation boundary is recorded in
 [ADR 0002](docs/adr/0002-interpretation-staging-and-experiment-boundary.md).
+The canonical-claim applicability boundary is recorded in
+[ADR 0003](docs/adr/0003-canonical-claim-scope-contracts.md).
 
 The roadmap is ordered by dependency, not by invented delivery dates. Every
 milestone must satisfy its exit gate before dependent work is treated as ready.
 
 ## Now
 
-**M0 is merged. M1 / PR 1 Interpretation Staging is implemented on its feature
-branch and pending review and merge.** The choice-first Writer delta is
-reconciled, the authority and AI boundary is recorded in ADR 0001, and the
-read-only workbench has been walked through with DelaySteer and a
-full-manuscript control.
+**M0 and M1 / PR 1 are merged. M1 / PR 2 Claim Scope Contracts is implemented
+and fully validated on its feature branch, pending review and merge.** The
+choice-first Writer delta is reconciled, the authority and AI boundary is
+recorded in ADR 0001, and the read-only workbench has been walked through with
+DelaySteer and a full-manuscript control.
 
 The walkthrough and its design revisions are recorded in
 [`2026-08-14-delaysteer-workbench-walkthrough.md`](docs/superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md).
@@ -27,10 +29,20 @@ The authority and stage contracts have researcher approval. PR 1 now includes
 the candidate schema and immutable audit history, exact source locators,
 duplicate/conflict hints, explicit promotion and revocation, deterministic
 review UI, REST/MCP/knowledge-pack parity, a full-suite release gate, an
-isolated Docker smoke test, and a disposable DelaySteer browser pilot. The
-next implementation target after this slice merges is **M1 / PR 2 claim scope
-contracts**; the PR 3 experiment boundary remains explicitly deferred until
-its schema is designed and reviewed.
+isolated Docker smoke test, and a disposable DelaySteer browser pilot. PR 2
+adds immutable canonical scope revisions, typed applicability conditions,
+explicit extension and falsifier policy, independent scope/evidence/source/
+contradiction axes, stale-content detection, fail-closed Writer eligibility,
+and complete REST/MCP/pack/graph/workbench projections. This rebased slice
+passed the full Python suite, production web build, isolated container smoke
+test, revision-conflict check, and browser walkthrough of missing, incomplete,
+ready, and stale states.
+
+After this slice merges, the immediate target is **M2 / PR 4 workbench shell
+and Context Capsule hardening over the authoritative interpretation and scope
+contracts**. PR 3 remains explicitly deferred until the experiment/run/result
+schema is separately designed and reviewed; the workbench must label that
+missing semantic layer rather than infer experiments from journal entries.
 
 ## Dependency map
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -139,6 +139,7 @@ RKA stores research knowledge in seven entity types. Each has a type-prefixed UL
 | **Checkpoint** | `chk_` | Escalation points where the Executor needs Brain/PI input. |
 | **Interpretation Candidate** | `icd_` | Reviewable, source-located interpretation that is not yet canonical knowledge. |
 | **Claim** | `clm_` | Atomic, source-grounded statement explicitly promoted from a reviewed candidate or intentionally recorded through the canonical claim API. |
+| **Claim Scope Version** | `csc_` | Immutable research-level applicability boundary for a canonical claim, including typed conditions, uncertainty, extension limits, and falsifier/disconfirmation information. |
 | **Evidence Cluster** | `ecl_` | Groups of related claims with a Brain-written synthesis. |
 
 ### 4.2 — Journal Entry Types
@@ -167,6 +168,32 @@ Each promoted claim has a type that describes what kind of knowledge it represen
 | `result` | An experiment outcome | "Throughput improved 3x after sharding" |
 | `observation` | Something noticed (not from controlled experiment) | "The LLM includes its prompt in the synthesis" |
 | `assumption` | Something taken as given without proof | "Network latency is negligible at this scale" |
+
+### 4.3.1 — Canonical Claim Scope
+
+Candidate scope (`icd_`) describes what a source-located interpretation appears
+to mean. Canonical scope (`csc_`) governs where a promoted `clm_` may be reused
+as research knowledge. Manuscript wording (`mcl_`) is a third, paper-specific
+boundary. They are intentionally separate.
+
+Open **Claim Scope Review** at `/claim-scopes` to inspect missing, stale,
+incomplete, unreviewed, and ready contracts. A reviewed contract requires at
+least one typed applicability condition, resolved uncertainty, an exact or
+bounded extension policy, prohibited extensions, and resolved falsifier
+applicability. Every edit appends an immutable revision using optimistic
+revision control. Editing claim wording later makes the older contract stale
+until it is reviewed again.
+
+MCP equivalents:
+
+```text
+rka_query(args={"operation": "claim_scope", "project_id": "prj_...", "id": "clm_..."})
+rka_execute(args={"operation": "set_claim_scope", "project_id": "prj_...", ...})
+```
+
+`scope_readiness=ready` does not mean that a claim is scientifically supported
+or uncontested. Check grounding, `evidence_status`, contradictions, and
+staleness independently.
 
 ### 4.4 — Confidence Levels
 
@@ -624,6 +651,9 @@ The web dashboard at `http://localhost:9712` provides a visual interface for bro
 | **Timeline** | `/timeline` | Event stream with causal chain visualization |
 | **Knowledge Graph** | `/graph` | Entity relationship network (low-level debugging view) |
 | **Research Map** | `/research-map` | Three-level drill-down: RQs → clusters → claims |
+| **Interpretation Review** | `/interpretations` | Review source-located `icd_` candidates before canonical promotion |
+| **Claim Scope Review** | `/claim-scopes` | Append and audit canonical `csc_` applicability contracts; resolve Writer scope blockers |
+| **Manuscript Workbench** | `/workbench` | Navigate manuscript stages, scope contracts, evidence lineage, and current readiness |
 | **Notebook** | `/notebook` | (historical) Q&A chat and summary generation — the LLM-backed Q&A/summary features were removed in v2.4.0 |
 | **Audit Log** | `/audit` | System audit trail with action/entity/actor filters |
 | **Context Inspector** | `/context` | Generate and inspect context packages |

--- a/docs/adr/0003-canonical-claim-scope-contracts.md
+++ b/docs/adr/0003-canonical-claim-scope-contracts.md
@@ -1,0 +1,150 @@
+# ADR 0003: Canonical claim scope contracts
+
+- Status: accepted and implemented in M1 PR 2
+- Date: 2026-08-14
+- Depends on: ADR 0002 Interpretation Staging
+
+## Context
+
+Canonical RKA claims (`clm_`) currently preserve source grounding, a numeric
+confidence, independent scientific evidence status, staleness, and graph
+contradictions. They do not preserve the conditions under which a claim is
+intended to hold, which extensions are licensed or prohibited, how uncertainty
+should be interpreted, or what would falsify the claim.
+
+Interpretation candidates (`icd_`) already carry source-bounded preliminary
+scope, uncertainty, and an optional falsifier. Those fields are immutable
+extraction-time observations. They are not a reviewed contract for later use.
+
+Native manuscript claims (`mcl_`) separately preserve exact, allowed, and
+prohibited paper wording. Those limits are manuscript-specific and PI-ratified.
+They must not be reused as the research-level scope of a canonical claim.
+
+## Decision
+
+### 1. Add immutable canonical claim-scope versions
+
+Each reviewed or revised scope contract is appended as a `csc_` row in
+`claim_scope_versions`. A claim stores only the current scope revision number.
+Earlier versions remain immutable and project-portable.
+
+Every version records:
+
+- the claim content/type fingerprint to which it applies;
+- typed applicability conditions;
+- uncertainty level and explanation;
+- an explicit extension policy: exact claim only, or bounded extensions;
+- allowed and prohibited extensions;
+- falsifier applicability, statement, and rationale;
+- same-project canonical claims treated as disconfirming observations;
+- draft/reviewed state, actor, reason, and optional originating candidate;
+- the prior scope version it supersedes.
+
+Appending a version requires `expected_revision`. Revision zero means the
+claim has no scope contract. Stale clients receive a conflict rather than
+overwriting newer review work.
+
+### 2. Keep three distinct boundaries
+
+| Boundary | Object | Meaning |
+|---|---|---|
+| Extracted/source-bounded | `icd_` | What the source passage appears to say under its recorded locator. |
+| Canonical research scope | `csc_` for `clm_` | Conditions and inference limits for reusing a canonical research claim. |
+| Manuscript wording | versioned `mcl_` | Paper-specific wording ratified for one manuscript. |
+
+Promotion from an interpretation candidate creates a draft canonical scope
+version that preserves candidate conditions, uncertainty, and falsifier
+without inferring extension policy, prohibited extensions, or missing
+semantics. It does not create manuscript wording or PI ratification.
+
+### 3. Represent conditions without pretending unparsed text is structured
+
+Canonical conditions are typed records with a condition kind, key, operator,
+value, optional unit, and optional note. Supported operators cover equality,
+set membership, ranges, inequalities, presence/absence, and a conservative
+`described_by` fallback.
+
+When a candidate contains only a free-text condition, promotion preserves it
+as `kind=other`, `key=source_condition`, `operator=described_by`. RKA does not
+guess a dataset, platform, threat model, metric, or numeric bound.
+
+### 4. Make absence and inapplicability explicit
+
+An extension policy is either:
+
+- `exact_only`: no extension beyond the canonical claim is licensed; or
+- `bounded`: one or more explicit extensions are licensed.
+
+The falsifier state is `unknown`, `applicable`, or `not_applicable`.
+`applicable` requires a falsifier statement. `not_applicable` requires a
+rationale. This avoids treating an empty field as a scientific judgment.
+
+### 5. Derive readiness; do not store a self-asserted ready flag
+
+`scope_readiness` is computed from the current immutable version:
+
+- `missing`: no scope version exists;
+- `stale`: the version fingerprint does not match the current claim
+  content/type;
+- `incomplete`: required semantic fields remain unresolved;
+- `needs_review`: semantically complete but still draft;
+- `ready`: complete, current, and explicitly reviewed.
+
+Contradiction, claim staleness, and scientific evidence status remain separate
+dimensions. A scope may be well specified while the claim is contradicted.
+RKA therefore returns explicit findings instead of laundering scientific
+standing into scope readiness.
+
+### 6. Preserve legacy behavior without inventing a backfill
+
+Migration 041 adds `claims.scope_revision` with default zero and creates the
+version table. Existing claims receive no generated scope row and project as
+`scope_readiness=missing`.
+
+Existing claim create/update clients remain valid. Scope writes use a separate
+revision-guarded API. Changing claim content or type does not mutate history;
+the prior scope projects as `stale` until a reviewer appends a new version.
+
+### 7. Make scope a first-class portable and observable contract
+
+Current scope and readiness are exposed through claim REST responses, MCP
+queries, graph claim metadata, native manuscript evidence reads, and the web
+workbench. Full immutable history is available through a dedicated claim-scope
+read endpoint. Scope writes are available through one explicit append
+operation shared by web and MCP clients.
+
+Knowledge packs export, remap, import, and integrity-check scope versions.
+Project deletion is the only authorized deletion path. Scope-version inserts
+emit semantic change events so manuscript impact analysis can trace affected
+evidence claims and units.
+
+## Review invariants
+
+A `reviewed` contract must:
+
+1. describe at least one condition;
+2. resolve uncertainty to a value other than `unknown`;
+3. choose an extension policy;
+4. provide allowed extensions when policy is `bounded`;
+5. provide at least one prohibited extension;
+6. resolve falsifier applicability and supply the corresponding statement or
+   rationale;
+7. reference only existing same-project disconfirming claims other than
+   itself.
+
+Draft versions may be incomplete so promotion and incremental curation remain
+lossless.
+
+## Consequences
+
+- Legacy projects visibly acquire scope-review work instead of fabricated
+  readiness.
+- Claim content/type edits invalidate, rather than silently reuse, an older
+  boundary.
+- Manuscript candidate generation can reject or flag evidence whose canonical
+  scope is missing, stale, incomplete, or unreviewed.
+- A reviewed scope contract does not establish scientific support, resolve a
+  contradiction, or ratify manuscript wording.
+- PR 3 remains responsible for experiments, runs, measurements, tested
+  conditions, and result locators. A scope condition does not prove that an
+  experiment was executed under that condition.

--- a/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
+++ b/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
@@ -1,8 +1,8 @@
 # RKA Epistemic Pipeline and Manuscript Drafting Workbench
 
-Status: roadmap design source; M0 merged; M1 PR 1 Interpretation Staging
-implemented on its feature branch and pending review and merge; M1 PR 2 is
-next.
+Status: roadmap design source; M0 and M1 PR 1 Interpretation Staging merged;
+M1 PR 2 Claim Scope Contracts implemented and fully validated on its feature
+branch, pending review and merge; M2 PR 4 workbench hardening follows.
 
 Date: 2026-08-14
 
@@ -16,6 +16,8 @@ The real-project validation and resulting design revisions are recorded in the
 [`M0 walkthrough`](../specs/2026-08-14-delaysteer-workbench-walkthrough.md).
 The M1 interpretation and experiment boundary is frozen in
 [`ADR 0002`](../../adr/0002-interpretation-staging-and-experiment-boundary.md).
+The M1 canonical-claim applicability boundary is frozen in
+[`ADR 0003`](../../adr/0003-canonical-claim-scope-contracts.md).
 
 ## 1. Baseline and source snapshots
 
@@ -23,11 +25,11 @@ This plan targets the clean default RKA branch at:
 
 - repository: `infinitywings/rka`
 - branch: `main`
-- commit: `fee76542d69aa69c9490b4107a3e1ce68c1c0388`
+- commit: `a3f02813b10c940907e9f736c6bae890c525cf7c`
 - RKA package version: `2.9.0`
-- latest migration: `040`
+- latest migration: `041`
 
-The Writer behavior had a relevant delta that the M0 implementation now
+The Writer behavior had a relevant delta that the local M0 implementation now
 reconciles onto the current baseline:
 
 - remote branch: `origin/codex/writer-framing-elicitation`
@@ -1230,18 +1232,28 @@ projects.
 
 ## 21. Immediate next step
 
-PR 0A, PR 0B, and PR 1 are complete locally. The next implementation slice is
-**M1 / PR 2 Claim Scope Contracts**:
+PR 0A, PR 0B, and PR 1 are merged; PR 2 is implemented on its feature branch.
+PR 2 freezes the distinction
+between source-bounded candidate scope and canonical claim scope; adds
+backward-compatible typed conditions, uncertainty, extension, and falsifier
+contracts; migrates legacy claims without invented semantics; projects scope
+through REST, MCP, packs, graph, Writer gating, and the web; and passed its
+full-suite, production-build, isolated-container, concurrency, and browser
+acceptance gates on the rebased feature branch.
 
-1. freeze the distinction between source-bounded candidate scope and canonical
-   claim scope;
-2. define backward-compatible structured conditions, uncertainty,
-   allowed/prohibited extension, and falsifier contracts;
-3. migrate existing claims without inventing missing semantics;
-4. expose scope readiness and disconfirming observations through REST, MCP,
-   packs, graph, and the workbench;
-5. add revision-safe review operations and change-impact behavior;
-6. validate with scoped, over-broad, conflicting, and legacy DelaySteer claims.
+After PR 2 merges, the next implementation slice is **M2 / PR 4 Workbench
+Shell and Context Capsule hardening**:
+
+1. make the Context Capsule summarize interpretation and canonical-scope
+   readiness without collapsing independent evidence axes;
+2. deep-link workbench evidence and blockers into the relevant interpretation,
+   claim-scope, source, and manuscript views;
+3. make route and selection state resumable without creating a second semantic
+   store;
+4. surface localized stale-impact paths and explicitly label the still-missing
+   experiment/result layer;
+5. validate read-only navigation on DelaySteer and a mature positive-path
+   project before any deliberation or mutation UI is enabled.
 
 PR 3 remains deferred until the experiment/run/result schema is separately
 designed and reviewed. Interpretation candidates and ordinary journal entries

--- a/plugin/skills/brain/SKILL.md
+++ b/plugin/skills/brain/SKILL.md
@@ -18,8 +18,8 @@ The rka MCP server ships a **discriminated-union dispatch surface**. Five tools 
 
 | Always-on tool | Purpose |
 |---|---|
-| `rka_query(args)` | All 51 read operations (status, context, journal, research map, native manuscripts, writing candidates, reference manifests, change impact, etc.) |
-| `rka_execute(args)` | All 58 write/lifecycle operations (notes, decisions, missions, native manuscripts, reference manifests, checkpoints, claims, hooks, maintenance) |
+| `rka_query(args)` | All 53 read operations (status, context, journal, research map, claim scope, native manuscripts, writing candidates, reference manifests, change impact, etc.) |
+| `rka_execute(args)` | All 62 write/lifecycle operations (notes, decisions, missions, interpretation promotion, claim-scope review, native manuscripts, checkpoints, hooks, maintenance) |
 | `rka_describe(operation)` | Schema lookup + worked example for any operation; `rka_describe('')` returns the <250-token index |
 | `rka_load_tools(names)` | Escape hatch — brings deferred legacy tools online when you specifically need backwards-compat access |
 | `rka_help(name)` | Deprecated alias for `rka_describe`; retained always-on for cockpits that learned the v2.6.3 navigator vocabulary |
@@ -190,6 +190,18 @@ support. `verified` records the categorical grounding review;
 **Confidence cap without full text**: claims extracted from abstracts or search snippets cap at **0.65**. To exceed that, you need full-text grounding with a direct quote.
 
 Full procedure with worked examples and cluster-assignment heuristic: `workflows.md` § "Claim Extraction".
+
+### Canonical claim-scope review
+
+Do not cluster or offer a `clm_` as manuscript support merely because its
+source grounding is verified. Inspect its canonical research boundary with
+`rka_query(args={"operation": "claim_scope", "project_id": <pinned>, "id":
+"clm_..."})`. If scope is missing, stale, incomplete, or unreviewed, append a
+revision with `set_claim_scope`; never infer a legacy boundary from claim prose.
+A reviewed contract records typed conditions, resolved uncertainty, an exact or
+bounded extension policy, prohibited extensions, and resolved falsifier
+applicability. Keep `scope_readiness`, `evidence_status`, contradiction, and
+staleness as separate review axes.
 
 ## Literature ingestion + Zotero linkage
 

--- a/plugin/skills/executor/SKILL.md
+++ b/plugin/skills/executor/SKILL.md
@@ -18,13 +18,13 @@ The rka MCP server ships a **discriminated-union dispatch surface**. Five tools 
 
 | Always-on tool | Purpose |
 |---|---|
-| `rka_query(args)` | All 52 read operations (missions, status, context, interpretation candidates, native manuscripts, writing candidates, reference manifests, change impact, reports, search, etc.) |
-| `rka_execute(args)` | All 61 write/lifecycle operations (notes, native manuscript and reference-manifest updates, checkpoints, reports, mission lifecycle, document ingest, interpretation staging, explicit claim promotion, etc.) |
+| `rka_query(args)` | All 53 read operations (missions, status, context, interpretation candidates, claim scope, native manuscripts, writing candidates, change impact, reports, search, etc.) |
+| `rka_execute(args)` | All 62 write/lifecycle operations (notes, manuscript updates, checkpoints, reports, document ingest, interpretation staging, explicit claim promotion, claim-scope review, etc.) |
 | `rka_describe(operation)` | Schema lookup + worked example; `rka_describe('')` returns the <250-token index |
 | `rka_load_tools(names)` | Escape hatch — brings deferred legacy tools online when you specifically need backwards-compat access |
 | `rka_help(name)` | Deprecated alias for `rka_describe` |
 
-`args` is a **typed Pydantic model** discriminated by `operation`. FastMCP renders the 109-model union as `inputSchema.oneOf` with per-branch enum + required-field constraints. The schema layer rejects wrong enum values, missing required fields, and missing provenance BEFORE the call is dispatched.
+`args` is a **typed Pydantic model** discriminated by `operation`. FastMCP renders the 115-model union as `inputSchema.oneOf` with per-branch enum + required-field constraints. The schema layer rejects wrong enum values, missing required fields, and missing provenance BEFORE the call is dispatched.
 
 > **Orchestrator subprocess note.** When this Executor instance is the LangGraph orchestrator's `claude-agent-sdk` subprocess (daemon under `orchestrator/docker-compose.yml`), it runs with `RKA_LEGACY_TOOLS=1`, restoring the v2.7.0a2 always-on surface (the 12-tool legacy baseline + the 8 v2.7.0a2 intent verbs) alongside the always-on dispatch tools (`rka_query` / `rka_execute` / `rka_describe`, which are never deferred); the remaining legacy tools stay `tier='deferred'` and are reachable via `rka_load_tools`. This preserves the parent-side TWO-TAP autonomy contract at `pi_decision_select` (per-tool ratification granularity in `WRITE_TOOLS`). Cockpit Executor sessions (Claude Desktop / Claude Code talking directly to the PI) see the typed dispatch surface described above.
 
@@ -116,6 +116,13 @@ not promote its own result to `supported`; the Brain performs that assessment
 against current positive evidence, qualifiers, and counterevidence. Never use
 `verified=true` as shorthand for scientific validity—it records source-grounding
 fidelity only.
+
+Record the exact experimental conditions, uncertainty, failed runs, and
+disconfirming observations needed for later scope review, but do not silently
+ratify a research-level boundary. The Brain or PI appends reviewed `csc_`
+contracts. If a mission explicitly delegates preparation of a draft scope, use
+`set_claim_scope` with `review_status="draft"`; do not label it reviewed or use
+scope readiness as a scientific-support verdict.
 
 ## Backbrief — Confirm Your Plan
 

--- a/plugin/skills/pi/SKILL.md
+++ b/plugin/skills/pi/SKILL.md
@@ -17,8 +17,8 @@ The rka MCP server ships a **discriminated-union dispatch surface**. Five tools 
 
 | Always-on tool | Purpose |
 |---|---|
-| `rka_query(args)` | All 51 read operations |
-| `rka_execute(args)` | All 58 write/lifecycle operations |
+| `rka_query(args)` | All 53 read operations |
+| `rka_execute(args)` | All 62 write/lifecycle operations |
 | `rka_describe(operation)` | Schema lookup + worked example; `rka_describe('')` returns the <250-token index |
 | `rka_load_tools(names)` | Escape hatch for explicit legacy-tool access |
 | `rka_help(name)` | Deprecated alias for `rka_describe` |

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -109,11 +109,15 @@ writer readiness` asks RKA for the authoritative target-phase gate.
    every operation. Native manuscript work uses `manuscript_context`,
    `manuscript_spine`, `manuscript_readiness`, `upsert_argument_spine`,
    `ratify_manuscript_claim`, checkpoint operations, and change/impact reads.
-7. Run `rka writer readiness --target-phase <phase>`. `BLOCK` or `ERROR`
+7. For every load-bearing `clm_`, inspect `claim_scope`. Resolve any
+   `missing`, `stale`, `incomplete`, or `needs_review` contract through the
+   Brain/PI before using it as positive support. Do not copy preliminary
+   candidate scope into a canonical boundary without review.
+8. Run `rka writer readiness --target-phase <phase>`. `BLOCK` or `ERROR`
    stops advancement. A changed dependency never rewrites PI-ratified wording;
    revalidate the claim and record a superseding PI decision before binding a
    materially changed version.
-8. Greet the PI (path a) or surface the mission state (path b) with the inferred next checkpoint or handler dispatch.
+9. Greet the PI (path a) or surface the mission state (path b) with the inferred next checkpoint or handler dispatch.
 
 Full worked walkthrough: [`references/workflows.md`](references/workflows.md) section "Session Start".
 
@@ -270,8 +274,11 @@ the current RKA graph:
    prohibited wording, and planned manuscript units.
 4. For an empirical claim, require one or more current, verified `clm_`
    records whose `source_entry_id` resolves to a current terminal `jrn_` or
-   `lit_`. A `dec_` ratifies wording but is not empirical evidence. An `ecl_`
-   guides synthesis and discovery but is not empirical evidence.
+   `lit_`, and require each supporting claim's canonical `csc_` contract to be
+   current, complete, and reviewed. Carry `csc_` IDs into candidate lineage and
+   union their prohibited extensions into candidate prohibited wording. A
+   `dec_` ratifies wording but is not empirical evidence. An `ecl_` guides
+   synthesis and discovery but is not empirical evidence.
 5. Dry-run the proposal with `rka writer import-spine`; inspect its evidence
    roles, result coverage, and revision. Apply only with `--apply` and an
    explicit expected revision. Import never creates ratifications.

--- a/plugin/skills/writer/references/evidence_to_spine_pipeline.md
+++ b/plugin/skills/writer/references/evidence_to_spine_pipeline.md
@@ -12,9 +12,17 @@ in RKA but does not silently enter the manuscript.
 ```text
 jrn_ observations and decisions
         |
-        | extraction fidelity, source linkage, currency
+        | exact locator, epistemic kind, explicit review
+        v
+icd_ interpretation candidates
+        |
+        | promotion with grounding fidelity and immutable lineage
         v
 clm_ atomic claims
+        |
+        | typed applicability, uncertainty, extension limits, falsifier
+        v
+csc_ canonical claim-scope versions
         |
         | cluster membership, duplicate grouping, contradiction edges
         v
@@ -74,6 +82,15 @@ true:
 - project ownership is attested;
 - the source is not manuscript prose;
 - unresolved contradiction edges do not touch the claim.
+- its current canonical `csc_` contract is complete, reviewed, and still
+  matches the claim's current content and type.
+
+Candidate scope on `icd_` is source-bounded extraction context. Canonical scope
+on `csc_` is the research-level applicability contract. Manuscript wording on
+`mcl_` is paper-specific and PI-ratified. Do not collapse these layers. Legacy
+claims with no `csc_` remain `scope_readiness=missing`, and a claim edit makes
+its older contract stale. Scope readiness never replaces grounding,
+scientific-support, contradiction, or currency checks.
 
 Claims that fail admission stay visible in the candidate report with reason
 codes. They are not silently discarded or converted into qualifiers.
@@ -130,6 +147,8 @@ The response includes:
 - qualifiers and counterevidence;
 - an unratified candidate spine;
 - candidate-to-cluster/RQ lineage.
+- canonical `csc_` IDs and prohibited extensions for every admitted support
+  claim.
 
 ## 4. Contribution contract
 

--- a/rka/api/routes/claims.py
+++ b/rka/api/routes/claims.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from rka.models.claim import (
@@ -9,13 +11,31 @@ from rka.models.claim import (
     ClaimCreate,
     ClaimEdge,
     ClaimEdgeCreate,
+    ClaimScopeHistory,
+    ClaimScopeWrite,
     ClaimUpdate,
     EvidenceStatus,
 )
-from rka.services.claims import ClaimService
+from rka.services.claims import (
+    ClaimNotFoundError,
+    ClaimScopeConflictError,
+    ClaimService,
+)
 from rka.api.deps import get_scoped_claim_service
 
 router = APIRouter()
+
+
+def _raise_claim_scope_error(exc: Exception) -> None:
+    if isinstance(exc, ClaimNotFoundError):
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if isinstance(exc, ClaimScopeConflictError):
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if isinstance(exc, sqlite3.IntegrityError):
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if isinstance(exc, ValueError):
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    raise exc
 
 
 @router.post("/claims", response_model=Claim, status_code=201)
@@ -59,6 +79,29 @@ async def get_claim(
     if claim is None:
         raise HTTPException(404, f"Claim {claim_id} not found")
     return claim
+
+
+@router.get("/claims/{claim_id}/scope", response_model=ClaimScopeHistory)
+async def get_claim_scope(
+    claim_id: str,
+    svc: ClaimService = Depends(get_scoped_claim_service),
+):
+    history = await svc.get_scope_history(claim_id)
+    if history is None:
+        raise HTTPException(404, f"Claim {claim_id} not found")
+    return history
+
+
+@router.post("/claims/{claim_id}/scope", response_model=ClaimScopeHistory)
+async def append_claim_scope(
+    claim_id: str,
+    data: ClaimScopeWrite,
+    svc: ClaimService = Depends(get_scoped_claim_service),
+):
+    try:
+        return await svc.append_scope(claim_id, data)
+    except Exception as exc:
+        _raise_claim_scope_error(exc)
 
 
 @router.put("/claims/{claim_id}", response_model=Claim)

--- a/rka/db/migrations/041_add_claim_scope_contracts.sql
+++ b/rka/db/migrations/041_add_claim_scope_contracts.sql
@@ -1,0 +1,191 @@
+-- Migration 041: immutable canonical claim-scope contracts.
+-- requires-table: projects, claims, interpretation_candidates, change_events, project_deletion_authorizations
+
+ALTER TABLE claims ADD COLUMN scope_revision INTEGER NOT NULL DEFAULT 0
+    CHECK (scope_revision >= 0);
+
+CREATE TABLE IF NOT EXISTS claim_scope_versions (
+    id TEXT PRIMARY KEY
+        CHECK (substr(id, 1, 4) = 'csc_' AND length(id) > 4),
+    claim_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    revision INTEGER NOT NULL CHECK (revision >= 1),
+    claim_content_hash TEXT NOT NULL
+        CHECK (length(claim_content_hash) = 64),
+    conditions TEXT NOT NULL DEFAULT '[]'
+        CHECK (json_valid(conditions) AND json_type(conditions) = 'array'),
+    uncertainty TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (uncertainty IN ('none', 'low', 'medium', 'high', 'unknown')),
+    uncertainty_note TEXT,
+    extension_policy TEXT
+        CHECK (extension_policy IS NULL OR extension_policy IN (
+            'exact_only', 'bounded'
+        )),
+    allowed_extensions TEXT NOT NULL DEFAULT '[]'
+        CHECK (
+            json_valid(allowed_extensions)
+            AND json_type(allowed_extensions) = 'array'
+        ),
+    prohibited_extensions TEXT NOT NULL DEFAULT '[]'
+        CHECK (
+            json_valid(prohibited_extensions)
+            AND json_type(prohibited_extensions) = 'array'
+        ),
+    falsifier_status TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (falsifier_status IN ('unknown', 'applicable', 'not_applicable')),
+    falsifier TEXT,
+    falsifier_rationale TEXT,
+    disconfirming_claim_ids TEXT NOT NULL DEFAULT '[]'
+        CHECK (
+            json_valid(disconfirming_claim_ids)
+            AND json_type(disconfirming_claim_ids) = 'array'
+        ),
+    review_status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (review_status IN ('draft', 'reviewed')),
+    created_by TEXT NOT NULL
+        CHECK (created_by IN (
+            'pi', 'brain', 'executor', 'web_ui', 'llm', 'import'
+        )),
+    reason TEXT NOT NULL CHECK (length(trim(reason)) > 0),
+    source_candidate_id TEXT,
+    supersedes_scope_id TEXT,
+    created_at TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE (id, project_id),
+    UNIQUE (claim_id, project_id, revision),
+    FOREIGN KEY (claim_id, project_id)
+        REFERENCES claims(id, project_id) ON DELETE RESTRICT,
+    FOREIGN KEY (source_candidate_id, project_id)
+        REFERENCES interpretation_candidates(id, project_id) ON DELETE RESTRICT,
+    FOREIGN KEY (supersedes_scope_id, project_id)
+        REFERENCES claim_scope_versions(id, project_id) ON DELETE RESTRICT,
+    CHECK (
+        (extension_policy = 'exact_only' AND json_array_length(allowed_extensions) = 0)
+        OR extension_policy = 'bounded'
+        OR extension_policy IS NULL
+    ),
+    CHECK (
+        falsifier_status <> 'applicable'
+        OR (falsifier IS NOT NULL AND length(trim(falsifier)) > 0)
+    ),
+    CHECK (
+        falsifier_status <> 'not_applicable'
+        OR (
+            falsifier_rationale IS NOT NULL
+            AND length(trim(falsifier_rationale)) > 0
+        )
+    ),
+    CHECK (
+        review_status <> 'reviewed'
+        OR (
+            json_array_length(conditions) >= 1
+            AND uncertainty <> 'unknown'
+            AND extension_policy IS NOT NULL
+            AND (
+                extension_policy = 'exact_only'
+                OR json_array_length(allowed_extensions) >= 1
+            )
+            AND json_array_length(prohibited_extensions) >= 1
+            AND falsifier_status <> 'unknown'
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_scope_versions_claim
+    ON claim_scope_versions(project_id, claim_id, revision DESC);
+CREATE INDEX IF NOT EXISTS idx_claim_scope_versions_review
+    ON claim_scope_versions(project_id, review_status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_claim_scope_versions_source_candidate
+    ON claim_scope_versions(project_id, source_candidate_id)
+    WHERE source_candidate_id IS NOT NULL;
+
+-- A new immutable version must be exactly one revision beyond the claim's
+-- current pointer and must name the current version as its predecessor.
+CREATE TRIGGER IF NOT EXISTS trg_claim_scope_versions_validate_insert
+BEFORE INSERT ON claim_scope_versions
+WHEN NEW.revision <> COALESCE((
+        SELECT scope_revision FROM claims
+        WHERE id = NEW.claim_id AND project_id = NEW.project_id
+    ), -1) + 1
+  OR (
+        NEW.revision = 1
+        AND NEW.supersedes_scope_id IS NOT NULL
+    )
+  OR (
+        NEW.revision > 1
+        AND NEW.supersedes_scope_id IS NOT (
+            SELECT id FROM claim_scope_versions
+            WHERE claim_id = NEW.claim_id
+              AND project_id = NEW.project_id
+              AND revision = NEW.revision - 1
+        )
+    )
+BEGIN
+    SELECT RAISE(ABORT, 'claim scope version must append to the current revision');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_claim_scope_versions_no_update
+BEFORE UPDATE ON claim_scope_versions
+BEGIN
+    SELECT RAISE(ABORT, 'claim scope versions are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_claim_scope_versions_no_delete
+BEFORE DELETE ON claim_scope_versions
+WHEN NOT EXISTS (
+    SELECT 1 FROM project_deletion_authorizations AS authorization
+    WHERE authorization.project_id = OLD.project_id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'claim scope versions require project-authorized deletion');
+END;
+
+-- The head pointer can only advance by one and only after the immutable row
+-- exists in the same transaction. Other claim fields remain governed by their
+-- existing update contract.
+CREATE TRIGGER IF NOT EXISTS trg_claims_validate_scope_revision_update
+BEFORE UPDATE OF scope_revision ON claims
+WHEN NEW.scope_revision IS NOT OLD.scope_revision
+ AND (
+        NEW.scope_revision <> OLD.scope_revision + 1
+        OR NOT EXISTS (
+            SELECT 1 FROM claim_scope_versions AS scope
+            WHERE scope.claim_id = NEW.id
+              AND scope.project_id = NEW.project_id
+              AND scope.revision = NEW.scope_revision
+        )
+    )
+BEGIN
+    SELECT RAISE(ABORT, 'claim scope revision must advance to an existing next version');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_change_claim_scope_versions_insert
+AFTER INSERT ON claim_scope_versions
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id,
+        related_entity_type, related_entity_id, details
+    ) VALUES (
+        NEW.project_id, 'claim_scope_versions', 'insert',
+        'claim_scope', NEW.id, 'claim', NEW.claim_id,
+        json_object(
+            'revision', NEW.revision,
+            'review_status', NEW.review_status,
+            'uncertainty', NEW.uncertainty,
+            'extension_policy', NEW.extension_policy
+        )
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_change_claim_scope_versions_delete
+AFTER DELETE ON claim_scope_versions
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id,
+        related_entity_type, related_entity_id, details
+    ) VALUES (
+        OLD.project_id, 'claim_scope_versions', 'delete',
+        'claim_scope', OLD.id, 'claim', OLD.claim_id,
+        json_object('revision', OLD.revision)
+    );
+END;

--- a/rka/infra/ids.py
+++ b/rka/infra/ids.py
@@ -23,6 +23,7 @@ _PREFIXES = {
     "keynode": "knd",
     "graphview": "gvw",
     "claim": "clm",
+    "claim_scope": "csc",
     "cluster": "ecl",
     "claim_edge": "ced",
     "interpretation_candidate": "icd",

--- a/rka/mcp/_enums.py
+++ b/rka/mcp/_enums.py
@@ -49,13 +49,21 @@ from typing import Literal
 # ``journal.confidence`` and ``rka/models/journal.py``. Run-5's empirical
 # Brain hallucination was ``'confirmed'`` — NOT in this set.
 ConfidenceLit = Literal[
-    "hypothesis", "tested", "verified", "superseded", "retracted",
+    "hypothesis",
+    "tested",
+    "verified",
+    "superseded",
+    "retracted",
 ]
 
 # Importance on journal entries — ``rka/db/schema.sql`` CHECK on
 # ``journal.importance``.
 ImportanceLit = Literal[
-    "critical", "high", "normal", "low", "archived",
+    "critical",
+    "high",
+    "normal",
+    "low",
+    "archived",
 ]
 
 # Actor-of-record across journal / decision / literature writes —
@@ -69,10 +77,19 @@ SourceLit = Literal["brain", "executor", "pi", "web_ui", "llm"]
 # ``AnyJournalType``.
 NoteTypeLit = Literal[
     # v2 canonical
-    "note", "log", "directive",
+    "note",
+    "log",
+    "directive",
     # Legacy (accepted; normalized to one of the v2 set above)
-    "finding", "insight", "pi_instruction", "exploration",
-    "idea", "observation", "hypothesis", "methodology", "summary",
+    "finding",
+    "insight",
+    "pi_instruction",
+    "exploration",
+    "idea",
+    "observation",
+    "hypothesis",
+    "methodology",
+    "summary",
 ]
 
 
@@ -89,7 +106,10 @@ DecidedByLit = Literal["pi", "brain", "executor"]
 # ``research_question`` is reserved for advanceable RQs (see
 # ``rka_advance_rq``); most decisions are ``decision`` or ``design_choice``.
 DecisionKindLit = Literal[
-    "research_question", "design_choice", "decision", "operational",
+    "research_question",
+    "design_choice",
+    "decision",
+    "operational",
 ]
 
 # Decision lifecycle status — ``rka/db/schema.sql`` CHECK on
@@ -100,7 +120,11 @@ DecisionKindLit = Literal[
 # CHECK constraint at INSERT time (HTTP 500). Phase-X²' polish promotes
 # this to a Literal alias so the typed-args layer rejects pre-dispatch.
 DecisionStatusLit = Literal[
-    "active", "abandoned", "superseded", "merged", "revisit",
+    "active",
+    "abandoned",
+    "superseded",
+    "merged",
+    "revisit",
 ]
 
 
@@ -111,7 +135,11 @@ DecisionStatusLit = Literal[
 # Reading lifecycle on a literature entry — ``rka/db/schema.sql`` CHECK
 # on ``literature.status``.
 LitStatusLit = Literal[
-    "to_read", "reading", "read", "cited", "excluded",
+    "to_read",
+    "reading",
+    "read",
+    "cited",
+    "excluded",
 ]
 
 
@@ -122,7 +150,12 @@ LitStatusLit = Literal[
 # Mission lifecycle status — ``rka/db/schema.sql`` CHECK on
 # ``missions.status``.
 MissionStatusLit = Literal[
-    "pending", "active", "complete", "partial", "blocked", "cancelled",
+    "pending",
+    "active",
+    "complete",
+    "partial",
+    "blocked",
+    "cancelled",
 ]
 
 
@@ -136,7 +169,10 @@ MissionStatusLit = Literal[
 # to include ``'gate'`` for the validation-gate subtype). The v2.7.0
 # verb surface accepts the Pydantic-level set.
 ChkTypeLit = Literal[
-    "decision", "clarification", "inspection", "gate",
+    "decision",
+    "clarification",
+    "inspection",
+    "gate",
 ]
 
 # Checkpoint resolver — ``rka/db/schema.sql`` CHECK on
@@ -151,14 +187,19 @@ CheckpointResolvedByLit = Literal["pi", "brain"]
 # line 24 CHECK on ``journal.status`` AND ``rka/models/journal.py``
 # ``JournalEntryCreate.status`` / ``JournalEntryUpdate.status``.
 JournalStatusLit = Literal[
-    "draft", "active", "superseded", "retracted",
+    "draft",
+    "active",
+    "superseded",
+    "retracted",
 ]
 
 # Validation-gate subtype — string-set validated in
 # ``rka/services/researcher_tools.py`` and the legacy
 # ``rka_create_gate`` MCP tool.
 GateTypeLit = Literal[
-    "problem_framing", "plan_validation", "evidence_review",
+    "problem_framing",
+    "plan_validation",
+    "evidence_review",
     "synthesis_validation",
 ]
 
@@ -174,16 +215,70 @@ VerdictLit = Literal["go", "kill", "hold", "recycle"]
 
 # Claim type — ``rka/models/claim.py`` ``ClaimType``.
 ClaimTypeLit = Literal[
-    "hypothesis", "evidence", "method", "result", "observation", "assumption",
+    "hypothesis",
+    "evidence",
+    "method",
+    "result",
+    "observation",
+    "assumption",
+]
+
+# Canonical claim-scope contracts (rka/models/claim.py). These are research-
+# level applicability bounds on clm_ claims, distinct from source-bounded
+# interpretation scope and manuscript-specific wording boundaries.
+ClaimScopeUncertaintyLit = Literal["none", "low", "medium", "high", "unknown"]
+ClaimScopeExtensionPolicyLit = Literal["exact_only", "bounded"]
+ClaimFalsifierStatusLit = Literal["unknown", "applicable", "not_applicable"]
+ClaimScopeReviewStatusLit = Literal["draft", "reviewed"]
+ClaimScopeReadinessLit = Literal[
+    "missing",
+    "stale",
+    "incomplete",
+    "needs_review",
+    "ready",
+]
+ClaimScopeActorLit = Literal["pi", "brain", "executor", "web_ui", "llm"]
+ClaimConditionKindLit = Literal[
+    "dataset",
+    "population",
+    "platform",
+    "environment",
+    "threat_model",
+    "baseline",
+    "workload",
+    "metric",
+    "parameter",
+    "assumption",
+    "time_window",
+    "other",
+]
+ClaimConditionOperatorLit = Literal[
+    "equals",
+    "one_of",
+    "range",
+    "at_least",
+    "at_most",
+    "present",
+    "absent",
+    "described_by",
 ]
 
 # Interpretation Staging (rka/models/interpretation.py).
 InterpretationSourceLit = Literal["journal", "literature", "artifact"]
 InterpretationLocatorLit = Literal[
-    "text_offset", "page", "line_range", "section", "url_fragment", "record",
+    "text_offset",
+    "page",
+    "line_range",
+    "section",
+    "url_fragment",
+    "record",
 ]
 EpistemicKindLit = Literal[
-    "observation", "reported_fact", "inference", "hypothesis", "plan",
+    "observation",
+    "reported_fact",
+    "inference",
+    "hypothesis",
+    "plan",
     "author_intent",
 ]
 InterpretationUncertaintyLit = Literal["none", "low", "medium", "high", "unknown"]
@@ -191,27 +286,48 @@ InterpretationActorLit = Literal["pi", "brain", "executor", "web_ui", "llm", "im
 InterpretationReviewActorLit = Literal["pi", "brain", "executor", "web_ui"]
 InterpretationReviewStatusLit = Literal["pending", "in_review", "resolved"]
 InterpretationDispositionLit = Literal[
-    "promoted", "merged", "deferred", "rejected", "classified_decision",
-    "classified_plan", "classified_author_intent", "evidence_mission_requested",
+    "promoted",
+    "merged",
+    "deferred",
+    "rejected",
+    "classified_decision",
+    "classified_plan",
+    "classified_author_intent",
+    "evidence_mission_requested",
 ]
 InterpretationHintKindLit = Literal["duplicate", "conflict"]
 InterpretationTriageActionLit = Literal[
-    "start_review", "promote", "merge", "defer", "reject",
-    "classify_decision", "classify_plan", "classify_author_intent",
-    "request_evidence_mission", "reopen", "revoke_promotion",
+    "start_review",
+    "promote",
+    "merge",
+    "defer",
+    "reject",
+    "classify_decision",
+    "classify_plan",
+    "classify_author_intent",
+    "request_evidence_mission",
+    "reopen",
+    "revoke_promotion",
 ]
 
 # Scientific evidence assessment on a claim. This is intentionally
 # independent from ``claims.verified``, which records extraction/grounding
 # fidelity against the source entry.
 EvidenceStatusLit = Literal[
-    "unassessed", "supported", "partially_supported", "inconclusive",
+    "unassessed",
+    "supported",
+    "partially_supported",
+    "inconclusive",
     "contradicted",
 ]
 
 # Cluster confidence — ``rka/models/claim.py`` ``ClusterConfidence``.
 ClusterConfLit = Literal[
-    "strong", "moderate", "emerging", "contested", "refuted",
+    "strong",
+    "moderate",
+    "emerging",
+    "contested",
+    "refuted",
 ]
 
 
@@ -224,7 +340,11 @@ ClusterConfLit = Literal[
 # on the underlying decision row (the ``decisions.status`` column owns
 # the decision-level lifecycle and is a different CHECK set).
 RQStatusLit = Literal[
-    "open", "partially_answered", "answered", "reframed", "closed",
+    "open",
+    "partially_answered",
+    "answered",
+    "reframed",
+    "closed",
 ]
 
 
@@ -306,7 +426,11 @@ HookCreatedByLit = Literal["pi", "brain", "executor", "system"]
 # string, but readiness checks and phase transitions are deliberately closed
 # to this set.
 ManuscriptReadinessPhaseLit = Literal[
-    "planning", "drafting", "review", "final", "submitted",
+    "planning",
+    "drafting",
+    "review",
+    "final",
+    "submitted",
 ]
 
 # Native manuscript creation is intentionally narrower than later lifecycle
@@ -351,13 +475,22 @@ ManuscriptUnitKindLit = Literal[
     "other",
 ]
 ManuscriptUnitStatusLit = Literal[
-    "planned", "drafted", "reviewed", "final", "removed",
+    "planned",
+    "drafted",
+    "reviewed",
+    "final",
+    "removed",
 ]
 ManuscriptEvidenceRoleLit = Literal[
-    "support", "qualifier", "counterevidence",
+    "support",
+    "qualifier",
+    "counterevidence",
 ]
 ManuscriptClaimUnitRelationshipLit = Literal[
-    "advances", "tests", "bounds", "mentions",
+    "advances",
+    "tests",
+    "bounds",
+    "mentions",
 ]
 
 # PI checkpoint lifecycle.
@@ -370,11 +503,16 @@ ManuscriptCheckpointKindLit = Literal[
     "final_layout",
 ]
 ManuscriptCheckpointResolutionStatusLit = Literal[
-    "resolved", "rejected",
+    "resolved",
+    "rejected",
 ]
 
 # Immutable multidimensional verification attestation verdicts.
 ManuscriptVerificationVerdictLit = Literal["pass", "warn", "block", "error"]
 ManuscriptVerificationDimensionVerdictLit = Literal[
-    "pass", "warn", "block", "error", "not_checked",
+    "pass",
+    "warn",
+    "block",
+    "error",
+    "not_checked",
 ]

--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from rka.models.claim import ClaimScopeCondition
 from rka.models.reference_validation import (
     MAX_REFERENCE_AUTHORS,
     MAX_REFERENCE_DOI_CHARS,
@@ -78,6 +79,11 @@ from rka.mcp._enums import (  # noqa: E402  (intentional post-docstring batch im
 # deduplicates so this is no cost. The lock-tests audit per-model that each
 # Annotated[Literal[...]] uses the imported alias.
 from rka.mcp._enums import (  # noqa: E402, F811
+    ClaimFalsifierStatusLit,
+    ClaimScopeActorLit,
+    ClaimScopeExtensionPolicyLit,
+    ClaimScopeReviewStatusLit,
+    ClaimScopeUncertaintyLit,
     ClaimTypeLit,
     DecidedByLit,
     DecisionKindLit,
@@ -241,9 +247,7 @@ class QuerySearchArgs(ProjectScopedArgs):
         Optional[dict[str, Any]],
         Field(
             default=None,
-            description=(
-                "Optional filters (e.g. {'entity_types': ['decision', 'journal']})."
-            ),
+            description=("Optional filters (e.g. {'entity_types': ['decision', 'journal']})."),
         ),
     ] = None
 
@@ -304,8 +308,7 @@ class QueryMissionArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Mission ID (mis_...). Omit to auto-locate the current "
-                "active or pending mission."
+                "Mission ID (mis_...). Omit to auto-locate the current active or pending mission."
             ),
         ),
     ] = None
@@ -452,6 +455,13 @@ class QueryClaimsArgs(ProjectScopedArgs, PaginatedFiltersMixin):
     operation: Literal["claims"] = "claims"
 
 
+class QueryClaimScopeArgs(ProjectScopedArgs):
+    """[ANY] Fetch immutable scope history and readiness for one claim."""
+
+    operation: Literal["claim_scope"] = "claim_scope"
+    id: Annotated[str, Field(description="Canonical clm_ claim id.")]
+
+
 class QueryInterpretationCandidatesArgs(ProjectScopedArgs, PaginatedFiltersMixin):
     """[ANY] List staged interpretations or fetch one candidate detail.
 
@@ -486,9 +496,7 @@ class QueryReferenceValidationStatusArgs(ProjectScopedArgs):
     manuscript scope to observe progress and retrieve the eventual result.
     """
 
-    operation: Literal["reference_validation_status"] = (
-        "reference_validation_status"
-    )
+    operation: Literal["reference_validation_status"] = "reference_validation_status"
 
     manuscript_id: Annotated[
         str,
@@ -540,8 +548,7 @@ class ResolveEntitiesArgs(ProjectScopedArgs):
         for entity_id in self.ids:
             if not entity_id or entity_id != entity_id.strip():
                 raise ValueError(
-                    "resolve_entities ids must be non-empty and contain no "
-                    "surrounding whitespace"
+                    "resolve_entities ids must be non-empty and contain no surrounding whitespace"
                 )
         return self
 
@@ -560,9 +567,7 @@ class QueryManuscriptContextArgs(ProjectScopedArgs):
 class QueryManuscriptReferenceManifestArgs(ProjectScopedArgs):
     """[ANY] Read active citation membership and validation currency."""
 
-    operation: Literal["manuscript_reference_manifest"] = (
-        "manuscript_reference_manifest"
-    )
+    operation: Literal["manuscript_reference_manifest"] = "manuscript_reference_manifest"
 
     id: Annotated[
         str,
@@ -602,9 +607,7 @@ class QueryManuscriptSpineArgs(ProjectScopedArgs):
 class QueryManuscriptWritingCandidatesArgs(ProjectScopedArgs):
     """[ANY] Smooth claims through reviewed clusters and research questions."""
 
-    operation: Literal["manuscript_writing_candidates"] = (
-        "manuscript_writing_candidates"
-    )
+    operation: Literal["manuscript_writing_candidates"] = "manuscript_writing_candidates"
 
     id: Annotated[
         str,
@@ -742,8 +745,7 @@ class QueryMultiHopArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Optional filters (e.g. {'seeds': [...], 'max_depth': 3, "
-                "'max_nodes': 50})."
+                "Optional filters (e.g. {'seeds': [...], 'max_depth': 3, 'max_nodes': 50})."
             ),
         ),
     ] = None
@@ -768,10 +770,12 @@ class QueryCollectReportContextArgs(ProjectScopedArgs):
 
     query: Annotated[
         str,
-        Field(description=(
-            "The report description — the PI's prose paragraph describing "
-            "what the report should cover."
-        )),
+        Field(
+            description=(
+                "The report description — the PI's prose paragraph describing "
+                "what the report should cover."
+            )
+        ),
     ]
     filters: Annotated[
         Optional[dict[str, Any]],
@@ -904,8 +908,7 @@ class QueryEvidenceArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Optional filters (e.g. {'format': "
-                "'progress_report'|'briefing'|'audit'})."
+                "Optional filters (e.g. {'format': 'progress_report'|'briefing'|'audit'})."
             ),
         ),
     ] = None
@@ -988,14 +991,10 @@ class QueryChangelogArgs(ProjectScopedArgs):
     @model_validator(mode="after")
     def _require_since(self) -> "QueryChangelogArgs":
         if self.filters is None or "since" not in self.filters:
-            raise ValueError(
-                "changelog requires filters.since as an ISO8601 date string"
-            )
+            raise ValueError("changelog requires filters.since as an ISO8601 date string")
         since_val = self.filters["since"]
         if not isinstance(since_val, str) or not since_val.strip():
-            raise ValueError(
-                "changelog filters.since must be a non-empty ISO8601 string"
-            )
+            raise ValueError("changelog filters.since must be a non-empty ISO8601 string")
         return self
 
 
@@ -1039,14 +1038,10 @@ class QueryWorkspaceTreeArgs(ProjectScopedArgs):
     @model_validator(mode="after")
     def _require_folder_path(self) -> "QueryWorkspaceTreeArgs":
         if self.filters is None or "folder_path" not in self.filters:
-            raise ValueError(
-                "workspace_tree requires filters.folder_path as an absolute path"
-            )
+            raise ValueError("workspace_tree requires filters.folder_path as an absolute path")
         fp = self.filters["folder_path"]
         if not isinstance(fp, str) or not fp.strip():
-            raise ValueError(
-                "workspace_tree filters.folder_path must be a non-empty string"
-            )
+            raise ValueError("workspace_tree filters.folder_path must be a non-empty string")
         return self
 
 
@@ -1062,9 +1057,7 @@ class QueryWorkspaceScanArgs(ProjectScopedArgs):
     filters: Annotated[
         dict[str, Any],
         Field(
-            description=(
-                "Required filter dict; MUST contain 'folder_path' as a string."
-            ),
+            description=("Required filter dict; MUST contain 'folder_path' as a string."),
         ),
     ]
     ignore_patterns: Annotated[
@@ -1083,14 +1076,10 @@ class QueryWorkspaceScanArgs(ProjectScopedArgs):
     @model_validator(mode="after")
     def _require_folder_path(self) -> "QueryWorkspaceScanArgs":
         if self.filters is None or "folder_path" not in self.filters:
-            raise ValueError(
-                "workspace_scan requires filters.folder_path as an absolute path"
-            )
+            raise ValueError("workspace_scan requires filters.folder_path as an absolute path")
         fp = self.filters["folder_path"]
         if not isinstance(fp, str) or not fp.strip():
-            raise ValueError(
-                "workspace_scan filters.folder_path must be a non-empty string"
-            )
+            raise ValueError("workspace_scan filters.folder_path must be a non-empty string")
         return self
 
 
@@ -1140,6 +1129,7 @@ QueryArgsUnion = Annotated[
         QueryReviewQueueArgs,
         QueryClustersArgs,
         QueryClaimsArgs,
+        QueryClaimScopeArgs,
         QueryInterpretationCandidatesArgs,
         QueryManuscriptArgs,
         QueryReferenceValidationStatusArgs,
@@ -1521,8 +1511,7 @@ class RecordDecisionArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Decision lifecycle status; defaults to 'active' at the "
-                "REST layer when omitted."
+                "Decision lifecycle status; defaults to 'active' at the REST layer when omitted."
             ),
         ),
     ] = None
@@ -1568,8 +1557,7 @@ class RecordLiteratureArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Paper title (PRIMARY for title-mode). Either title OR doi "
-                "must be provided."
+                "Paper title (PRIMARY for title-mode). Either title OR doi must be provided."
             ),
         ),
     ] = None
@@ -1694,9 +1682,7 @@ class BatchImportArgs(ProjectScopedArgs):
         allowed_types = {"note", "literature", "decision"}
         for idx, entry in enumerate(self.entries):
             if not isinstance(entry, dict):
-                raise ValueError(
-                    f"batch_import: entries[{idx}] is not a dict."
-                )
+                raise ValueError(f"batch_import: entries[{idx}] is not a dict.")
             entity_type = entry.get("entity_type")
             if entity_type not in allowed_types:
                 raise ValueError(
@@ -1706,8 +1692,7 @@ class BatchImportArgs(ProjectScopedArgs):
             data = entry.get("data")
             if not isinstance(data, dict):
                 raise ValueError(
-                    f"batch_import: entries[{idx}].data must be a dict "
-                    f"(got {type(data).__name__})."
+                    f"batch_import: entries[{idx}].data must be a dict (got {type(data).__name__})."
                 )
         return self
 
@@ -1786,19 +1771,14 @@ class _ManuscriptSpineClaimArgs(BaseModel):
     exact_wording: Annotated[str, Field(min_length=1)]
     allowed_wording: Annotated[str, Field(min_length=1)]
     prohibited_wording: Annotated[list[str], Field(min_length=1)]
-    evidence: _ManuscriptSpineEvidenceArgs = Field(
-        default_factory=_ManuscriptSpineEvidenceArgs
-    )
+    evidence: _ManuscriptSpineEvidenceArgs = Field(default_factory=_ManuscriptSpineEvidenceArgs)
     unit_links: list[_ManuscriptSpineUnitLinkArgs] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _validate_wording_and_links(self) -> "_ManuscriptSpineClaimArgs":
         if any(not value.strip() for value in self.prohibited_wording):
             raise ValueError("prohibited_wording entries must be non-empty")
-        linked = [
-            (item.unit_key, item.relationship)
-            for item in self.unit_links
-        ]
+        linked = [(item.unit_key, item.relationship) for item in self.unit_links]
         if len(linked) != len(set(linked)):
             raise ValueError("duplicate claim-to-unit relationship")
         return self
@@ -1818,9 +1798,7 @@ class _ManuscriptSpineUnitArgs(BaseModel):
     prohibited_interpretation: Optional[str] = None
     sequence: Annotated[int, Field(ge=0)] = 0
     status: ManuscriptUnitStatusLit = "planned"
-    evidence: _ManuscriptSpineEvidenceArgs = Field(
-        default_factory=_ManuscriptSpineEvidenceArgs
-    )
+    evidence: _ManuscriptSpineEvidenceArgs = Field(default_factory=_ManuscriptSpineEvidenceArgs)
 
     @model_validator(mode="after")
     def _require_result_boundaries(self) -> "_ManuscriptSpineUnitArgs":
@@ -1857,17 +1835,16 @@ class _ManuscriptArgumentSpineArgs(BaseModel):
             if len(keys) != len(set(keys)):
                 raise ValueError(f"duplicate {label} local_key")
         unit_keys = {unit.local_key for unit in self.units}
-        missing = sorted({
-            link.unit_key
-            for claim in self.claims
-            for link in claim.unit_links
-            if link.unit_key not in unit_keys
-        })
+        missing = sorted(
+            {
+                link.unit_key
+                for claim in self.claims
+                for link in claim.unit_links
+                if link.unit_key not in unit_keys
+            }
+        )
         if missing:
-            raise ValueError(
-                "claim unit_links reference unknown unit keys: "
-                + ", ".join(missing)
-            )
+            raise ValueError("claim unit_links reference unknown unit keys: " + ", ".join(missing))
         return self
 
 
@@ -1945,9 +1922,7 @@ class ReplaceManuscriptReferenceManifestArgs(ProjectScopedArgs):
         list[ManuscriptReferenceMemberInput],
         Field(
             max_length=2_000,
-            description=(
-                "Complete active citation set; omission retires a prior member."
-            ),
+            description=("Complete active citation set; omission retires a prior member."),
         ),
     ]
 
@@ -1999,9 +1974,7 @@ class RatifyManuscriptClaimArgs(ProjectScopedArgs):
 class TransitionManuscriptPhaseArgs(ProjectScopedArgs):
     """[ANY] Run readiness gates and transition the manuscript lifecycle."""
 
-    operation: Literal["transition_manuscript_phase"] = (
-        "transition_manuscript_phase"
-    )
+    operation: Literal["transition_manuscript_phase"] = "transition_manuscript_phase"
 
     id: Annotated[
         str,
@@ -2015,9 +1988,7 @@ class TransitionManuscriptPhaseArgs(ProjectScopedArgs):
 class CreateManuscriptCheckpointArgs(ProjectScopedArgs):
     """[PI] Create a pending native manuscript checkpoint."""
 
-    operation: Literal["create_manuscript_checkpoint"] = (
-        "create_manuscript_checkpoint"
-    )
+    operation: Literal["create_manuscript_checkpoint"] = "create_manuscript_checkpoint"
 
     id: Annotated[
         str,
@@ -2040,9 +2011,7 @@ class CreateManuscriptCheckpointArgs(ProjectScopedArgs):
 class ResolveManuscriptCheckpointArgs(ProjectScopedArgs):
     """[PI] Resolve a pending manuscript checkpoint through a PI decision."""
 
-    operation: Literal["resolve_manuscript_checkpoint"] = (
-        "resolve_manuscript_checkpoint"
-    )
+    operation: Literal["resolve_manuscript_checkpoint"] = "resolve_manuscript_checkpoint"
 
     checkpoint_id: Annotated[str, Field(min_length=1)]
     expected_revision: Annotated[int, Field(ge=1)]
@@ -2054,9 +2023,7 @@ class ResolveManuscriptCheckpointArgs(ProjectScopedArgs):
 class RecordVerificationAttestationArgs(ProjectScopedArgs):
     """[ANY] Append one immutable multidimensional claim verification."""
 
-    operation: Literal["record_verification_attestation"] = (
-        "record_verification_attestation"
-    )
+    operation: Literal["record_verification_attestation"] = "record_verification_attestation"
 
     id: Annotated[
         str,
@@ -2227,14 +2194,16 @@ class _ExtractClaimItem(BaseModel):
         ClaimTypeLit,
         Field(
             description=(
-                "Type of claim: hypothesis | evidence | method | "
-                "result | observation | assumption."
+                "Type of claim: hypothesis | evidence | method | result | observation | assumption."
             ),
         ),
     ]
     epistemic_kind: Annotated[
         Optional[EpistemicKindLit],
-        Field(default=None, description="Explicit interpretation kind; inferred from claim_type when omitted."),
+        Field(
+            default=None,
+            description="Explicit interpretation kind; inferred from claim_type when omitted.",
+        ),
     ] = None
     source_offset_start: Annotated[Optional[int], Field(default=None, ge=0)] = None
     source_offset_end: Annotated[Optional[int], Field(default=None, ge=0)] = None
@@ -2273,23 +2242,21 @@ class ExtractClaimsArgs(ProjectScopedArgs):
 class CreateInterpretationCandidateArgs(ProjectScopedArgs):
     """[BRAIN/EXECUTOR/PI] Stage one atomic source interpretation."""
 
-    operation: Literal["create_interpretation_candidate"] = (
-        "create_interpretation_candidate"
-    )
+    operation: Literal["create_interpretation_candidate"] = "create_interpretation_candidate"
     source_type: Annotated[InterpretationSourceLit, Field(description="Source entity type.")]
     source_id: Annotated[str, Field(min_length=1, max_length=128)]
     locator_kind: Annotated[InterpretationLocatorLit, Field(description="Exact locator shape.")]
     statement: Annotated[str, Field(min_length=1, max_length=20_000)]
-    epistemic_kind: Annotated[EpistemicKindLit, Field(description="Meaning of this staged statement.")]
+    epistemic_kind: Annotated[
+        EpistemicKindLit, Field(description="Meaning of this staged statement.")
+    ]
     created_by: Annotated[InterpretationActorLit, Field(description="Candidate author/extractor.")]
     extraction_tool: Annotated[str, Field(min_length=1, max_length=256)]
     locator_start: Annotated[Optional[int], Field(default=None, ge=0)] = None
     locator_end: Annotated[Optional[int], Field(default=None, ge=0)] = None
     locator_value: Annotated[Optional[str], Field(default=None, max_length=2048)] = None
     scope_conditions: Annotated[Optional[list[str]], Field(default=None, max_length=100)] = None
-    uncertainty: Annotated[
-        InterpretationUncertaintyLit, Field(default="unknown")
-    ] = "unknown"
+    uncertainty: Annotated[InterpretationUncertaintyLit, Field(default="unknown")] = "unknown"
     uncertainty_note: Annotated[Optional[str], Field(default=None, max_length=4000)] = None
     falsifier: Annotated[Optional[str], Field(default=None, max_length=10_000)] = None
     proposed_claim_type: Annotated[Optional[ClaimTypeLit], Field(default=None)] = None
@@ -2323,9 +2290,7 @@ class AddInterpretationHintArgs(ProjectScopedArgs):
 class TriageInterpretationCandidateArgs(ProjectScopedArgs):
     """[BRAIN/PI] Review, promote, reopen, or revoke one candidate."""
 
-    operation: Literal["triage_interpretation_candidate"] = (
-        "triage_interpretation_candidate"
-    )
+    operation: Literal["triage_interpretation_candidate"] = "triage_interpretation_candidate"
     id: Annotated[str, Field(description="Interpretation candidate id.")]
     action: Annotated[InterpretationTriageActionLit, Field(description="Review action.")]
     expected_revision: Annotated[int, Field(ge=1)]
@@ -2344,6 +2309,70 @@ class TriageInterpretationCandidateArgs(ProjectScopedArgs):
             raise ValueError("merge requires target_candidate_id")
         if self.action == "promote" and not self.grounding_verified:
             raise ValueError("promote requires grounding_verified=true")
+        return self
+
+
+class SetClaimScopeArgs(ProjectScopedArgs):
+    """[BRAIN/PI] Append a revision-guarded canonical claim-scope contract."""
+
+    operation: Literal["set_claim_scope"] = "set_claim_scope"
+    claim_id: Annotated[str, Field(min_length=1, description="Canonical clm_ id.")]
+    expected_revision: Annotated[int, Field(ge=0)]
+    actor: Annotated[ClaimScopeActorLit, Field(description="Scope contract author.")]
+    reason: Annotated[str, Field(min_length=1, max_length=10_000)]
+    conditions: Annotated[
+        list[ClaimScopeCondition],
+        Field(default_factory=list, max_length=100),
+    ]
+    uncertainty: Annotated[
+        ClaimScopeUncertaintyLit,
+        Field(default="unknown"),
+    ] = "unknown"
+    uncertainty_note: Annotated[
+        Optional[str],
+        Field(default=None, max_length=4000),
+    ] = None
+    extension_policy: Annotated[
+        Optional[ClaimScopeExtensionPolicyLit],
+        Field(default=None),
+    ] = None
+    allowed_extensions: Annotated[
+        list[str],
+        Field(default_factory=list, max_length=100),
+    ]
+    prohibited_extensions: Annotated[
+        list[str],
+        Field(default_factory=list, max_length=100),
+    ]
+    falsifier_status: Annotated[
+        ClaimFalsifierStatusLit,
+        Field(default="unknown"),
+    ] = "unknown"
+    falsifier: Annotated[
+        Optional[str],
+        Field(default=None, max_length=10_000),
+    ] = None
+    falsifier_rationale: Annotated[
+        Optional[str],
+        Field(default=None, max_length=4000),
+    ] = None
+    disconfirming_claim_ids: Annotated[
+        list[str],
+        Field(default_factory=list, max_length=200),
+    ]
+    review_status: Annotated[
+        ClaimScopeReviewStatusLit,
+        Field(default="draft"),
+    ] = "draft"
+
+    @model_validator(mode="after")
+    def _validate_scope_contract(self) -> "SetClaimScopeArgs":
+        # Keep MCP and REST cross-field semantics identical.
+        from rka.models.claim import ClaimScopeWrite
+
+        ClaimScopeWrite.model_validate(
+            self.model_dump(exclude={"operation", "project_id", "claim_id"})
+        )
         return self
 
 
@@ -2499,6 +2528,7 @@ BatchBExecuteUnion = Annotated[
         CreateInterpretationCandidateArgs,
         AddInterpretationHintArgs,
         TriageInterpretationCandidateArgs,
+        SetClaimScopeArgs,
     ],
     Field(discriminator="operation"),
 ]
@@ -2650,9 +2680,7 @@ class ReviewClaimsArgs(ProjectScopedArgs):
         list[str],
         Field(
             min_length=1,
-            description=(
-                "Claim IDs to review (``clm_...``). Must be non-empty."
-            ),
+            description=("Claim IDs to review (``clm_...``). Must be non-empty."),
         ),
     ]
 
@@ -2676,8 +2704,7 @@ class ReviewClaimsArgs(ProjectScopedArgs):
             ge=0.0,
             le=1.0,
             description=(
-                "Override the claim's numeric confidence (0.0-1.0). "
-                "Used with action='adjust'."
+                "Override the claim's numeric confidence (0.0-1.0). Used with action='adjust'."
             ),
         ),
     ] = None
@@ -2700,9 +2727,7 @@ class ReviewClaimsArgs(ProjectScopedArgs):
             and self.confidence_override is None
             and self.evidence_status is None
         ):
-            raise ValueError(
-                "action='adjust' requires confidence_override or evidence_status"
-            )
+            raise ValueError("action='adjust' requires confidence_override or evidence_status")
         return self
 
 
@@ -2756,8 +2781,7 @@ class ReviewClusterArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Contradiction descriptions to surface for "
-                "``resolve_contradiction`` follow-up."
+                "Contradiction descriptions to surface for ``resolve_contradiction`` follow-up."
             ),
         ),
     ] = None
@@ -2898,10 +2922,7 @@ class BrainNotificationsClearArgs(ProjectScopedArgs):
         list[str],
         Field(
             min_length=1,
-            description=(
-                "Notification IDs to clear (``bn_...``). Must be "
-                "non-empty."
-            ),
+            description=("Notification IDs to clear (``bn_...``). Must be non-empty."),
         ),
     ]
 
@@ -2953,8 +2974,7 @@ class BootstrapWorkspaceArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Tags to apply to every generated entry (overrides the "
-                "default tagging policy)."
+                "Tags to apply to every generated entry (overrides the default tagging policy)."
             ),
         ),
     ] = None
@@ -2962,10 +2982,7 @@ class BootstrapWorkspaceArgs(ProjectScopedArgs):
         Optional[list[str]],
         Field(
             default=None,
-            description=(
-                "List of file paths or glob patterns to skip during the "
-                "walk."
-            ),
+            description=("List of file paths or glob patterns to skip during the walk."),
         ),
     ] = None
     use_llm: Annotated[
@@ -2984,8 +3001,7 @@ class BootstrapWorkspaceArgs(ProjectScopedArgs):
         Field(
             default=False,
             description=(
-                "When True, simulate the bootstrap and emit a preview "
-                "without writing any rows."
+                "When True, simulate the bootstrap and emit a preview without writing any rows."
             ),
         ),
     ] = False
@@ -3075,8 +3091,7 @@ class FlagStaleArgs(ProjectScopedArgs):
         str,
         Field(
             description=(
-                "Free-form reason for the staleness flag (e.g., "
-                "'Superseded by new benchmark')."
+                "Free-form reason for the staleness flag (e.g., 'Superseded by new benchmark')."
             ),
         ),
     ]
@@ -3317,7 +3332,10 @@ class UpdateDecisionArgs(ProjectScopedArgs):
 
     status: Annotated[
         Optional[DecisionStatusLit],
-        Field(default=None, description="New decision lifecycle status (active|abandoned|superseded|merged|revisit)."),
+        Field(
+            default=None,
+            description="New decision lifecycle status (active|abandoned|superseded|merged|revisit).",
+        ),
     ] = None
     chosen: Annotated[
         Optional[str],
@@ -3381,9 +3399,7 @@ class UpdateDecisionArgs(ProjectScopedArgs):
             self.abandonment_reason,
         )
         if all(f is None for f in mutable_fields):
-            raise ValueError(
-                "update_decision: at least one mutable field must be non-None."
-            )
+            raise ValueError("update_decision: at least one mutable field must be non-None.")
         return self
 
 
@@ -3494,9 +3510,7 @@ class UpdateLiteratureArgs(ProjectScopedArgs):
             self.tags,
         )
         if all(f is None for f in mutable_fields):
-            raise ValueError(
-                "update_literature: at least one mutable field must be non-None."
-            )
+            raise ValueError("update_literature: at least one mutable field must be non-None.")
         return self
 
 
@@ -3566,9 +3580,7 @@ class UpdateMissionArgs(ProjectScopedArgs):
             self.tags,
         )
         if all(f is None for f in mutable_fields):
-            raise ValueError(
-                "update_mission: at least one mutable field must be non-None."
-            )
+            raise ValueError("update_mission: at least one mutable field must be non-None.")
         return self
 
 
@@ -3620,7 +3632,9 @@ class UpdateMissionStatusArgs(ProjectScopedArgs):
     ]
     status: Annotated[
         MissionStatusLit,
-        Field(description="New lifecycle state (pending|active|complete|partial|blocked|cancelled)."),
+        Field(
+            description="New lifecycle state (pending|active|complete|partial|blocked|cancelled)."
+        ),
     ]
 
     tasks: Annotated[
@@ -3652,13 +3666,9 @@ class BulkUpdateArgs(ProjectScopedArgs):
     def _enforce_id_on_every_item(self) -> "BulkUpdateArgs":
         for idx, item in enumerate(self.updates):
             if not isinstance(item, dict):
-                raise ValueError(
-                    f"bulk_update: updates[{idx}] is not a dict."
-                )
+                raise ValueError(f"bulk_update: updates[{idx}] is not a dict.")
             if "id" not in item or not item["id"]:
-                raise ValueError(
-                    f"bulk_update: updates[{idx}] missing required 'id' key."
-                )
+                raise ValueError(f"bulk_update: updates[{idx}] missing required 'id' key.")
         return self
 
 
@@ -3775,9 +3785,7 @@ class PresentDecisionArgs(ProjectScopedArgs):
         # record_pi_selection.selected_option_id must be dereferenceable.
         for idx, opt in enumerate(self.options):
             if not isinstance(opt, dict):
-                raise ValueError(
-                    f"present_decision: options[{idx}] is not a dict."
-                )
+                raise ValueError(f"present_decision: options[{idx}] is not a dict.")
             if "id" not in opt or not opt["id"]:
                 raise ValueError(
                     f"present_decision: options[{idx}] missing required "
@@ -3933,9 +3941,7 @@ class ProcessPaperArgs(ProjectScopedArgs):
     def _enforce_text_on_every_annotation(self) -> "ProcessPaperArgs":
         for idx, ann in enumerate(self.annotations):
             if not isinstance(ann, dict):
-                raise ValueError(
-                    f"process_paper: annotations[{idx}] is not a dict."
-                )
+                raise ValueError(f"process_paper: annotations[{idx}] is not a dict.")
             if "text" not in ann or not ann["text"]:
                 raise ValueError(
                     f"process_paper: annotations[{idx}] missing required "
@@ -3961,9 +3967,8 @@ class ValidateReferenceArgs(ProjectScopedArgs):
             min_length=1,
             max_length=128,
             description=(
-                "Canonical man_ id or compatibility jrn_ alias whose "
-                "reference is being validated."
-            )
+                "Canonical man_ id or compatibility jrn_ alias whose reference is being validated."
+            ),
         ),
     ]
 
@@ -3991,8 +3996,7 @@ class ValidateReferenceArgs(ProjectScopedArgs):
             default=None,
             max_length=MAX_REFERENCE_AUTHORS,
             description=(
-                "Optional CSL-JSON author list. Supplying authors enables "
-                "Stage E disambiguation."
+                "Optional CSL-JSON author list. Supplying authors enables Stage E disambiguation."
             ),
         ),
     ] = None
@@ -4049,8 +4053,7 @@ class SubmitReportArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Report narrative body (CANONICAL). One of summary or "
-                "content is required."
+                "Report narrative body (CANONICAL). One of summary or content is required."
             ),
         ),
     ] = None
@@ -4059,8 +4062,7 @@ class SubmitReportArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Phase-X²' alias for `summary`. If both are supplied, "
-                "`summary` wins (canonical)."
+                "Phase-X²' alias for `summary`. If both are supplied, `summary` wins (canonical)."
             ),
         ),
     ] = None
@@ -4159,8 +4161,7 @@ class SubmitCheckpointArgs(ProjectScopedArgs):
         Field(
             default=None,
             description=(
-                "Checkpoint description (CANONICAL). One of description "
-                "or content is required."
+                "Checkpoint description (CANONICAL). One of description or content is required."
             ),
         ),
     ] = None
@@ -4400,6 +4401,7 @@ ExecuteArgsUnion = Annotated[
         CreateInterpretationCandidateArgs,
         AddInterpretationHintArgs,
         TriageInterpretationCandidateArgs,
+        SetClaimScopeArgs,
         # ===== Batch C — UPDATE/LIFECYCLE/SUBMIT (22) =====
         UpdateNoteArgs,
         UpdateDecisionArgs,
@@ -4467,6 +4469,7 @@ __all__ = [
     "QueryReviewQueueArgs",
     "QueryClustersArgs",
     "QueryClaimsArgs",
+    "QueryClaimScopeArgs",
     "QueryInterpretationCandidatesArgs",
     "QueryManuscriptArgs",
     "QueryReferenceValidationStatusArgs",
@@ -4529,6 +4532,7 @@ __all__ = [
     "CreateInterpretationCandidateArgs",
     "AddInterpretationHintArgs",
     "TriageInterpretationCandidateArgs",
+    "SetClaimScopeArgs",
     # Batch B partial union
     "BatchBExecuteUnion",
     # Batch D — Review / Maintenance / Hooks / Workspace write models

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -30,7 +30,7 @@ Design choices (decision #3 in the project locked-decisions list):
   hints, and the Phase-X²' canonical-field-name lessons (e.g. the
   `description=` vs `content=` checkpoint pitfall from the 2026-06-01
   hyperscaler-auditing PA-2 bug).
-- Single dict, one entry per operation. Total 113 entries.
+- Single dict, one entry per operation. Total 115 entries.
 - Enum value-sets reference rka.mcp._enums for drift-detection — the
   enums dict here cites the values directly (mirror of _enums.py) so
   consumers don't need to import _enums. The lock-test in
@@ -56,44 +56,123 @@ from typing import Any
 
 _ENUMS = {
     "confidence": [
-        "hypothesis", "tested", "verified", "superseded", "retracted",
+        "hypothesis",
+        "tested",
+        "verified",
+        "superseded",
+        "retracted",
     ],
     "importance": [
-        "critical", "high", "normal", "low", "archived",
+        "critical",
+        "high",
+        "normal",
+        "low",
+        "archived",
     ],
     "source": ["brain", "executor", "pi", "web_ui", "llm"],
     "note_type": [
-        "note", "log", "directive",
-        "finding", "insight", "pi_instruction", "exploration",
-        "idea", "observation", "hypothesis", "methodology", "summary",
+        "note",
+        "log",
+        "directive",
+        "finding",
+        "insight",
+        "pi_instruction",
+        "exploration",
+        "idea",
+        "observation",
+        "hypothesis",
+        "methodology",
+        "summary",
     ],
     "decided_by": ["pi", "brain", "executor"],
     "decision_kind": [
-        "research_question", "design_choice", "decision", "operational",
+        "research_question",
+        "design_choice",
+        "decision",
+        "operational",
     ],
     "lit_status": ["to_read", "reading", "read", "cited", "excluded"],
     "lit_added_by": ["brain", "executor", "pi", "import", "web_ui"],
     "mission_status": [
-        "pending", "active", "complete", "partial", "blocked", "cancelled",
+        "pending",
+        "active",
+        "complete",
+        "partial",
+        "blocked",
+        "cancelled",
     ],
     "checkpoint_type": [
-        "decision", "clarification", "inspection", "gate",
+        "decision",
+        "clarification",
+        "inspection",
+        "gate",
     ],
     "gate_type": [
-        "problem_framing", "plan_validation", "evidence_review",
+        "problem_framing",
+        "plan_validation",
+        "evidence_review",
         "synthesis_validation",
     ],
     "verdict": ["go", "kill", "hold", "recycle"],
     "claim_type": [
-        "hypothesis", "evidence", "method", "result", "observation",
+        "hypothesis",
+        "evidence",
+        "method",
+        "result",
+        "observation",
         "assumption",
+    ],
+    "claim_scope_uncertainty": ["none", "low", "medium", "high", "unknown"],
+    "claim_scope_extension_policy": ["exact_only", "bounded"],
+    "claim_falsifier_status": ["unknown", "applicable", "not_applicable"],
+    "claim_scope_review_status": ["draft", "reviewed"],
+    "claim_scope_readiness": [
+        "missing",
+        "stale",
+        "incomplete",
+        "needs_review",
+        "ready",
+    ],
+    "claim_scope_actor": ["pi", "brain", "executor", "web_ui", "llm"],
+    "claim_condition_kind": [
+        "dataset",
+        "population",
+        "platform",
+        "environment",
+        "threat_model",
+        "baseline",
+        "workload",
+        "metric",
+        "parameter",
+        "assumption",
+        "time_window",
+        "other",
+    ],
+    "claim_condition_operator": [
+        "equals",
+        "one_of",
+        "range",
+        "at_least",
+        "at_most",
+        "present",
+        "absent",
+        "described_by",
     ],
     "interpretation_source": ["journal", "literature", "artifact"],
     "interpretation_locator": [
-        "text_offset", "page", "line_range", "section", "url_fragment", "record",
+        "text_offset",
+        "page",
+        "line_range",
+        "section",
+        "url_fragment",
+        "record",
     ],
     "epistemic_kind": [
-        "observation", "reported_fact", "inference", "hypothesis", "plan",
+        "observation",
+        "reported_fact",
+        "inference",
+        "hypothesis",
+        "plan",
         "author_intent",
     ],
     "interpretation_uncertainty": ["none", "low", "medium", "high", "unknown"],
@@ -101,24 +180,49 @@ _ENUMS = {
     "interpretation_review_actor": ["pi", "brain", "executor", "web_ui"],
     "interpretation_review_status": ["pending", "in_review", "resolved"],
     "interpretation_disposition": [
-        "promoted", "merged", "deferred", "rejected", "classified_decision",
-        "classified_plan", "classified_author_intent", "evidence_mission_requested",
+        "promoted",
+        "merged",
+        "deferred",
+        "rejected",
+        "classified_decision",
+        "classified_plan",
+        "classified_author_intent",
+        "evidence_mission_requested",
     ],
     "interpretation_hint_kind": ["duplicate", "conflict"],
     "interpretation_triage_action": [
-        "start_review", "promote", "merge", "defer", "reject",
-        "classify_decision", "classify_plan", "classify_author_intent",
-        "request_evidence_mission", "reopen", "revoke_promotion",
+        "start_review",
+        "promote",
+        "merge",
+        "defer",
+        "reject",
+        "classify_decision",
+        "classify_plan",
+        "classify_author_intent",
+        "request_evidence_mission",
+        "reopen",
+        "revoke_promotion",
     ],
     "evidence_status": [
-        "unassessed", "supported", "partially_supported", "inconclusive",
+        "unassessed",
+        "supported",
+        "partially_supported",
+        "inconclusive",
         "contradicted",
     ],
     "cluster_confidence": [
-        "strong", "moderate", "emerging", "contested", "refuted",
+        "strong",
+        "moderate",
+        "emerging",
+        "contested",
+        "refuted",
     ],
     "rq_status": [
-        "open", "partially_answered", "answered", "reframed", "closed",
+        "open",
+        "partially_answered",
+        "answered",
+        "reframed",
+        "closed",
     ],
     "outcome": ["succeeded", "failed", "mixed", "unresolved"],
     "staleness": ["yellow", "red"],
@@ -126,40 +230,80 @@ _ENUMS = {
     "resolved_by": ["pi", "brain", "executor"],
     "review_action": ["approve", "reject", "adjust"],
     "manuscript_phase": [
-        "planning", "drafting", "review", "final", "submitted",
+        "planning",
+        "drafting",
+        "review",
+        "final",
+        "submitted",
     ],
     "manuscript_state": [
-        "active", "on_hold", "submitted", "accepted", "rejected",
-        "withdrawn", "archived",
+        "active",
+        "on_hold",
+        "submitted",
+        "accepted",
+        "rejected",
+        "withdrawn",
+        "archived",
     ],
     "manuscript_claim_kind": [
-        "empirical", "methodological", "theoretical", "survey", "position",
+        "empirical",
+        "methodological",
+        "theoretical",
+        "survey",
+        "position",
     ],
     "manuscript_claim_state": ["candidate", "active", "retired"],
     "manuscript_unit_kind": [
-        "abstract", "introduction", "related_work", "background", "method",
-        "result", "discussion", "limitation", "conclusion", "caption",
-        "appendix", "other",
+        "abstract",
+        "introduction",
+        "related_work",
+        "background",
+        "method",
+        "result",
+        "discussion",
+        "limitation",
+        "conclusion",
+        "caption",
+        "appendix",
+        "other",
     ],
     "manuscript_unit_status": [
-        "planned", "drafted", "reviewed", "final", "removed",
+        "planned",
+        "drafted",
+        "reviewed",
+        "final",
+        "removed",
     ],
     "manuscript_evidence_role": [
-        "support", "qualifier", "counterevidence",
+        "support",
+        "qualifier",
+        "counterevidence",
     ],
     "manuscript_claim_unit_relationship": [
-        "advances", "tests", "bounds", "mentions",
+        "advances",
+        "tests",
+        "bounds",
+        "mentions",
     ],
     "manuscript_checkpoint_kind": [
-        "venue", "outline", "table_figure_plan", "reference_set",
-        "draft_section", "final_layout",
+        "venue",
+        "outline",
+        "table_figure_plan",
+        "reference_set",
+        "draft_section",
+        "final_layout",
     ],
     "manuscript_checkpoint_resolution_status": [
-        "resolved", "rejected",
+        "resolved",
+        "rejected",
     ],
     "manuscript_verification_verdict": ["pass", "warn", "block", "error"],
     "manuscript_verification_dimension_verdict": [
-        "pass", "warn", "block", "error", "not_checked",
+        "pass",
+        "warn",
+        "block",
+        "error",
+        "not_checked",
     ],
 }
 
@@ -178,11 +322,9 @@ def _e(*names: str) -> dict[str, list[str]]:
 # rka_query/rka_execute Literal enums is detected by the lock-tests.
 
 OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
-
     # =====================================================================
     # rka_query — read operations
     # =====================================================================
-
     "status": {
         "operation": "status",
         "tool": "rka_query",
@@ -202,7 +344,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["context", "pending_maintenance", "checkpoints"],
         "notes": None,
     },
-
     "context": {
         "operation": "context",
         "tool": "rka_query",
@@ -234,7 +375,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status", "summarize", "search"],
         "notes": None,
     },
-
     "search": {
         "operation": "search",
         "tool": "rka_query",
@@ -249,8 +389,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "optional_fields": ["limit", "filters"],
         "enums": {
             "entity_types": [
-                "journal", "decision", "literature", "mission",
-                "claim", "cluster", "checkpoint",
+                "journal",
+                "decision",
+                "literature",
+                "mission",
+                "claim",
+                "cluster",
+                "checkpoint",
             ],
         },
         "examples": [
@@ -267,7 +412,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["multi_hop", "context", "entity"],
         "notes": "Pass 2-4 keyword terms; longer queries reduce recall.",
     },
-
     "entity": {
         "operation": "entity",
         "tool": "rka_query",
@@ -291,7 +435,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["provenance", "search"],
         "notes": "Entity prefix is auto-routed (jrn_, dec_, lit_, mis_, clm_, ecl_, chk_).",
     },
-
     "journal": {
         "operation": "journal",
         "tool": "rka_query",
@@ -326,7 +469,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["entity", "search", "record_note"],
         "notes": None,
     },
-
     "literature": {
         "operation": "literature",
         "tool": "rka_query",
@@ -353,7 +495,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["entity", "record_literature"],
         "notes": None,
     },
-
     "mission": {
         "operation": "mission",
         "tool": "rka_query",
@@ -381,7 +522,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["report", "create_mission", "update_mission"],
         "notes": "Omit `id` to auto-locate the most recent active or pending mission.",
     },
-
     "report": {
         "operation": "report",
         "tool": "rka_query",
@@ -405,7 +545,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["mission", "submit_report"],
         "notes": "`id` is the mission_id, not a report_id.",
     },
-
     "checkpoints": {
         "operation": "checkpoints",
         "tool": "rka_query",
@@ -430,11 +569,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "submit_checkpoint", "resolve_checkpoint", "entity",
+            "submit_checkpoint",
+            "resolve_checkpoint",
+            "entity",
         ],
         "notes": None,
     },
-
     "decision_tree": {
         "operation": "decision_tree",
         "tool": "rka_query",
@@ -461,7 +601,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["entity", "graph", "research_map"],
         "notes": None,
     },
-
     "calibration_metrics": {
         "operation": "calibration_metrics",
         "tool": "rka_query",
@@ -484,7 +623,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_outcome"],
         "notes": None,
     },
-
     "hooks": {
         "operation": "hooks",
         "tool": "rka_query",
@@ -492,8 +630,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "ANY",
         "summary": "List configured hooks.",
         "signature": (
-            "rka_query(operation='hooks', *, project_id, "
-            "filters={'event', 'enabled_only'})"
+            "rka_query(operation='hooks', *, project_id, filters={'event', 'enabled_only'})"
         ),
         "required_fields": ["project_id"],
         "optional_fields": ["filters"],
@@ -505,11 +642,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "hook_executions", "hook_add", "hook_enable", "hook_disable",
+            "hook_executions",
+            "hook_add",
+            "hook_enable",
+            "hook_disable",
         ],
         "notes": None,
     },
-
     "hook_executions": {
         "operation": "hook_executions",
         "tool": "rka_query",
@@ -535,7 +674,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["hooks"],
         "notes": None,
     },
-
     "brain_notifications": {
         "operation": "brain_notifications",
         "tool": "rka_query",
@@ -561,7 +699,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["brain_notifications_clear"],
         "notes": None,
     },
-
     "research_map": {
         "operation": "research_map",
         "tool": "rka_query",
@@ -584,7 +721,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["clusters", "claims", "decision_tree"],
         "notes": None,
     },
-
     "review_queue": {
         "operation": "review_queue",
         "tool": "rka_query",
@@ -611,7 +747,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["review_claims", "review_cluster"],
         "notes": None,
     },
-
     "clusters": {
         "operation": "clusters",
         "tool": "rka_query",
@@ -636,12 +771,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "claims", "create_cluster", "review_cluster",
+            "claims",
+            "create_cluster",
+            "review_cluster",
             "assign_claims_to_cluster",
         ],
         "notes": None,
     },
-
     "claims": {
         "operation": "claims",
         "tool": "rka_query",
@@ -667,14 +803,38 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "clusters", "extract_claims", "review_claims",
+            "clusters",
+            "extract_claims",
+            "review_claims",
         ],
         "notes": (
             "verified filters source-grounding fidelity. evidence_status "
             "filters the independent scientific evidence assessment."
         ),
     },
-
+    "claim_scope": {
+        "operation": "claim_scope",
+        "tool": "rka_query",
+        "category": "claims",
+        "role_tag": "ANY",
+        "summary": "Fetch immutable scope history and readiness for one claim.",
+        "signature": "rka_query(operation='claim_scope', *, project_id, id)",
+        "required_fields": ["project_id", "id"],
+        "optional_fields": [],
+        "enums": _e("claim_scope_readiness"),
+        "examples": [
+            {
+                "description": "Inspect the current scope and prior revisions.",
+                "call": {
+                    "operation": "claim_scope",
+                    "project_id": "prj_01ABC...",
+                    "id": "clm_01XYZ...",
+                },
+            },
+        ],
+        "related_operations": ["claims", "set_claim_scope"],
+        "notes": "Legacy claims return readiness=missing; no scope is invented.",
+    },
     "interpretation_candidates": {
         "operation": "interpretation_candidates",
         "tool": "rka_query",
@@ -720,7 +880,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ],
         "notes": "Candidates are not canonical claims or scientific support.",
     },
-
     "manuscript": {
         "operation": "manuscript",
         "tool": "rka_query",
@@ -742,26 +901,22 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "register_manuscript", "create_manuscript", "manuscript_context",
+            "register_manuscript",
+            "create_manuscript",
+            "manuscript_context",
         ],
         "notes": (
             "Accepts canonical man_ IDs and compatibility jrn_ aliases. "
             "Legacy-ID responses include canonical_id and deprecation metadata."
         ),
     },
-
     "manuscript_reference_manifest": {
         "operation": "manuscript_reference_manifest",
         "tool": "rka_query",
         "category": "manuscript",
         "role_tag": "ANY",
-        "summary": (
-            "Read the authoritative citation-key membership and validation state."
-        ),
-        "signature": (
-            "rka_query(operation='manuscript_reference_manifest', *, "
-            "project_id, id)"
-        ),
+        "summary": ("Read the authoritative citation-key membership and validation state."),
+        "signature": ("rka_query(operation='manuscript_reference_manifest', *, project_id, id)"),
         "required_fields": ["project_id", "id"],
         "optional_fields": [],
         "enums": {},
@@ -787,7 +942,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "cannot authorize a citation."
         ),
     },
-
     "reference_validation_status": {
         "operation": "reference_validation_status",
         "tool": "rka_query",
@@ -819,7 +973,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "cross-scope jobs return 404."
         ),
     },
-
     "resolve_entities": {
         "operation": "resolve_entities",
         "tool": "rka_query",
@@ -850,17 +1003,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "records are reported opaquely and never returned as resolved."
         ),
     },
-
     "changes_since": {
         "operation": "changes_since",
         "tool": "rka_query",
         "category": "maintenance",
         "role_tag": "ANY",
         "summary": "Page the durable project-scoped semantic change ledger.",
-        "signature": (
-            "rka_query(operation='changes_since', *, project_id, cursor=0, "
-            "limit=100)"
-        ),
+        "signature": ("rka_query(operation='changes_since', *, project_id, cursor=0, limit=100)"),
         "required_fields": ["project_id"],
         "optional_fields": ["cursor", "limit"],
         "enums": {},
@@ -881,16 +1030,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "next_cursor while has_more is true; cursors are project scoped."
         ),
     },
-
     "manuscript_context": {
         "operation": "manuscript_context",
         "tool": "rka_query",
         "category": "manuscript",
         "role_tag": "ANY",
         "summary": "Read the authoritative native manuscript aggregate.",
-        "signature": (
-            "rka_query(operation='manuscript_context', *, project_id, id)"
-        ),
+        "signature": ("rka_query(operation='manuscript_context', *, project_id, id)"),
         "required_fields": ["project_id", "id"],
         "optional_fields": [],
         "enums": {},
@@ -905,12 +1051,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "manuscript", "manuscript_readiness", "manuscript_spine",
+            "manuscript",
+            "manuscript_readiness",
+            "manuscript_spine",
             "manuscript_writing_candidates",
         ],
         "notes": "RKA is authoritative; Writer files are projections.",
     },
-
     "manuscript_readiness": {
         "operation": "manuscript_readiness",
         "tool": "rka_query",
@@ -936,23 +1083,21 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "transition_manuscript_phase", "manuscript_context",
+            "transition_manuscript_phase",
+            "manuscript_context",
         ],
         "notes": (
             "Readiness is mechanical and evidence-linked; it does not infer "
             "scientific validity or PI ratification."
         ),
     },
-
     "manuscript_spine": {
         "operation": "manuscript_spine",
         "tool": "rka_query",
         "category": "manuscript",
         "role_tag": "ANY",
         "summary": "Export the deterministic Writer projection of the RKA spine.",
-        "signature": (
-            "rka_query(operation='manuscript_spine', *, project_id, id)"
-        ),
+        "signature": ("rka_query(operation='manuscript_spine', *, project_id, id)"),
         "required_fields": ["project_id", "id"],
         "optional_fields": [],
         "enums": {},
@@ -967,32 +1112,27 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "upsert_argument_spine", "manuscript_context",
+            "upsert_argument_spine",
+            "manuscript_context",
         ],
         "notes": "The export is a cache projection, not an independent store.",
     },
-
     "manuscript_writing_candidates": {
         "operation": "manuscript_writing_candidates",
         "tool": "rka_query",
         "category": "manuscript",
         "role_tag": "ANY",
         "summary": (
-            "Discover writing candidates through reviewed clusters and "
-            "research questions."
+            "Discover writing candidates through reviewed clusters and research questions."
         ),
-        "signature": (
-            "rka_query(operation='manuscript_writing_candidates', *, "
-            "project_id, id)"
-        ),
+        "signature": ("rka_query(operation='manuscript_writing_candidates', *, project_id, id)"),
         "required_fields": ["project_id", "id"],
         "optional_fields": [],
         "enums": {},
         "examples": [
             {
                 "description": (
-                    "Inspect smoothed, unratified candidates before building "
-                    "the manuscript spine."
+                    "Inspect smoothed, unratified candidates before building the manuscript spine."
                 ),
                 "call": {
                     "operation": "manuscript_writing_candidates",
@@ -1013,7 +1153,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "still requires PI selection, exact wording, and ratification."
         ),
     },
-
     "manuscript_impact": {
         "operation": "manuscript_impact",
         "tool": "rka_query",
@@ -1021,8 +1160,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "ANY",
         "summary": "Map changed dependencies to manuscript claims and units.",
         "signature": (
-            "rka_query(operation='manuscript_impact', *, project_id, id, "
-            "since_cursor=0, limit=100)"
+            "rka_query(operation='manuscript_impact', *, project_id, id, since_cursor=0, limit=100)"
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": ["since_cursor", "limit"],
@@ -1040,14 +1178,15 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "changes_since", "manuscript_context", "manuscript_spine",
+            "changes_since",
+            "manuscript_context",
+            "manuscript_spine",
         ],
         "notes": (
             "Returns next_cursor/latest_cursor/has_more even when one page has "
             "no relevant changes. Continue until has_more is false."
         ),
     },
-
     "graph": {
         "operation": "graph",
         "tool": "rka_query",
@@ -1072,11 +1211,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "ego_graph", "graph_stats", "graph_mermaid",
+            "ego_graph",
+            "graph_stats",
+            "graph_mermaid",
         ],
         "notes": None,
     },
-
     "ego_graph": {
         "operation": "ego_graph",
         "tool": "rka_query",
@@ -1084,8 +1224,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "ANY",
         "summary": "Local neighborhood graph centered on one entity.",
         "signature": (
-            "rka_query(operation='ego_graph', *, project_id, id, "
-            "filters={'depth': int})"
+            "rka_query(operation='ego_graph', *, project_id, id, filters={'depth': int})"
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": ["filters"],
@@ -1104,7 +1243,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["graph", "provenance"],
         "notes": None,
     },
-
     "graph_stats": {
         "operation": "graph_stats",
         "tool": "rka_query",
@@ -1127,7 +1265,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["graph"],
         "notes": None,
     },
-
     "graph_mermaid": {
         "operation": "graph_mermaid",
         "tool": "rka_query",
@@ -1135,8 +1272,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "ANY",
         "summary": "Render the decision tree as Mermaid graph syntax.",
         "signature": (
-            "rka_query(operation='graph_mermaid', *, project_id, "
-            "filters={'phase', 'active_only'})"
+            "rka_query(operation='graph_mermaid', *, project_id, filters={'phase', 'active_only'})"
         ),
         "required_fields": ["project_id"],
         "optional_fields": ["filters"],
@@ -1154,7 +1290,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["graph", "decision_tree"],
         "notes": None,
     },
-
     "provenance": {
         "operation": "provenance",
         "tool": "rka_query",
@@ -1182,7 +1317,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["ego_graph", "entity"],
         "notes": None,
     },
-
     "multi_hop": {
         "operation": "multi_hop",
         "tool": "rka_query",
@@ -1210,7 +1344,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["search", "provenance"],
         "notes": "Pass `filters.seeds=[...]` to override the query-based seeding.",
     },
-
     "collect_report_context": {
         "operation": "collect_report_context",
         "tool": "rka_query",
@@ -1246,10 +1379,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     ),
                     "filters": {
                         "angle_queries": [
-                            "pluggable embeddings", "fastembed",
-                            "embedding config", "dimension mismatch",
+                            "pluggable embeddings",
+                            "fastembed",
+                            "embedding config",
+                            "dimension mismatch",
                         ],
-                        "max_depth": 2, "max_nodes": 60,
+                        "max_depth": 2,
+                        "max_nodes": 60,
                     },
                 },
             },
@@ -1261,7 +1397,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "verify borderline nodes by content, re-search thin dimensions."
         ),
     },
-
     "staleness_impact": {
         "operation": "staleness_impact",
         "tool": "rka_query",
@@ -1272,8 +1407,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "reasoning rests on it, via dependent-direction links."
         ),
         "signature": (
-            "rka_query(operation='staleness_impact', *, project_id, id, "
-            "filters={'max_depth': 3})"
+            "rka_query(operation='staleness_impact', *, project_id, id, filters={'max_depth': 3})"
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": ["filters"],
@@ -1291,7 +1425,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["ego_graph", "multi_hop", "freshness"],
         "notes": "Raw observations (produced links) are immutable and excluded.",
     },
-
     "mission_guard": {
         "operation": "mission_guard",
         "tool": "rka_query",
@@ -1318,7 +1451,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["mission", "context", "contradictions"],
         "notes": "Call alongside mission context; warnings list approaches already falsified.",
     },
-
     "belief_as_of": {
         "operation": "belief_as_of",
         "tool": "rka_query",
@@ -1348,7 +1480,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "retraction transitions are approximated by updated_at."
         ),
     },
-
     "summarize": {
         "operation": "summarize",
         "tool": "rka_query",
@@ -1375,7 +1506,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["generate_summary", "context"],
         "notes": None,
     },
-
     "generate_summary": {
         "operation": "generate_summary",
         "tool": "rka_query",
@@ -1409,7 +1539,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "until it is rewired through the orchestrator."
         ),
     },
-
     "evidence": {
         "operation": "evidence",
         "tool": "rka_query",
@@ -1439,7 +1568,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["clusters", "claims", "advance_rq"],
         "notes": "`id` is the research_question_id (stored as a decision id with kind='research_question').",
     },
-
     "freshness": {
         "operation": "freshness",
         "tool": "rka_query",
@@ -1447,8 +1575,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "BRAIN",
         "summary": "Check freshness/staleness of claims and clusters.",
         "signature": (
-            "rka_query(operation='freshness', *, project_id, "
-            "filters={'days_threshold': int})"
+            "rka_query(operation='freshness', *, project_id, filters={'days_threshold': int})"
         ),
         "required_fields": ["project_id"],
         "optional_fields": ["filters"],
@@ -1466,7 +1593,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["flag_stale", "pending_maintenance"],
         "notes": None,
     },
-
     "contradictions": {
         "operation": "contradictions",
         "tool": "rka_query",
@@ -1493,7 +1619,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["resolve_contradiction"],
         "notes": None,
     },
-
     "integrity": {
         "operation": "integrity",
         "tool": "rka_query",
@@ -1516,7 +1641,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["pending_maintenance"],
         "notes": None,
     },
-
     "pending_maintenance": {
         "operation": "pending_maintenance",
         "tool": "rka_query",
@@ -1539,7 +1663,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["integrity", "freshness", "contradictions"],
         "notes": None,
     },
-
     "changelog": {
         "operation": "changelog",
         "tool": "rka_query",
@@ -1547,8 +1670,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "ANY",
         "summary": "Project changelog since a given date.",
         "signature": (
-            "rka_query(operation='changelog', *, project_id, limit=50, "
-            "filters={'since': ISO8601})"
+            "rka_query(operation='changelog', *, project_id, limit=50, filters={'since': ISO8601})"
         ),
         "required_fields": ["project_id", "filters"],
         "optional_fields": ["limit"],
@@ -1566,7 +1688,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status"],
         "notes": "`filters.since` is REQUIRED.",
     },
-
     "bootstrap_review": {
         "operation": "bootstrap_review",
         "tool": "rka_query",
@@ -1590,7 +1711,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["bootstrap_workspace", "workspace_scan"],
         "notes": "`id` is the scan_id (scn_...).",
     },
-
     "workspace_tree": {
         "operation": "workspace_tree",
         "tool": "rka_query",
@@ -1620,7 +1740,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["workspace_scan"],
         "notes": None,
     },
-
     "workspace_scan": {
         "operation": "workspace_scan",
         "tool": "rka_query",
@@ -1634,7 +1753,9 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "filters"],
         "optional_fields": [
-            "ignore_patterns", "max_file_size_mb", "use_llm",
+            "ignore_patterns",
+            "max_file_size_mb",
+            "use_llm",
         ],
         "enums": {},
         "examples": [
@@ -1653,7 +1774,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["workspace_tree", "bootstrap_workspace"],
         "notes": None,
     },
-
     "list_projects": {
         "operation": "list_projects",
         "tool": "rka_query",
@@ -1673,7 +1793,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status", "create_project"],
         "notes": "UNSCOPED — does not require project_id.",
     },
-
     "health": {
         "operation": "health",
         "tool": "rka_query",
@@ -1693,13 +1812,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status"],
         "notes": "UNSCOPED.",
     },
-
     # =====================================================================
     # rka_execute — write/lifecycle operations
     # =====================================================================
-
     # --- journal / notes ------------------------------------------------
-
     "record_note": {
         "operation": "record_note",
         "tool": "rka_execute",
@@ -1716,9 +1832,17 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "content"],
         "optional_fields": [
-            "source", "type", "confidence", "importance",
-            "verbatim_input", "phase", "tags", "summary", "status",
-            "pinned", "provenance",
+            "source",
+            "type",
+            "confidence",
+            "importance",
+            "verbatim_input",
+            "phase",
+            "tags",
+            "summary",
+            "status",
+            "pinned",
+            "provenance",
         ],
         "enums": _e("source", "note_type", "confidence", "importance"),
         "examples": [
@@ -1747,14 +1871,15 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "update_note", "ingest_document", "record_decision",
+            "update_note",
+            "ingest_document",
+            "record_decision",
         ],
         "notes": (
             "Phase-X²' rule: source='pi' REQUIRES verbatim_input. The "
             "verb rejects calls without it pre-flight."
         ),
     },
-
     "ingest_document": {
         "operation": "ingest_document",
         "tool": "rka_execute",
@@ -1768,8 +1893,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "content"],
         "optional_fields": [
-            "source", "default_type", "split_by_headings",
-            "phase", "tags", "provenance",
+            "source",
+            "default_type",
+            "split_by_headings",
+            "phase",
+            "tags",
+            "provenance",
         ],
         "enums": _e("ingest_source", "note_type"),
         "examples": [
@@ -1787,7 +1916,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_note", "batch_import"],
         "notes": None,
     },
-
     "update_note": {
         "operation": "update_note",
         "tool": "rka_execute",
@@ -1802,9 +1930,17 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": [
-            "content", "type", "confidence", "importance",
-            "tags", "phase", "verbatim_input", "source",
-            "related_decisions", "related_literature", "related_mission",
+            "content",
+            "type",
+            "confidence",
+            "importance",
+            "tags",
+            "phase",
+            "verbatim_input",
+            "source",
+            "related_decisions",
+            "related_literature",
+            "related_mission",
         ],
         "enums": _e("confidence", "importance", "source", "note_type"),
         "examples": [
@@ -1821,9 +1957,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_note", "bulk_update"],
         "notes": None,
     },
-
     # --- decisions ------------------------------------------------------
-
     "record_decision": {
         "operation": "record_decision",
         "tool": "rka_execute",
@@ -1838,12 +1972,24 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "related_literature=None, assumptions=None)"
         ),
         "required_fields": [
-            "project_id", "question", "chosen", "rationale",
-            "decided_by", "kind", "related_journal", "phase",
+            "project_id",
+            "question",
+            "chosen",
+            "rationale",
+            "decided_by",
+            "kind",
+            "related_journal",
+            "phase",
         ],
         "optional_fields": [
-            "options", "supersedes_decision_id", "confidence", "tags",
-            "parent_id", "related_literature", "related_missions", "status",
+            "options",
+            "supersedes_decision_id",
+            "confidence",
+            "tags",
+            "parent_id",
+            "related_literature",
+            "related_missions",
+            "status",
             "assumptions",
         ],
         "enums": _e("decided_by", "decision_kind", "confidence"),
@@ -1864,7 +2010,9 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "update_decision", "supersede_decision", "present_decision",
+            "update_decision",
+            "supersede_decision",
+            "present_decision",
             "record_pi_selection",
         ],
         "notes": (
@@ -1873,7 +2021,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "valid; use 'verified' or 'tested'."
         ),
     },
-
     "update_decision": {
         "operation": "update_decision",
         "tool": "rka_execute",
@@ -1889,9 +2036,18 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": [
-            "status", "chosen", "rationale", "kind", "related_journal",
-            "parent_id", "related_literature", "related_missions",
-            "phase", "tags", "assumptions", "abandonment_reason",
+            "status",
+            "chosen",
+            "rationale",
+            "kind",
+            "related_journal",
+            "parent_id",
+            "related_literature",
+            "related_missions",
+            "phase",
+            "tags",
+            "assumptions",
+            "abandonment_reason",
         ],
         "enums": _e("decision_kind"),
         "examples": [
@@ -1906,11 +2062,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "record_decision", "supersede_decision",
+            "record_decision",
+            "supersede_decision",
         ],
         "notes": None,
     },
-
     "supersede_decision": {
         "operation": "supersede_decision",
         "tool": "rka_execute",
@@ -1923,8 +2079,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "decided_by='brain', phase='', kind='decision')"
         ),
         "required_fields": [
-            "project_id", "old_decision_id",
-            "question", "chosen", "rationale", "related_journal",
+            "project_id",
+            "old_decision_id",
+            "question",
+            "chosen",
+            "rationale",
+            "related_journal",
         ],
         "optional_fields": ["decided_by", "phase", "kind"],
         "enums": _e("decided_by", "decision_kind"),
@@ -1950,7 +2110,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "supersedes_decision_id='dec_...')."
         ),
     },
-
     "present_decision": {
         "operation": "present_decision",
         "tool": "rka_execute",
@@ -1962,7 +2121,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "decision_id, confirmation_brief, options, pi_preference=None)"
         ),
         "required_fields": [
-            "project_id", "decision_id", "confirmation_brief", "options",
+            "project_id",
+            "decision_id",
+            "confirmation_brief",
+            "options",
         ],
         "optional_fields": ["pi_preference"],
         "enums": {},
@@ -1988,7 +2150,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "direct presentation."
         ),
     },
-
     "record_pi_selection": {
         "operation": "record_pi_selection",
         "tool": "rka_execute",
@@ -2017,7 +2178,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["present_decision"],
         "notes": None,
     },
-
     "record_outcome": {
         "operation": "record_outcome",
         "tool": "rka_execute",
@@ -2046,9 +2206,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["calibration_metrics", "record_decision"],
         "notes": None,
     },
-
     # --- literature -----------------------------------------------------
-
     "record_literature": {
         "operation": "record_literature",
         "tool": "rka_execute",
@@ -2063,8 +2221,16 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id"],
         "optional_fields": [
-            "title", "authors", "year", "venue", "doi", "url", "abstract",
-            "status", "tags", "related_decisions",
+            "title",
+            "authors",
+            "year",
+            "venue",
+            "doi",
+            "url",
+            "abstract",
+            "status",
+            "tags",
+            "related_decisions",
         ],
         "enums": _e("lit_status"),
         "examples": [
@@ -2080,12 +2246,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "update_literature", "import_bibtex", "enrich_doi",
+            "update_literature",
+            "import_bibtex",
+            "enrich_doi",
             "link_literature_to_zotero",
         ],
         "notes": "At least one of `title` or `doi` is required.",
     },
-
     "update_literature": {
         "operation": "update_literature",
         "tool": "rka_execute",
@@ -2102,10 +2269,23 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": [
-            "title", "authors", "year", "venue", "doi", "url",
-            "bibtex", "pdf_path", "abstract", "status", "key_findings",
-            "methodology_notes", "relevance", "relevance_score",
-            "related_decisions", "notes", "tags",
+            "title",
+            "authors",
+            "year",
+            "venue",
+            "doi",
+            "url",
+            "bibtex",
+            "pdf_path",
+            "abstract",
+            "status",
+            "key_findings",
+            "methodology_notes",
+            "relevance",
+            "relevance_score",
+            "related_decisions",
+            "notes",
+            "tags",
         ],
         "enums": _e("lit_status"),
         "examples": [
@@ -2123,7 +2303,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_literature", "process_paper"],
         "notes": None,
     },
-
     "import_bibtex": {
         "operation": "import_bibtex",
         "tool": "rka_execute",
@@ -2150,16 +2329,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_literature", "batch_import"],
         "notes": None,
     },
-
     "enrich_doi": {
         "operation": "enrich_doi",
         "tool": "rka_execute",
         "category": "literature",
         "role_tag": "ANY",
         "summary": "Enrich a literature entry's metadata from its DOI.",
-        "signature": (
-            "rka_execute(operation='enrich_doi', *, project_id, lit_id)"
-        ),
+        "signature": ("rka_execute(operation='enrich_doi', *, project_id, lit_id)"),
         "required_fields": ["project_id", "lit_id"],
         "optional_fields": [],
         "enums": {},
@@ -2176,7 +2352,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_literature", "update_literature"],
         "notes": None,
     },
-
     "link_literature_to_zotero": {
         "operation": "link_literature_to_zotero",
         "tool": "rka_execute",
@@ -2203,7 +2378,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["record_literature", "update_literature"],
         "notes": None,
     },
-
     "process_paper": {
         "operation": "process_paper",
         "tool": "rka_execute",
@@ -2232,7 +2406,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["update_literature", "extract_claims"],
         "notes": None,
     },
-
     "validate_reference": {
         "operation": "validate_reference",
         "tool": "rka_execute",
@@ -2270,7 +2443,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "a completed job carries the immutable validation result."
         ),
     },
-
     "batch_import": {
         "operation": "batch_import",
         "tool": "rka_execute",
@@ -2278,8 +2450,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "ANY",
         "summary": "Bulk import mixed entity types in one call.",
         "signature": (
-            "rka_execute(operation='batch_import', *, project_id, "
-            "entries, actor='system')"
+            "rka_execute(operation='batch_import', *, project_id, entries, actor='system')"
         ),
         "required_fields": ["project_id", "entries"],
         "optional_fields": ["actor"],
@@ -2301,7 +2472,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "(system is the canonical value for programmatic ingestion)."
         ),
     },
-
     "register_manuscript": {
         "operation": "register_manuscript",
         "tool": "rka_execute",
@@ -2327,14 +2497,15 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "manuscript", "create_manuscript", "validate_reference",
+            "manuscript",
+            "create_manuscript",
+            "validate_reference",
         ],
         "notes": (
             "Compatibility operation. The response contains deprecated jrn_ "
             "id plus canonical man_ id; new callers should create_manuscript."
         ),
     },
-
     "create_manuscript": {
         "operation": "create_manuscript",
         "tool": "rka_execute",
@@ -2349,7 +2520,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "title"],
         "optional_fields": [
-            "abstract", "venue", "phase", "state", "workspace_ref",
+            "abstract",
+            "venue",
+            "phase",
+            "state",
+            "workspace_ref",
             "legacy_journal_id",
         ],
         "enums": {
@@ -2368,7 +2543,9 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "update_manuscript", "upsert_argument_spine", "manuscript_context",
+            "update_manuscript",
+            "upsert_argument_spine",
+            "manuscript_context",
         ],
         "notes": (
             "phase and state are explicit typed fields whose only accepted "
@@ -2376,7 +2553,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "PI ratification."
         ),
     },
-
     "update_manuscript": {
         "operation": "update_manuscript",
         "tool": "rka_execute",
@@ -2389,7 +2565,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "id", "expected_revision"],
         "optional_fields": [
-            "title", "abstract", "venue", "workspace_ref",
+            "title",
+            "abstract",
+            "venue",
+            "workspace_ref",
         ],
         "enums": {},
         "examples": [
@@ -2411,7 +2590,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "Lifecycle phase/state changes require transition_manuscript_phase."
         ),
     },
-
     "upsert_argument_spine": {
         "operation": "upsert_argument_spine",
         "tool": "rka_execute",
@@ -2423,7 +2601,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "id, expected_revision, spine={'claims': [...], 'units': [...]})"
         ),
         "required_fields": [
-            "project_id", "id", "expected_revision", "spine",
+            "project_id",
+            "id",
+            "expected_revision",
+            "spine",
         ],
         "optional_fields": [],
         "enums": _e(
@@ -2474,7 +2655,8 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "ratify_manuscript_claim", "manuscript_spine",
+            "ratify_manuscript_claim",
+            "manuscript_spine",
             "manuscript_readiness",
         ],
         "notes": (
@@ -2482,7 +2664,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "omitted units are removed. Both claims and units lists are required."
         ),
     },
-
     "replace_manuscript_reference_manifest": {
         "operation": "replace_manuscript_reference_manifest",
         "tool": "rka_execute",
@@ -2495,7 +2676,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "{'citation_key', 'literature_id'}, ...])"
         ),
         "required_fields": [
-            "project_id", "id", "expected_revision", "members",
+            "project_id",
+            "id",
+            "expected_revision",
+            "members",
         ],
         "optional_fields": [],
         "enums": {},
@@ -2532,7 +2716,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "literature row must belong to the manuscript project."
         ),
     },
-
     "ratify_manuscript_claim": {
         "operation": "ratify_manuscript_claim",
         "tool": "rka_execute",
@@ -2545,7 +2728,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "ratified_at=None)"
         ),
         "required_fields": [
-            "project_id", "id", "claim_ref", "expected_revision", "decision_id",
+            "project_id",
+            "id",
+            "claim_ref",
+            "expected_revision",
+            "decision_id",
         ],
         "optional_fields": ["claim_version", "ratified_at"],
         "enums": {},
@@ -2563,7 +2750,8 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "record_decision", "upsert_argument_spine",
+            "record_decision",
+            "upsert_argument_spine",
             "record_verification_attestation",
         ],
         "notes": (
@@ -2571,7 +2759,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "Ratification is never inferred from notes or legacy tags."
         ),
     },
-
     "transition_manuscript_phase": {
         "operation": "transition_manuscript_phase",
         "tool": "rka_execute",
@@ -2584,7 +2771,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "target_state=None)"
         ),
         "required_fields": [
-            "project_id", "id", "expected_revision", "target_phase",
+            "project_id",
+            "id",
+            "expected_revision",
+            "target_phase",
         ],
         "optional_fields": ["target_state"],
         "enums": {
@@ -2604,11 +2794,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "manuscript_readiness", "create_manuscript_checkpoint",
+            "manuscript_readiness",
+            "create_manuscript_checkpoint",
         ],
         "notes": "The server rejects transitions with BLOCK or ERROR findings.",
     },
-
     "create_manuscript_checkpoint": {
         "operation": "create_manuscript_checkpoint",
         "tool": "rka_execute",
@@ -2621,7 +2811,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "supersedes_id=None)"
         ),
         "required_fields": [
-            "project_id", "id", "expected_revision", "kind",
+            "project_id",
+            "id",
+            "expected_revision",
+            "kind",
         ],
         "optional_fields": ["unit_id", "supersedes_id"],
         "enums": {"kind": list(_ENUMS["manuscript_checkpoint_kind"])},
@@ -2638,11 +2831,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "resolve_manuscript_checkpoint", "manuscript_readiness",
+            "resolve_manuscript_checkpoint",
+            "manuscript_readiness",
         ],
         "notes": "draft_section checkpoints require unit_id; other kinds forbid it.",
     },
-
     "resolve_manuscript_checkpoint": {
         "operation": "resolve_manuscript_checkpoint",
         "tool": "rka_execute",
@@ -2655,14 +2848,16 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "status, resolved_at)"
         ),
         "required_fields": [
-            "project_id", "checkpoint_id", "expected_revision", "decision_id",
-            "status", "resolved_at",
+            "project_id",
+            "checkpoint_id",
+            "expected_revision",
+            "decision_id",
+            "status",
+            "resolved_at",
         ],
         "optional_fields": [],
         "enums": {
-            "status": list(
-                _ENUMS["manuscript_checkpoint_resolution_status"]
-            ),
+            "status": list(_ENUMS["manuscript_checkpoint_resolution_status"]),
         },
         "examples": [
             {
@@ -2679,11 +2874,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "create_manuscript_checkpoint", "record_decision",
+            "create_manuscript_checkpoint",
+            "record_decision",
         ],
         "notes": "Only pending checkpoints can be resolved.",
     },
-
     "record_verification_attestation": {
         "operation": "record_verification_attestation",
         "tool": "rka_execute",
@@ -2700,22 +2895,30 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "validator_version=None)"
         ),
         "required_fields": [
-            "project_id", "id", "expected_revision", "claim_id",
-            "claim_version", "overall_verdict", "grounding_verdict",
-            "evidence_verdict", "contradiction_verdict", "currency_verdict",
-            "ratification_verdict", "unit_coverage_verdict",
-            "full_json_payload", "started_at", "completed_at",
+            "project_id",
+            "id",
+            "expected_revision",
+            "claim_id",
+            "claim_version",
+            "overall_verdict",
+            "grounding_verdict",
+            "evidence_verdict",
+            "contradiction_verdict",
+            "currency_verdict",
+            "ratification_verdict",
+            "unit_coverage_verdict",
+            "full_json_payload",
+            "started_at",
+            "completed_at",
         ],
         "optional_fields": [
-            "changelog_cursor", "dependency_snapshot", "validator_version",
+            "changelog_cursor",
+            "dependency_snapshot",
+            "validator_version",
         ],
         "enums": {
-            "overall_verdict": list(
-                _ENUMS["manuscript_verification_verdict"]
-            ),
-            "dimension_verdicts": list(
-                _ENUMS["manuscript_verification_dimension_verdict"]
-            ),
+            "overall_verdict": list(_ENUMS["manuscript_verification_verdict"]),
+            "dimension_verdicts": list(_ENUMS["manuscript_verification_dimension_verdict"]),
         },
         "examples": [
             {
@@ -2741,14 +2944,14 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "manuscript_readiness", "ratify_manuscript_claim",
+            "manuscript_readiness",
+            "ratify_manuscript_claim",
         ],
         "notes": (
             "Attestations are append-only. Per-dimension verdicts remain "
             "separate so a single pass/fail flag cannot hide the blocking cause."
         ),
     },
-
     "update_status": {
         "operation": "update_status",
         "tool": "rka_execute",
@@ -2761,7 +2964,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id"],
         "optional_fields": [
-            "current_phase", "summary", "blockers", "metrics",
+            "current_phase",
+            "summary",
+            "blockers",
+            "metrics",
         ],
         "enums": {},
         "examples": [
@@ -2778,16 +2984,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status"],
         "notes": None,
     },
-
     "bulk_update": {
         "operation": "bulk_update",
         "tool": "rka_execute",
         "category": "core",
         "role_tag": "BRAIN",
         "summary": "Update many entities in one atomic call.",
-        "signature": (
-            "rka_execute(operation='bulk_update', *, project_id, updates)"
-        ),
+        "signature": ("rka_execute(operation='bulk_update', *, project_id, updates)"),
         "required_fields": ["project_id", "updates"],
         "optional_fields": [],
         "enums": {},
@@ -2807,9 +3010,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["update_note", "update_decision"],
         "notes": None,
     },
-
     # --- missions -------------------------------------------------------
-
     "create_mission": {
         "operation": "create_mission",
         "tool": "rka_execute",
@@ -2824,12 +3025,19 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "depends_on=None, tags=None)"
         ),
         "required_fields": [
-            "project_id", "objective", "motivated_by_decision",
+            "project_id",
+            "objective",
+            "motivated_by_decision",
         ],
         "optional_fields": [
-            "phase", "tasks", "context", "acceptance_criteria",
-            "scope_boundaries", "checkpoint_triggers",
-            "depends_on", "tags",
+            "phase",
+            "tasks",
+            "context",
+            "acceptance_criteria",
+            "scope_boundaries",
+            "checkpoint_triggers",
+            "depends_on",
+            "tags",
         ],
         "enums": {},
         "examples": [
@@ -2845,15 +3053,16 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "update_mission", "update_mission_status",
-            "submit_report", "mission",
+            "update_mission",
+            "update_mission_status",
+            "submit_report",
+            "mission",
         ],
         "notes": (
             "Provenance discipline: motivated_by_decision is REQUIRED "
             "to preserve the decision -> mission causality chain."
         ),
     },
-
     "update_mission": {
         "operation": "update_mission",
         "tool": "rka_execute",
@@ -2869,9 +3078,16 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "mission_id"],
         "optional_fields": [
-            "phase", "objective", "context", "acceptance_criteria",
-            "scope_boundaries", "checkpoint_triggers", "depends_on",
-            "parent_mission_id", "motivated_by_decision", "tags",
+            "phase",
+            "objective",
+            "context",
+            "acceptance_criteria",
+            "scope_boundaries",
+            "checkpoint_triggers",
+            "depends_on",
+            "parent_mission_id",
+            "motivated_by_decision",
+            "tags",
         ],
         "enums": {},
         "examples": [
@@ -2888,7 +3104,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["create_mission", "update_mission_status"],
         "notes": None,
     },
-
     "update_mission_status": {
         "operation": "update_mission_status",
         "tool": "rka_execute",
@@ -2919,7 +3134,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "Also: partial, blocked, cancelled."
         ),
     },
-
     "submit_report": {
         "operation": "submit_report",
         "tool": "rka_execute",
@@ -2933,11 +3147,17 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "recommended_next=None)"
         ),
         "required_fields": [
-            "project_id", "mission_id",
+            "project_id",
+            "mission_id",
         ],
         "optional_fields": [
-            "summary", "content", "findings", "anomalies", "questions",
-            "codebase_state", "recommended_next",
+            "summary",
+            "content",
+            "findings",
+            "anomalies",
+            "questions",
+            "codebase_state",
+            "recommended_next",
         ],
         "enums": {},
         "examples": [
@@ -2959,7 +3179,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "Phase-X²' adapter also accepts `content` as an alias."
         ),
     },
-
     "advance_rq": {
         "operation": "advance_rq",
         "tool": "rka_execute",
@@ -2988,9 +3207,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["evidence", "clusters"],
         "notes": None,
     },
-
     # --- checkpoints + gates -------------------------------------------
-
     "submit_checkpoint": {
         "operation": "submit_checkpoint",
         "tool": "rka_execute",
@@ -3004,11 +3221,18 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "recommendation=None, blocking=True)"
         ),
         "required_fields": [
-            "project_id", "mission_id", "type",
+            "project_id",
+            "mission_id",
+            "type",
         ],
         "optional_fields": [
-            "description", "content", "task_reference", "context", "options",
-            "recommendation", "blocking",
+            "description",
+            "content",
+            "task_reference",
+            "context",
+            "options",
+            "recommendation",
+            "blocking",
         ],
         "enums": _e("checkpoint_type"),
         "examples": [
@@ -3025,14 +3249,15 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "resolve_checkpoint", "checkpoints", "create_gate",
+            "resolve_checkpoint",
+            "checkpoints",
+            "create_gate",
         ],
         "notes": (
             "One of `description` or `content` is required. `description` is "
             "canonical; `content` is the legacy alias."
         ),
     },
-
     "resolve_checkpoint": {
         "operation": "resolve_checkpoint",
         "tool": "rka_execute",
@@ -3044,7 +3269,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "resolution, resolved_by, rationale=None, create_decision=False)"
         ),
         "required_fields": [
-            "project_id", "id", "resolution", "resolved_by",
+            "project_id",
+            "id",
+            "resolution",
+            "resolved_by",
         ],
         "optional_fields": ["rationale", "create_decision"],
         "enums": _e("resolved_by"),
@@ -3064,7 +3292,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["submit_checkpoint", "checkpoints"],
         "notes": None,
     },
-
     "create_gate": {
         "operation": "create_gate",
         "tool": "rka_execute",
@@ -3077,8 +3304,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "assumptions_to_verify=None)"
         ),
         "required_fields": [
-            "project_id", "mission_id", "gate_type",
-            "deliverables", "pass_criteria",
+            "project_id",
+            "mission_id",
+            "gate_type",
+            "deliverables",
+            "pass_criteria",
         ],
         "optional_fields": ["assumptions_to_verify"],
         "enums": _e("gate_type"),
@@ -3098,7 +3328,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["evaluate_gate"],
         "notes": None,
     },
-
     "evaluate_gate": {
         "operation": "evaluate_gate",
         "tool": "rka_execute",
@@ -3110,7 +3339,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "gate_id, verdict, notes, assumption_status=None)"
         ),
         "required_fields": [
-            "project_id", "gate_id", "verdict", "notes",
+            "project_id",
+            "gate_id",
+            "verdict",
+            "notes",
         ],
         "optional_fields": ["assumption_status"],
         "enums": _e("verdict"),
@@ -3129,19 +3361,14 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["create_gate"],
         "notes": None,
     },
-
     # --- claims / clusters ---------------------------------------------
-
     "extract_claims": {
         "operation": "extract_claims",
         "tool": "rka_execute",
         "category": "claims",
         "role_tag": "BRAIN",
         "summary": "Stage atomic interpretations from an existing entry.",
-        "signature": (
-            "rka_execute(operation='extract_claims', *, project_id, "
-            "entry_id, claims)"
-        ),
+        "signature": ("rka_execute(operation='extract_claims', *, project_id, entry_id, claims)"),
         "required_fields": ["project_id", "entry_id", "claims"],
         "optional_fields": [],
         "enums": _e("claim_type"),
@@ -3153,14 +3380,14 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     "project_id": "prj_01ABC...",
                     "entry_id": "jrn_01XYZ...",
                     "claims": [
-                        {"text": "Latency improves linearly.",
-                         "claim_type": "evidence"},
+                        {"text": "Latency improves linearly.", "claim_type": "evidence"},
                     ],
                 },
             },
         ],
         "related_operations": [
-            "interpretation_candidates", "triage_interpretation_candidate",
+            "interpretation_candidates",
+            "triage_interpretation_candidate",
             "claims",
         ],
         "notes": (
@@ -3168,7 +3395,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "not clm_ records; explicit reviewed promotion is required."
         ),
     },
-
     "create_interpretation_candidate": {
         "operation": "create_interpretation_candidate",
         "tool": "rka_execute",
@@ -3181,17 +3407,33 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "epistemic_kind, created_by, extraction_tool, ...)"
         ),
         "required_fields": [
-            "project_id", "source_type", "source_id", "locator_kind",
-            "statement", "epistemic_kind", "created_by", "extraction_tool",
+            "project_id",
+            "source_type",
+            "source_id",
+            "locator_kind",
+            "statement",
+            "epistemic_kind",
+            "created_by",
+            "extraction_tool",
         ],
         "optional_fields": [
-            "locator_start", "locator_end", "locator_value", "scope_conditions",
-            "uncertainty", "uncertainty_note", "falsifier",
-            "proposed_claim_type", "extraction_model",
+            "locator_start",
+            "locator_end",
+            "locator_value",
+            "scope_conditions",
+            "uncertainty",
+            "uncertainty_note",
+            "falsifier",
+            "proposed_claim_type",
+            "extraction_model",
         ],
         "enums": _e(
-            "interpretation_source", "interpretation_locator", "epistemic_kind",
-            "interpretation_actor", "interpretation_uncertainty", "claim_type",
+            "interpretation_source",
+            "interpretation_locator",
+            "epistemic_kind",
+            "interpretation_actor",
+            "interpretation_uncertainty",
+            "claim_type",
         ),
         "examples": [
             {
@@ -3213,12 +3455,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "interpretation_candidates", "add_interpretation_hint",
+            "interpretation_candidates",
+            "add_interpretation_hint",
             "triage_interpretation_candidate",
         ],
         "notes": "Creation never promotes a canonical claim.",
     },
-
     "add_interpretation_hint": {
         "operation": "add_interpretation_hint",
         "tool": "rka_execute",
@@ -3231,8 +3473,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "expected_revision, confidence=0.5)"
         ),
         "required_fields": [
-            "project_id", "id", "related_candidate_id", "kind", "rationale",
-            "created_by", "expected_revision",
+            "project_id",
+            "id",
+            "related_candidate_id",
+            "kind",
+            "rationale",
+            "created_by",
+            "expected_revision",
         ],
         "optional_fields": ["confidence"],
         "enums": _e("interpretation_hint_kind", "interpretation_actor"),
@@ -3254,7 +3501,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["interpretation_candidates"],
         "notes": "Hints inform review; they do not merge or reject candidates.",
     },
-
     "triage_interpretation_candidate": {
         "operation": "triage_interpretation_candidate",
         "tool": "rka_execute",
@@ -3266,11 +3512,18 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "project_id, id, action, expected_revision, actor, reason=None, ...)"
         ),
         "required_fields": [
-            "project_id", "id", "action", "expected_revision", "actor",
+            "project_id",
+            "id",
+            "action",
+            "expected_revision",
+            "actor",
         ],
         "optional_fields": [
-            "reason", "target_candidate_id", "target_entity_id",
-            "grounding_verified", "claim_confidence",
+            "reason",
+            "target_candidate_id",
+            "target_entity_id",
+            "grounding_verified",
+            "claim_confidence",
         ],
         "enums": _e("interpretation_triage_action", "interpretation_review_actor"),
         "examples": [
@@ -3294,7 +3547,79 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "status unassessed. Revoke preserves the claim and marks it stale."
         ),
     },
-
+    "set_claim_scope": {
+        "operation": "set_claim_scope",
+        "tool": "rka_execute",
+        "category": "claims",
+        "role_tag": "BRAIN",
+        "summary": "Append a versioned applicability contract to a canonical claim.",
+        "signature": (
+            "rka_execute(operation='set_claim_scope', *, project_id, claim_id, "
+            "expected_revision, actor, reason, conditions=[], ...)"
+        ),
+        "required_fields": [
+            "project_id",
+            "claim_id",
+            "expected_revision",
+            "actor",
+            "reason",
+        ],
+        "optional_fields": [
+            "conditions",
+            "uncertainty",
+            "uncertainty_note",
+            "extension_policy",
+            "allowed_extensions",
+            "prohibited_extensions",
+            "falsifier_status",
+            "falsifier",
+            "falsifier_rationale",
+            "disconfirming_claim_ids",
+            "review_status",
+        ],
+        "enums": _e(
+            "claim_scope_actor",
+            "claim_scope_uncertainty",
+            "claim_scope_extension_policy",
+            "claim_falsifier_status",
+            "claim_scope_review_status",
+            "claim_condition_kind",
+            "claim_condition_operator",
+        ),
+        "examples": [
+            {
+                "description": "Ratify a bounded empirical result scope.",
+                "call": {
+                    "operation": "set_claim_scope",
+                    "project_id": "prj_01ABC...",
+                    "claim_id": "clm_01XYZ...",
+                    "expected_revision": 0,
+                    "actor": "brain",
+                    "reason": "Reviewed against the source and evaluation design.",
+                    "conditions": [
+                        {
+                            "kind": "dataset",
+                            "key": "evaluation_dataset",
+                            "operator": "equals",
+                            "value": "Dataset A",
+                        },
+                    ],
+                    "uncertainty": "low",
+                    "extension_policy": "exact_only",
+                    "prohibited_extensions": ["other datasets without evidence"],
+                    "falsifier_status": "applicable",
+                    "falsifier": "Independent replication fails on Dataset A.",
+                    "review_status": "reviewed",
+                },
+            },
+        ],
+        "related_operations": ["claim_scope", "claims", "review_claims"],
+        "notes": (
+            "Reviewed contracts require typed conditions, resolved uncertainty, "
+            "an extension policy, prohibited extensions, and resolved falsifier "
+            "applicability. expected_revision prevents stale writes."
+        ),
+    },
     "review_claims": {
         "operation": "review_claims",
         "tool": "rka_execute",
@@ -3326,7 +3651,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "explicitly for scientific support; approve/reject never infer it."
         ),
     },
-
     "create_cluster": {
         "operation": "create_cluster",
         "tool": "rka_execute",
@@ -3340,7 +3664,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "label"],
         "optional_fields": [
-            "research_question_id", "synthesis", "confidence", "claim_ids",
+            "research_question_id",
+            "synthesis",
+            "confidence",
+            "claim_ids",
         ],
         "enums": _e("cluster_confidence"),
         "examples": [
@@ -3356,11 +3683,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "clusters", "assign_claims_to_cluster", "review_cluster",
+            "clusters",
+            "assign_claims_to_cluster",
+            "review_cluster",
         ],
         "notes": None,
     },
-
     "assign_claims_to_cluster": {
         "operation": "assign_claims_to_cluster",
         "tool": "rka_execute",
@@ -3386,11 +3714,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "create_cluster", "split_cluster", "merge_clusters",
+            "create_cluster",
+            "split_cluster",
+            "merge_clusters",
         ],
         "notes": None,
     },
-
     "split_cluster": {
         "operation": "split_cluster",
         "tool": "rka_execute",
@@ -3398,8 +3727,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "role_tag": "BRAIN",
         "summary": "Split a cluster into multiple smaller clusters.",
         "signature": (
-            "rka_execute(operation='split_cluster', *, project_id, "
-            "source_id, new_clusters)"
+            "rka_execute(operation='split_cluster', *, project_id, source_id, new_clusters)"
         ),
         "required_fields": ["project_id", "source_id", "new_clusters"],
         "optional_fields": [],
@@ -3419,11 +3747,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "merge_clusters", "assign_claims_to_cluster",
+            "merge_clusters",
+            "assign_claims_to_cluster",
         ],
         "notes": None,
     },
-
     "merge_clusters": {
         "operation": "merge_clusters",
         "tool": "rka_execute",
@@ -3452,7 +3780,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["split_cluster", "create_cluster"],
         "notes": None,
     },
-
     "review_cluster": {
         "operation": "review_cluster",
         "tool": "rka_execute",
@@ -3466,10 +3793,15 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "research_question_id=None)"
         ),
         "required_fields": [
-            "project_id", "cluster_id", "confidence", "synthesis",
+            "project_id",
+            "cluster_id",
+            "confidence",
+            "synthesis",
         ],
         "optional_fields": [
-            "gaps", "contradictions", "resolve_queue_items",
+            "gaps",
+            "contradictions",
+            "resolve_queue_items",
             "research_question_id",
         ],
         "enums": _e("cluster_confidence"),
@@ -3486,11 +3818,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "clusters", "review_claims", "resolve_contradiction",
+            "clusters",
+            "review_claims",
+            "resolve_contradiction",
         ],
         "notes": None,
     },
-
     "resolve_contradiction": {
         "operation": "resolve_contradiction",
         "tool": "rka_execute",
@@ -3521,9 +3854,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["review_cluster", "contradictions"],
         "notes": None,
     },
-
     # --- hooks ----------------------------------------------------------
-
     "hook_add": {
         "operation": "hook_add",
         "tool": "rka_execute",
@@ -3536,8 +3867,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "enabled=True, created_by='pi')"
         ),
         "required_fields": [
-            "project_id", "event", "handler_type",
-            "handler_config", "name",
+            "project_id",
+            "event",
+            "handler_type",
+            "handler_config",
+            "name",
         ],
         "optional_fields": ["enabled", "created_by"],
         "enums": {},
@@ -3555,20 +3889,20 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "hooks", "hook_enable", "hook_disable", "hook_delete",
+            "hooks",
+            "hook_enable",
+            "hook_disable",
+            "hook_delete",
         ],
         "notes": None,
     },
-
     "hook_enable": {
         "operation": "hook_enable",
         "tool": "rka_execute",
         "category": "hooks",
         "role_tag": "PI",
         "summary": "Enable a hook.",
-        "signature": (
-            "rka_execute(operation='hook_enable', *, project_id, hook_id)"
-        ),
+        "signature": ("rka_execute(operation='hook_enable', *, project_id, hook_id)"),
         "required_fields": ["project_id", "hook_id"],
         "optional_fields": [],
         "enums": {},
@@ -3585,16 +3919,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["hook_add", "hook_disable"],
         "notes": None,
     },
-
     "hook_disable": {
         "operation": "hook_disable",
         "tool": "rka_execute",
         "category": "hooks",
         "role_tag": "PI",
         "summary": "Disable a hook (preserves config).",
-        "signature": (
-            "rka_execute(operation='hook_disable', *, project_id, hook_id)"
-        ),
+        "signature": ("rka_execute(operation='hook_disable', *, project_id, hook_id)"),
         "required_fields": ["project_id", "hook_id"],
         "optional_fields": [],
         "enums": {},
@@ -3611,16 +3942,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["hook_enable", "hook_delete"],
         "notes": None,
     },
-
     "hook_delete": {
         "operation": "hook_delete",
         "tool": "rka_execute",
         "category": "hooks",
         "role_tag": "PI",
         "summary": "Permanently delete a hook.",
-        "signature": (
-            "rka_execute(operation='hook_delete', *, project_id, hook_id)"
-        ),
+        "signature": ("rka_execute(operation='hook_delete', *, project_id, hook_id)"),
         "required_fields": ["project_id", "hook_id"],
         "optional_fields": [],
         "enums": {},
@@ -3637,17 +3965,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["hook_disable"],
         "notes": None,
     },
-
     "brain_notifications_clear": {
         "operation": "brain_notifications_clear",
         "tool": "rka_execute",
         "category": "notifications",
         "role_tag": "BRAIN",
         "summary": "Clear Brain notifications by ID.",
-        "signature": (
-            "rka_execute(operation='brain_notifications_clear', *, "
-            "project_id, ids)"
-        ),
+        "signature": ("rka_execute(operation='brain_notifications_clear', *, project_id, ids)"),
         "required_fields": ["project_id", "ids"],
         "optional_fields": [],
         "enums": {},
@@ -3664,9 +3988,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["brain_notifications"],
         "notes": None,
     },
-
     # --- workspace + maintenance ---------------------------------------
-
     "bootstrap_workspace": {
         "operation": "bootstrap_workspace",
         "tool": "rka_execute",
@@ -3680,7 +4002,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "folder_path"],
         "optional_fields": [
-            "phase", "override_tags", "skip_files", "use_llm", "dry_run",
+            "phase",
+            "override_tags",
+            "skip_files",
+            "use_llm",
+            "dry_run",
         ],
         "enums": {},
         "examples": [
@@ -3695,11 +4021,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": [
-            "workspace_scan", "workspace_tree", "bootstrap_review",
+            "workspace_scan",
+            "workspace_tree",
+            "bootstrap_review",
         ],
         "notes": None,
     },
-
     "scan_workspace": {
         "operation": "scan_workspace",
         "tool": "rka_execute",
@@ -3713,7 +4040,9 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id", "folder_path"],
         "optional_fields": [
-            "ignore_patterns", "max_file_size_mb", "use_llm",
+            "ignore_patterns",
+            "max_file_size_mb",
+            "use_llm",
         ],
         "enums": {},
         "examples": [
@@ -3729,7 +4058,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["workspace_scan", "bootstrap_workspace"],
         "notes": None,
     },
-
     "flag_stale": {
         "operation": "flag_stale",
         "tool": "rka_execute",
@@ -3758,17 +4086,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["freshness", "eviction_sweep"],
         "notes": None,
     },
-
     "eviction_sweep": {
         "operation": "eviction_sweep",
         "tool": "rka_execute",
         "category": "maintenance",
         "role_tag": "BRAIN",
         "summary": "Evict knowledge per policy (defaults to dry_run).",
-        "signature": (
-            "rka_execute(operation='eviction_sweep', *, project_id, "
-            "dry_run=True)"
-        ),
+        "signature": ("rka_execute(operation='eviction_sweep', *, project_id, dry_run=True)"),
         "required_fields": ["project_id"],
         "optional_fields": ["dry_run"],
         "enums": {},
@@ -3785,19 +4109,14 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["flag_stale", "freshness"],
         "notes": None,
     },
-
     # --- session (unscoped + project lifecycle) ------------------------
-
     "create_project": {
         "operation": "create_project",
         "tool": "rka_execute",
         "category": "session",
         "role_tag": "PI",
         "summary": "Bootstrap a new RKA project (UNSCOPED — no project_id required).",
-        "signature": (
-            "rka_execute(operation='create_project', *, name, "
-            "description=None)"
-        ),
+        "signature": ("rka_execute(operation='create_project', *, name, description=None)"),
         "required_fields": ["name"],
         "optional_fields": ["description"],
         "enums": {},
@@ -3814,7 +4133,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["list_projects", "status"],
         "notes": "UNSCOPED — does not require project_id.",
     },
-
     "reset_session": {
         "operation": "reset_session",
         "tool": "rka_execute",
@@ -3834,16 +4152,13 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status"],
         "notes": "UNSCOPED.",
     },
-
     "session_digest": {
         "operation": "session_digest",
         "tool": "rka_execute",
         "category": "session",
         "role_tag": "ANY",
         "summary": "Compact session summary (mutates session state).",
-        "signature": (
-            "rka_execute(operation='session_digest', *, project_id)"
-        ),
+        "signature": ("rka_execute(operation='session_digest', *, project_id)"),
         "required_fields": ["project_id"],
         "optional_fields": [],
         "enums": {},

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -4458,11 +4458,65 @@ async def rka_get_claims(
         lines.append(
             f"  [{cl['id']}] ({cl['claim_type']}) "
             f"grounded={v} evidence={evidence} contradicted={contradicted} "
+            f"scope={cl.get('scope_readiness', 'missing')} "
+            f"scope_rev={cl.get('scope_revision', 0)} "
             f"conf={cl.get('confidence', '?'):.2f}{s}"
         )
         lines.append(f"    {cl['content'][:500]}")
         lines.append(f"    source: {cl['source_entry_id']}")
     return "\n".join(lines)
+
+
+@tool(category="claims")
+async def rka_get_claim_scope(claim_id: str, *, project_id: str) -> str:
+    """Fetch current claim-scope readiness plus immutable scope history."""
+    async with _client(project_id) as c:
+        r = await c.get(f"/api/claims/{claim_id}/scope")
+        _raise_with_detail(r)
+    return json.dumps(r.json(), indent=2, ensure_ascii=False)
+
+
+@tool(category="claims")
+async def rka_set_claim_scope(
+    claim_id: str,
+    expected_revision: int,
+    actor: str,
+    reason: str,
+    conditions: list[dict] | None = None,
+    uncertainty: str = "unknown",
+    uncertainty_note: str | None = None,
+    extension_policy: str | None = None,
+    allowed_extensions: list[str] | None = None,
+    prohibited_extensions: list[str] | None = None,
+    falsifier_status: str = "unknown",
+    falsifier: str | None = None,
+    falsifier_rationale: str | None = None,
+    disconfirming_claim_ids: list[str] | None = None,
+    review_status: str = "draft",
+    *,
+    project_id: str,
+) -> str:
+    """Append a revision-guarded canonical claim-scope contract."""
+    payload = {
+        "expected_revision": expected_revision,
+        "actor": actor,
+        "reason": reason,
+        "conditions": conditions or [],
+        "uncertainty": uncertainty,
+        "uncertainty_note": uncertainty_note,
+        "extension_policy": extension_policy,
+        "allowed_extensions": allowed_extensions or [],
+        "prohibited_extensions": prohibited_extensions or [],
+        "falsifier_status": falsifier_status,
+        "falsifier": falsifier,
+        "falsifier_rationale": falsifier_rationale,
+        "disconfirming_claim_ids": disconfirming_claim_ids or [],
+        "review_status": review_status,
+    }
+    async with _client(project_id) as c:
+        r = await c.post(f"/api/claims/{claim_id}/scope", json=payload)
+        _raise_with_detail(r)
+    return json.dumps(r.json(), indent=2, ensure_ascii=False)
 
 
 @tool(category="claims")

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -191,9 +191,7 @@ async def dispatch_record_literature(
                 "missing_field",
                 "action='enrich_doi' requires lit_id",
             )
-        return await _legacy("rka_enrich_doi")(
-            lit_id=lit_id, project_id=project_id
-        )
+        return await _legacy("rka_enrich_doi")(lit_id=lit_id, project_id=project_id)
 
     if action == "search_semantic_scholar" or search_source == "semantic_scholar":
         q = search_query
@@ -297,10 +295,7 @@ async def dispatch_mission(action: str, *, project_id: str, **kw: Any) -> str:
     """
     if action == "create":
         provenance = kw.get("provenance") or {}
-        motivated_by = (
-            kw.get("motivated_by_decision")
-            or provenance.get("motivated_by_decision")
-        )
+        motivated_by = kw.get("motivated_by_decision") or provenance.get("motivated_by_decision")
         if not motivated_by:
             return _err(
                 "missing_provenance",
@@ -631,9 +626,7 @@ async def dispatch_review(target: str, *, project_id: str, payload: dict[str, An
     if target == "bulk_update":
         if not p.get("updates"):
             return _err("missing_field", "review bulk_update requires payload.updates")
-        return await _legacy("rka_bulk_update")(
-            updates=p["updates"], project_id=project_id
-        )
+        return await _legacy("rka_bulk_update")(updates=p["updates"], project_id=project_id)
 
     if target == "batch_import":
         if not p.get("entries"):
@@ -683,9 +676,7 @@ async def dispatch_review(target: str, *, project_id: str, payload: dict[str, An
                 "missing_field",
                 "brain_notifications_clear requires payload.ids",
             )
-        return await _legacy("rka_clear_brain_notifications")(
-            ids=p["ids"], project_id=project_id
-        )
+        return await _legacy("rka_clear_brain_notifications")(ids=p["ids"], project_id=project_id)
 
     if target == "extract_claims":
         if not p.get("entry_id") or not p.get("claims"):
@@ -908,29 +899,25 @@ _QUERY_DISPATCH: dict[str, str] = {
     "checkpoints": "rka_get_checkpoints",
     "research_map": "rka_get_research_map",
     "review_queue": "rka_get_review_queue",
-
     # search / get-by-id
     "search": "rka_search",
     "entity": "rka_get",
-
     # journal / decisions / literature / missions / reports lists
     "journal": "rka_get_journal",
     "literature": "rka_get_literature",
     "report": "rka_get_report",
     "mission": "rka_get_mission",
-
     # decisions / graph
     "decision_tree": "rka_get_decision_tree",
     "graph": "rka_get_graph",
     "ego_graph": "rka_get_ego_graph",
     "graph_stats": "rka_graph_stats",
     "graph_mermaid": "rka_export_mermaid",
-
     # claims / clusters
     "clusters": "rka_list_clusters",
     "claims": "rka_get_claims",
+    "claim_scope": "rka_get_claim_scope",
     "interpretation_candidates": "rka_get_interpretation_candidates",
-
     # provenance / multi-hop
     "provenance": "rka_trace_provenance",
     "multi_hop": "rka_multi_hop_retrieval",
@@ -939,28 +926,23 @@ _QUERY_DISPATCH: dict[str, str] = {
     "mission_guard": "rka_mission_guard",
     "belief_as_of": "rka_belief_as_of",
     "evidence": "rka_assemble_evidence",
-
     # session-flavored project-scoped reads
     "summarize": "rka_summarize",
     "generate_summary": "rka_generate_summary",
     "calibration_metrics": "rka_get_calibration_metrics",
     "changelog": "rka_get_changelog",
-
     # hooks reads
     "hooks": "rka_list_hooks",
     "hook_executions": "rka_get_hook_executions",
     "brain_notifications": "rka_get_brain_notifications",
-
     # maintenance / freshness reads
     "integrity": "rka_check_integrity",
     "freshness": "rka_check_freshness",
     "contradictions": "rka_detect_contradictions",
-
     # workspace
     "workspace_tree": "rka_scan_workspace_tree",
     "workspace_scan": "rka_scan_workspace",
     "bootstrap_review": "rka_review_bootstrap",
-
     # manuscript
     "manuscript": "rka_get_manuscript",
     "manuscript_context": "rka_get_manuscript_context",
@@ -970,10 +952,8 @@ _QUERY_DISPATCH: dict[str, str] = {
     "manuscript_writing_candidates": "rka_get_manuscript_writing_candidates",
     "manuscript_impact": "rka_get_manuscript_impact",
     "reference_validation_status": "rka_get_reference_validation_status",
-
     # bounded heterogeneous resolver
     "resolve_entities": "rka_resolve_entities",
-
     # durable semantic change cursor
     "changes_since": "rka_changes_since",
 }
@@ -1073,21 +1053,23 @@ async def dispatch_query(
 
     if scope == "staleness_impact":
         if not id:
-            return _err("missing_field",
-                        "rka_query(scope='staleness_impact'): id (entity) is required")
-        return await legacy(entity_id=id, max_depth=f.get("max_depth", 3),
-                            project_id=project_id)
+            return _err(
+                "missing_field", "rka_query(scope='staleness_impact'): id (entity) is required"
+            )
+        return await legacy(entity_id=id, max_depth=f.get("max_depth", 3), project_id=project_id)
 
     if scope == "mission_guard":
         if not id:
-            return _err("missing_field",
-                        "rka_query(scope='mission_guard'): id (mission) is required")
+            return _err(
+                "missing_field", "rka_query(scope='mission_guard'): id (mission) is required"
+            )
         return await legacy(mission_id=id, project_id=project_id)
 
     if scope == "belief_as_of":
         if not query:
-            return _err("missing_field",
-                        "rka_query(scope='belief_as_of'): query (the ISO date) is required")
+            return _err(
+                "missing_field", "rka_query(scope='belief_as_of'): query (the ISO date) is required"
+            )
         return await legacy(date=query, project_id=project_id)
 
     if scope == "collect_report_context":
@@ -1142,7 +1124,8 @@ async def dispatch_query(
 
     if scope == "checkpoints":
         return await legacy(
-            status=f.get("status", "open"), project_id=project_id,
+            status=f.get("status", "open"),
+            project_id=project_id,
         )
 
     if scope == "review_queue":
@@ -1172,7 +1155,9 @@ async def dispatch_query(
         if not id:
             return _err("missing_field", "rka_query(scope='ego_graph'): id is required")
         return await legacy(
-            entity_id=id, depth=f.get("depth", 1), project_id=project_id,
+            entity_id=id,
+            depth=f.get("depth", 1),
+            project_id=project_id,
         )
 
     if scope == "graph_mermaid":
@@ -1201,6 +1186,14 @@ async def dispatch_query(
             limit=limit or f.get("limit", 20),
             project_id=project_id,
         )
+
+    if scope == "claim_scope":
+        if not id:
+            return _err(
+                "missing_field",
+                "rka_query(operation='claim_scope'): id is required",
+            )
+        return await legacy(claim_id=id, project_id=project_id)
 
     if scope == "interpretation_candidates":
         return await legacy(
@@ -1422,8 +1415,7 @@ async def dispatch_query(
         if not id:
             return _err(
                 "missing_field",
-                "rka_query(scope='manuscript_reference_manifest'): "
-                "id required",
+                "rka_query(scope='manuscript_reference_manifest'): id required",
             )
         return await legacy(
             manuscript_id=id,
@@ -1434,8 +1426,7 @@ async def dispatch_query(
         if not manuscript_id or not job_id:
             return _err(
                 "missing_field",
-                "rka_query(scope='reference_validation_status') requires "
-                "manuscript_id and job_id",
+                "rka_query(scope='reference_validation_status') requires manuscript_id and job_id",
             )
         return await legacy(
             manuscript_id=manuscript_id,
@@ -1536,18 +1527,24 @@ async def dispatch_record_note(
     if action == "ingest_document":
         return await _legacy("rka_ingest_document")(
             content=content,
-            source=source if source in (
-                "brain", "executor", "pi", "llm", "web_ui", "system",
-            ) else "brain",
+            source=source
+            if source
+            in (
+                "brain",
+                "executor",
+                "pi",
+                "llm",
+                "web_ui",
+                "system",
+            )
+            else "brain",
             default_type=default_type or "finding",
             phase=phase,
             tags=tags,
             related_literature=merged["related_literature"],
             related_decisions=merged["related_decisions"],
             related_mission=merged["related_mission"],
-            split_by_headings=(
-                True if split_by_headings is None else split_by_headings
-            ),
+            split_by_headings=(True if split_by_headings is None else split_by_headings),
             project_id=project_id,
         )
 
@@ -1639,7 +1636,9 @@ async def dispatch_record_decision(
         "parent_id": parent_id,
     }
     merged = _unpack_provenance(
-        provenance, explicit, _DECISION_PROVENANCE_KEYS,
+        provenance,
+        explicit,
+        _DECISION_PROVENANCE_KEYS,
     )
 
     if supersedes_decision_id:
@@ -1756,7 +1755,8 @@ async def dispatch_session(
                 "rka_session(action='create_project'): name is required",
             )
         return await _legacy("rka_create_project")(
-            name=name, description=description,
+            name=name,
+            description=description,
         )
 
     if action == "set_project":
@@ -1790,25 +1790,34 @@ async def dispatch_session(
                 ok = r.is_success
                 code = r.status_code
         except Exception as exc:
-            return json.dumps({
-                "status": "unhealthy",
-                "error": str(exc)[:200],
-            }, indent=2)
-        return json.dumps({
-            "status": "healthy" if ok else "degraded",
-            "rest_status_code": code,
-        }, indent=2)
+            return json.dumps(
+                {
+                    "status": "unhealthy",
+                    "error": str(exc)[:200],
+                },
+                indent=2,
+            )
+        return json.dumps(
+            {
+                "status": "healthy" if ok else "degraded",
+                "rest_status_code": code,
+            },
+            indent=2,
+        )
 
     if action == "help":
         if not name_lookup:
-            return json.dumps({
-                "verbs": list(VERBS),
-                "session_actions": list(_SESSION_ACTIONS),
-                "hint": (
-                    "Pass name_lookup=<tool_name> for per-legacy-tool "
-                    "help (e.g. name_lookup='rka_add_note')."
-                ),
-            }, indent=2)
+            return json.dumps(
+                {
+                    "verbs": list(VERBS),
+                    "session_actions": list(_SESSION_ACTIONS),
+                    "hint": (
+                        "Pass name_lookup=<tool_name> for per-legacy-tool "
+                        "help (e.g. name_lookup='rka_add_note')."
+                    ),
+                },
+                indent=2,
+            )
         return await _legacy("rka_help")(name=name_lookup)
 
     if action == "export":
@@ -1818,7 +1827,9 @@ async def dispatch_session(
                 "rka_session(action='export'): project_id is required",
             )
         return await _legacy("rka_export")(
-            format=format, scope=scope, project_id=project_id,
+            format=format,
+            scope=scope,
+            project_id=project_id,
         )
 
     if action == "generate_claude_md":
@@ -1828,11 +1839,13 @@ async def dispatch_session(
                 "rka_session(action='generate_claude_md'): project_id is required",
             )
         return await _legacy("rka_generate_claude_md")(
-            role=role, project_id=project_id,
+            role=role,
+            project_id=project_id,
         )
 
     return _err(
-        "invalid_action", f"rka_session: unhandled action {action!r}",
+        "invalid_action",
+        f"rka_session: unhandled action {action!r}",
     )
 
 
@@ -1887,55 +1900,92 @@ async def dispatch_session(
 # `missing_field` error matching the v2.6 contract.
 
 # Operations that are unscoped (no project_id required).
-_EXECUTE_UNSCOPED_OPS = frozenset({
-    "create_project",
-    "reset_session",
-})
+_EXECUTE_UNSCOPED_OPS = frozenset(
+    {
+        "create_project",
+        "reset_session",
+    }
+)
 
 # Canonical set of execute operations — single source of truth, mirrors
 # the ExecuteOpLit Literal in server.py. Drift between this set and the
 # Literal is checked by tests in tests/test_mcp.
 EXECUTE_OPERATIONS = (
     # record / ingest / import
-    "record_note", "record_decision", "record_literature",
-    "ingest_document", "import_bibtex", "batch_import",
+    "record_note",
+    "record_decision",
+    "record_literature",
+    "ingest_document",
+    "import_bibtex",
+    "batch_import",
     "register_manuscript",
     # canonical native manuscript aggregate
-    "create_manuscript", "update_manuscript", "upsert_argument_spine",
+    "create_manuscript",
+    "update_manuscript",
+    "upsert_argument_spine",
     "replace_manuscript_reference_manifest",
-    "ratify_manuscript_claim", "transition_manuscript_phase",
-    "create_manuscript_checkpoint", "resolve_manuscript_checkpoint",
+    "ratify_manuscript_claim",
+    "transition_manuscript_phase",
+    "create_manuscript_checkpoint",
+    "resolve_manuscript_checkpoint",
     "record_verification_attestation",
     # interpretation staging
-    "create_interpretation_candidate", "add_interpretation_hint",
+    "create_interpretation_candidate",
+    "add_interpretation_hint",
     "triage_interpretation_candidate",
+    "set_claim_scope",
     # update
-    "update_note", "update_decision", "update_literature",
-    "update_status", "bulk_update", "supersede_decision",
+    "update_note",
+    "update_decision",
+    "update_literature",
+    "update_status",
+    "bulk_update",
+    "supersede_decision",
     # decision lifecycle (PI ratification + calibration)
-    "record_pi_selection", "record_outcome",
+    "record_pi_selection",
+    "record_outcome",
     # literature lifecycle
-    "enrich_doi", "link_literature_to_zotero",
-    "process_paper", "validate_reference",
+    "enrich_doi",
+    "link_literature_to_zotero",
+    "process_paper",
+    "validate_reference",
     # mission lifecycle
-    "create_mission", "update_mission", "update_mission_status",
-    "submit_report", "advance_rq",
+    "create_mission",
+    "update_mission",
+    "update_mission_status",
+    "submit_report",
+    "advance_rq",
     # checkpoint / gate lifecycle
-    "submit_checkpoint", "resolve_checkpoint", "create_gate",
-    "evaluate_gate", "present_decision",
+    "submit_checkpoint",
+    "resolve_checkpoint",
+    "create_gate",
+    "evaluate_gate",
+    "present_decision",
     # claims / clusters
-    "extract_claims", "create_cluster", "assign_claims_to_cluster",
-    "split_cluster", "merge_clusters", "review_claims", "review_cluster",
+    "extract_claims",
+    "create_cluster",
+    "assign_claims_to_cluster",
+    "split_cluster",
+    "merge_clusters",
+    "review_claims",
+    "review_cluster",
     "resolve_contradiction",
     # hooks / notifications
-    "hook_add", "hook_enable", "hook_disable", "hook_delete",
+    "hook_add",
+    "hook_enable",
+    "hook_disable",
+    "hook_delete",
     "brain_notifications_clear",
     # workspace
-    "bootstrap_workspace", "scan_workspace",
+    "bootstrap_workspace",
+    "scan_workspace",
     # maintenance
-    "flag_stale", "eviction_sweep",
+    "flag_stale",
+    "eviction_sweep",
     # session / project
-    "create_project", "reset_session", "session_digest",
+    "create_project",
+    "reset_session",
+    "session_digest",
 )
 
 
@@ -2046,6 +2096,26 @@ async def dispatch_execute(
             project_id=project_id,
         )
 
+    if op == "set_claim_scope":
+        return await _legacy("rka_set_claim_scope")(
+            claim_id=kw.get("claim_id"),
+            expected_revision=kw.get("expected_revision"),
+            actor=kw.get("actor"),
+            reason=kw.get("reason"),
+            conditions=kw.get("conditions") or [],
+            uncertainty=kw.get("uncertainty", "unknown"),
+            uncertainty_note=kw.get("uncertainty_note"),
+            extension_policy=kw.get("extension_policy"),
+            allowed_extensions=kw.get("allowed_extensions") or [],
+            prohibited_extensions=kw.get("prohibited_extensions") or [],
+            falsifier_status=kw.get("falsifier_status", "unknown"),
+            falsifier=kw.get("falsifier"),
+            falsifier_rationale=kw.get("falsifier_rationale"),
+            disconfirming_claim_ids=kw.get("disconfirming_claim_ids") or [],
+            review_status=kw.get("review_status", "draft"),
+            project_id=project_id,
+        )
+
     # --- canonical native manuscript aggregate ---
     if op == "create_manuscript":
         return await _legacy("rka_create_native_manuscript")(
@@ -2088,9 +2158,7 @@ async def dispatch_execute(
         ):
             if field_name not in provided_fields:
                 continue
-            updates[field_name] = phase if field_name == "phase" else kw.get(
-                field_name
-            )
+            updates[field_name] = phase if field_name == "phase" else kw.get(field_name)
         return await _legacy("rka_update_native_manuscript")(
             manuscript_id=kw.get("id"),
             expected_revision=kw.get("expected_revision"),
@@ -2173,9 +2241,7 @@ async def dispatch_execute(
             "completed_at",
         )
         attestation = {
-            field_name: kw[field_name]
-            for field_name in attestation_fields
-            if field_name in kw
+            field_name: kw[field_name] for field_name in attestation_fields if field_name in kw
         }
         return await _legacy("rka_record_manuscript_verification_attestation")(
             manuscript_id=kw.get("id"),
@@ -2220,8 +2286,7 @@ async def dispatch_execute(
         if not question or not chosen or not rationale:
             return _err(
                 "missing_field",
-                "rka_execute(operation='record_decision') requires "
-                "question + chosen + rationale",
+                "rka_execute(operation='record_decision') requires question + chosen + rationale",
             )
         decided_by = kw.get("decided_by") or "brain"
         return await dispatch_record_decision(
@@ -2275,8 +2340,12 @@ async def dispatch_execute(
 
     # --- record_literature + literature-action ops ---
     if op in (
-        "record_literature", "import_bibtex", "enrich_doi",
-        "link_literature_to_zotero", "process_paper", "validate_reference",
+        "record_literature",
+        "import_bibtex",
+        "enrich_doi",
+        "link_literature_to_zotero",
+        "process_paper",
+        "validate_reference",
     ):
         # Map our v2.7.0a3 op name to the action= sub-mode that
         # dispatch_record_literature understands.
@@ -2320,8 +2389,11 @@ async def dispatch_execute(
 
     # --- mission ops ---
     if op in (
-        "create_mission", "update_mission", "update_mission_status",
-        "submit_report", "advance_rq",
+        "create_mission",
+        "update_mission",
+        "update_mission_status",
+        "submit_report",
+        "advance_rq",
     ):
         action_map = {
             "create_mission": "create",
@@ -2365,8 +2437,12 @@ async def dispatch_execute(
 
     # --- checkpoint / gate / decision-ratification ops ---
     if op in (
-        "submit_checkpoint", "resolve_checkpoint", "create_gate",
-        "evaluate_gate", "present_decision", "record_pi_selection",
+        "submit_checkpoint",
+        "resolve_checkpoint",
+        "create_gate",
+        "evaluate_gate",
+        "present_decision",
+        "record_pi_selection",
         "record_outcome",
     ):
         action_map = {
@@ -2663,8 +2739,15 @@ async def dispatch_execute_typed(args: "BaseModel") -> str:  # type: ignore[name
     # Lift the v2.7.0a3 ``operation-common`` kwargs out of the dump and
     # pass them as explicit named arguments. dispatch_execute signs them
     # at the top of its signature.
-    common_keys = ("source", "confidence", "importance",
-                   "verbatim_input", "provenance", "tags", "phase")
+    common_keys = (
+        "source",
+        "confidence",
+        "importance",
+        "verbatim_input",
+        "provenance",
+        "tags",
+        "phase",
+    )
     common_kw = {k: kw_all.pop(k) for k in common_keys if k in kw_all}
 
     return _coerce_result_to_str(

--- a/rka/models/claim.py
+++ b/rka/models/claim.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 # ── Claims ──────────────────────────────────────────────────
 
-ClaimType = Literal[
-    "hypothesis", "evidence", "method", "result", "observation", "assumption"
-]
+ClaimType = Literal["hypothesis", "evidence", "method", "result", "observation", "assumption"]
 
 EvidenceStatus = Literal[
     "unassessed",
@@ -20,6 +18,197 @@ EvidenceStatus = Literal[
     "inconclusive",
     "contradicted",
 ]
+
+ScopeUncertainty = Literal["none", "low", "medium", "high", "unknown"]
+ScopeExtensionPolicy = Literal["exact_only", "bounded"]
+FalsifierStatus = Literal["unknown", "applicable", "not_applicable"]
+ClaimScopeReviewStatus = Literal["draft", "reviewed"]
+ClaimScopeReadiness = Literal["missing", "stale", "incomplete", "needs_review", "ready"]
+ClaimScopeActor = Literal["pi", "brain", "executor", "web_ui", "llm"]
+ClaimConditionKind = Literal[
+    "dataset",
+    "population",
+    "platform",
+    "environment",
+    "threat_model",
+    "baseline",
+    "workload",
+    "metric",
+    "parameter",
+    "assumption",
+    "time_window",
+    "other",
+]
+ClaimConditionOperator = Literal[
+    "equals",
+    "one_of",
+    "range",
+    "at_least",
+    "at_most",
+    "present",
+    "absent",
+    "described_by",
+]
+ConditionScalar = str | int | float | bool
+
+
+class ClaimScopeCondition(BaseModel):
+    """One machine-labeled applicability condition for a canonical claim."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ClaimConditionKind
+    key: str = Field(min_length=1, max_length=128)
+    operator: ClaimConditionOperator
+    value: ConditionScalar | list[ConditionScalar]
+    unit: str | None = Field(default=None, max_length=64)
+    note: str | None = Field(default=None, max_length=2000)
+
+    @model_validator(mode="after")
+    def validate_operator_value(self) -> "ClaimScopeCondition":
+        self.key = self.key.strip()
+        if isinstance(self.value, str):
+            self.value = self.value.strip()
+            if not self.value:
+                raise ValueError("condition value cannot be blank")
+        elif isinstance(self.value, list):
+            self.value = [item.strip() if isinstance(item, str) else item for item in self.value]
+            if any(isinstance(item, str) and not item for item in self.value):
+                raise ValueError("condition values cannot be blank")
+
+        if self.operator == "one_of":
+            if not isinstance(self.value, list) or not self.value:
+                raise ValueError("one_of requires a non-empty list value")
+        elif self.operator == "range":
+            if not isinstance(self.value, list) or len(self.value) != 2:
+                raise ValueError("range requires exactly two boundary values")
+        elif self.operator in {"present", "absent"}:
+            if not isinstance(self.value, bool):
+                raise ValueError(f"{self.operator} requires a boolean value")
+        elif isinstance(self.value, list):
+            raise ValueError(f"{self.operator} requires a scalar value")
+
+        if self.unit is not None:
+            self.unit = self.unit.strip() or None
+        if self.note is not None:
+            self.note = self.note.strip() or None
+        return self
+
+
+class ClaimScopeWrite(BaseModel):
+    """Append one immutable scope version with optimistic revision control."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    expected_revision: int = Field(ge=0)
+    actor: ClaimScopeActor
+    reason: str = Field(min_length=1, max_length=10_000)
+    conditions: list[ClaimScopeCondition] = Field(default_factory=list, max_length=100)
+    uncertainty: ScopeUncertainty = "unknown"
+    uncertainty_note: str | None = Field(default=None, max_length=4000)
+    extension_policy: ScopeExtensionPolicy | None = None
+    allowed_extensions: list[str] = Field(default_factory=list, max_length=100)
+    prohibited_extensions: list[str] = Field(default_factory=list, max_length=100)
+    falsifier_status: FalsifierStatus = "unknown"
+    falsifier: str | None = Field(default=None, max_length=10_000)
+    falsifier_rationale: str | None = Field(default=None, max_length=4000)
+    disconfirming_claim_ids: list[str] = Field(default_factory=list, max_length=200)
+    review_status: ClaimScopeReviewStatus = "draft"
+    source_candidate_id: str | None = Field(default=None, max_length=128)
+
+    @field_validator(
+        "allowed_extensions",
+        "prohibited_extensions",
+        "disconfirming_claim_ids",
+        mode="after",
+    )
+    @classmethod
+    def normalize_unique_strings(cls, values: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for raw in values:
+            value = raw.strip()
+            if value and value not in seen:
+                normalized.append(value)
+                seen.add(value)
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_contract(self) -> "ClaimScopeWrite":
+        self.reason = self.reason.strip()
+        for field in (
+            "uncertainty_note",
+            "falsifier",
+            "falsifier_rationale",
+            "source_candidate_id",
+        ):
+            value = getattr(self, field)
+            if isinstance(value, str):
+                setattr(self, field, value.strip() or None)
+
+        if self.extension_policy == "exact_only" and self.allowed_extensions:
+            raise ValueError("exact_only scope cannot contain allowed_extensions")
+        if self.falsifier_status == "applicable" and not self.falsifier:
+            raise ValueError("applicable falsifier requires a falsifier statement")
+        if self.falsifier_status == "not_applicable" and not self.falsifier_rationale:
+            raise ValueError("not_applicable falsifier requires a rationale")
+
+        if self.review_status == "reviewed":
+            if self.actor not in {"pi", "brain", "web_ui"}:
+                raise ValueError("reviewed scope requires pi, brain, or web_ui actor")
+            if not self.conditions:
+                raise ValueError("reviewed scope requires at least one condition")
+            if self.uncertainty == "unknown":
+                raise ValueError("reviewed scope must resolve uncertainty")
+            if self.extension_policy is None:
+                raise ValueError("reviewed scope requires an extension_policy")
+            if self.extension_policy == "bounded" and not self.allowed_extensions:
+                raise ValueError("bounded scope requires allowed_extensions")
+            if not self.prohibited_extensions:
+                raise ValueError("reviewed scope requires prohibited_extensions")
+            if self.falsifier_status == "unknown":
+                raise ValueError("reviewed scope must resolve falsifier applicability")
+        return self
+
+
+class ClaimScopeVersion(BaseModel):
+    id: str
+    claim_id: str
+    project_id: str
+    revision: int
+    claim_content_hash: str
+    conditions: list[ClaimScopeCondition] = Field(default_factory=list)
+    uncertainty: ScopeUncertainty = "unknown"
+    uncertainty_note: str | None = None
+    extension_policy: ScopeExtensionPolicy | None = None
+    allowed_extensions: list[str] = Field(default_factory=list)
+    prohibited_extensions: list[str] = Field(default_factory=list)
+    falsifier_status: FalsifierStatus = "unknown"
+    falsifier: str | None = None
+    falsifier_rationale: str | None = None
+    disconfirming_claim_ids: list[str] = Field(default_factory=list)
+    review_status: ClaimScopeReviewStatus = "draft"
+    created_by: str
+    reason: str
+    source_candidate_id: str | None = None
+    supersedes_scope_id: str | None = None
+    created_at: str | None = None
+
+
+class ClaimScopeFinding(BaseModel):
+    code: str
+    severity: Literal["block", "warn", "info"]
+    message: str
+
+
+class ClaimScopeHistory(BaseModel):
+    claim_id: str
+    project_id: str
+    current_revision: int = 0
+    scope_readiness: ClaimScopeReadiness = "missing"
+    findings: list[ClaimScopeFinding] = Field(default_factory=list)
+    current: ClaimScopeVersion | None = None
+    versions: list[ClaimScopeVersion] = Field(default_factory=list)
 
 
 class ClaimCreate(BaseModel):
@@ -101,6 +290,10 @@ class Claim(BaseModel):
     stale: bool = False
     source_offset_start: int | None = None
     source_offset_end: int | None = None
+    scope_revision: int = 0
+    scope_readiness: ClaimScopeReadiness = "missing"
+    scope_contract: ClaimScopeVersion | None = None
+    scope_findings: list[ClaimScopeFinding] = Field(default_factory=list)
     project_id: str
     created_at: str | None = None
     updated_at: str | None = None
@@ -162,9 +355,7 @@ class EvidenceCluster(BaseModel):
 
 # ── Claim Edges ─────────────────────────────────────────────
 
-ClaimRelationType = Literal[
-    "member_of", "supports", "contradicts", "qualifies", "supersedes"
-]
+ClaimRelationType = Literal["member_of", "supports", "contradicts", "qualifies", "supersedes"]
 
 
 class ClaimEdgeCreate(BaseModel):

--- a/rka/services/claims.py
+++ b/rka/services/claims.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 
 from rka.infra.ids import generate_id
@@ -10,6 +12,11 @@ from rka.models.claim import (
     ClaimCreate,
     ClaimEdge,
     ClaimEdgeCreate,
+    ClaimScopeFinding,
+    ClaimScopeHistory,
+    ClaimScopeReadiness,
+    ClaimScopeVersion,
+    ClaimScopeWrite,
     ClaimUpdate,
     EvidenceStatus,
 )
@@ -21,6 +28,10 @@ logger = logging.getLogger(__name__)
 
 class ClaimNotFoundError(ValueError):
     """Raised when a claim is absent from the active project scope."""
+
+
+class ClaimScopeConflictError(ValueError):
+    """Raised when a scope append loses its optimistic revision race."""
 
 
 class ClaimService(BaseService):
@@ -48,6 +59,36 @@ class ClaimService(BaseService):
         ) AS contradicted
     """
 
+    _SCOPE_PROJECTION = """
+        scope.id AS scope_id,
+        scope.claim_id AS scope_claim_id,
+        scope.revision AS scope_version_revision,
+        scope.claim_content_hash AS scope_claim_content_hash,
+        scope.conditions AS scope_conditions,
+        scope.uncertainty AS scope_uncertainty,
+        scope.uncertainty_note AS scope_uncertainty_note,
+        scope.extension_policy AS scope_extension_policy,
+        scope.allowed_extensions AS scope_allowed_extensions,
+        scope.prohibited_extensions AS scope_prohibited_extensions,
+        scope.falsifier_status AS scope_falsifier_status,
+        scope.falsifier AS scope_falsifier,
+        scope.falsifier_rationale AS scope_falsifier_rationale,
+        scope.disconfirming_claim_ids AS scope_disconfirming_claim_ids,
+        scope.review_status AS scope_review_status,
+        scope.created_by AS scope_created_by,
+        scope.reason AS scope_reason,
+        scope.source_candidate_id AS scope_source_candidate_id,
+        scope.supersedes_scope_id AS scope_supersedes_scope_id,
+        scope.created_at AS scope_created_at
+    """
+
+    _SCOPE_JOIN = """
+        LEFT JOIN claim_scope_versions AS scope
+          ON scope.claim_id = c.id
+         AND scope.project_id = c.project_id
+         AND scope.revision = c.scope_revision
+    """
+
     def _job_dedupe_key(self, entity_id: str, operation: str) -> str:
         return f"{self.project_id}:claim:{entity_id}:{operation}"
 
@@ -70,9 +111,7 @@ class ClaimService(BaseService):
                 [data.source_entry_id, self.project_id],
             )
             if source is None:
-                raise ValueError(
-                    "source journal entry is not available in this project"
-                )
+                raise ValueError("source journal entry is not available in this project")
             await self.db.execute(
                 """INSERT INTO claims
                    (id, source_entry_id, claim_type, content, confidence, verified,
@@ -119,8 +158,10 @@ class ClaimService(BaseService):
 
     async def get(self, claim_id: str) -> Claim | None:
         row = await self.db.fetchone(
-            f"""SELECT c.*, {self._CONTRADICTED_PROJECTION}
+            f"""SELECT c.*, {self._CONTRADICTED_PROJECTION},
+                       {self._SCOPE_PROJECTION}
                 FROM claims AS c
+                {self._SCOPE_JOIN}
                 WHERE c.id = ? AND c.project_id = ?""",
             [claim_id, self.project_id],
         )
@@ -171,17 +212,21 @@ class ClaimService(BaseService):
 
         if cluster_id:
             sql = f"""
-                SELECT c.*, {self._CONTRADICTED_PROJECTION}
+                SELECT c.*, {self._CONTRADICTED_PROJECTION},
+                       {self._SCOPE_PROJECTION}
                 FROM claims AS c
                 JOIN claim_edges AS membership
                   ON membership.source_claim_id = c.id
                  AND membership.relation = 'member_of'
+                {self._SCOPE_JOIN}
                 WHERE {where}
                 ORDER BY c.created_at DESC LIMIT ? OFFSET ?
             """
         else:
-            sql = f"""SELECT c.*, {self._CONTRADICTED_PROJECTION}
+            sql = f"""SELECT c.*, {self._CONTRADICTED_PROJECTION},
+                       {self._SCOPE_PROJECTION}
                 FROM claims AS c
+                {self._SCOPE_JOIN}
                 WHERE {where}
                 ORDER BY c.created_at DESC LIMIT ? OFFSET ?"""
 
@@ -194,8 +239,7 @@ class ClaimService(BaseService):
             current = await self.get(claim_id)
             if current is None:
                 raise ClaimNotFoundError(
-                    f"claim {claim_id!r} not found in project "
-                    f"{self.project_id}"
+                    f"claim {claim_id!r} not found in project {self.project_id}"
                 )
             return current
 
@@ -215,8 +259,7 @@ class ClaimService(BaseService):
             )
             if cursor.rowcount != 1:
                 raise ClaimNotFoundError(
-                    f"claim {claim_id!r} not found in project "
-                    f"{self.project_id}"
+                    f"claim {claim_id!r} not found in project {self.project_id}"
                 )
 
             # v2.7.0.7 — re-sync derived indexes when the searchable/embeddable
@@ -256,6 +299,162 @@ class ClaimService(BaseService):
         """Get all claims extracted from a specific journal entry."""
         return await self.list(source_entry_id=entry_id)
 
+    # ── Immutable claim-scope contracts ─────────────────────
+
+    async def get_scope_history(self, claim_id: str) -> ClaimScopeHistory | None:
+        claim = await self.get(claim_id)
+        if claim is None:
+            return None
+        rows = await self.db.fetchall(
+            """SELECT * FROM claim_scope_versions
+               WHERE claim_id = ? AND project_id = ?
+               ORDER BY revision DESC""",
+            [claim_id, self.project_id],
+        )
+        versions = [self._scope_row_to_model(row) for row in rows]
+        return ClaimScopeHistory(
+            claim_id=claim.id,
+            project_id=claim.project_id,
+            current_revision=claim.scope_revision,
+            scope_readiness=claim.scope_readiness,
+            findings=claim.scope_findings,
+            current=claim.scope_contract,
+            versions=versions,
+        )
+
+    async def append_scope(
+        self,
+        claim_id: str,
+        data: ClaimScopeWrite,
+    ) -> ClaimScopeHistory:
+        """Append and select one immutable, revision-guarded scope contract."""
+        self._validate_actor(data.actor)
+        async with self.db.transaction():
+            claim = await self.db.fetchone(
+                """SELECT id, claim_type, content, scope_revision
+                   FROM claims WHERE id = ? AND project_id = ?""",
+                [claim_id, self.project_id],
+            )
+            if claim is None:
+                raise ClaimNotFoundError(
+                    f"claim {claim_id!r} not found in project {self.project_id}"
+                )
+            current_revision = int(claim.get("scope_revision") or 0)
+            if current_revision != data.expected_revision:
+                raise ClaimScopeConflictError(
+                    "claim scope revision changed; reload before appending"
+                )
+
+            if data.source_candidate_id:
+                candidate = await self.db.fetchone(
+                    """SELECT 1 FROM interpretation_candidates
+                       WHERE id = ? AND project_id = ?""",
+                    [data.source_candidate_id, self.project_id],
+                )
+                if candidate is None:
+                    raise ValueError("source candidate is not available in this project")
+
+            if claim_id in data.disconfirming_claim_ids:
+                raise ValueError("a claim cannot disconfirm itself")
+            if data.disconfirming_claim_ids:
+                placeholders = ",".join("?" for _ in data.disconfirming_claim_ids)
+                rows = await self.db.fetchall(
+                    f"""SELECT id FROM claims
+                        WHERE project_id = ? AND id IN ({placeholders})""",
+                    [self.project_id, *data.disconfirming_claim_ids],
+                )
+                found = {row["id"] for row in rows}
+                missing = sorted(set(data.disconfirming_claim_ids) - found)
+                if missing:
+                    raise ValueError(
+                        "disconfirming claims are not available in this project: "
+                        + ", ".join(missing)
+                    )
+
+            supersedes_scope_id = None
+            if current_revision:
+                previous = await self.db.fetchone(
+                    """SELECT id FROM claim_scope_versions
+                       WHERE claim_id = ? AND project_id = ? AND revision = ?""",
+                    [claim_id, self.project_id, current_revision],
+                )
+                if previous is None:
+                    raise ClaimScopeConflictError(
+                        "claim scope pointer is inconsistent with immutable history"
+                    )
+                supersedes_scope_id = previous["id"]
+
+            scope_id = generate_id("claim_scope")
+            next_revision = current_revision + 1
+            content_hash = self._claim_content_hash(claim["claim_type"], claim["content"])
+            await self.db.execute(
+                """INSERT INTO claim_scope_versions (
+                       id, claim_id, project_id, revision, claim_content_hash,
+                       conditions, uncertainty, uncertainty_note,
+                       extension_policy, allowed_extensions,
+                       prohibited_extensions, falsifier_status, falsifier,
+                       falsifier_rationale, disconfirming_claim_ids,
+                       review_status, created_by, reason, source_candidate_id,
+                       supersedes_scope_id
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    scope_id,
+                    claim_id,
+                    self.project_id,
+                    next_revision,
+                    content_hash,
+                    json.dumps(
+                        [condition.model_dump(mode="json") for condition in data.conditions],
+                        sort_keys=True,
+                    ),
+                    data.uncertainty,
+                    data.uncertainty_note,
+                    data.extension_policy,
+                    json.dumps(data.allowed_extensions, sort_keys=True),
+                    json.dumps(data.prohibited_extensions, sort_keys=True),
+                    data.falsifier_status,
+                    data.falsifier,
+                    data.falsifier_rationale,
+                    json.dumps(data.disconfirming_claim_ids, sort_keys=True),
+                    data.review_status,
+                    data.actor,
+                    data.reason,
+                    data.source_candidate_id,
+                    supersedes_scope_id,
+                ],
+            )
+            cursor = await self.db.execute(
+                """UPDATE claims SET scope_revision = ?, updated_at = ?
+                   WHERE id = ? AND project_id = ? AND scope_revision = ?""",
+                [
+                    next_revision,
+                    _now(),
+                    claim_id,
+                    self.project_id,
+                    data.expected_revision,
+                ],
+            )
+            if cursor.rowcount != 1:
+                raise ClaimScopeConflictError(
+                    "claim scope revision changed; reload before appending"
+                )
+            await self.audit(
+                "create",
+                "claim_scope",
+                scope_id,
+                data.actor,
+                {
+                    "claim_id": claim_id,
+                    "revision": next_revision,
+                    "review_status": data.review_status,
+                },
+            )
+
+        history = await self.get_scope_history(claim_id)
+        if history is None:  # pragma: no cover - claim exists transactionally
+            raise ClaimNotFoundError(f"claim {claim_id!r} disappeared")
+        return history
+
     # ── Claim Edges ──────────────────────────────────────────
 
     async def create_edge(self, data: ClaimEdgeCreate) -> ClaimEdge:
@@ -263,18 +462,12 @@ class ClaimService(BaseService):
         async with self.db.transaction():
             if data.relation == "member_of":
                 if data.cluster_id is None or data.target_claim_id is not None:
-                    raise ValueError(
-                        "member_of edges require one cluster and no target claim"
-                    )
+                    raise ValueError("member_of edges require one cluster and no target claim")
             elif data.relation == "contradicts":
                 if data.target_claim_id is None and data.cluster_id is None:
-                    raise ValueError(
-                        "contradicts edges require a target claim or cluster"
-                    )
+                    raise ValueError("contradicts edges require a target claim or cluster")
             elif data.target_claim_id is None:
-                raise ValueError(
-                    f"{data.relation} edges require a target claim"
-                )
+                raise ValueError(f"{data.relation} edges require a target claim")
             if data.target_claim_id == data.source_claim_id:
                 raise ValueError("claim edges cannot target their source claim")
 
@@ -284,9 +477,7 @@ class ClaimService(BaseService):
                 [data.source_claim_id, self.project_id],
             )
             if source is None:
-                raise ValueError(
-                    "source claim is not available in this project"
-                )
+                raise ValueError("source claim is not available in this project")
             if data.target_claim_id is not None:
                 target = await self.db.fetchone(
                     """SELECT 1 FROM claims
@@ -294,9 +485,7 @@ class ClaimService(BaseService):
                     [data.target_claim_id, self.project_id],
                 )
                 if target is None:
-                    raise ValueError(
-                        "target claim is not available in this project"
-                    )
+                    raise ValueError("target claim is not available in this project")
             if data.cluster_id is not None:
                 cluster = await self.db.fetchone(
                     """SELECT 1 FROM evidence_clusters
@@ -304,9 +493,7 @@ class ClaimService(BaseService):
                     [data.cluster_id, self.project_id],
                 )
                 if cluster is None:
-                    raise ValueError(
-                        "cluster is not available in this project"
-                    )
+                    raise ValueError("cluster is not available in this project")
             await self.db.execute(
                 """INSERT INTO claim_edges
                    (id, source_claim_id, target_claim_id, cluster_id, relation,
@@ -406,9 +593,10 @@ class ClaimService(BaseService):
         from rka.services.interpretation import InterpretationService
 
         interpretation = InterpretationService(self.db, project_id=self.project_id)
-        extraction_model = getattr(
-            getattr(self.llm, "config", None), "llm_model", None
-        ) or self.llm.__class__.__name__
+        extraction_model = (
+            getattr(getattr(self.llm, "config", None), "llm_model", None)
+            or self.llm.__class__.__name__
+        )
 
         created_ids = []
         async with self.db.transaction():
@@ -525,28 +713,36 @@ class ClaimService(BaseService):
         if not self.embeddings:
             return {"outcome": "skipped", "reason": "embeddings_disabled"}
 
-        await self.embeddings.embed_and_store("claim", claim_id, row["content"], project_id=self.project_id)
+        await self.embeddings.embed_and_store(
+            "claim", claim_id, row["content"], project_id=self.project_id
+        )
         return {"outcome": "updated", "char_count": len(row["content"])}
 
     async def _flag_for_review(self, item_id: str, item_type: str, issues: list[str]) -> None:
         """Flag an item for Brain review."""
-        import json
         review_id = generate_id("review")
         await self.db.execute(
             """INSERT OR IGNORE INTO review_queue
                (id, item_type, item_id, flag, context, priority, project_id)
                VALUES (?, ?, ?, ?, ?, ?, ?)""",
             [
-                review_id, item_type, item_id, "low_confidence_cluster",
-                json.dumps({"issues": issues}), 80, self.project_id,
+                review_id,
+                item_type,
+                item_id,
+                "low_confidence_cluster",
+                json.dumps({"issues": issues}),
+                80,
+                self.project_id,
             ],
         )
         await self.db.commit()
 
     # ── Helpers ──────────────────────────────────────────────
 
-    @staticmethod
-    def _row_to_model(row: dict) -> Claim:
+    @classmethod
+    def _row_to_model(cls, row: dict) -> Claim:
+        scope = cls._scope_projection_to_model(row)
+        readiness, findings = cls._assess_scope(row, scope)
         return Claim(
             id=row["id"],
             source_entry_id=row["source_entry_id"],
@@ -559,10 +755,202 @@ class ClaimService(BaseService):
             stale=bool(row.get("stale", 0)),
             source_offset_start=row.get("source_offset_start"),
             source_offset_end=row.get("source_offset_end"),
+            scope_revision=int(row.get("scope_revision") or 0),
+            scope_readiness=readiness,
+            scope_contract=scope,
+            scope_findings=findings,
             project_id=row["project_id"],
             created_at=row.get("created_at"),
             updated_at=row.get("updated_at"),
         )
+
+    @staticmethod
+    def _claim_content_hash(claim_type: str, content: str) -> str:
+        material = f"{claim_type}\0{content}".encode("utf-8")
+        return hashlib.sha256(material).hexdigest()
+
+    @staticmethod
+    def _json_list(raw: object) -> list:
+        if isinstance(raw, list):
+            return raw
+        if not isinstance(raw, str) or not raw:
+            return []
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, list) else []
+
+    @classmethod
+    def _scope_projection_to_model(cls, row: dict) -> ClaimScopeVersion | None:
+        if not row.get("scope_id"):
+            return None
+        return ClaimScopeVersion(
+            id=row["scope_id"],
+            claim_id=row["scope_claim_id"],
+            project_id=row["project_id"],
+            revision=int(row["scope_version_revision"]),
+            claim_content_hash=row["scope_claim_content_hash"],
+            conditions=cls._json_list(row.get("scope_conditions")),
+            uncertainty=row.get("scope_uncertainty") or "unknown",
+            uncertainty_note=row.get("scope_uncertainty_note"),
+            extension_policy=row.get("scope_extension_policy"),
+            allowed_extensions=cls._json_list(row.get("scope_allowed_extensions")),
+            prohibited_extensions=cls._json_list(row.get("scope_prohibited_extensions")),
+            falsifier_status=row.get("scope_falsifier_status") or "unknown",
+            falsifier=row.get("scope_falsifier"),
+            falsifier_rationale=row.get("scope_falsifier_rationale"),
+            disconfirming_claim_ids=cls._json_list(row.get("scope_disconfirming_claim_ids")),
+            review_status=row.get("scope_review_status") or "draft",
+            created_by=row.get("scope_created_by") or "import",
+            reason=row.get("scope_reason") or "Imported scope history",
+            source_candidate_id=row.get("scope_source_candidate_id"),
+            supersedes_scope_id=row.get("scope_supersedes_scope_id"),
+            created_at=row.get("scope_created_at"),
+        )
+
+    @classmethod
+    def _scope_row_to_model(cls, row: dict) -> ClaimScopeVersion:
+        return ClaimScopeVersion(
+            id=row["id"],
+            claim_id=row["claim_id"],
+            project_id=row["project_id"],
+            revision=int(row["revision"]),
+            claim_content_hash=row["claim_content_hash"],
+            conditions=cls._json_list(row.get("conditions")),
+            uncertainty=row.get("uncertainty") or "unknown",
+            uncertainty_note=row.get("uncertainty_note"),
+            extension_policy=row.get("extension_policy"),
+            allowed_extensions=cls._json_list(row.get("allowed_extensions")),
+            prohibited_extensions=cls._json_list(row.get("prohibited_extensions")),
+            falsifier_status=row.get("falsifier_status") or "unknown",
+            falsifier=row.get("falsifier"),
+            falsifier_rationale=row.get("falsifier_rationale"),
+            disconfirming_claim_ids=cls._json_list(row.get("disconfirming_claim_ids")),
+            review_status=row.get("review_status") or "draft",
+            created_by=row["created_by"],
+            reason=row["reason"],
+            source_candidate_id=row.get("source_candidate_id"),
+            supersedes_scope_id=row.get("supersedes_scope_id"),
+            created_at=row.get("created_at"),
+        )
+
+    @classmethod
+    def _assess_scope(
+        cls,
+        row: dict,
+        scope: ClaimScopeVersion | None,
+    ) -> tuple[ClaimScopeReadiness, list[ClaimScopeFinding]]:
+        findings: list[ClaimScopeFinding] = []
+
+        def add(code: str, severity: str, message: str) -> None:
+            findings.append(
+                ClaimScopeFinding(
+                    code=code,
+                    severity=severity,
+                    message=message,
+                )
+            )
+
+        if scope is None:
+            readiness: ClaimScopeReadiness = "missing"
+            add(
+                "CLAIM_SCOPE_MISSING",
+                "block",
+                "canonical claim has no reviewed reuse boundary",
+            )
+            if int(row.get("scope_revision") or 0) > 0:
+                add(
+                    "CLAIM_SCOPE_POINTER_BROKEN",
+                    "block",
+                    "claim scope pointer does not resolve to immutable history",
+                )
+        elif scope.claim_content_hash != cls._claim_content_hash(row["claim_type"], row["content"]):
+            readiness = "stale"
+            add(
+                "CLAIM_SCOPE_STALE",
+                "block",
+                "claim content or type changed after this scope version",
+            )
+        else:
+            incomplete = False
+            checks = [
+                (
+                    not scope.conditions,
+                    "CLAIM_SCOPE_CONDITIONS_MISSING",
+                    "at least one applicability condition is required",
+                ),
+                (
+                    scope.uncertainty == "unknown",
+                    "CLAIM_SCOPE_UNCERTAINTY_UNKNOWN",
+                    "uncertainty has not been resolved",
+                ),
+                (
+                    scope.extension_policy is None,
+                    "CLAIM_SCOPE_EXTENSION_POLICY_MISSING",
+                    "exact-only or bounded extension policy is required",
+                ),
+                (
+                    scope.extension_policy == "bounded" and not scope.allowed_extensions,
+                    "CLAIM_SCOPE_ALLOWED_EXTENSIONS_MISSING",
+                    "bounded policy requires at least one allowed extension",
+                ),
+                (
+                    not scope.prohibited_extensions,
+                    "CLAIM_SCOPE_PROHIBITED_EXTENSIONS_MISSING",
+                    "at least one prohibited extension is required",
+                ),
+                (
+                    scope.falsifier_status == "unknown",
+                    "CLAIM_SCOPE_FALSIFIER_UNRESOLVED",
+                    "falsifier applicability has not been resolved",
+                ),
+            ]
+            for failed, code, message in checks:
+                if failed:
+                    incomplete = True
+                    add(code, "block", message)
+            if incomplete:
+                readiness = "incomplete"
+            elif scope.review_status != "reviewed":
+                readiness = "needs_review"
+                add(
+                    "CLAIM_SCOPE_REVIEW_REQUIRED",
+                    "block",
+                    "complete scope contract has not been explicitly reviewed",
+                )
+            else:
+                readiness = "ready"
+
+            if scope.disconfirming_claim_ids:
+                add(
+                    "CLAIM_SCOPE_DISCONFIRMING_OBSERVATIONS",
+                    "warn",
+                    "scope cites canonical claims that may bound or disconfirm use",
+                )
+
+        if bool(row.get("stale", 0)):
+            add(
+                "CLAIM_NOT_CURRENT",
+                "block",
+                "claim is marked stale independently of its scope contract",
+            )
+        if bool(row.get("contradicted", 0)):
+            add(
+                "CLAIM_CONTRADICTION_PRESENT",
+                "block",
+                "claim graph contains an unresolved contradiction",
+            )
+        if row.get("evidence_status") == "contradicted":
+            add(
+                "CLAIM_EVIDENCE_CONTRADICTED",
+                "block",
+                "scientific evidence assessment is contradicted",
+            )
+        elif row.get("evidence_status") == "unassessed":
+            add(
+                "CLAIM_EVIDENCE_UNASSESSED",
+                "info",
+                "scope readiness does not establish scientific support",
+            )
+        return readiness, findings
 
     @staticmethod
     def _edge_to_model(row: dict) -> ClaimEdge:

--- a/rka/services/entity_resolver.py
+++ b/rka/services/entity_resolver.py
@@ -127,6 +127,18 @@ _ENTITY_SPECS: dict[str, _EntitySpec] = {
         "claim",
         "claims",
         bool_fields=("verified", "stale", "embedding_pending"),
+        version_fields=("scope_revision",),
+    ),
+    "csc": _EntitySpec(
+        "claim_scope",
+        "claim_scope_versions",
+        json_fields=(
+            "conditions",
+            "allowed_extensions",
+            "prohibited_extensions",
+            "disconfirming_claim_ids",
+        ),
+        version_fields=("revision",),
     ),
     "icd": _EntitySpec(
         "interpretation_candidate",
@@ -358,11 +370,7 @@ def _revision(
         sort_keys=True,
     ).encode("utf-8")
     version = next(
-        (
-            record.get(field)
-            for field in spec.version_fields
-            if record.get(field) is not None
-        ),
+        (record.get(field) for field in spec.version_fields if record.get(field) is not None),
         None,
     )
     timestamp = next(
@@ -443,8 +451,7 @@ class EntityResolverService:
         duplicates_removed = len(normalized_ids) - len(requested_ids)
 
         specs_by_id: dict[str, _EntitySpec | None] = {
-            entity_id: _ENTITY_SPECS.get(_prefix(entity_id))
-            for entity_id in requested_ids
+            entity_id: _ENTITY_SPECS.get(_prefix(entity_id)) for entity_id in requested_ids
         }
         rows_by_id = await self._fetch_entity_rows(specs_by_id)
 
@@ -493,8 +500,7 @@ class EntityResolverService:
                 tags=tags_by_id.get(entity_id, []),
                 contradicted=(
                     entity_id in contradicted_claims
-                    if specs_by_id.get(entity_id)
-                    and specs_by_id[entity_id].entity_type == "claim"
+                    if specs_by_id.get(entity_id) and specs_by_id[entity_id].entity_type == "claim"
                     else None
                 ),
                 as_of=as_of,
@@ -530,14 +536,11 @@ class EntityResolverService:
         }
         if include_sources:
             packet["terminal_sources"] = {
-                claim_id: terminal_sources[claim_id]
-                for claim_id in sorted(terminal_sources)
+                claim_id: terminal_sources[claim_id] for claim_id in sorted(terminal_sources)
             }
         if include_edges:
             resolved_ids = sorted(
-                entity_id
-                for entity_id, resolution in entities.items()
-                if resolution["found"]
+                entity_id for entity_id, resolution in entities.items() if resolution["found"]
             )
             packet["entity_links"] = await self._fetch_entity_links(
                 resolved_ids,
@@ -593,9 +596,7 @@ class EntityResolverService:
             if spec is None or spec.entity_type != "claim":
                 continue
             row = rows_by_id.get(entity_id)
-            stored_project = (
-                EntityResolverService._stored_project_id(spec, row) if row else None
-            )
+            stored_project = EntityResolverService._stored_project_id(spec, row) if row else None
             source_id = row.get("source_entry_id") if row and stored_project == project_id else None
             source_id = source_id if isinstance(source_id, str) and source_id else None
             closures[entity_id] = {
@@ -617,8 +618,7 @@ class EntityResolverService:
         if not resolved:
             return {}
         allowed_pairs = {
-            (spec.entity_type, entity_id)
-            for entity_id, (spec, _row) in resolved.items()
+            (spec.entity_type, entity_id) for entity_id, (spec, _row) in resolved.items()
         }
         tags: dict[str, set[str]] = {}
         for chunk in _chunks(sorted(resolved)):
@@ -698,9 +698,7 @@ class EntityResolverService:
             record["contradicted"] = bool(contradicted)
         sorted_tags = sorted(set(tags), key=lambda value: (value.casefold(), value))
         flattened = {
-            key: value
-            for key, value in record.items()
-            if key not in _RESERVED_PACKET_FIELDS
+            key: value for key, value in record.items() if key not in _RESERVED_PACKET_FIELDS
         }
         flattened.update(
             {

--- a/rka/services/graph.py
+++ b/rka/services/graph.py
@@ -58,12 +58,14 @@ class GraphService:
                 etype = row[f"{prefix}_type"]
                 eid = row[f"{prefix}_id"]
                 entity_ids.setdefault(etype, set()).add(eid)
-            edges.append({
-                "source": row["source_id"],
-                "target": row["target_id"],
-                "link_type": row["link_type"],
-                "created_at": row["created_at"],
-            })
+            edges.append(
+                {
+                    "source": row["source_id"],
+                    "target": row["target_id"],
+                    "link_type": row["link_type"],
+                    "created_at": row["created_at"],
+                }
+            )
 
         # Also include entities that have no links yet (orphans)
         for etype, table, label_col, status_col, has_phase in [
@@ -236,8 +238,7 @@ class GraphService:
         params = {"top_per_kind": top_per_kind, "min_importance": min_importance}
         async with self.db.transaction():
             await self.db.execute(
-                f"DELETE FROM keynodes "
-                f"WHERE blessed = 0 AND {self._project_clause()}",
+                f"DELETE FROM keynodes WHERE blessed = 0 AND {self._project_clause()}",
                 [project_id],
             )
             for row in keynode_rows:
@@ -275,7 +276,9 @@ class GraphService:
     # Ego graph (neighborhood of a single entity)
     # ------------------------------------------------------------------
 
-    async def get_ego_graph(self, entity_id: str, depth: int = 1, project_id: str = "proj_default") -> dict[str, Any]:
+    async def get_ego_graph(
+        self, entity_id: str, depth: int = 1, project_id: str = "proj_default"
+    ) -> dict[str, Any]:
         """Return the subgraph centered on entity_id up to `depth` hops."""
         visited: set[str] = set()
         frontier: set[str] = {entity_id}
@@ -310,12 +313,14 @@ class GraphService:
             visited |= frontier
             next_frontier: set[str] = set()
             for row in rows:
-                all_edges.append({
-                    "source": row["source_id"],
-                    "target": row["target_id"],
-                    "link_type": row["link_type"],
-                    "created_at": row["created_at"],
-                })
+                all_edges.append(
+                    {
+                        "source": row["source_id"],
+                        "target": row["target_id"],
+                        "link_type": row["link_type"],
+                        "created_at": row["created_at"],
+                    }
+                )
                 for eid in (row["source_id"], row["target_id"]):
                     if eid not in visited:
                         next_frontier.add(eid)
@@ -323,15 +328,19 @@ class GraphService:
                 src = row["source_claim_id"]
                 # member_of edges point claim -> cluster (target_claim_id is NULL).
                 # All other relations point claim -> claim.
-                tgt = row["cluster_id"] if row["relation"] == "member_of" else row["target_claim_id"]
+                tgt = (
+                    row["cluster_id"] if row["relation"] == "member_of" else row["target_claim_id"]
+                )
                 if not src or not tgt:
                     continue
-                all_edges.append({
-                    "source": src,
-                    "target": tgt,
-                    "link_type": row["relation"],
-                    "created_at": row["created_at"],
-                })
+                all_edges.append(
+                    {
+                        "source": src,
+                        "target": tgt,
+                        "link_type": row["relation"],
+                        "created_at": row["created_at"],
+                    }
+                )
                 for eid in (src, tgt):
                     if eid not in visited:
                         next_frontier.add(eid)
@@ -427,7 +436,9 @@ class GraphService:
         # Step 1: seed selection
         if seeds is None:
             if search_service is None:
-                raise ValueError("multi_hop_retrieval requires either explicit seeds or a search_service")
+                raise ValueError(
+                    "multi_hop_retrieval requires either explicit seeds or a search_service"
+                )
             hits = await search_service.with_project(project_id).search(query, limit=10)
             seeds = [h.entity_id for h in hits]
         if not seeds:
@@ -477,13 +488,15 @@ class GraphService:
                 edge_key = (src, tgt, link)
                 if edge_key not in edges_seen:
                     edges_seen.add(edge_key)
-                    all_edges.append({
-                        "source": src,
-                        "target": tgt,
-                        "link_type": link,
-                        "weight": w,
-                        "created_at": row["created_at"],
-                    })
+                    all_edges.append(
+                        {
+                            "source": src,
+                            "target": tgt,
+                            "link_type": link,
+                            "weight": w,
+                            "created_at": row["created_at"],
+                        }
+                    )
                 # Propagate score across the edge (both directions count for
                 # relevance; an edge from a high-score seed to a neighbor
                 # makes that neighbor relevant).
@@ -508,13 +521,15 @@ class GraphService:
                 edge_key = (src, tgt, relation)
                 if edge_key not in edges_seen:
                     edges_seen.add(edge_key)
-                    all_edges.append({
-                        "source": src,
-                        "target": tgt,
-                        "link_type": relation,
-                        "weight": w,
-                        "created_at": row["created_at"],
-                    })
+                    all_edges.append(
+                        {
+                            "source": src,
+                            "target": tgt,
+                            "link_type": relation,
+                            "weight": w,
+                            "created_at": row["created_at"],
+                        }
+                    )
                 for parent, child in ((src, tgt), (tgt, src)):
                     parent_score = scores.get(parent)
                     if parent_score is None:
@@ -538,12 +553,14 @@ class GraphService:
         # budget. Final order remains score-descending.
         expansion_ranked = sorted(
             (nid for nid in scores if nid not in seeds_set),
-            key=lambda nid: scores[nid], reverse=True,
+            key=lambda nid: scores[nid],
+            reverse=True,
         )
         budget = max(max_nodes - len(seeds_set), 0)
         ranked_ids = sorted(
             list(seeds_set) + expansion_ranked[:budget],
-            key=lambda nid: scores[nid], reverse=True,
+            key=lambda nid: scores[nid],
+            reverse=True,
         )
         ranked_set = set(ranked_ids)
 
@@ -563,7 +580,9 @@ class GraphService:
             result_nodes.append(n)
 
         # Filter edges to those connecting two ranked nodes (drops noise)
-        result_edges = [e for e in all_edges if e["source"] in ranked_set and e["target"] in ranked_set]
+        result_edges = [
+            e for e in all_edges if e["source"] in ranked_set and e["target"] in ranked_set
+        ]
 
         return {
             "nodes": result_nodes,
@@ -642,11 +661,12 @@ class GraphService:
         import re as _re
 
         desc_terms = [
-            t for t in _re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]+", description.lower())
+            t
+            for t in _re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]+", description.lower())
             if t not in self._REPORT_STOPWORDS and len(t) > 2
         ]
         queries: list[str] = []
-        for q in (angle_queries or []):
+        for q in angle_queries or []:
             q = q.strip()
             if q and q.lower() not in {x.lower() for x in queries}:
                 queries.append(q)
@@ -655,8 +675,13 @@ class GraphService:
             if norm.lower() not in {x.lower() for x in queries}:
                 queries.append(norm)
         if not queries:
-            return {"nodes": [], "queries": [], "seed_count": 0,
-                    "expanded_count": 0, "truncated": False}
+            return {
+                "nodes": [],
+                "queries": [],
+                "seed_count": 0,
+                "expanded_count": 0,
+                "truncated": False,
+            }
 
         # Step 2: seed from every angle. Seed score = best (highest) rank
         # score across angles; rank 0 → 1.0, decaying to 0.5 at seed_limit.
@@ -672,12 +697,19 @@ class GraphService:
                     scores[h.entity_id] = s
                     depths[h.entity_id] = 0
                     included_via[h.entity_id] = {
-                        "via": "search", "query": q, "rank": rank,
+                        "via": "search",
+                        "query": q,
+                        "rank": rank,
                     }
         seeds_set = set(scores.keys())
         if not seeds_set:
-            return {"nodes": [], "queries": queries, "seed_count": 0,
-                    "expanded_count": 0, "truncated": False}
+            return {
+                "nodes": [],
+                "queries": queries,
+                "seed_count": 0,
+                "expanded_count": 0,
+                "truncated": False,
+            }
 
         # Step 3: BFS expansion (same edge sources as multi_hop_retrieval,
         # plus inclusion-provenance tracking on every score improvement).
@@ -721,7 +753,9 @@ class GraphService:
                         scores[child] = new_score
                         depths[child] = hop + 1
                         included_via[child] = {
-                            "via": "link", "from": parent, "link_type": link,
+                            "via": "link",
+                            "from": parent,
+                            "link_type": link,
                         }
                         next_frontier.add(child)
 
@@ -740,12 +774,14 @@ class GraphService:
         # nodes fill the remaining budget by score.
         expansion_ranked = sorted(
             (nid for nid in scores if nid not in seeds_set),
-            key=lambda nid: scores[nid], reverse=True,
+            key=lambda nid: scores[nid],
+            reverse=True,
         )
         budget = max(max_nodes - len(seeds_set), 0)
         truncated = len(expansion_ranked) > budget
-        kept = sorted(seeds_set, key=lambda nid: scores[nid], reverse=True) \
-            + expansion_ranked[:budget]
+        kept = (
+            sorted(seeds_set, key=lambda nid: scores[nid], reverse=True) + expansion_ranked[:budget]
+        )
 
         # Step 5: hydrate metadata + tags.
         node_ids: dict[str, set[str]] = {}
@@ -784,7 +820,9 @@ class GraphService:
     # Decision tree (hierarchical)
     # ------------------------------------------------------------------
 
-    async def get_decision_tree(self, root_id: str | None = None, project_id: str = "proj_default") -> list[dict]:
+    async def get_decision_tree(
+        self, root_id: str | None = None, project_id: str = "proj_default"
+    ) -> list[dict]:
         """Return decisions as a tree structure.
 
         If root_id is given, return only that subtree.
@@ -827,14 +865,22 @@ class GraphService:
             for link in links:
                 for dec_id in dec_ids:
                     if link["source_id"] == dec_id or link["target_id"] == dec_id:
-                        other_id = link["target_id"] if link["source_id"] == dec_id else link["source_id"]
-                        other_type = link["target_type"] if link["source_id"] == dec_id else link["source_type"]
+                        other_id = (
+                            link["target_id"] if link["source_id"] == dec_id else link["source_id"]
+                        )
+                        other_type = (
+                            link["target_type"]
+                            if link["source_id"] == dec_id
+                            else link["source_type"]
+                        )
                         if dec_id in by_id:
-                            by_id[dec_id]["linked_entities"].append({
-                                "id": other_id,
-                                "type": other_type,
-                                "link_type": link["link_type"],
-                            })
+                            by_id[dec_id]["linked_entities"].append(
+                                {
+                                    "id": other_id,
+                                    "type": other_type,
+                                    "link_type": link["link_type"],
+                                }
+                            )
 
         # Build tree
         roots: list[dict] = []
@@ -915,11 +961,25 @@ class GraphService:
         )
         edge_counts = {r["link_type"]: r["cnt"] for r in edge_type_rows}
 
+        # Canonical claim scope is metadata on claim nodes, not a competing
+        # graph node type. Count the derived readiness projection separately.
+        from rka.services.claims import ClaimService
+
+        scope_readiness_counts: dict[str, int] = {}
+        for claim in await ClaimService(
+            self.db,
+            project_id=project_id,
+        ).list(limit=1_000_000):
+            scope_readiness_counts[claim.scope_readiness] = (
+                scope_readiness_counts.get(claim.scope_readiness, 0) + 1
+            )
+
         return {
             "node_counts": node_counts,
             "total_nodes": sum(node_counts.values()),
             "total_edges": total_edges,
             "edge_counts_by_type": edge_counts,
+            "claim_scope_readiness_counts": scope_readiness_counts,
         }
 
     # ------------------------------------------------------------------
@@ -959,7 +1019,14 @@ class GraphService:
             info = table_map.get(etype)
             if not info:
                 for eid in missing:
-                    nodes[eid] = {"id": eid, "type": etype, "label": eid, "status": None, "phase": "", "created_at": ""}
+                    nodes[eid] = {
+                        "id": eid,
+                        "type": etype,
+                        "label": eid,
+                        "status": None,
+                        "phase": "",
+                        "created_at": "",
+                    }
                 continue
             table, label_col, status_col, has_phase = info
             placeholders = ",".join("?" for _ in missing)
@@ -976,9 +1043,9 @@ class GraphService:
                 if etype == "cluster":
                     # Apply STALE prefix BEFORE the 120-char truncation so
                     # the prefix isn't truncated off long cluster labels.
-                    label_text = with_staleness_prefix(
-                        label_text, r.get("needs_reprocessing")
-                    ) or ""
+                    label_text = (
+                        with_staleness_prefix(label_text, r.get("needs_reprocessing")) or ""
+                    )
                 nodes[r["id"]] = {
                     "id": r["id"],
                     "type": etype,
@@ -991,7 +1058,53 @@ class GraphService:
             fetched = {r["id"] for r in rows}
             for eid in missing:
                 if eid not in fetched:
-                    nodes[eid] = {"id": eid, "type": etype, "label": eid, "status": None, "phase": "", "created_at": ""}
+                    nodes[eid] = {
+                        "id": eid,
+                        "type": etype,
+                        "label": eid,
+                        "status": None,
+                        "phase": "",
+                        "created_at": "",
+                    }
+
+        await self._augment_claim_scope_nodes(nodes, project_id)
+
+    async def _augment_claim_scope_nodes(
+        self,
+        nodes: dict[str, dict],
+        project_id: str,
+    ) -> None:
+        """Attach the current canonical scope projection to claim nodes."""
+        claim_ids = sorted(
+            node_id for node_id, node in nodes.items() if node.get("type") == "claim"
+        )
+        if not claim_ids:
+            return
+
+        from rka.services.claims import ClaimService
+
+        placeholders = ",".join("?" for _ in claim_ids)
+        rows = await self.db.fetchall(
+            f"""SELECT c.*, {ClaimService._CONTRADICTED_PROJECTION},
+                       {ClaimService._SCOPE_PROJECTION}
+                FROM claims AS c
+                {ClaimService._SCOPE_JOIN}
+                WHERE c.project_id = ? AND c.id IN ({placeholders})""",
+            [project_id, *claim_ids],
+        )
+        for row in rows:
+            claim = ClaimService._row_to_model(row)
+            node = nodes.get(claim.id)
+            if node is None:
+                continue
+            node["scope_revision"] = claim.scope_revision
+            node["scope_readiness"] = claim.scope_readiness
+            node["scope_findings"] = [
+                finding.model_dump(mode="json") for finding in claim.scope_findings
+            ]
+            node["scope_contract"] = (
+                claim.scope_contract.model_dump(mode="json") if claim.scope_contract else None
+            )
 
     async def _collect_keynode_candidates(
         self,
@@ -1057,7 +1170,13 @@ class GraphService:
                LIMIT ?""",
             [project_id, top_per_kind * 5],
         )
-        dec_bonus = {"active": 0.30, "merged": 0.20, "revisit": 0.16, "superseded": 0.10, "abandoned": 0.08}
+        dec_bonus = {
+            "active": 0.30,
+            "merged": 0.20,
+            "revisit": 0.16,
+            "superseded": 0.10,
+            "abandoned": 0.08,
+        }
         for row in dec_rows:
             imp = 0.52 + dec_bonus.get((row.get("status") or "").lower(), 0.1)
             candidates.append(
@@ -1094,7 +1213,12 @@ class GraphService:
                 }
             )
 
-        per_kind: dict[str, list[dict[str, Any]]] = {"finding": [], "literature": [], "decision": [], "milestone": []}
+        per_kind: dict[str, list[dict[str, Any]]] = {
+            "finding": [],
+            "literature": [],
+            "decision": [],
+            "milestone": [],
+        }
         for candidate in candidates:
             per_kind[candidate["kind"]].append(candidate)
 
@@ -1140,7 +1264,8 @@ class GraphService:
                     "target": tgt_keynode,
                     "link_type": row["link_type"],
                     "weight": max(0.2, weight),
-                    "reason": row.get("link_reason") or "Aggregated from linked supporting entities.",
+                    "reason": row.get("link_reason")
+                    or "Aggregated from linked supporting entities.",
                 }
             else:
                 current["weight"] = max(current["weight"], weight)
@@ -1188,20 +1313,20 @@ class GraphService:
     #   contradicts  -- disagreement, not dependency.
     _IMPACT_DEPENDENT: dict[str, str] = {
         # dependent = source (source depends on target)
-        "derived_from": "source",   # claim depends on its source journal
-        "justified_by": "source",   # decision depends on its evidence
-        "cites": "source",          # journal depends on cited literature
-        "references": "source",     # weak contextual dependency
-        "answers": "source",        # cluster depends on its parent RQ
+        "derived_from": "source",  # claim depends on its source journal
+        "justified_by": "source",  # decision depends on its evidence
+        "cites": "source",  # journal depends on cited literature
+        "references": "source",  # weak contextual dependency
+        "answers": "source",  # cluster depends on its parent RQ
         "builds_on": "source",
         # dependent = target (target depends on source)
-        "informed_by": "target",    # decision depends on informing literature
-        "motivated": "target",      # mission depends on motivating decision
+        "informed_by": "target",  # decision depends on informing literature
+        "motivated": "target",  # mission depends on motivating decision
         "supports": "target",
         "evidence_for": "target",
         "qualifies": "target",
         # claim_edges relations
-        "member_of": "target",      # cluster depends on member claims
+        "member_of": "target",  # cluster depends on member claims
     }
 
     _STALE_STATUSES = ("superseded", "retracted", "abandoned")

--- a/rka/services/interpretation.py
+++ b/rka/services/interpretation.py
@@ -6,7 +6,7 @@ import json
 from typing import Any
 
 from rka.infra.ids import generate_id
-from rka.models.claim import ClaimCreate
+from rka.models.claim import ClaimCreate, ClaimScopeCondition, ClaimScopeWrite
 from rka.models.interpretation import (
     InterpretationCandidate,
     InterpretationCandidateCreate,
@@ -173,7 +173,7 @@ class InterpretationService(BaseService):
         params.extend([limit, offset])
         rows = await self.db.fetchall(
             f"""{self._candidate_select()}
-                WHERE {' AND '.join(conditions)}
+                WHERE {" AND ".join(conditions)}
                 ORDER BY CASE c.review_status
                     WHEN 'in_review' THEN 0 WHEN 'pending' THEN 1 ELSE 2 END,
                     c.created_at ASC, c.id ASC
@@ -191,9 +191,7 @@ class InterpretationService(BaseService):
             raise ValueError("a candidate cannot hint against itself")
         hint_id = generate_id("interpretation_hint")
         async with self.db.transaction():
-            source = await self._require_candidate_revision(
-                candidate_id, data.expected_revision
-            )
+            source = await self._require_candidate_revision(candidate_id, data.expected_revision)
             target = await self._candidate_row(data.related_candidate_id)
             if target is None:
                 raise InterpretationNotFoundError(
@@ -250,9 +248,7 @@ class InterpretationService(BaseService):
             row = await self._require_candidate_revision(candidate_id, data.expected_revision)
             if data.action == "start_review":
                 self._require_status(row, {"pending"}, data.action)
-                await self._transition(
-                    row, data, status="in_review", disposition=None
-                )
+                await self._transition(row, data, status="in_review", disposition=None)
             elif data.action == "promote":
                 self._require_status(row, {"pending", "in_review"}, data.action)
                 await self._promote(row, data)
@@ -289,9 +285,7 @@ class InterpretationService(BaseService):
                 raise ValueError("a candidate cannot merge into itself")
             target = await self._candidate_row(data.target_candidate_id or "")
             if target is None:
-                raise InterpretationNotFoundError(
-                    "merge target is not available in this project"
-                )
+                raise InterpretationNotFoundError("merge target is not available in this project")
             target_type = "interpretation_candidate"
             target_id = data.target_candidate_id
         elif data.action == "request_evidence_mission":
@@ -349,17 +343,41 @@ class InterpretationService(BaseService):
                 verified=True,
                 evidence_status="unassessed",
                 source_offset_start=(
-                    row["locator_start"]
-                    if row["locator_kind"] == "text_offset"
-                    else None
+                    row["locator_start"] if row["locator_kind"] == "text_offset" else None
                 ),
                 source_offset_end=(
-                    row["locator_end"]
-                    if row["locator_kind"] == "text_offset"
-                    else None
+                    row["locator_end"] if row["locator_kind"] == "text_offset" else None
                 ),
             ),
             actor=data.actor,
+        )
+        source_conditions = json.loads(row.get("scope_conditions") or "[]")
+        await claim_service.append_scope(
+            claim.id,
+            ClaimScopeWrite(
+                expected_revision=0,
+                actor=data.actor,
+                reason=(
+                    f"Transferred source-bounded fields from {row['id']} during "
+                    f"explicit promotion: {data.reason}"
+                ),
+                conditions=[
+                    ClaimScopeCondition(
+                        kind="other",
+                        key="source_condition",
+                        operator="described_by",
+                        value=condition,
+                    )
+                    for condition in source_conditions
+                    if isinstance(condition, str) and condition.strip()
+                ],
+                uncertainty=row.get("uncertainty") or "unknown",
+                uncertainty_note=row.get("uncertainty_note"),
+                falsifier_status=("applicable" if row.get("falsifier") else "unknown"),
+                falsifier=row.get("falsifier"),
+                review_status="draft",
+                source_candidate_id=row["id"],
+            ),
         )
         promotion_id = generate_id("interpretation_promotion")
         await self.db.execute(
@@ -517,9 +535,7 @@ class InterpretationService(BaseService):
         table = self._SOURCE_TABLES[source_type]
         await self._require_entity(table, source_id)
 
-    async def _validate_locator_grounding(
-        self, data: InterpretationCandidateCreate
-    ) -> None:
+    async def _validate_locator_grounding(self, data: InterpretationCandidateCreate) -> None:
         """Reject journal offsets that cannot identify a real source span."""
         if data.source_type != "journal" or data.locator_kind != "text_offset":
             return
@@ -636,10 +652,6 @@ class InterpretationService(BaseService):
         except json.JSONDecodeError:
             scope = []
         return InterpretationCandidate(
-            **{
-                key: value
-                for key, value in dict(row).items()
-                if key != "scope_conditions"
-            },
+            **{key: value for key, value in dict(row).items() if key != "scope_conditions"},
             scope_conditions=scope if isinstance(scope, list) else [],
         )

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -17,7 +17,7 @@ from rka.infra.ids import generate_id
 from rka.models.knowledge_pack import KnowledgePackImportResult
 from rka.services.base import BaseService, _now
 
-PACK_SCHEMA_VERSION = 3
+PACK_SCHEMA_VERSION = 4
 PACK_FILE_SUFFIX = ".rka-pack.zip"
 _IMPORT_PROJECT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 
@@ -29,8 +29,7 @@ _IMPORT_PROJECT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 # immutable attestation tables in ``core_data``.
 _PORTABILITY_EXCLUSIONS: dict[str, str] = {
     "change_events": (
-        "Target-local cursor ledger; import emits fresh events with target-local "
-        "watermarks."
+        "Target-local cursor ledger; import emits fresh events with target-local watermarks."
     ),
     "jobs": (
         "Worker queue state, retries, leases, and pending external work are "
@@ -56,13 +55,18 @@ _PORTABILITY_EXCLUSIONS: dict[str, str] = {
 # matching against this set; the set is preserved for backward-
 # compatibility with any external caller importing the symbol, but
 # new code SHOULD prefer the severity field.
-_CRITICAL_INTEGRITY_CATEGORIES: frozenset[str] = frozenset({
-    "orphaned_entity_link_sources",
-    "orphaned_entity_link_targets",
-    "orphaned_claim_edge_sources",
-    "orphaned_claim_edge_targets",
-    "orphaned_claim_edge_clusters",
-})
+_CRITICAL_INTEGRITY_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "orphaned_entity_link_sources",
+        "orphaned_entity_link_targets",
+        "orphaned_claim_edge_sources",
+        "orphaned_claim_edge_targets",
+        "orphaned_claim_edge_clusters",
+        "claim_scope_pointer_mismatch",
+        "claim_scope_revision_chain_invalid",
+        "claim_scope_disconfirming_refs_invalid",
+    }
+)
 
 
 class KnowledgePackIntegrityError(RuntimeError):
@@ -77,9 +81,8 @@ class KnowledgePackIntegrityError(RuntimeError):
     def __init__(self, issues: list[dict]):
         self.issues = issues
         cats = sorted({issue["category"] for issue in issues})
-        super().__init__(
-            "Pack import rejected: critical integrity issues — " + ", ".join(cats)
-        )
+        super().__init__("Pack import rejected: critical integrity issues — " + ", ".join(cats))
+
 
 # Categorized table registry — all tables with project_id MUST be listed here.
 # Export validation will FAIL if any uncategorized table has data.
@@ -95,6 +98,7 @@ _TABLE_CATEGORIES: dict[str, list[str]] = {
         "interpretation_candidate_hints",
         "interpretation_review_events",
         "claims",
+        "claim_scope_versions",
         "interpretation_promotions",
         "evidence_clusters",
         "claim_edges",
@@ -174,6 +178,7 @@ _INSERT_ORDER = (
     "interpretation_candidate_hints",
     "interpretation_review_events",
     "claims",
+    "claim_scope_versions",
     "interpretation_promotions",
     "claim_edges",
     "entity_links",
@@ -212,9 +217,7 @@ _INSERT_ORDER = (
     "qa_logs",
     "hook_executions",
 )
-_IMPORT_INSERT_TABLES = frozenset(
-    ("projects", "project_states", *_INSERT_ORDER)
-)
+_IMPORT_INSERT_TABLES = frozenset(("projects", "project_states", *_INSERT_ORDER))
 _IMPORT_TRANSIENT_COLUMNS: dict[str, frozenset[str]] = {
     # Bundled-file metadata is consumed by ``_restore_artifact_files`` and is
     # deliberately not a column in the destination artifacts table.
@@ -229,6 +232,7 @@ _SELF_REFERENTIAL_TABLES: dict[str, str | list[str]] = {
     "missions": ["depends_on", "parent_mission_id"],
     "decisions": ["parent_id", "superseded_by"],
     "journal": "supersedes",
+    "claim_scope_versions": "supersedes_scope_id",
     "events": "caused_by_event",
     "manuscript_checkpoints": "supersedes_id",
     "topics": "parent_id",
@@ -240,6 +244,7 @@ _ID_ENTITY_TYPES = {
     "journal": "journal",
     "checkpoints": "checkpoint",
     "claims": "claim",
+    "claim_scope_versions": "claim_scope",
     "interpretation_candidates": "interpretation_candidate",
     "interpretation_candidate_hints": "interpretation_hint",
     "interpretation_review_events": "interpretation_review",
@@ -275,16 +280,32 @@ _ID_ENTITY_TYPES = {
 _DIRECT_ID_COLUMNS = {
     "literature": ("id",),
     "missions": ("id", "depends_on", "parent_mission_id", "motivated_by_decision"),
-    "decisions": ("id", "parent_id", "superseded_by", "recommended_option_id", "pi_selected_option_id"),
+    "decisions": (
+        "id",
+        "parent_id",
+        "superseded_by",
+        "recommended_option_id",
+        "pi_selected_option_id",
+    ),
     "journal": ("id", "related_mission", "supersedes", "superseded_by"),
     "checkpoints": ("id", "mission_id", "linked_decision_id"),
     "claims": ("id", "source_entry_id"),
+    "claim_scope_versions": (
+        "id",
+        "claim_id",
+        "source_candidate_id",
+        "supersedes_scope_id",
+    ),
     "interpretation_candidates": ("id", "source_id", "disposition_target_id"),
     "interpretation_candidate_hints": (
-        "id", "candidate_id", "related_candidate_id",
+        "id",
+        "candidate_id",
+        "related_candidate_id",
     ),
     "interpretation_review_events": (
-        "id", "candidate_id", "target_id",
+        "id",
+        "candidate_id",
+        "target_id",
     ),
     "interpretation_promotions": ("id", "candidate_id", "claim_id"),
     "evidence_clusters": ("id", "research_question_id"),
@@ -304,28 +325,45 @@ _DIRECT_ID_COLUMNS = {
     ),
     "manuscripts": ("id", "legacy_journal_id"),
     "manuscript_reference_members": (
-        "id", "manuscript_id", "literature_id",
+        "id",
+        "manuscript_id",
+        "literature_id",
     ),
     "manuscript_claims": ("id", "manuscript_id"),
     "manuscript_claim_versions": ("claim_id", "manuscript_id"),
     "manuscript_claim_ratifications": (
-        "id", "manuscript_id", "claim_id", "decision_id",
+        "id",
+        "manuscript_id",
+        "claim_id",
+        "decision_id",
     ),
     "manuscript_units": ("id", "manuscript_id", "artifact_ref"),
     "manuscript_claim_evidence": (
-        "manuscript_id", "manuscript_claim_id", "evidence_claim_id",
+        "manuscript_id",
+        "manuscript_claim_id",
+        "evidence_claim_id",
     ),
     "manuscript_unit_evidence": (
-        "manuscript_id", "unit_id", "evidence_claim_id",
+        "manuscript_id",
+        "unit_id",
+        "evidence_claim_id",
     ),
     "manuscript_claim_units": (
-        "manuscript_id", "manuscript_claim_id", "unit_id",
+        "manuscript_id",
+        "manuscript_claim_id",
+        "unit_id",
     ),
     "manuscript_checkpoints": (
-        "id", "manuscript_id", "unit_id", "decision_id", "supersedes_id",
+        "id",
+        "manuscript_id",
+        "unit_id",
+        "decision_id",
+        "supersedes_id",
     ),
     "manuscript_claim_verification_attestations": (
-        "id", "manuscript_id", "claim_id",
+        "id",
+        "manuscript_id",
+        "claim_id",
     ),
     "hooks": ("id",),
     "hook_executions": ("id", "hook_id"),
@@ -356,8 +394,14 @@ _FK_COLUMNS: dict[str, set[str]] = {
     "journal": {"supersedes"},
     "checkpoints": {"mission_id", "linked_decision_id"},
     "claims": {"source_entry_id"},
+    "claim_scope_versions": {
+        "claim_id",
+        "source_candidate_id",
+        "supersedes_scope_id",
+    },
     "interpretation_candidate_hints": {
-        "candidate_id", "related_candidate_id",
+        "candidate_id",
+        "related_candidate_id",
     },
     "interpretation_review_events": {"candidate_id"},
     "interpretation_promotions": {"candidate_id", "claim_id"},
@@ -377,23 +421,35 @@ _FK_COLUMNS: dict[str, set[str]] = {
     "manuscript_claims": {"manuscript_id"},
     "manuscript_claim_versions": {"claim_id", "manuscript_id"},
     "manuscript_claim_ratifications": {
-        "manuscript_id", "claim_id", "decision_id",
+        "manuscript_id",
+        "claim_id",
+        "decision_id",
     },
     "manuscript_units": {"manuscript_id"},
     "manuscript_claim_evidence": {
-        "manuscript_id", "manuscript_claim_id", "evidence_claim_id",
+        "manuscript_id",
+        "manuscript_claim_id",
+        "evidence_claim_id",
     },
     "manuscript_unit_evidence": {
-        "manuscript_id", "unit_id", "evidence_claim_id",
+        "manuscript_id",
+        "unit_id",
+        "evidence_claim_id",
     },
     "manuscript_claim_units": {
-        "manuscript_id", "manuscript_claim_id", "unit_id",
+        "manuscript_id",
+        "manuscript_claim_id",
+        "unit_id",
     },
     "manuscript_checkpoints": {
-        "manuscript_id", "unit_id", "decision_id", "supersedes_id",
+        "manuscript_id",
+        "unit_id",
+        "decision_id",
+        "supersedes_id",
     },
     "manuscript_claim_verification_attestations": {
-        "manuscript_id", "claim_id",
+        "manuscript_id",
+        "claim_id",
     },
     "topics": {"parent_id"},
     "entity_topics": {"topic_id"},
@@ -415,8 +471,17 @@ _PROSE_TEXT_COLUMNS: dict[str, tuple[str, ...]] = {
     "missions": ("objective", "context", "tasks", "acceptance_criteria"),
     "literature": ("abstract", "notes"),
     "claims": ("content",),
+    "claim_scope_versions": (
+        "uncertainty_note",
+        "falsifier",
+        "falsifier_rationale",
+        "reason",
+    ),
     "interpretation_candidates": (
-        "statement", "uncertainty_note", "falsifier", "disposition_reason",
+        "statement",
+        "uncertainty_note",
+        "falsifier",
+        "disposition_reason",
     ),
     "interpretation_candidate_hints": ("rationale",),
     "interpretation_review_events": ("reason",),
@@ -426,7 +491,8 @@ _PROSE_TEXT_COLUMNS: dict[str, tuple[str, ...]] = {
     "events": ("summary",),
     "manuscript_claim_versions": ("exact_wording", "allowed_wording"),
     "manuscript_units": (
-        "allowed_interpretation", "prohibited_interpretation",
+        "allowed_interpretation",
+        "prohibited_interpretation",
     ),
 }
 
@@ -435,6 +501,12 @@ _JSON_ID_COLUMNS = {
     "decisions": ("related_missions", "related_literature", "related_journal"),
     "journal": ("related_decisions", "related_literature"),
     "interpretation_candidates": ("scope_conditions",),
+    "claim_scope_versions": (
+        "conditions",
+        "allowed_extensions",
+        "prohibited_extensions",
+        "disconfirming_claim_ids",
+    ),
     "exploration_summaries": ("source_refs",),
     "qa_logs": ("answer_structured", "sources"),
     "events": ("details",),
@@ -442,7 +514,8 @@ _JSON_ID_COLUMNS = {
     "reference_validation_attestations": ("full_json_payload",),
     "manuscript_claim_versions": ("prohibited_wording",),
     "manuscript_claim_verification_attestations": (
-        "dependency_snapshot", "full_json_payload",
+        "dependency_snapshot",
+        "full_json_payload",
     ),
     "context_snapshots": ("entry_ids",),
     "keynodes": ("node_refs",),
@@ -457,6 +530,7 @@ _ENTITY_LINK_ENDPOINT_TABLES: dict[str, str] = {
     "artifact": "artifacts",
     "checkpoint": "checkpoints",
     "claim": "claims",
+    "claim_scope": "claim_scope_versions",
     "interpretation_candidate": "interpretation_candidates",
     "interpretation_hint": "interpretation_candidate_hints",
     "interpretation_promotion": "interpretation_promotions",
@@ -474,9 +548,7 @@ _ENTITY_LINK_ENDPOINT_TABLES: dict[str, str] = {
     "manuscript_checkpoint": "manuscript_checkpoints",
     "manuscript_claim": "manuscript_claims",
     "manuscript_claim_ratification": "manuscript_claim_ratifications",
-    "manuscript_claim_verification": (
-        "manuscript_claim_verification_attestations"
-    ),
+    "manuscript_claim_verification": ("manuscript_claim_verification_attestations"),
     "manuscript_reference": "manuscript_reference_members",
     "manuscript_unit": "manuscript_units",
     "mission": "missions",
@@ -490,7 +562,9 @@ _ENTITY_LINK_ENDPOINT_TABLES: dict[str, str] = {
 class KnowledgePackService(BaseService):
     """Export and import a full project-scoped knowledge pack."""
 
-    async def export_pack(self, project_id: str | None = None, include_logs: bool = False) -> tuple[str, str]:
+    async def export_pack(
+        self, project_id: str | None = None, include_logs: bool = False
+    ) -> tuple[str, str]:
         """Export one transactionally consistent project snapshot."""
         async with self.db.transaction(write=False):
             return await self._export_pack(project_id, include_logs)
@@ -531,7 +605,8 @@ class KnowledgePackService(BaseService):
             "pack_format_version": PACK_SCHEMA_VERSION,
             "exported_at": _now(),
             "rka_version": __version__,
-            "categories_exported": ["core_data", "derived_data"] + (["bulk_logs"] if include_logs else []),
+            "categories_exported": ["core_data", "derived_data"]
+            + (["bulk_logs"] if include_logs else []),
             "project": dict(project),
             "project_state": dict(project_state) if project_state else None,
             "portability": {
@@ -592,18 +667,13 @@ class KnowledgePackService(BaseService):
             source_project = manifest["project"]
             source_state = manifest.get("project_state")
             source_tables: dict[str, list[dict[str, Any]]] = manifest.get("tables", {})
-            pack_format = (
-                manifest.get("pack_format_version")
-                or manifest.get("schema_version")
-            )
+            pack_format = manifest.get("pack_format_version") or manifest.get("schema_version")
 
             raw_target_project_id = (
                 project_id if project_id is not None else source_project.get("id")
             )
             raw_target_project_name = (
-                project_name
-                if project_name is not None
-                else source_project.get("name")
+                project_name if project_name is not None else source_project.get("name")
             )
             if not isinstance(raw_target_project_id, str):
                 raise ValueError("Imported project ID must be a string")
@@ -644,8 +714,7 @@ class KnowledgePackService(BaseService):
             if tables.get("artifacts"):
                 if artifact_project_root.exists():
                     raise ValueError(
-                        "Artifact storage for imported project already exists: "
-                        f"{target_project_id}"
+                        f"Artifact storage for imported project already exists: {target_project_id}"
                     )
                 artifact_storage_root.mkdir(parents=True, exist_ok=True)
                 staging_project_root = Path(
@@ -688,9 +757,7 @@ class KnowledgePackService(BaseService):
 
                     for table in _INSERT_ORDER:
                         rows = [dict(row) for row in tables.get(table, [])]
-                        rows = self._prepare_rows_for_insert(
-                            table, rows, target_project_id
-                        )
+                        rows = self._prepare_rows_for_insert(table, rows, target_project_id)
 
                         if table == "artifacts":
                             staging_artifact_root = (
@@ -708,6 +775,16 @@ class KnowledgePackService(BaseService):
 
                         for row in rows:
                             await self._insert_row(table, row)
+                            if table == "claim_scope_versions":
+                                await self.db.execute(
+                                    """UPDATE claims SET scope_revision = ?
+                                       WHERE id = ? AND project_id = ?""",
+                                    [
+                                        row["revision"],
+                                        row["claim_id"],
+                                        target_project_id,
+                                    ],
+                                )
 
                         imported_counts[table] = len(rows)
 
@@ -717,20 +794,14 @@ class KnowledgePackService(BaseService):
                     # This creates identity/metadata only: never claims,
                     # evidence links, ratifications, or checkpoints.
                     if pack_format in (1, 2):
-                        imported_counts["manuscripts"] += (
-                            await self._backfill_legacy_manuscripts(
-                                target_project_id
-                            )
+                        imported_counts["manuscripts"] += await self._backfill_legacy_manuscripts(
+                            target_project_id
                         )
 
                     # The integrity gate runs inside the managed transaction so
                     # critical issues roll back the complete imported graph.
                     integrity_issues = await self.check_integrity(target_project_id)
-                    critical = [
-                        i
-                        for i in integrity_issues
-                        if i.get("severity") == "critical"
-                    ]
+                    critical = [i for i in integrity_issues if i.get("severity") == "critical"]
                     if critical:
                         raise KnowledgePackIntegrityError(critical)
 
@@ -743,10 +814,7 @@ class KnowledgePackService(BaseService):
                         staging_project_root.replace(artifact_project_root)
                         published_project_root = True
             except BaseException:
-                if (
-                    staging_project_root is not None
-                    and staging_project_root.exists()
-                ):
+                if staging_project_root is not None and staging_project_root.exists():
                     shutil.rmtree(staging_project_root, ignore_errors=True)
                 if published_project_root and artifact_project_root.exists():
                     shutil.rmtree(artifact_project_root, ignore_errors=True)
@@ -756,8 +824,7 @@ class KnowledgePackService(BaseService):
         # non-critical findings so the import doesn't land with stale derived
         # counts (Brain-ratified addition during the upfront Backbrief).
         await self._sync_imported_indexes(tables, target_project_id)
-        if any(i.get("category") == "claim_count_mismatch"
-               for i in integrity_issues):
+        if any(i.get("category") == "claim_count_mismatch" for i in integrity_issues):
             await self._recompute_cluster_claim_counts(target_project_id)
 
         return KnowledgePackImportResult(
@@ -808,12 +875,10 @@ class KnowledgePackService(BaseService):
                 [legacy_id],
             )
             manuscript_tags = [
-                tag for tag in tag_rows
-                if str(tag.get("tag") or "").casefold() == "manuscript"
+                tag for tag in tag_rows if str(tag.get("tag") or "").casefold() == "manuscript"
             ]
             scoped_manuscript_tags = [
-                tag for tag in manuscript_tags
-                if tag.get("project_id") == project_id
+                tag for tag in manuscript_tags if tag.get("project_id") == project_id
             ]
             venue_tags = [
                 str(tag.get("tag") or "")[6:].strip()
@@ -827,9 +892,7 @@ class KnowledgePackService(BaseService):
                 if tag.get("project_id") == project_id
                 and str(tag.get("tag") or "")[:6].casefold() == "phase:"
             ]
-            normalized_input = str(row.get("verbatim_input") or "").replace(
-                "\r", ""
-            )
+            normalized_input = str(row.get("verbatim_input") or "").replace("\r", "")
             title, separator, remainder = normalized_input.partition("\n\n")
             title = title.strip()
             abstract = (remainder.strip() or None) if separator else None
@@ -841,9 +904,7 @@ class KnowledgePackService(BaseService):
                         "tag_project_mismatch",
                         {
                             "manuscript_tag_count": len(manuscript_tags),
-                            "same_project_tag_count": len(
-                                scoped_manuscript_tags
-                            ),
+                            "same_project_tag_count": len(scoped_manuscript_tags),
                         },
                     )
                 )
@@ -861,33 +922,17 @@ class KnowledgePackService(BaseService):
                 issues.append(
                     (
                         "missing_title",
-                        {
-                            "source": (
-                                "journal.verbatim_input:first_paragraph"
-                            )
-                        },
+                        {"source": ("journal.verbatim_input:first_paragraph")},
                     )
                 )
-            if len(venue_tags) == 0 or (
-                len(venue_tags) == 1 and not venue_tags[0]
-            ):
-                issues.append(
-                    ("missing_venue", {"venue_tag_count": len(venue_tags)})
-                )
+            if len(venue_tags) == 0 or (len(venue_tags) == 1 and not venue_tags[0]):
+                issues.append(("missing_venue", {"venue_tag_count": len(venue_tags)}))
             elif len(venue_tags) > 1:
-                issues.append(
-                    ("ambiguous_venue", {"venue_tag_count": len(venue_tags)})
-                )
-            if len(phase_tags) == 0 or (
-                len(phase_tags) == 1 and not phase_tags[0]
-            ):
-                issues.append(
-                    ("missing_phase", {"phase_tag_count": len(phase_tags)})
-                )
+                issues.append(("ambiguous_venue", {"venue_tag_count": len(venue_tags)}))
+            if len(phase_tags) == 0 or (len(phase_tags) == 1 and not phase_tags[0]):
+                issues.append(("missing_phase", {"phase_tag_count": len(phase_tags)}))
             elif len(phase_tags) > 1:
-                issues.append(
-                    ("ambiguous_phase", {"phase_tag_count": len(phase_tags)})
-                )
+                issues.append(("ambiguous_phase", {"phase_tag_count": len(phase_tags)}))
             elif phase_tags[0] not in {"draft", "drafting", "review", "final"}:
                 issues.append(
                     (
@@ -932,9 +977,7 @@ class KnowledgePackService(BaseService):
                         "deterministic_id_conflict",
                         {
                             "candidate_id": candidate_id,
-                            "existing_legacy_journal_id": collision.get(
-                                "legacy_journal_id"
-                            ),
+                            "existing_legacy_journal_id": collision.get("legacy_journal_id"),
                             "existing_project_id": collision.get("project_id"),
                         },
                     )
@@ -1040,9 +1083,7 @@ class KnowledgePackService(BaseService):
                 )
             safe_name = self._safe_filename(path.name)
             pack_file = f"artifacts/{artifact['id']}/{safe_name}"
-            with path.open("rb") as src, archive.open(
-                pack_file, "w"
-            ) as dst:
+            with path.open("rb") as src, archive.open(pack_file, "w") as dst:
                 actual_hash = self._copy_and_hash(src, dst)
             self._assert_artifact_content_hash(
                 artifact,
@@ -1064,10 +1105,8 @@ class KnowledgePackService(BaseService):
             raise ValueError("Knowledge pack manifest is not valid JSON") from exc
 
         pack_format = manifest.get("pack_format_version") or manifest.get("schema_version")
-        if pack_format not in (1, 2, PACK_SCHEMA_VERSION):
-            raise ValueError(
-                f"Unsupported knowledge pack format version: {pack_format}"
-            )
+        if pack_format not in (1, 2, 3, PACK_SCHEMA_VERSION):
+            raise ValueError(f"Unsupported knowledge pack format version: {pack_format}")
         if not manifest.get("project"):
             raise ValueError("Knowledge pack manifest is missing project metadata")
         return manifest
@@ -1077,7 +1116,9 @@ class KnowledgePackService(BaseService):
         if existing_id:
             raise ValueError(f"Project '{project_id}' already exists")
 
-        existing_name = await self.db.fetchone("SELECT id FROM projects WHERE name = ?", [project_name])
+        existing_name = await self.db.fetchone(
+            "SELECT id FROM projects WHERE name = ?", [project_name]
+        )
         if existing_name:
             raise ValueError(
                 f"Project name '{project_name}' already exists. Choose a different import name."
@@ -1088,9 +1129,7 @@ class KnowledgePackService(BaseService):
         duplicate_dois = sorted(doi for doi, count in Counter(dois).items() if count > 1)
         if duplicate_dois:
             sample = ", ".join(duplicate_dois[:5])
-            raise ValueError(
-                f"Knowledge pack contains duplicate literature DOI(s): {sample}"
-            )
+            raise ValueError(f"Knowledge pack contains duplicate literature DOI(s): {sample}")
 
     @staticmethod
     def _validate_portable_child_links(
@@ -1110,10 +1149,7 @@ class KnowledgePackService(BaseService):
                 str(row["id"])
                 for row in tables.get(table, [])
                 if row.get("id")
-                and (
-                    "project_id" not in row
-                    or row.get("project_id") == project_id
-                )
+                and ("project_id" not in row or row.get("project_id") == project_id)
             }
         endpoint_ids["project"] = {project_id}
 
@@ -1123,13 +1159,11 @@ class KnowledgePackService(BaseService):
             entity_id = str(membership.get("entity_id") or "")
             if topic_id not in topic_ids:
                 raise ValueError(
-                    "Knowledge pack entity_topics contains a topic outside "
-                    f"project {project_id!r}"
+                    f"Knowledge pack entity_topics contains a topic outside project {project_id!r}"
                 )
             if entity_type not in endpoint_ids:
                 raise ValueError(
-                    "Knowledge pack entity_topics contains unsupported "
-                    f"entity type {entity_type!r}"
+                    f"Knowledge pack entity_topics contains unsupported entity type {entity_type!r}"
                 )
             if entity_id not in endpoint_ids[entity_type]:
                 raise ValueError(
@@ -1211,17 +1245,12 @@ class KnowledgePackService(BaseService):
 
         for column in _JSON_ID_COLUMNS.get(table, ()):
             if remapped.get(column):
-                if (
-                    table == "reference_validation_attestations"
-                    and column == "full_json_payload"
-                ):
-                    remapped[column] = (
-                        self._rewrite_reference_validation_payload(
-                            remapped[column],
-                            id_map=id_map,
-                            source_project_id=source_project_id,
-                            target_project_id=target_project_id,
-                        )
+                if table == "reference_validation_attestations" and column == "full_json_payload":
+                    remapped[column] = self._rewrite_reference_validation_payload(
+                        remapped[column],
+                        id_map=id_map,
+                        source_project_id=source_project_id,
+                        target_project_id=target_project_id,
                     )
                 else:
                     remapped[column] = self._rewrite_json_refs(
@@ -1265,7 +1294,14 @@ class KnowledgePackService(BaseService):
         if table == "exploration_summaries" and column == "scope_id":
             if scope_type == "project" and value == source_project_id:
                 return target_project_id
-            if scope_type in {"mission", "decision", "journal", "literature", "checkpoint", "summary"}:
+            if scope_type in {
+                "mission",
+                "decision",
+                "journal",
+                "literature",
+                "checkpoint",
+                "summary",
+            }:
                 return id_map.get(value, value)
             return value
 
@@ -1330,9 +1366,7 @@ class KnowledgePackService(BaseService):
             preserved_source_job_id = source_result.get("source_job_id")
             preserved_source_project_id = source_result.get("source_project_id")
 
-        rewritten = self._rewrite_nested_refs(
-            payload, id_map, source_project_id, target_project_id
-        )
+        rewritten = self._rewrite_nested_refs(payload, id_map, source_project_id, target_project_id)
         if isinstance(rewritten, dict):
             result = rewritten.get("result")
             if isinstance(result, dict) and "job_id" in result:
@@ -1382,14 +1416,16 @@ class KnowledgePackService(BaseService):
         if source_state:
             phases = source_state.get("phases_config")
         if not phases:
-            phases = json.dumps([
-                "literature",
-                "planning",
-                "data_collection",
-                "implementation",
-                "evaluation",
-                "paper_writing",
-            ])
+            phases = json.dumps(
+                [
+                    "literature",
+                    "planning",
+                    "data_collection",
+                    "implementation",
+                    "evaluation",
+                    "paper_writing",
+                ]
+            )
         return {
             "project_id": target_project_id,
             "project_name": target_project_name,
@@ -1399,8 +1435,12 @@ class KnowledgePackService(BaseService):
             "summary": (source_state or {}).get("summary"),
             "blockers": (source_state or {}).get("blockers"),
             "metrics": (source_state or {}).get("metrics"),
-            "created_at": (source_state or {}).get("created_at") or source_project.get("created_at") or _now(),
-            "updated_at": (source_state or {}).get("updated_at") or source_project.get("updated_at") or _now(),
+            "created_at": (source_state or {}).get("created_at")
+            or source_project.get("created_at")
+            or _now(),
+            "updated_at": (source_state or {}).get("updated_at")
+            or source_project.get("updated_at")
+            or _now(),
         }
 
     def _prepare_rows_for_insert(
@@ -1420,6 +1460,13 @@ class KnowledgePackService(BaseService):
         if table == "audit_log" or table == "bootstrap_log":
             for row in prepared:
                 row.pop("id", None)
+        if table == "claims":
+            # Scope rows are inserted after claims. Rebuild the monotonic head
+            # pointer as each immutable version is imported so migration 041's
+            # append triggers remain active during untrusted pack ingestion.
+            for row in prepared:
+                if "scope_revision" in row:
+                    row["scope_revision"] = 0
         return prepared
 
     def _rewrite_project_scope(
@@ -1474,9 +1521,7 @@ class KnowledgePackService(BaseService):
 
         resolved_artifact_root = artifact_root.resolve()
         resolved_persisted_root = (
-            persisted_root.resolve()
-            if persisted_root is not None
-            else resolved_artifact_root
+            persisted_root.resolve() if persisted_root is not None else resolved_artifact_root
         )
         prepared: list[dict[str, Any]] = []
         for row in rows:
@@ -1487,12 +1532,8 @@ class KnowledgePackService(BaseService):
                     f"Knowledge pack artifact '{artifact.get('id') or '<unknown>'}' "
                     "has no bundled file"
                 )
-            safe_filename = self._safe_filename(
-                artifact.get("filename") or "artifact.bin"
-            )
-            destination = (
-                resolved_artifact_root / artifact["id"] / safe_filename
-            ).resolve()
+            safe_filename = self._safe_filename(artifact.get("filename") or "artifact.bin")
+            destination = (resolved_artifact_root / artifact["id"] / safe_filename).resolve()
             if not destination.is_relative_to(resolved_artifact_root):
                 raise ValueError("Unsafe artifact destination in knowledge pack")
             destination.parent.mkdir(parents=True, exist_ok=True)
@@ -1507,12 +1548,8 @@ class KnowledgePackService(BaseService):
                 persisted_destination = (
                     resolved_persisted_root / artifact["id"] / safe_filename
                 ).resolve()
-                if not persisted_destination.is_relative_to(
-                    resolved_persisted_root
-                ):
-                    raise ValueError(
-                        "Unsafe persisted artifact destination in knowledge pack"
-                    )
+                if not persisted_destination.is_relative_to(resolved_persisted_root):
+                    raise ValueError("Unsafe persisted artifact destination in knowledge pack")
                 artifact["filepath"] = str(persisted_destination)
                 restored += 1
             except KeyError as exc:
@@ -1526,9 +1563,7 @@ class KnowledgePackService(BaseService):
     async def _table_columns(self, table: str) -> frozenset[str]:
         """Return the live column allowlist for a fixed import table."""
         if table not in _IMPORT_INSERT_TABLES:
-            raise ValueError(
-                f"Knowledge pack targets unsupported table {table!r}"
-            )
+            raise ValueError(f"Knowledge pack targets unsupported table {table!r}")
         cache: dict[str, frozenset[str]] = getattr(
             self,
             "_import_table_columns_cache",
@@ -1539,9 +1574,7 @@ class KnowledgePackService(BaseService):
         columns = await self.db.fetchall(f"PRAGMA table_info([{table}])")
         names = frozenset(str(column["name"]) for column in columns)
         if not names:
-            raise ValueError(
-                f"Knowledge pack target table {table!r} is unavailable"
-            )
+            raise ValueError(f"Knowledge pack target table {table!r} is unavailable")
         cache[table] = names
         self._import_table_columns_cache = cache
         return names
@@ -1554,8 +1587,7 @@ class KnowledgePackService(BaseService):
         unknown_tables = sorted(set(tables) - set(_INSERT_ORDER))
         if unknown_tables:
             raise ValueError(
-                "Knowledge pack contains unsupported table(s): "
-                + ", ".join(unknown_tables)
+                "Knowledge pack contains unsupported table(s): " + ", ".join(unknown_tables)
             )
 
         for table, rows in tables.items():
@@ -1563,9 +1595,7 @@ class KnowledgePackService(BaseService):
             transient = _IMPORT_TRANSIENT_COLUMNS.get(table, frozenset())
             for index, row in enumerate(rows):
                 if not isinstance(row, dict):
-                    raise ValueError(
-                        f"Knowledge pack {table}[{index}] must be an object"
-                    )
+                    raise ValueError(f"Knowledge pack {table}[{index}] must be an object")
                 unknown_columns = sorted(
                     str(column)
                     for column in row
@@ -1574,27 +1604,21 @@ class KnowledgePackService(BaseService):
                 if unknown_columns:
                     raise ValueError(
                         f"Knowledge pack {table}[{index}] contains unsupported "
-                        "column(s): "
-                        + ", ".join(unknown_columns)
+                        "column(s): " + ", ".join(unknown_columns)
                     )
 
     async def _insert_row(self, table: str, row: dict[str, Any]) -> None:
         """Insert one already-remapped row using schema-approved identifiers."""
         allowed = await self._table_columns(table)
         columns = list(row.keys())
-        unknown_columns = [
-            str(column) for column in columns if column not in allowed
-        ]
+        unknown_columns = [str(column) for column in columns if column not in allowed]
         if unknown_columns:
             raise ValueError(
                 f"Knowledge pack row for {table!r} contains unsupported "
-                "column(s): "
-                + ", ".join(sorted(unknown_columns))
+                "column(s): " + ", ".join(sorted(unknown_columns))
             )
         if not columns:
-            raise ValueError(
-                f"Knowledge pack row for {table!r} cannot be empty"
-            )
+            raise ValueError(f"Knowledge pack row for {table!r} cannot be empty")
         placeholders = ", ".join("?" for _ in columns)
         # Identifiers come only from PRAGMA table_info above. Bracket quoting
         # keeps approved names syntactically isolated from uploaded content.
@@ -1655,15 +1679,12 @@ class KnowledgePackService(BaseService):
         """Fail closed when bundled bytes disagree with artifact metadata."""
         expected_hash = artifact.get("content_hash")
         normalized_expected = (
-            expected_hash.removeprefix("sha256:").lower()
-            if isinstance(expected_hash, str)
-            else ""
+            expected_hash.removeprefix("sha256:").lower() if isinstance(expected_hash, str) else ""
         )
         if normalized_expected != actual_hash:
             artifact_id = artifact.get("id") or "<unknown>"
             raise ValueError(
-                f"Artifact '{artifact_id}' content hash mismatch during "
-                f"knowledge pack {operation}"
+                f"Artifact '{artifact_id}' content hash mismatch during knowledge pack {operation}"
             )
 
     async def _recompute_cluster_claim_counts(self, project_id: str) -> None:
@@ -1698,10 +1719,7 @@ class KnowledgePackService(BaseService):
     @staticmethod
     def _validate_import_project_id(project_id: str) -> None:
         """Require one bounded, filesystem-safe path component for imports."""
-        if (
-            project_id in {".", ".."}
-            or not _IMPORT_PROJECT_ID_RE.fullmatch(project_id)
-        ):
+        if project_id in {".", ".."} or not _IMPORT_PROJECT_ID_RE.fullmatch(project_id):
             raise ValueError(
                 "Imported project ID must use only letters, numbers, '.', "
                 "'_', or '-' and cannot contain path separators"
@@ -1718,9 +1736,7 @@ class KnowledgePackService(BaseService):
 
     async def _validate_registry(self, project_id: str) -> None:
         """Fail if any table with project_id data exists but isn't categorized."""
-        all_tables = await self.db.fetchall(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        )
+        all_tables = await self.db.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
         for row in all_tables:
             table_name = row["name"]
             if table_name.startswith(("vec_", "fts_", "sqlite_")):
@@ -1767,6 +1783,9 @@ class KnowledgePackService(BaseService):
         "orphaned_claim_edge_sources": "critical",
         "orphaned_claim_edge_targets": "critical",
         "orphaned_claim_edge_clusters": "critical",
+        "claim_scope_pointer_mismatch": "critical",
+        "claim_scope_revision_chain_invalid": "critical",
+        "claim_scope_disconfirming_refs_invalid": "critical",
         "claim_count_mismatch": "warning",
     }
 
@@ -1805,17 +1824,19 @@ class KnowledgePackService(BaseService):
         )
         if orphaned_source:
             cat = "orphaned_entity_link_sources"
-            issues.append({
-                "category": cat,
-                "severity": self._severity_for(cat),
-                "count": len(orphaned_source),
-                "ids": [r["id"] for r in orphaned_source[:10]],
-                "description": (
-                    "entity_links whose declared source type/id is missing "
-                    "from the edge project"
-                ),
-                "fix_action": "Delete orphaned edges or re-import missing entities",
-            })
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(orphaned_source),
+                    "ids": [r["id"] for r in orphaned_source[:10]],
+                    "description": (
+                        "entity_links whose declared source type/id is missing "
+                        "from the edge project"
+                    ),
+                    "fix_action": "Delete orphaned edges or re-import missing entities",
+                }
+            )
 
         # 2. Same invariant for target endpoints.
         orphaned_target = await self.db.fetchall(
@@ -1827,17 +1848,19 @@ class KnowledgePackService(BaseService):
         )
         if orphaned_target:
             cat = "orphaned_entity_link_targets"
-            issues.append({
-                "category": cat,
-                "severity": self._severity_for(cat),
-                "count": len(orphaned_target),
-                "ids": [r["id"] for r in orphaned_target[:10]],
-                "description": (
-                    "entity_links whose declared target type/id is missing "
-                    "from the edge project"
-                ),
-                "fix_action": "Delete orphaned edges or re-import missing entities",
-            })
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(orphaned_target),
+                    "ids": [r["id"] for r in orphaned_target[:10]],
+                    "description": (
+                        "entity_links whose declared target type/id is missing "
+                        "from the edge project"
+                    ),
+                    "fix_action": "Delete orphaned edges or re-import missing entities",
+                }
+            )
 
         # 3. claim_edges with orphaned source_claim_id
         orphaned_claims = await self.db.fetchall(
@@ -1853,14 +1876,16 @@ class KnowledgePackService(BaseService):
         )
         if orphaned_claims:
             cat = "orphaned_claim_edge_sources"
-            issues.append({
-                "category": cat,
-                "severity": self._severity_for(cat),
-                "count": len(orphaned_claims),
-                "ids": [r["id"] for r in orphaned_claims[:10]],
-                "description": "claim_edges referencing non-existent claims",
-                "fix_action": "Delete orphaned claim edges",
-            })
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(orphaned_claims),
+                    "ids": [r["id"] for r in orphaned_claims[:10]],
+                    "description": "claim_edges referencing non-existent claims",
+                    "fix_action": "Delete orphaned claim edges",
+                }
+            )
 
         # 4. Non-membership claim edges need a same-project target claim.
         orphaned_targets = await self.db.fetchall(
@@ -1886,17 +1911,19 @@ class KnowledgePackService(BaseService):
         )
         if orphaned_targets:
             cat = "orphaned_claim_edge_targets"
-            issues.append({
-                "category": cat,
-                "severity": self._severity_for(cat),
-                "count": len(orphaned_targets),
-                "ids": [r["id"] for r in orphaned_targets[:10]],
-                "description": (
-                    "non-membership claim_edges whose target claim is missing "
-                    "from the edge project"
-                ),
-                "fix_action": "Delete orphaned claim edges or restore target claims",
-            })
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(orphaned_targets),
+                    "ids": [r["id"] for r in orphaned_targets[:10]],
+                    "description": (
+                        "non-membership claim_edges whose target claim is missing "
+                        "from the edge project"
+                    ),
+                    "fix_action": "Delete orphaned claim edges or restore target claims",
+                }
+            )
 
         # 5. Any declared cluster must be same-project; membership requires one.
         orphaned_clusters = await self.db.fetchall(
@@ -1918,14 +1945,16 @@ class KnowledgePackService(BaseService):
         )
         if orphaned_clusters:
             cat = "orphaned_claim_edge_clusters"
-            issues.append({
-                "category": cat,
-                "severity": self._severity_for(cat),
-                "count": len(orphaned_clusters),
-                "ids": [r["id"] for r in orphaned_clusters[:10]],
-                "description": "claim_edges referencing non-existent clusters",
-                "fix_action": "Delete orphaned claim edges or re-create clusters",
-            })
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(orphaned_clusters),
+                    "ids": [r["id"] for r in orphaned_clusters[:10]],
+                    "description": "claim_edges referencing non-existent clusters",
+                    "fix_action": "Delete orphaned claim edges or re-create clusters",
+                }
+            )
 
         # 6. evidence_clusters.claim_count mismatch
         mismatched = await self.db.fetchall(
@@ -1945,21 +1974,114 @@ class KnowledgePackService(BaseService):
         )
         if mismatched:
             cat = "claim_count_mismatch"
-            issues.append({
-                "category": cat,
-                "severity": self._severity_for(cat),
-                "count": len(mismatched),
-                "ids": [r["id"] for r in mismatched[:10]],
-                "description": "evidence_clusters with claim_count != actual claim_edges count",
-                "fix_action": "Run migration 016 to recompute claim counts",
-            })
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(mismatched),
+                    "ids": [r["id"] for r in mismatched[:10]],
+                    "description": "evidence_clusters with claim_count != actual claim_edges count",
+                    "fix_action": "Run migration 016 to recompute claim counts",
+                }
+            )
+
+        # 7. Every claim head points to the latest immutable scope version, or
+        # remains zero when no contract exists. This also detects a missing
+        # imported history row without relying on a mutable ready flag.
+        bad_scope_pointers = await self.db.fetchall(
+            """SELECT c.id FROM claims AS c
+               WHERE c.project_id = ?
+                 AND c.scope_revision <> COALESCE((
+                     SELECT MAX(scope.revision)
+                     FROM claim_scope_versions AS scope
+                     WHERE scope.claim_id = c.id
+                       AND scope.project_id = c.project_id
+                 ), 0)
+               LIMIT 50""",
+            [pid],
+        )
+        if bad_scope_pointers:
+            cat = "claim_scope_pointer_mismatch"
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(bad_scope_pointers),
+                    "ids": [row["id"] for row in bad_scope_pointers[:10]],
+                    "description": "claims whose scope head does not match immutable history",
+                    "fix_action": "Restore the missing history or reset the claim scope through reviewed repair",
+                }
+            )
+
+        # 8. Revisions must form one explicit predecessor chain per claim.
+        broken_scope_chains = await self.db.fetchall(
+            """SELECT scope.id FROM claim_scope_versions AS scope
+               WHERE scope.project_id = ?
+                 AND (
+                     (scope.revision = 1 AND scope.supersedes_scope_id IS NOT NULL)
+                     OR (
+                         scope.revision > 1
+                         AND NOT EXISTS (
+                             SELECT 1 FROM claim_scope_versions AS previous
+                             WHERE previous.claim_id = scope.claim_id
+                               AND previous.project_id = scope.project_id
+                               AND previous.revision = scope.revision - 1
+                               AND previous.id = scope.supersedes_scope_id
+                         )
+                     )
+                 )
+               LIMIT 50""",
+            [pid],
+        )
+        if broken_scope_chains:
+            cat = "claim_scope_revision_chain_invalid"
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(broken_scope_chains),
+                    "ids": [row["id"] for row in broken_scope_chains[:10]],
+                    "description": "claim scope versions with a missing or incorrect predecessor",
+                    "fix_action": "Restore the immutable predecessor chain",
+                }
+            )
+
+        # 9. JSON-carried disconfirming references remain same-project and
+        # cannot point back to the scoped claim itself.
+        bad_disconfirming_refs = await self.db.fetchall(
+            """SELECT DISTINCT scope.id
+               FROM claim_scope_versions AS scope,
+                    json_each(scope.disconfirming_claim_ids) AS reference
+               WHERE scope.project_id = ?
+                 AND (
+                     reference.type <> 'text'
+                     OR reference.value = scope.claim_id
+                     OR NOT EXISTS (
+                         SELECT 1 FROM claims AS target
+                         WHERE target.id = reference.value
+                           AND target.project_id = scope.project_id
+                     )
+                 )
+               LIMIT 50""",
+            [pid],
+        )
+        if bad_disconfirming_refs:
+            cat = "claim_scope_disconfirming_refs_invalid"
+            issues.append(
+                {
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(bad_disconfirming_refs),
+                    "ids": [row["id"] for row in bad_disconfirming_refs[:10]],
+                    "description": "claim scope versions with invalid disconfirming claim references",
+                    "fix_action": "Restore same-project canonical references or append a corrected scope version",
+                }
+            )
 
         return issues
 
     @staticmethod
-    def _typed_entity_link_endpoint_sql(
-        *, type_column: str, id_column: str
-    ) -> str:
+    def _typed_entity_link_endpoint_sql(*, type_column: str, id_column: str) -> str:
         """Return a trusted SQL predicate for a typed, project-local endpoint."""
         clauses = []
         for entity_type, table in _ENTITY_LINK_ENDPOINT_TABLES.items():

--- a/rka/services/manuscript_native.py
+++ b/rka/services/manuscript_native.py
@@ -28,6 +28,7 @@ from rka.models.manuscript_native import (
     ManuscriptUpdate,
 )
 from rka.services.base import BaseService, _now
+from rka.services.claims import ClaimService
 
 
 def _normalized_reference_doi(value: Any) -> str | None:
@@ -68,9 +69,7 @@ def _timestamp_is_strictly_after(later: Any, earlier: Any) -> bool:
     parsed_later = parse(later)
     parsed_earlier = parse(earlier)
     return bool(
-        parsed_later is not None
-        and parsed_earlier is not None
-        and parsed_later > parsed_earlier
+        parsed_later is not None and parsed_earlier is not None and parsed_later > parsed_earlier
     )
 
 
@@ -229,9 +228,7 @@ class NativeManuscriptService(BaseService):
         self._validate_actor(actor)
         lifecycle_fields = {"phase", "state"} & data.model_fields_set
         if lifecycle_fields and not allow_lifecycle:
-            raise ValueError(
-                "phase and state are lifecycle fields; use transition_phase"
-            )
+            raise ValueError("phase and state are lifecycle fields; use transition_phase")
         canonical_id = await self._require_id(manuscript_id)
         updates = data.model_dump(
             exclude={"expected_revision"},
@@ -252,9 +249,7 @@ class NativeManuscriptService(BaseService):
                 ],
             )
             if cursor.rowcount != 1:
-                await self._raise_revision_conflict(
-                    canonical_id, data.expected_revision
-                )
+                await self._raise_revision_conflict(canonical_id, data.expected_revision)
             if "venue" in updates:
                 await self._invalidate_resolved_checkpoints(
                     canonical_id,
@@ -290,18 +285,12 @@ class NativeManuscriptService(BaseService):
         async with self.db.transaction():
             current = await self.get(manuscript_id)
             if current is None:
-                raise ManuscriptNotFoundError(
-                    f"manuscript {manuscript_id!r} not found"
-                )
+                raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
             if current.phase not in self._PHASE_ORDER:
-                raise ValueError(
-                    f"current manuscript phase {current.phase!r} is not managed"
-                )
+                raise ValueError(f"current manuscript phase {current.phase!r} is not managed")
             current_index = self._PHASE_ORDER.index(current.phase)
             target_index = (
-                self._PHASE_ORDER.index(target_phase)
-                if target_phase in self._PHASE_ORDER
-                else -1
+                self._PHASE_ORDER.index(target_phase) if target_phase in self._PHASE_ORDER else -1
             )
             if target_index <= current_index:
                 raise ValueError(
@@ -310,15 +299,10 @@ class NativeManuscriptService(BaseService):
                 )
             if target_phase == "submitted":
                 if target_state not in {None, "submitted"}:
-                    raise ValueError(
-                        "transitioning to submitted may only set state='submitted'"
-                    )
+                    raise ValueError("transitioning to submitted may only set state='submitted'")
                 target_state = "submitted"
             elif target_state not in {None, "active"}:
-                raise ValueError(
-                    "pre-submission phase transitions may only retain "
-                    "state='active'"
-                )
+                raise ValueError("pre-submission phase transitions may only retain state='active'")
             readiness = await self.get_readiness(
                 manuscript_id,
                 target_phase=target_phase,
@@ -326,8 +310,7 @@ class NativeManuscriptService(BaseService):
             if not readiness["ready"]:
                 codes = sorted({item["code"] for item in readiness["findings"]})
                 raise ValueError(
-                    f"manuscript cannot transition to {target_phase!r}: "
-                    + ", ".join(codes)
+                    f"manuscript cannot transition to {target_phase!r}: " + ", ".join(codes)
                 )
             payload: dict[str, Any] = {
                 "expected_revision": expected_revision,
@@ -418,9 +401,7 @@ class NativeManuscriptService(BaseService):
             raise ValueError("provide exactly one of claim_id or local_key")
         async with self.db.transaction():
             await self._assert_revision(canonical_id, expected_revision)
-            claim = await self._find_claim(
-                canonical_id, claim_id=claim_id, local_key=local_key
-            )
+            claim = await self._find_claim(canonical_id, claim_id=claim_id, local_key=local_key)
             if claim is None:
                 raise ValueError("manuscript claim not found")
             version = claim_version or await self._latest_claim_version(claim["id"])
@@ -490,9 +471,7 @@ class NativeManuscriptService(BaseService):
         """Replace the active citation-key set without rewriting its history."""
         self._validate_actor(actor)
         canonical_id = await self._require_id(manuscript_id)
-        desired = {
-            member.citation_key: member.literature_id for member in data.members
-        }
+        desired = {member.citation_key: member.literature_id for member in data.members}
 
         async with self.db.transaction():
             await self._assert_revision(canonical_id, data.expected_revision)
@@ -512,8 +491,7 @@ class NativeManuscriptService(BaseService):
                 # Keep the project boundary opaque: a foreign row and a missing
                 # row produce the same caller-visible failure.
                 raise ValueError(
-                    "reference manifest contains literature that is not "
-                    "available in this project"
+                    "reference manifest contains literature that is not available in this project"
                 )
 
             active_rows = await self.db.fetchall(
@@ -525,8 +503,7 @@ class NativeManuscriptService(BaseService):
                 [canonical_id, self.project_id],
             )
             active_exact = {
-                (str(row["citation_key"]), str(row["literature_id"]))
-                for row in active_rows
+                (str(row["citation_key"]), str(row["literature_id"])) for row in active_rows
             }
             desired_exact = set(desired.items())
             changed = active_exact != desired_exact
@@ -591,26 +568,20 @@ class NativeManuscriptService(BaseService):
 
             return await self._get_reference_manifest_snapshot(canonical_id)
 
-    async def get_reference_manifest(
-        self, manuscript_id: str
-    ) -> dict[str, Any]:
+    async def get_reference_manifest(self, manuscript_id: str) -> dict[str, Any]:
         """Read the authoritative active citation set and validation currency."""
         async with self.db.transaction(write=False):
             canonical_id = await self._require_id(manuscript_id)
             return await self._get_reference_manifest_snapshot(canonical_id)
 
-    async def _get_reference_manifest_snapshot(
-        self, canonical_id: str
-    ) -> dict[str, Any]:
+    async def _get_reference_manifest_snapshot(self, canonical_id: str) -> dict[str, Any]:
         manuscript = await self.db.fetchone(
             """SELECT revision FROM manuscripts
                WHERE id = ? AND project_id = ?""",
             [canonical_id, self.project_id],
         )
         if manuscript is None:
-            raise ManuscriptNotFoundError(
-                f"manuscript {canonical_id!r} not found"
-            )
+            raise ManuscriptNotFoundError(f"manuscript {canonical_id!r} not found")
         rows = await self.db.fetchall(
             """WITH ranked_validations AS (
                    SELECT rv.*,
@@ -672,9 +643,7 @@ class NativeManuscriptService(BaseService):
             validation_status = row.pop("validation_status", None)
             retraction_enabled = row.pop("retraction_check_enabled", None)
             retraction_checked = row.pop("retraction_checked", None)
-            sources_confirmed = self._json_loads(
-                row.pop("validation_sources_confirmed", None), []
-            )
+            sources_confirmed = self._json_loads(row.pop("validation_sources_confirmed", None), [])
             pipeline_version = row.pop("validation_pipeline_version", None)
             completed_at = row.pop("validation_completed_at", None)
             literature_updated_at = row.get("literature_updated_at")
@@ -691,10 +660,7 @@ class NativeManuscriptService(BaseService):
                 validation_id
                 and identity_matches
                 and validation_status == "VERIFIED"
-                and (
-                    retraction_enabled != 1
-                    or retraction_checked == 1
-                )
+                and (retraction_enabled != 1 or retraction_checked == 1)
                 and row.get("literature_status") != "excluded"
                 and (
                     not literature_updated_at
@@ -726,12 +692,9 @@ class NativeManuscriptService(BaseService):
             "manuscript_id": canonical_id,
             "manuscript_revision": int(manuscript["revision"]),
             "members": members,
-            "active_citation_keys": [
-                str(member["citation_key"]) for member in members
-            ],
+            "active_citation_keys": [str(member["citation_key"]) for member in members],
             "approved_citation_keys": approved_keys,
-            "all_members_verified": bool(members)
-            and len(approved_keys) == len(members),
+            "all_members_verified": bool(members) and len(approved_keys) == len(members),
             "authoritative_source": "rka",
         }
 
@@ -767,8 +730,7 @@ class NativeManuscriptService(BaseService):
             )
             if data.supersedes_id is None and existing_head is not None:
                 raise ValueError(
-                    "an active checkpoint head already exists; set "
-                    "supersedes_id explicitly"
+                    "an active checkpoint head already exists; set supersedes_id explicitly"
                 )
             if data.supersedes_id is not None:
                 prior = await self.db.fetchone(
@@ -779,24 +741,12 @@ class NativeManuscriptService(BaseService):
                 )
                 if prior is None:
                     raise ValueError("superseded checkpoint is not in this manuscript")
-                if (
-                    prior["kind"] != data.kind
-                    or prior.get("unit_id") != data.unit_id
-                ):
-                    raise ValueError(
-                        "a checkpoint may supersede only the same kind and unit"
-                    )
+                if prior["kind"] != data.kind or prior.get("unit_id") != data.unit_id:
+                    raise ValueError("a checkpoint may supersede only the same kind and unit")
                 if prior["status"] == "pending":
-                    raise ValueError(
-                        "a pending checkpoint must be resolved before replacement"
-                    )
-                if (
-                    existing_head is None
-                    or existing_head["id"] != data.supersedes_id
-                ):
-                    raise ValueError(
-                        "supersedes_id must name the current checkpoint head"
-                    )
+                    raise ValueError("a pending checkpoint must be resolved before replacement")
+                if existing_head is None or existing_head["id"] != data.supersedes_id:
+                    raise ValueError("supersedes_id must name the current checkpoint head")
                 await self.db.execute(
                     """UPDATE manuscript_checkpoints
                        SET status = 'superseded'
@@ -987,9 +937,7 @@ class NativeManuscriptService(BaseService):
         """Read the full current native manuscript aggregate."""
         manuscript = await self.get(manuscript_id)
         if manuscript is None:
-            raise ManuscriptNotFoundError(
-                f"manuscript {manuscript_id!r} not found"
-            )
+            raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
         canonical_id = manuscript.id
 
         claim_rows = await self.db.fetchall(
@@ -1010,9 +958,7 @@ class NativeManuscriptService(BaseService):
         claims: list[dict[str, Any]] = []
         for row in claim_rows:
             claim = dict(row)
-            claim["prohibited_wording"] = self._json_loads(
-                claim.get("prohibited_wording"), []
-            )
+            claim["prohibited_wording"] = self._json_loads(claim.get("prohibited_wording"), [])
             claim["ratifications"] = await self.db.fetchall(
                 """SELECT r.*, d.status AS decision_status,
                           d.decided_by, d.chosen, d.superseded_by
@@ -1026,8 +972,9 @@ class NativeManuscriptService(BaseService):
             claim["evidence"] = await self._claim_evidence(
                 canonical_id, row["id"], row.get("version")
             )
-            claim["unit_links"] = await self.db.fetchall(
-                """SELECT cu.*, u.local_key AS unit_local_key,
+            claim["unit_links"] = (
+                await self.db.fetchall(
+                    """SELECT cu.*, u.local_key AS unit_local_key,
                           u.kind AS unit_kind, u.location AS unit_location
                    FROM manuscript_claim_units AS cu
                    JOIN manuscript_units AS u
@@ -1038,8 +985,11 @@ class NativeManuscriptService(BaseService):
                      AND cu.claim_version = ?
                      AND cu.project_id = ?
                    ORDER BY u.sequence, u.local_key, cu.relationship""",
-                [row["id"], row.get("version"), self.project_id],
-            ) if row.get("version") is not None else []
+                    [row["id"], row.get("version"), self.project_id],
+                )
+                if row.get("version") is not None
+                else []
+            )
             claims.append(claim)
 
         unit_rows = await self.db.fetchall(
@@ -1053,9 +1003,7 @@ class NativeManuscriptService(BaseService):
             unit = dict(row)
             unit["evidence"] = await self._unit_evidence(canonical_id, row["id"])
             if unit.get("kind") == "result":
-                unit["artifact_binding"] = await self._artifact_binding(
-                    unit.get("artifact_ref")
-                )
+                unit["artifact_binding"] = await self._artifact_binding(unit.get("artifact_ref"))
             units.append(unit)
 
         checkpoints = await self.db.fetchall(
@@ -1072,14 +1020,13 @@ class NativeManuscriptService(BaseService):
             checkpoint["dependency_snapshot"] = self._json_loads(
                 checkpoint.get("dependency_snapshot"), {}
             )
-            checkpoint["dependency_current"] = (
-                checkpoint.get("status") in {"resolved", "rejected"}
-                and checkpoint["dependency_snapshot"]
-                == await self._checkpoint_dependency_snapshot(
-                    canonical_id,
-                    kind=checkpoint["kind"],
-                    unit_id=checkpoint.get("unit_id"),
-                )
+            checkpoint["dependency_current"] = checkpoint.get("status") in {
+                "resolved",
+                "rejected",
+            } and checkpoint["dependency_snapshot"] == await self._checkpoint_dependency_snapshot(
+                canonical_id,
+                kind=checkpoint["kind"],
+                unit_id=checkpoint.get("unit_id"),
             )
         verifications = await self.db.fetchall(
             """SELECT * FROM manuscript_claim_verification_attestations
@@ -1088,12 +1035,8 @@ class NativeManuscriptService(BaseService):
             [canonical_id, self.project_id],
         )
         for row in verifications:
-            row["dependency_snapshot"] = self._json_loads(
-                row.get("dependency_snapshot"), {}
-            )
-            row["full_json_payload"] = self._json_loads(
-                row.get("full_json_payload"), {}
-            )
+            row["dependency_snapshot"] = self._json_loads(row.get("dependency_snapshot"), {})
+            row["full_json_payload"] = self._json_loads(row.get("full_json_payload"), {})
         reference_validations = await self.db.fetchall(
             """SELECT rv.*, l.title AS literature_title,
                       l.authors AS literature_authors,
@@ -1122,9 +1065,7 @@ class NativeManuscriptService(BaseService):
                 ("full_json_payload", {}),
             ):
                 row[field] = self._json_loads(row.get(field), default)
-        reference_manifest = await self._get_reference_manifest_snapshot(
-            canonical_id
-        )
+        reference_manifest = await self._get_reference_manifest_snapshot(canonical_id)
 
         return {
             "schema_version": "rka.manuscript-context/v1",
@@ -1147,9 +1088,7 @@ class NativeManuscriptService(BaseService):
     ) -> dict[str, Any]:
         """Return categorical, evidence-linked readiness findings."""
         if target_phase not in self._CHECKPOINTS_BY_TARGET:
-            raise ValueError(
-                f"target_phase must be one of {sorted(self._CHECKPOINTS_BY_TARGET)}"
-            )
+            raise ValueError(f"target_phase must be one of {sorted(self._CHECKPOINTS_BY_TARGET)}")
         context = await self.get_context(manuscript_id)
         findings: list[dict[str, Any]] = []
         manuscript = context["manuscript"]
@@ -1184,16 +1123,12 @@ class NativeManuscriptService(BaseService):
         if target_phase != "planning" and not manuscript.get("venue"):
             add("BLOCK", "VENUE_REQUIRED", "target venue is not set")
 
-        active_claims = [
-            claim for claim in context["claims"] if claim.get("state") == "active"
-        ]
+        active_claims = [claim for claim in context["claims"] if claim.get("state") == "active"]
         if not active_claims:
             add("BLOCK", "NO_ACTIVE_CLAIMS", "argument spine has no active claims")
 
         active_unit_ids = {
-            unit["id"]
-            for unit in context["units"]
-            if unit.get("status") != "removed"
+            unit["id"] for unit in context["units"] if unit.get("status") != "removed"
         }
         result_units = {
             unit["id"]: unit
@@ -1233,11 +1168,7 @@ class NativeManuscriptService(BaseService):
 
             evidence = claim.get("evidence", [])
             support = [item for item in evidence if item.get("role") == "support"]
-            counterevidence = [
-                item
-                for item in evidence
-                if item.get("role") == "counterevidence"
-            ]
+            counterevidence = [item for item in evidence if item.get("role") == "counterevidence"]
             if counterevidence:
                 add(
                     "BLOCK",
@@ -1260,10 +1191,10 @@ class NativeManuscriptService(BaseService):
             for item in support:
                 if (
                     item.get("verified") != 1
-                    or item.get("evidence_status")
-                    not in self._READY_EVIDENCE_STATUSES
+                    or item.get("evidence_status") not in self._READY_EVIDENCE_STATUSES
                     or item.get("stale") != 0
                     or item.get("contradicted") != 0
+                    or item.get("scope_readiness") != "ready"
                     or item.get("source_current") != 1
                     or item.get("source_is_manuscript") != 0
                 ):
@@ -1271,7 +1202,7 @@ class NativeManuscriptService(BaseService):
                         "BLOCK",
                         "EVIDENCE_NOT_MANUSCRIPT_READY",
                         f"support claim {item.get('evidence_claim_id')} is not "
-                        "grounded, supported, current, and uncontested",
+                        "grounded, supported, scope-reviewed, current, and uncontested",
                         claim_id=claim_id,
                     )
 
@@ -1299,14 +1230,9 @@ class NativeManuscriptService(BaseService):
                     "result unit is not linked to an active claim",
                     unit_id=unit_id,
                 )
-            support = [
-                item for item in unit.get("evidence", [])
-                if item.get("role") == "support"
-            ]
+            support = [item for item in unit.get("evidence", []) if item.get("role") == "support"]
             counterevidence = [
-                item
-                for item in unit.get("evidence", [])
-                if item.get("role") == "counterevidence"
+                item for item in unit.get("evidence", []) if item.get("role") == "counterevidence"
             ]
             if counterevidence:
                 add(
@@ -1326,10 +1252,10 @@ class NativeManuscriptService(BaseService):
             for item in support:
                 if (
                     item.get("verified") != 1
-                    or item.get("evidence_status")
-                    not in self._READY_EVIDENCE_STATUSES
+                    or item.get("evidence_status") not in self._READY_EVIDENCE_STATUSES
                     or item.get("stale") != 0
                     or item.get("contradicted") != 0
+                    or item.get("scope_readiness") != "ready"
                     or item.get("source_current") != 1
                     or item.get("source_is_manuscript") != 0
                 ):
@@ -1337,7 +1263,7 @@ class NativeManuscriptService(BaseService):
                         "BLOCK",
                         "RESULT_EVIDENCE_NOT_READY",
                         f"result support claim {item.get('evidence_claim_id')} "
-                        "is not grounded, supported, current, and uncontested",
+                        "is not grounded, supported, scope-reviewed, current, and uncontested",
                         unit_id=unit_id,
                     )
             if target_phase in {"review", "final", "submitted"}:
@@ -1358,8 +1284,7 @@ class NativeManuscriptService(BaseService):
                 add(
                     "BLOCK",
                     "REFERENCE_MANIFEST_REQUIRED",
-                    "review readiness requires an explicit authoritative "
-                    "citation-key manifest",
+                    "review readiness requires an explicit authoritative citation-key manifest",
                 )
             for member in reference_members:
                 citation_key = member.get("citation_key")
@@ -1379,8 +1304,7 @@ class NativeManuscriptService(BaseService):
                     add(
                         "BLOCK",
                         "REFERENCE_NOT_VERIFIED",
-                        "the latest validation attempt for this active citation "
-                        "is not VERIFIED",
+                        "the latest validation attempt for this active citation is not VERIFIED",
                         citation_key=citation_key,
                         literature_id=literature_id,
                     )
@@ -1414,12 +1338,9 @@ class NativeManuscriptService(BaseService):
                     )
                 literature_updated = member.get("literature_updated_at")
                 completed_at = validation.get("completed_at")
-                if (
-                    literature_updated
-                    and not _timestamp_is_strictly_after(
-                        completed_at,
-                        literature_updated,
-                    )
+                if literature_updated and not _timestamp_is_strictly_after(
+                    completed_at,
+                    literature_updated,
                 ):
                     add(
                         "BLOCK",
@@ -1439,8 +1360,7 @@ class NativeManuscriptService(BaseService):
                 and checkpoint.get("decision_status") == "active"
                 and checkpoint.get("decided_by") == "pi"
                 and not checkpoint.get("superseded_by")
-                and checkpoint.get("chosen")
-                == checkpoint.get("approved_choice")
+                and checkpoint.get("chosen") == checkpoint.get("approved_choice")
             ]
             resolved = [
                 checkpoint
@@ -1448,9 +1368,7 @@ class NativeManuscriptService(BaseService):
                 if checkpoint.get("dependency_current") is True
             ]
             if checkpoint_kind == "draft_section":
-                resolved_units = {
-                    checkpoint.get("unit_id") for checkpoint in resolved
-                }
+                resolved_units = {checkpoint.get("unit_id") for checkpoint in resolved}
                 missing = sorted(active_unit_ids - resolved_units)
                 for unit_id in missing:
                     add(
@@ -1459,12 +1377,14 @@ class NativeManuscriptService(BaseService):
                         "active manuscript unit lacks a resolved draft checkpoint",
                         unit_id=unit_id,
                     )
-                stale_units = sorted({
-                    checkpoint.get("unit_id")
-                    for checkpoint in approved
-                    if checkpoint.get("dependency_current") is not True
-                    and checkpoint.get("unit_id") in active_unit_ids
-                })
+                stale_units = sorted(
+                    {
+                        checkpoint.get("unit_id")
+                        for checkpoint in approved
+                        if checkpoint.get("dependency_current") is not True
+                        and checkpoint.get("unit_id") in active_unit_ids
+                    }
+                )
                 for unit_id in stale_units:
                     add(
                         "BLOCK",
@@ -1476,8 +1396,7 @@ class NativeManuscriptService(BaseService):
                 add(
                     "BLOCK",
                     "CHECKPOINT_STALE",
-                    f"checkpoint {checkpoint_kind!r} dependencies changed "
-                    "after PI approval",
+                    f"checkpoint {checkpoint_kind!r} dependencies changed after PI approval",
                 )
             elif not resolved:
                 add(
@@ -1519,9 +1438,7 @@ class NativeManuscriptService(BaseService):
             canonical_id = await self._require_id(manuscript_id)
             manuscript = await self.get(canonical_id)
             if manuscript is None:  # pragma: no cover - guarded by _require_id
-                raise ManuscriptNotFoundError(
-                    f"manuscript {manuscript_id!r} not found"
-                )
+                raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
             cluster_rows = await self.db.fetchall(
                 """SELECT ec.*, rq.question AS research_question,
                           rq.status AS rq_status,
@@ -1554,10 +1471,11 @@ class NativeManuscriptService(BaseService):
                 [self.project_id],
             )
             membership_rows = await self.db.fetchall(
-                """SELECT ce.cluster_id, c.id, c.claim_type, c.content,
+                f"""SELECT ce.cluster_id, c.id, c.claim_type, c.content,
                           c.confidence, c.verified, c.evidence_status,
                           c.stale, coalesce(c.staleness, 'green') AS staleness,
-                          c.source_entry_id,
+                          c.source_entry_id, c.scope_revision, c.project_id,
+                          {ClaimService._SCOPE_PROJECTION},
                           CASE
                               WHEN j.id IS NOT NULL
                                AND j.status = 'active'
@@ -1590,6 +1508,7 @@ class NativeManuscriptService(BaseService):
                    JOIN claims AS c
                      ON c.id = ce.source_claim_id
                     AND c.project_id = ce.project_id
+                   {ClaimService._SCOPE_JOIN}
                    LEFT JOIN journal AS j
                      ON j.id = c.source_entry_id
                     AND j.project_id = c.project_id
@@ -1624,9 +1543,7 @@ class NativeManuscriptService(BaseService):
                     cluster_ids.update(claim_clusters.get(claim_id, set()))
             for cluster_id in cluster_ids:
                 if row["relation"] == "qualifies":
-                    qualifiers.setdefault(cluster_id, set()).add(
-                        row["source_claim_id"]
-                    )
+                    qualifiers.setdefault(cluster_id, set()).add(row["source_claim_id"])
                 else:
                     touched = contradictions.setdefault(cluster_id, set())
                     touched.add(row["source_claim_id"])
@@ -1643,7 +1560,19 @@ class NativeManuscriptService(BaseService):
             cluster_qualifiers = qualifiers.get(cluster_id, set())
             cluster_counterevidence = contradictions.get(cluster_id, set())
             ready_support: list[dict[str, Any]] = []
-            for claim in cluster_members:
+            for raw_claim in cluster_members:
+                claim = dict(raw_claim)
+                claim["contradicted"] = claim["id"] in cluster_counterevidence
+                scope = ClaimService._scope_projection_to_model(claim)
+                scope_readiness, scope_findings = ClaimService._assess_scope(
+                    claim,
+                    scope,
+                )
+                claim["scope_readiness"] = scope_readiness
+                claim["scope_contract"] = scope.model_dump(mode="json") if scope else None
+                claim["scope_findings"] = [
+                    finding.model_dump(mode="json") for finding in scope_findings
+                ]
                 reasons: list[str] = []
                 if claim.get("verified") != 1:
                     reasons.append("SOURCE_GROUNDING_NOT_VERIFIED")
@@ -1660,20 +1589,22 @@ class NativeManuscriptService(BaseService):
                     reasons.append("MANUSCRIPT_DERIVED")
                 if claim["id"] in cluster_counterevidence:
                     reasons.append("UNRESOLVED_CONTRADICTION")
+                if scope_readiness != "ready":
+                    reasons.append("CLAIM_SCOPE_NOT_READY")
                 if reasons:
-                    excluded_claims.append({
-                        "claim_id": claim["id"],
-                        "cluster_id": cluster_id,
-                        "reasons": sorted(set(reasons)),
-                    })
+                    excluded_claims.append(
+                        {
+                            "claim_id": claim["id"],
+                            "cluster_id": cluster_id,
+                            "reasons": sorted(set(reasons)),
+                        }
+                    )
                 else:
                     ready_support.append(claim)
 
             normalized_groups: dict[str, list[dict[str, Any]]] = {}
             for claim in ready_support:
-                normalized = " ".join(
-                    str(claim.get("content") or "").casefold().split()
-                )
+                normalized = " ".join(str(claim.get("content") or "").casefold().split())
                 normalized_groups.setdefault(normalized, []).append(claim)
             representative_ids = [
                 sorted(
@@ -1687,22 +1618,19 @@ class NativeManuscriptService(BaseService):
             ]
 
             blockers: list[str] = []
-            if not cluster.get("research_question_id") or not cluster.get(
-                "research_question"
-            ):
+            if not cluster.get("research_question_id") or not cluster.get("research_question"):
                 blockers.append("RESEARCH_QUESTION_REQUIRED")
-            elif (
-                cluster.get("rq_status") != "active"
-                or cluster.get("rq_superseded_by")
-            ):
+            elif cluster.get("rq_status") != "active" or cluster.get("rq_superseded_by"):
                 blockers.append("RESEARCH_QUESTION_NOT_CURRENT")
-            if cluster.get("synthesized_by") != "brain" or not str(
-                cluster.get("synthesis") or ""
-            ).strip():
+            if (
+                cluster.get("synthesized_by") != "brain"
+                or not str(cluster.get("synthesis") or "").strip()
+            ):
                 blockers.append("BRAIN_CLUSTER_REVIEW_REQUIRED")
-            if cluster.get("needs_reprocessing") == 1 or cluster.get(
-                "staleness"
-            ) not in {"green", "dismissed"}:
+            if cluster.get("needs_reprocessing") == 1 or cluster.get("staleness") not in {
+                "green",
+                "dismissed",
+            }:
                 blockers.append("CLUSTER_NOT_CURRENT")
             if cluster.get("confidence") not in {"strong", "moderate"}:
                 blockers.append("CLUSTER_EVIDENCE_NOT_READY")
@@ -1727,9 +1655,7 @@ class NativeManuscriptService(BaseService):
                 "synthesis": cluster.get("synthesis"),
                 "confidence": cluster.get("confidence"),
                 "synthesized_by": cluster.get("synthesized_by"),
-                "support_claim_ids": [
-                    claim["id"] for claim in ready_support
-                ],
+                "support_claim_ids": [claim["id"] for claim in ready_support],
                 "representative_claim_ids": representative_ids,
                 "qualifier_claim_ids": sorted(cluster_qualifiers),
                 "counterevidence_claim_ids": sorted(cluster_counterevidence),
@@ -1744,35 +1670,49 @@ class NativeManuscriptService(BaseService):
             clusters.append(cluster_record)
             if disposition == "eligible":
                 local_key = f"C{len(candidate_claims) + 1}"
-                claim_kinds = {
-                    claim.get("claim_type") for claim in ready_support
-                }
+                claim_kinds = {claim.get("claim_type") for claim in ready_support}
                 claim_type = (
-                    "methodological"
-                    if claim_kinds and claim_kinds <= {"method"}
-                    else "empirical"
+                    "methodological" if claim_kinds and claim_kinds <= {"method"} else "empirical"
                 )
-                candidate_claims.append({
-                    "claim_id": local_key,
-                    "claim_type": claim_type,
-                    "status": "candidate",
-                    "text": str(cluster["synthesis"]).strip(),
-                    "allowed_wording": str(cluster["synthesis"]).strip(),
-                    "prohibited_wording": [],
-                    "ratified_by": None,
-                    "evidence_ids": [
-                        claim["id"] for claim in ready_support
-                    ],
-                    "qualifier_ids": sorted(cluster_qualifiers),
-                    "counterevidence_ids": [],
-                    "manuscript_units": [],
-                })
+                candidate_claims.append(
+                    {
+                        "claim_id": local_key,
+                        "claim_type": claim_type,
+                        "status": "candidate",
+                        "text": str(cluster["synthesis"]).strip(),
+                        "allowed_wording": str(cluster["synthesis"]).strip(),
+                        "prohibited_wording": sorted(
+                            {
+                                boundary
+                                for claim in ready_support
+                                for boundary in (
+                                    claim.get("scope_contract", {}).get("prohibited_extensions", [])
+                                    if claim.get("scope_contract")
+                                    else []
+                                )
+                            }
+                        ),
+                        "ratified_by": None,
+                        "evidence_ids": [claim["id"] for claim in ready_support],
+                        "qualifier_ids": sorted(cluster_qualifiers),
+                        "counterevidence_ids": [],
+                        "manuscript_units": [],
+                        "scope_contract_ids": sorted(
+                            claim["scope_contract"]["id"]
+                            for claim in ready_support
+                            if claim.get("scope_contract")
+                        ),
+                    }
+                )
                 candidate_lineage[local_key] = {
                     "cluster_id": cluster_id,
-                    "research_question_id": cluster.get(
-                        "research_question_id"
-                    ),
+                    "research_question_id": cluster.get("research_question_id"),
                     "representative_claim_ids": representative_ids,
+                    "scope_contract_ids": sorted(
+                        claim["scope_contract"]["id"]
+                        for claim in ready_support
+                        if claim.get("scope_contract")
+                    ),
                 }
 
         return {
@@ -1807,9 +1747,7 @@ class NativeManuscriptService(BaseService):
             "candidate_lineage": candidate_lineage,
             "summary": {
                 "clusters_total": len(clusters),
-                "clusters_eligible": sum(
-                    item["disposition"] == "eligible" for item in clusters
-                ),
+                "clusters_eligible": sum(item["disposition"] == "eligible" for item in clusters),
                 "clusters_needing_review": sum(
                     item["disposition"] != "eligible" for item in clusters
                 ),
@@ -1862,8 +1800,7 @@ class NativeManuscriptService(BaseService):
         else:
             return {"verified": False, "reason": "untyped_reference"}
         binding["verified"] = bool(
-            binding.get("content_hash")
-            and binding.get("extraction_status") == "complete"
+            binding.get("content_hash") and binding.get("extraction_status") == "complete"
         )
         return binding
 
@@ -1936,15 +1873,11 @@ class NativeManuscriptService(BaseService):
                 [manuscript_id, self.project_id],
             )
             for row in rows:
-                row["artifact_binding"] = await self._artifact_binding(
-                    row.get("artifact_ref")
-                )
+                row["artifact_binding"] = await self._artifact_binding(row.get("artifact_ref"))
                 row.pop("artifact_ref", None)
             components["result_units"] = rows
         elif kind == "reference_set":
-            manifest = await self._get_reference_manifest_snapshot(
-                manuscript_id
-            )
+            manifest = await self._get_reference_manifest_snapshot(manuscript_id)
             components["reference_manifest"] = [
                 {
                     "citation_key": member["citation_key"],
@@ -1955,9 +1888,7 @@ class NativeManuscriptService(BaseService):
                     "literature_doi": member.get("literature_doi"),
                     "literature_url": member.get("literature_url"),
                     "literature_status": member.get("literature_status"),
-                    "literature_updated_at": member.get(
-                        "literature_updated_at"
-                    ),
+                    "literature_updated_at": member.get("literature_updated_at"),
                     # Checkpoints approve the semantic reference set, not
                     # installation-local row identities. Knowledge-pack import
                     # intentionally re-keys memberships, literature, and
@@ -1982,9 +1913,7 @@ class NativeManuscriptService(BaseService):
                 [unit_id, manuscript_id, self.project_id],
             )
             if unit is not None:
-                unit["artifact_binding"] = await self._artifact_binding(
-                    unit.get("artifact_ref")
-                )
+                unit["artifact_binding"] = await self._artifact_binding(unit.get("artifact_ref"))
                 unit.pop("artifact_ref", None)
             components["unit"] = unit
             components["claims"] = await self.db.fetchall(
@@ -2031,9 +1960,7 @@ class NativeManuscriptService(BaseService):
             )
             for row in rows:
                 if row.get("artifact_ref"):
-                    row["artifact_binding"] = await self._artifact_binding(
-                        row["artifact_ref"]
-                    )
+                    row["artifact_binding"] = await self._artifact_binding(row["artifact_ref"])
                 row.pop("artifact_ref", None)
             components["units"] = rows
         else:
@@ -2063,9 +1990,7 @@ class NativeManuscriptService(BaseService):
         for claim in context["claims"]:
             evidence_by_role = {
                 role: [
-                    item["evidence_claim_id"]
-                    for item in claim["evidence"]
-                    if item["role"] == role
+                    item["evidence_claim_id"] for item in claim["evidence"] if item["role"] == role
                 ]
                 for role in ("support", "qualifier", "counterevidence")
             }
@@ -2083,47 +2008,46 @@ class NativeManuscriptService(BaseService):
             )
             local_claim_id = claim["local_key"]
             for link in claim["unit_links"]:
-                unit_claims.setdefault(link["unit_local_key"], []).append(
-                    local_claim_id
-                )
-            claims.append({
-                "claim_id": local_claim_id,
-                "rka_manuscript_claim_id": claim["id"],
-                "version": claim.get("version"),
-                "claim_type": claim["kind"],
-                "status": claim["state"],
-                "text": claim.get("exact_wording"),
-                "allowed_wording": claim.get("allowed_wording"),
-                "prohibited_wording": claim.get("prohibited_wording") or [],
-                "ratified_by": (
-                    current_ratification.get("decision_id")
-                    if current_ratification else None
-                ),
-                "evidence_ids": evidence_by_role["support"],
-                "qualifier_ids": evidence_by_role["qualifier"],
-                "counterevidence_ids": evidence_by_role["counterevidence"],
-                "manuscript_units": [
-                    link["unit_local_key"] for link in claim["unit_links"]
-                ],
-            })
+                unit_claims.setdefault(link["unit_local_key"], []).append(local_claim_id)
+            claims.append(
+                {
+                    "claim_id": local_claim_id,
+                    "rka_manuscript_claim_id": claim["id"],
+                    "version": claim.get("version"),
+                    "claim_type": claim["kind"],
+                    "status": claim["state"],
+                    "text": claim.get("exact_wording"),
+                    "allowed_wording": claim.get("allowed_wording"),
+                    "prohibited_wording": claim.get("prohibited_wording") or [],
+                    "ratified_by": (
+                        current_ratification.get("decision_id") if current_ratification else None
+                    ),
+                    "evidence_ids": evidence_by_role["support"],
+                    "qualifier_ids": evidence_by_role["qualifier"],
+                    "counterevidence_ids": evidence_by_role["counterevidence"],
+                    "manuscript_units": [link["unit_local_key"] for link in claim["unit_links"]],
+                }
+            )
         units = []
         for unit in context["units"]:
-            units.append({
-                "unit_id": unit["local_key"],
-                "rka_manuscript_unit_id": unit["id"],
-                "kind": unit["kind"],
-                "location": unit["location"],
-                "artifact_ref": unit.get("artifact_ref"),
-                "allowed_interpretation": unit.get("allowed_interpretation"),
-                "prohibited_interpretation": unit.get("prohibited_interpretation"),
-                "status": unit["status"],
-                "evidence_ids": [
-                    item["evidence_claim_id"]
-                    for item in unit["evidence"]
-                    if item["role"] == "support"
-                ],
-                "claim_ids": sorted(set(unit_claims.get(unit["local_key"], []))),
-            })
+            units.append(
+                {
+                    "unit_id": unit["local_key"],
+                    "rka_manuscript_unit_id": unit["id"],
+                    "kind": unit["kind"],
+                    "location": unit["location"],
+                    "artifact_ref": unit.get("artifact_ref"),
+                    "allowed_interpretation": unit.get("allowed_interpretation"),
+                    "prohibited_interpretation": unit.get("prohibited_interpretation"),
+                    "status": unit["status"],
+                    "evidence_ids": [
+                        item["evidence_claim_id"]
+                        for item in unit["evidence"]
+                        if item["role"] == "support"
+                    ],
+                    "claim_ids": sorted(set(unit_claims.get(unit["local_key"], []))),
+                }
+            )
         return {
             "schema_version": "rka-claim-spine/v2",
             "authoritative_source": "rka",
@@ -2139,8 +2063,7 @@ class NativeManuscriptService(BaseService):
         canonical_id = await self.resolve_id(manuscript_id)
         if canonical_id is None:
             raise ManuscriptNotFoundError(
-                f"manuscript {manuscript_id!r} does not belong to project "
-                f"{self.project_id}"
+                f"manuscript {manuscript_id!r} does not belong to project {self.project_id}"
             )
         return canonical_id
 
@@ -2150,34 +2073,26 @@ class NativeManuscriptService(BaseService):
             [manuscript_id, self.project_id],
         )
         if row is None:
-            raise ManuscriptNotFoundError(
-                f"manuscript {manuscript_id!r} not found"
-            )
+            raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
         if int(row["revision"]) != expected_revision:
             raise ManuscriptRevisionConflict(
                 f"manuscript {manuscript_id} revision is {row['revision']}, "
                 f"expected {expected_revision}"
             )
 
-    async def _raise_revision_conflict(
-        self, manuscript_id: str, expected_revision: int
-    ) -> None:
+    async def _raise_revision_conflict(self, manuscript_id: str, expected_revision: int) -> None:
         row = await self.db.fetchone(
             "SELECT revision FROM manuscripts WHERE id = ? AND project_id = ?",
             [manuscript_id, self.project_id],
         )
         if row is None:
-            raise ManuscriptNotFoundError(
-                f"manuscript {manuscript_id!r} not found"
-            )
+            raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
         raise ManuscriptRevisionConflict(
             f"manuscript {manuscript_id} revision is {row['revision']}, "
             f"expected {expected_revision}"
         )
 
-    async def _bump_revision(
-        self, manuscript_id: str, expected_revision: int
-    ) -> None:
+    async def _bump_revision(self, manuscript_id: str, expected_revision: int) -> None:
         cursor = await self.db.execute(
             """UPDATE manuscripts
                SET revision = revision + 1, updated_at = ?
@@ -2208,9 +2123,7 @@ class NativeManuscriptService(BaseService):
         )
         stale_ids: list[str] = []
         for checkpoint in checkpoints:
-            stored_snapshot = self._json_loads(
-                checkpoint.get("dependency_snapshot"), {}
-            )
+            stored_snapshot = self._json_loads(checkpoint.get("dependency_snapshot"), {})
             current_snapshot = await self._checkpoint_dependency_snapshot(
                 manuscript_id,
                 kind=checkpoint["kind"],
@@ -2258,76 +2171,77 @@ class NativeManuscriptService(BaseService):
                 not local_key
                 or not exact
                 or not allowed
-                or kind not in {
-                    "empirical", "methodological", "theoretical", "survey", "position"
-                }
+                or kind not in {"empirical", "methodological", "theoretical", "survey", "position"}
                 or state not in {"candidate", "active", "retired"}
                 or not isinstance(prohibited, list)
                 or not prohibited
                 or any(not isinstance(item, str) or not item.strip() for item in prohibited)
             ):
-                raise ValueError(
-                    f"invalid native manuscript claim specification {local_key!r}"
-                )
+                raise ValueError(f"invalid native manuscript claim specification {local_key!r}")
             evidence = raw.get("evidence") or {}
             if not isinstance(evidence, Mapping):
                 raise ValueError(f"claim {local_key} evidence must be an object")
             support = evidence.get("support", raw.get("evidence_ids", []))
             qualifier = evidence.get("qualifier", raw.get("qualifier_ids", []))
-            counter = evidence.get(
-                "counterevidence", raw.get("counterevidence_ids", [])
-            )
+            counter = evidence.get("counterevidence", raw.get("counterevidence_ids", []))
             raw_links = raw.get("unit_links", raw.get("manuscript_units", []))
             links = []
             for item in raw_links or []:
                 if isinstance(item, str):
                     links.append({"unit_key": item, "relationship": "advances"})
                 elif isinstance(item, Mapping):
-                    links.append({
-                        "unit_key": item.get("unit_key") or item.get("unit_id"),
-                        "relationship": item.get("relationship", "advances"),
-                    })
+                    links.append(
+                        {
+                            "unit_key": item.get("unit_key") or item.get("unit_id"),
+                            "relationship": item.get("relationship", "advances"),
+                        }
+                    )
                 else:
                     raise ValueError(f"claim {local_key} has an invalid unit link")
-            normalized.append({
-                "local_key": local_key,
-                "kind": kind,
-                "state": state,
-                "exact_wording": exact,
-                "allowed_wording": allowed,
-                "prohibited_wording": [item.strip() for item in prohibited],
-                "evidence": {
-                    "support": self._id_list(support, f"claim {local_key} support"),
-                    "qualifier": self._id_list(
-                        qualifier, f"claim {local_key} qualifiers"
-                    ),
-                    "counterevidence": self._id_list(
-                        counter, f"claim {local_key} counterevidence"
-                    ),
-                },
-                "unit_links": links,
-            })
+            normalized.append(
+                {
+                    "local_key": local_key,
+                    "kind": kind,
+                    "state": state,
+                    "exact_wording": exact,
+                    "allowed_wording": allowed,
+                    "prohibited_wording": [item.strip() for item in prohibited],
+                    "evidence": {
+                        "support": self._id_list(support, f"claim {local_key} support"),
+                        "qualifier": self._id_list(qualifier, f"claim {local_key} qualifiers"),
+                        "counterevidence": self._id_list(
+                            counter, f"claim {local_key} counterevidence"
+                        ),
+                    },
+                    "unit_links": links,
+                }
+            )
         return normalized
 
     def _normalize_unit_specs(self, value: Any) -> list[dict[str, Any]]:
         normalized = []
         valid_kinds = {
-            "abstract", "introduction", "related_work", "background", "method",
-            "result", "discussion", "limitation", "conclusion", "caption",
-            "appendix", "other",
+            "abstract",
+            "introduction",
+            "related_work",
+            "background",
+            "method",
+            "result",
+            "discussion",
+            "limitation",
+            "conclusion",
+            "caption",
+            "appendix",
+            "other",
         }
         valid_statuses = {"planned", "drafted", "reviewed", "final", "removed"}
         for raw in self._spec_list(value, "units"):
             local_key = str(raw.get("local_key") or raw.get("unit_id") or "").strip()
             kind = str(raw.get("kind") or "").strip()
-            location = str(
-                raw.get("location") or raw.get("source_location") or ""
-            ).strip()
+            location = str(raw.get("location") or raw.get("source_location") or "").strip()
             status = str(raw.get("status") or "planned").strip()
             if not local_key or kind not in valid_kinds or not location:
-                raise ValueError(
-                    f"invalid native manuscript unit specification {local_key!r}"
-                )
+                raise ValueError(f"invalid native manuscript unit specification {local_key!r}")
             if status not in valid_statuses:
                 raise ValueError(f"unit {local_key} has invalid status {status!r}")
             if kind == "result":
@@ -2341,33 +2255,33 @@ class NativeManuscriptService(BaseService):
             evidence = raw.get("evidence") or {}
             if not isinstance(evidence, Mapping):
                 raise ValueError(f"unit {local_key} evidence must be an object")
-            normalized.append({
-                "local_key": local_key,
-                "kind": kind,
-                "location": location,
-                "title": raw.get("title"),
-                "artifact_ref": raw.get("artifact_ref"),
-                "allowed_interpretation": raw.get("allowed_interpretation"),
-                "prohibited_interpretation": raw.get("prohibited_interpretation"),
-                "sequence": int(raw.get("sequence", 0)),
-                "status": status,
-                "evidence": {
-                    "support": self._id_list(
-                        evidence.get("support", raw.get("evidence_ids", [])),
-                        f"unit {local_key} support",
-                    ),
-                    "qualifier": self._id_list(
-                        evidence.get("qualifier", raw.get("qualifier_ids", [])),
-                        f"unit {local_key} qualifiers",
-                    ),
-                    "counterevidence": self._id_list(
-                        evidence.get(
-                            "counterevidence", raw.get("counterevidence_ids", [])
+            normalized.append(
+                {
+                    "local_key": local_key,
+                    "kind": kind,
+                    "location": location,
+                    "title": raw.get("title"),
+                    "artifact_ref": raw.get("artifact_ref"),
+                    "allowed_interpretation": raw.get("allowed_interpretation"),
+                    "prohibited_interpretation": raw.get("prohibited_interpretation"),
+                    "sequence": int(raw.get("sequence", 0)),
+                    "status": status,
+                    "evidence": {
+                        "support": self._id_list(
+                            evidence.get("support", raw.get("evidence_ids", [])),
+                            f"unit {local_key} support",
                         ),
-                        f"unit {local_key} counterevidence",
-                    ),
-                },
-            })
+                        "qualifier": self._id_list(
+                            evidence.get("qualifier", raw.get("qualifier_ids", [])),
+                            f"unit {local_key} qualifiers",
+                        ),
+                        "counterevidence": self._id_list(
+                            evidence.get("counterevidence", raw.get("counterevidence_ids", [])),
+                            f"unit {local_key} counterevidence",
+                        ),
+                    },
+                }
+            )
         return normalized
 
     @staticmethod
@@ -2426,8 +2340,7 @@ class NativeManuscriptService(BaseService):
                 claim_id = row["id"]
                 if row["kind"] != spec["kind"]:
                     raise ValueError(
-                        f"claim {local_key} kind is immutable; retire it and "
-                        "create a new local_key"
+                        f"claim {local_key} kind is immutable; retire it and create a new local_key"
                     )
                 await self.db.execute(
                     """UPDATE manuscript_claims
@@ -2455,8 +2368,7 @@ class NativeManuscriptService(BaseService):
                 latest
                 and latest["exact_wording"] == spec["exact_wording"]
                 and latest["allowed_wording"] == spec["allowed_wording"]
-                and self._json_loads(latest["prohibited_wording"], [])
-                == spec["prohibited_wording"]
+                and self._json_loads(latest["prohibited_wording"], []) == spec["prohibited_wording"]
             )
             version = previous_version if same_wording else previous_version + 1
             if not same_wording:
@@ -2475,9 +2387,7 @@ class NativeManuscriptService(BaseService):
                         json.dumps(spec["prohibited_wording"], sort_keys=True),
                     ],
                 )
-            await self._replace_claim_evidence(
-                manuscript_id, claim_id, version, spec["evidence"]
-            )
+            await self._replace_claim_evidence(manuscript_id, claim_id, version, spec["evidence"])
             result[local_key] = (claim_id, version)
 
         for local_key, row in existing.items():
@@ -2550,9 +2460,7 @@ class NativeManuscriptService(BaseService):
                         self.project_id,
                     ],
                 )
-            await self._replace_unit_evidence(
-                manuscript_id, unit_id, spec["evidence"]
-            )
+            await self._replace_unit_evidence(manuscript_id, unit_id, spec["evidence"])
             result[local_key] = unit_id
 
         for local_key, row in existing.items():
@@ -2648,9 +2556,7 @@ class NativeManuscriptService(BaseService):
                         f"claim {spec['local_key']} references unknown unit {unit_key!r}"
                     )
                 if relationship not in {"advances", "tests", "bounds", "mentions"}:
-                    raise ValueError(
-                        f"claim {spec['local_key']} has invalid unit relationship"
-                    )
+                    raise ValueError(f"claim {spec['local_key']} has invalid unit relationship")
                 await self.db.execute(
                     """INSERT INTO manuscript_claim_units
                        (manuscript_id, project_id, manuscript_claim_id,
@@ -2697,9 +2603,10 @@ class NativeManuscriptService(BaseService):
     ) -> list[dict[str, Any]]:
         if version is None:
             return []
-        return await self.db.fetchall(
-            """SELECT e.*, c.content, c.claim_type, c.confidence, c.verified,
+        rows = await self.db.fetchall(
+            f"""SELECT e.*, c.content, c.claim_type, c.confidence, c.verified,
                       c.evidence_status, c.stale, c.source_entry_id,
+                      c.scope_revision, {ClaimService._SCOPE_PROJECTION},
                       EXISTS (
                           SELECT 1 FROM claim_edges AS ce
                           WHERE ce.project_id = c.project_id
@@ -2735,6 +2642,7 @@ class NativeManuscriptService(BaseService):
                JOIN claims AS c
                  ON c.id = e.evidence_claim_id
                 AND c.project_id = e.project_id
+               {ClaimService._SCOPE_JOIN}
                LEFT JOIN journal AS j
                  ON j.id = c.source_entry_id
                 AND j.project_id = c.project_id
@@ -2745,13 +2653,13 @@ class NativeManuscriptService(BaseService):
                ORDER BY e.role, e.ordinal, e.evidence_claim_id""",
             [manuscript_id, claim_id, version, self.project_id],
         )
+        return self._decorate_evidence_scope(rows)
 
-    async def _unit_evidence(
-        self, manuscript_id: str, unit_id: str
-    ) -> list[dict[str, Any]]:
-        return await self.db.fetchall(
-            """SELECT e.*, c.content, c.claim_type, c.confidence, c.verified,
+    async def _unit_evidence(self, manuscript_id: str, unit_id: str) -> list[dict[str, Any]]:
+        rows = await self.db.fetchall(
+            f"""SELECT e.*, c.content, c.claim_type, c.confidence, c.verified,
                       c.evidence_status, c.stale, c.source_entry_id,
+                      c.scope_revision, {ClaimService._SCOPE_PROJECTION},
                       EXISTS (
                           SELECT 1 FROM claim_edges AS ce
                           WHERE ce.project_id = c.project_id
@@ -2787,6 +2695,7 @@ class NativeManuscriptService(BaseService):
                JOIN claims AS c
                  ON c.id = e.evidence_claim_id
                 AND c.project_id = e.project_id
+               {ClaimService._SCOPE_JOIN}
                LEFT JOIN journal AS j
                  ON j.id = c.source_entry_id
                 AND j.project_id = c.project_id
@@ -2795,3 +2704,19 @@ class NativeManuscriptService(BaseService):
                ORDER BY e.role, e.ordinal, e.evidence_claim_id""",
             [manuscript_id, unit_id, self.project_id],
         )
+        return self._decorate_evidence_scope(rows)
+
+    @staticmethod
+    def _decorate_evidence_scope(
+        rows: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        decorated: list[dict[str, Any]] = []
+        for raw in rows:
+            row = dict(raw)
+            scope = ClaimService._scope_projection_to_model(row)
+            readiness, findings = ClaimService._assess_scope(row, scope)
+            row["scope_readiness"] = readiness
+            row["scope_contract"] = scope.model_dump(mode="json") if scope else None
+            row["scope_findings"] = [finding.model_dump(mode="json") for finding in findings]
+            decorated.append(row)
+        return decorated

--- a/rka/services/project.py
+++ b/rka/services/project.py
@@ -18,9 +18,7 @@ class ProjectService(BaseService):
     """Manages projects and per-project state."""
 
     DEFAULT_PROJECT_ID = DEFAULT_PROJECT_ID
-    _SAFE_STORAGE_PROJECT_ID = re.compile(
-        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z"
-    )
+    _SAFE_STORAGE_PROJECT_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 
     async def list_projects(self) -> list[ProjectInfo]:
         rows = await self.db.fetchall(
@@ -44,7 +42,9 @@ class ProjectService(BaseService):
         if existing_id:
             raise ValueError(f"Project '{project_id}' already exists")
 
-        existing_name = await self.db.fetchone("SELECT id FROM projects WHERE name = ?", [data.name])
+        existing_name = await self.db.fetchone(
+            "SELECT id FROM projects WHERE name = ?", [data.name]
+        )
         if existing_name:
             raise ValueError(f"Project name '{data.name}' already exists")
 
@@ -56,7 +56,12 @@ class ProjectService(BaseService):
         )
 
         phases = data.phases_config or [
-            "literature", "planning", "data_collection", "implementation", "evaluation", "paper_writing",
+            "literature",
+            "planning",
+            "data_collection",
+            "implementation",
+            "evaluation",
+            "paper_writing",
         ]
         await self.db.execute(
             """INSERT OR IGNORE INTO project_states
@@ -65,7 +70,9 @@ class ProjectService(BaseService):
             [project_id, data.name, data.description, phases[0], json.dumps(phases), now, now],
         )
         await self.db.commit()
-        await self.audit("create", "project", project_id, actor, {"name": data.name}, project_id=project_id)
+        await self.audit(
+            "create", "project", project_id, actor, {"name": data.name}, project_id=project_id
+        )
         row = await self.db.fetchone("SELECT * FROM projects WHERE id = ?", [project_id])
         return ProjectInfo(**dict(row))
 
@@ -108,8 +115,12 @@ class ProjectService(BaseService):
     ) -> ProjectState:
         """Implementation for :meth:`initialize` inside its transaction."""
         default_phases = phases or [
-            "literature", "planning", "data_collection",
-            "implementation", "evaluation", "paper_writing",
+            "literature",
+            "planning",
+            "data_collection",
+            "implementation",
+            "evaluation",
+            "paper_writing",
         ]
         await self.db.execute(
             """INSERT OR IGNORE INTO projects (id, name, description, created_by)
@@ -120,10 +131,21 @@ class ProjectService(BaseService):
             """INSERT OR REPLACE INTO project_states
                (project_id, project_name, project_description, current_phase, phases_config, created_at, updated_at)
                VALUES (?, ?, ?, ?, ?, COALESCE((SELECT created_at FROM project_states WHERE project_id = ?), ?), ?)""",
-            [project_id, name, description, default_phases[0], json.dumps(default_phases), project_id, _now(), _now()],
+            [
+                project_id,
+                name,
+                description,
+                default_phases[0],
+                json.dumps(default_phases),
+                project_id,
+                _now(),
+                _now(),
+            ],
         )
         await self.db.commit()
-        await self.audit("create", "project", project_id, "system", {"name": name}, project_id=project_id)
+        await self.audit(
+            "create", "project", project_id, "system", {"name": name}, project_id=project_id
+        )
         return await self.get(project_id=project_id)
 
     async def update(
@@ -181,7 +203,14 @@ class ProjectService(BaseService):
                 project_id=project_id,
             )
 
-        await self.audit("update", "project", project_id, actor, {"fields": list(updates.keys())}, project_id=project_id)
+        await self.audit(
+            "update",
+            "project",
+            project_id,
+            actor,
+            {"fields": list(updates.keys())},
+            project_id=project_id,
+        )
         return await self.get(project_id=project_id)
 
     # All project-scoped tables that must be cascade-deleted.
@@ -204,6 +233,7 @@ class ProjectService(BaseService):
         "reference_validation_migration_issues",
         # Research graph and operational records.
         "review_queue",
+        "claim_scope_versions",
         "interpretation_review_events",
         "interpretation_candidate_hints",
         "interpretation_promotions",
@@ -327,40 +357,27 @@ class ProjectService(BaseService):
 
     def _knowledge_pack_project_dir(self, project_id: str) -> Path:
         """Return the service-owned project directory after strict validation."""
-        if (
-            project_id in {".", ".."}
-            or not self._SAFE_STORAGE_PROJECT_ID.fullmatch(project_id)
-        ):
-            raise ValueError(
-                "Project ID is not safe for knowledge-pack storage cleanup"
-            )
+        if project_id in {".", ".."} or not self._SAFE_STORAGE_PROJECT_ID.fullmatch(project_id):
+            raise ValueError("Project ID is not safe for knowledge-pack storage cleanup")
 
         db_dir = Path(self.db.db_path).resolve().parent
         storage_root = db_dir / "knowledge-packs"
         if storage_root.is_symlink():
-            raise ValueError(
-                "Knowledge-pack storage root must not be a symbolic link"
-            )
+            raise ValueError("Knowledge-pack storage root must not be a symbolic link")
 
         resolved_root = storage_root.resolve()
         project_dir = storage_root / project_id
         if project_dir.is_symlink():
-            raise ValueError(
-                "Knowledge-pack project directory must not be a symbolic link"
-            )
+            raise ValueError("Knowledge-pack project directory must not be a symbolic link")
 
         resolved_project_dir = project_dir.resolve()
         if (
             not resolved_project_dir.is_relative_to(resolved_root)
             or resolved_project_dir.parent != resolved_root
         ):
-            raise ValueError(
-                "Project ID escapes knowledge-pack storage cleanup root"
-            )
+            raise ValueError("Project ID escapes knowledge-pack storage cleanup root")
         if project_dir.exists() and not project_dir.is_dir():
-            raise ValueError(
-                "Knowledge-pack project storage path is not a directory"
-            )
+            raise ValueError("Knowledge-pack project storage path is not a directory")
         return project_dir
 
     def _remove_knowledge_pack_project_dir(
@@ -372,9 +389,7 @@ class ProjectService(BaseService):
         """Remove only the validated service-owned directory after DB commit."""
         project_dir = self._knowledge_pack_project_dir(project_id)
         if project_dir != expected_path:
-            raise RuntimeError(
-                "Knowledge-pack project storage path changed during deletion"
-            )
+            raise RuntimeError("Knowledge-pack project storage path changed during deletion")
         if project_dir.exists():
             shutil.rmtree(project_dir)
             return True

--- a/rka/skills/brain/SKILL.md
+++ b/rka/skills/brain/SKILL.md
@@ -18,8 +18,8 @@ The rka MCP server ships a **discriminated-union dispatch surface**. Five tools 
 
 | Always-on tool | Purpose |
 |---|---|
-| `rka_query(args)` | All 51 read operations (status, context, journal, research map, native manuscripts, writing candidates, reference manifests, change impact, etc.) |
-| `rka_execute(args)` | All 58 write/lifecycle operations (notes, decisions, missions, native manuscripts, reference manifests, checkpoints, claims, hooks, maintenance) |
+| `rka_query(args)` | All 53 read operations (status, context, journal, research map, claim scope, native manuscripts, writing candidates, reference manifests, change impact, etc.) |
+| `rka_execute(args)` | All 62 write/lifecycle operations (notes, decisions, missions, interpretation promotion, claim-scope review, native manuscripts, checkpoints, hooks, maintenance) |
 | `rka_describe(operation)` | Schema lookup + worked example for any operation; `rka_describe('')` returns the <250-token index |
 | `rka_load_tools(names)` | Escape hatch — brings deferred legacy tools online when you specifically need backwards-compat access |
 | `rka_help(name)` | Deprecated alias for `rka_describe`; retained always-on for cockpits that learned the v2.6.3 navigator vocabulary |
@@ -190,6 +190,18 @@ support. `verified` records the categorical grounding review;
 **Confidence cap without full text**: claims extracted from abstracts or search snippets cap at **0.65**. To exceed that, you need full-text grounding with a direct quote.
 
 Full procedure with worked examples and cluster-assignment heuristic: `workflows.md` § "Claim Extraction".
+
+### Canonical claim-scope review
+
+Do not cluster or offer a `clm_` as manuscript support merely because its
+source grounding is verified. Inspect its canonical research boundary with
+`rka_query(args={"operation": "claim_scope", "project_id": <pinned>, "id":
+"clm_..."})`. If scope is missing, stale, incomplete, or unreviewed, append a
+revision with `set_claim_scope`; never infer a legacy boundary from claim prose.
+A reviewed contract records typed conditions, resolved uncertainty, an exact or
+bounded extension policy, prohibited extensions, and resolved falsifier
+applicability. Keep `scope_readiness`, `evidence_status`, contradiction, and
+staleness as separate review axes.
 
 ## Literature ingestion + Zotero linkage
 

--- a/rka/skills/executor/SKILL.md
+++ b/rka/skills/executor/SKILL.md
@@ -18,13 +18,13 @@ The rka MCP server ships a **discriminated-union dispatch surface**. Five tools 
 
 | Always-on tool | Purpose |
 |---|---|
-| `rka_query(args)` | All 52 read operations (missions, status, context, interpretation candidates, native manuscripts, writing candidates, reference manifests, change impact, reports, search, etc.) |
-| `rka_execute(args)` | All 61 write/lifecycle operations (notes, native manuscript and reference-manifest updates, checkpoints, reports, mission lifecycle, document ingest, interpretation staging, explicit claim promotion, etc.) |
+| `rka_query(args)` | All 53 read operations (missions, status, context, interpretation candidates, claim scope, native manuscripts, writing candidates, change impact, reports, search, etc.) |
+| `rka_execute(args)` | All 62 write/lifecycle operations (notes, manuscript updates, checkpoints, reports, document ingest, interpretation staging, explicit claim promotion, claim-scope review, etc.) |
 | `rka_describe(operation)` | Schema lookup + worked example; `rka_describe('')` returns the <250-token index |
 | `rka_load_tools(names)` | Escape hatch — brings deferred legacy tools online when you specifically need backwards-compat access |
 | `rka_help(name)` | Deprecated alias for `rka_describe` |
 
-`args` is a **typed Pydantic model** discriminated by `operation`. FastMCP renders the 109-model union as `inputSchema.oneOf` with per-branch enum + required-field constraints. The schema layer rejects wrong enum values, missing required fields, and missing provenance BEFORE the call is dispatched.
+`args` is a **typed Pydantic model** discriminated by `operation`. FastMCP renders the 115-model union as `inputSchema.oneOf` with per-branch enum + required-field constraints. The schema layer rejects wrong enum values, missing required fields, and missing provenance BEFORE the call is dispatched.
 
 > **Orchestrator subprocess note.** When this Executor instance is the LangGraph orchestrator's `claude-agent-sdk` subprocess (daemon under `orchestrator/docker-compose.yml`), it runs with `RKA_LEGACY_TOOLS=1`, restoring the v2.7.0a2 always-on surface (the 12-tool legacy baseline + the 8 v2.7.0a2 intent verbs) alongside the always-on dispatch tools (`rka_query` / `rka_execute` / `rka_describe`, which are never deferred); the remaining legacy tools stay `tier='deferred'` and are reachable via `rka_load_tools`. This preserves the parent-side TWO-TAP autonomy contract at `pi_decision_select` (per-tool ratification granularity in `WRITE_TOOLS`). Cockpit Executor sessions (Claude Desktop / Claude Code talking directly to the PI) see the typed dispatch surface described above.
 
@@ -116,6 +116,13 @@ not promote its own result to `supported`; the Brain performs that assessment
 against current positive evidence, qualifiers, and counterevidence. Never use
 `verified=true` as shorthand for scientific validity—it records source-grounding
 fidelity only.
+
+Record the exact experimental conditions, uncertainty, failed runs, and
+disconfirming observations needed for later scope review, but do not silently
+ratify a research-level boundary. The Brain or PI appends reviewed `csc_`
+contracts. If a mission explicitly delegates preparation of a draft scope, use
+`set_claim_scope` with `review_status="draft"`; do not label it reviewed or use
+scope readiness as a scientific-support verdict.
 
 ## Backbrief — Confirm Your Plan
 

--- a/rka/skills/pi/SKILL.md
+++ b/rka/skills/pi/SKILL.md
@@ -17,8 +17,8 @@ The rka MCP server ships a **discriminated-union dispatch surface**. Five tools 
 
 | Always-on tool | Purpose |
 |---|---|
-| `rka_query(args)` | All 51 read operations |
-| `rka_execute(args)` | All 58 write/lifecycle operations |
+| `rka_query(args)` | All 53 read operations |
+| `rka_execute(args)` | All 62 write/lifecycle operations |
 | `rka_describe(operation)` | Schema lookup + worked example; `rka_describe('')` returns the <250-token index |
 | `rka_load_tools(names)` | Escape hatch for explicit legacy-tool access |
 | `rka_help(name)` | Deprecated alias for `rka_describe` |

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -109,11 +109,15 @@ writer readiness` asks RKA for the authoritative target-phase gate.
    every operation. Native manuscript work uses `manuscript_context`,
    `manuscript_spine`, `manuscript_readiness`, `upsert_argument_spine`,
    `ratify_manuscript_claim`, checkpoint operations, and change/impact reads.
-7. Run `rka writer readiness --target-phase <phase>`. `BLOCK` or `ERROR`
+7. For every load-bearing `clm_`, inspect `claim_scope`. Resolve any
+   `missing`, `stale`, `incomplete`, or `needs_review` contract through the
+   Brain/PI before using it as positive support. Do not copy preliminary
+   candidate scope into a canonical boundary without review.
+8. Run `rka writer readiness --target-phase <phase>`. `BLOCK` or `ERROR`
    stops advancement. A changed dependency never rewrites PI-ratified wording;
    revalidate the claim and record a superseding PI decision before binding a
    materially changed version.
-8. Greet the PI (path a) or surface the mission state (path b) with the inferred next checkpoint or handler dispatch.
+9. Greet the PI (path a) or surface the mission state (path b) with the inferred next checkpoint or handler dispatch.
 
 Full worked walkthrough: [`references/workflows.md`](references/workflows.md) section "Session Start".
 
@@ -270,8 +274,11 @@ the current RKA graph:
    prohibited wording, and planned manuscript units.
 4. For an empirical claim, require one or more current, verified `clm_`
    records whose `source_entry_id` resolves to a current terminal `jrn_` or
-   `lit_`. A `dec_` ratifies wording but is not empirical evidence. An `ecl_`
-   guides synthesis and discovery but is not empirical evidence.
+   `lit_`, and require each supporting claim's canonical `csc_` contract to be
+   current, complete, and reviewed. Carry `csc_` IDs into candidate lineage and
+   union their prohibited extensions into candidate prohibited wording. A
+   `dec_` ratifies wording but is not empirical evidence. An `ecl_` guides
+   synthesis and discovery but is not empirical evidence.
 5. Dry-run the proposal with `rka writer import-spine`; inspect its evidence
    roles, result coverage, and revision. Apply only with `--apply` and an
    explicit expected revision. Import never creates ratifications.

--- a/rka/skills/writer/references/evidence_to_spine_pipeline.md
+++ b/rka/skills/writer/references/evidence_to_spine_pipeline.md
@@ -12,9 +12,17 @@ in RKA but does not silently enter the manuscript.
 ```text
 jrn_ observations and decisions
         |
-        | extraction fidelity, source linkage, currency
+        | exact locator, epistemic kind, explicit review
+        v
+icd_ interpretation candidates
+        |
+        | promotion with grounding fidelity and immutable lineage
         v
 clm_ atomic claims
+        |
+        | typed applicability, uncertainty, extension limits, falsifier
+        v
+csc_ canonical claim-scope versions
         |
         | cluster membership, duplicate grouping, contradiction edges
         v
@@ -74,6 +82,15 @@ true:
 - project ownership is attested;
 - the source is not manuscript prose;
 - unresolved contradiction edges do not touch the claim.
+- its current canonical `csc_` contract is complete, reviewed, and still
+  matches the claim's current content and type.
+
+Candidate scope on `icd_` is source-bounded extraction context. Canonical scope
+on `csc_` is the research-level applicability contract. Manuscript wording on
+`mcl_` is paper-specific and PI-ratified. Do not collapse these layers. Legacy
+claims with no `csc_` remain `scope_readiness=missing`, and a claim edit makes
+its older contract stale. Scope readiness never replaces grounding,
+scientific-support, contradiction, or currency checks.
 
 Claims that fail admission stay visible in the candidate report with reason
 codes. They are not silently discarded or converted into qualifiers.
@@ -130,6 +147,8 @@ The response includes:
 - qualifiers and counterevidence;
 - an unratified candidate spine;
 - candidate-to-cluster/RQ lineage.
+- canonical `csc_` IDs and prohibited extensions for every admitted support
+  claim.
 
 ## 4. Contribution contract
 

--- a/tests/test_api/test_claim_scope_contracts.py
+++ b/tests/test_api/test_claim_scope_contracts.py
@@ -1,0 +1,119 @@
+"""REST contracts for canonical claim-scope history and review."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+
+
+@pytest_asyncio.fixture
+async def api_client(tmp_path: Path):
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path("claim-scopes.db"),
+        llm_enabled=False,
+        embeddings_enabled=False,
+    )
+    app = create_app(config)
+    lifespan = app.router.lifespan_context(app)
+    await lifespan.__aenter__()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            yield client
+    finally:
+        await lifespan.__aexit__(None, None, None)
+
+
+async def _claim(client: httpx.AsyncClient) -> dict:
+    note = await client.post(
+        "/api/notes",
+        json={"content": "Delay was 42 ms.", "source": "executor"},
+    )
+    assert note.status_code == 201
+    response = await client.post(
+        "/api/claims",
+        json={
+            "source_entry_id": note.json()["id"],
+            "claim_type": "result",
+            "content": "Delay was 42 ms.",
+            "verified": True,
+            "evidence_status": "supported",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _scope(expected_revision: int) -> dict:
+    return {
+        "expected_revision": expected_revision,
+        "actor": "web_ui",
+        "reason": "Reviewed exact DelaySteer boundary.",
+        "conditions": [
+            {
+                "kind": "environment",
+                "key": "testbed",
+                "operator": "equals",
+                "value": "isolated local testbed",
+            }
+        ],
+        "uncertainty": "low",
+        "extension_policy": "exact_only",
+        "prohibited_extensions": ["Do not generalize to remote deployments."],
+        "falsifier_status": "applicable",
+        "falsifier": "Repeated runs do not reproduce the direction.",
+        "review_status": "reviewed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_scope_api_is_revision_guarded_and_visible_on_claim(api_client) -> None:
+    claim = await _claim(api_client)
+    assert claim["scope_readiness"] == "missing"
+
+    initial = await api_client.get(f"/api/claims/{claim['id']}/scope")
+    assert initial.status_code == 200
+    assert initial.json()["current_revision"] == 0
+
+    appended = await api_client.post(
+        f"/api/claims/{claim['id']}/scope",
+        json=_scope(0),
+    )
+    assert appended.status_code == 200, appended.text
+    assert appended.json()["scope_readiness"] == "ready"
+    assert appended.json()["current"]["id"].startswith("csc_")
+
+    stale = await api_client.post(
+        f"/api/claims/{claim['id']}/scope",
+        json=_scope(0),
+    )
+    assert stale.status_code == 409
+
+    refreshed = await api_client.get(f"/api/claims/{claim['id']}")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["scope_revision"] == 1
+    assert refreshed.json()["scope_readiness"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_scope_api_rejects_unreviewable_contract(api_client) -> None:
+    claim = await _claim(api_client)
+    response = await api_client.post(
+        f"/api/claims/{claim['id']}/scope",
+        json={
+            "expected_revision": 0,
+            "actor": "web_ui",
+            "reason": "Missing semantic boundaries.",
+            "review_status": "reviewed",
+        },
+    )
+    assert response.status_code == 422

--- a/tests/test_mcp/test_claim_scope_contracts.py
+++ b/tests/test_mcp/test_claim_scope_contracts.py
@@ -1,0 +1,131 @@
+"""Typed MCP coverage for canonical claim-scope contracts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from rka.mcp import server
+from rka.mcp.operation_args import ExecuteArgsUnion, QueryArgsUnion
+from rka.mcp.verb_dispatch import dispatch_execute_typed, dispatch_query_typed
+
+
+@pytest.fixture
+def captured_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        captured.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": body,
+            }
+        )
+        return httpx.Response(
+            200,
+            json={
+                "claim_id": "clm_scope",
+                "project_id": "prj_scope",
+                "current_revision": 1 if request.method == "POST" else 0,
+                "scope_readiness": "ready" if request.method == "POST" else "missing",
+                "findings": [],
+                "current": None,
+                "versions": [],
+            },
+        )
+
+    def client(_project_id: str | None = None) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://testserver",
+        )
+
+    monkeypatch.setattr(server, "_client", client)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_query_claim_scope_routes_to_history_endpoint(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    args = TypeAdapter(QueryArgsUnion).validate_python(
+        {
+            "operation": "claim_scope",
+            "project_id": "prj_scope",
+            "id": "clm_scope",
+        }
+    )
+    result = json.loads(await dispatch_query_typed(args))
+
+    assert result["scope_readiness"] == "missing"
+    claim_requests = [
+        request for request in captured_requests if request["path"] == "/api/claims/clm_scope/scope"
+    ]
+    assert claim_requests == [
+        {
+            "method": "GET",
+            "path": "/api/claims/clm_scope/scope",
+            "body": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_claim_scope_forwards_full_reviewed_contract(
+    captured_requests: list[dict[str, Any]],
+) -> None:
+    args = TypeAdapter(ExecuteArgsUnion).validate_python(
+        {
+            "operation": "set_claim_scope",
+            "project_id": "prj_scope",
+            "claim_id": "clm_scope",
+            "expected_revision": 0,
+            "actor": "brain",
+            "reason": "Checked source and evaluation boundaries.",
+            "conditions": [
+                {
+                    "kind": "dataset",
+                    "key": "evaluation_dataset",
+                    "operator": "equals",
+                    "value": "Dataset A",
+                }
+            ],
+            "uncertainty": "low",
+            "extension_policy": "exact_only",
+            "prohibited_extensions": ["other datasets without evidence"],
+            "falsifier_status": "applicable",
+            "falsifier": "Independent replication fails on Dataset A.",
+            "review_status": "reviewed",
+        }
+    )
+    result = json.loads(await dispatch_execute_typed(args))
+
+    assert result["scope_readiness"] == "ready"
+    assert captured_requests[0]["method"] == "POST"
+    assert captured_requests[0]["path"] == "/api/claims/clm_scope/scope"
+    assert captured_requests[0]["body"]["conditions"][0]["kind"] == "dataset"
+    assert captured_requests[0]["body"]["review_status"] == "reviewed"
+    assert "project_id" not in captured_requests[0]["body"]
+
+
+def test_reviewed_scope_rejects_ambiguous_contract_before_dispatch() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(ExecuteArgsUnion).validate_python(
+            {
+                "operation": "set_claim_scope",
+                "project_id": "prj_scope",
+                "claim_id": "clm_scope",
+                "expected_revision": 0,
+                "actor": "brain",
+                "reason": "Too vague.",
+                "review_status": "reviewed",
+            }
+        )

--- a/tests/test_services/test_claim_scope_contracts.py
+++ b/tests/test_services/test_claim_scope_contracts.py
@@ -1,0 +1,215 @@
+"""Canonical claim-scope contracts are versioned, bounded, and auditable."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from pydantic import ValidationError
+
+from rka.models.claim import (
+    ClaimCreate,
+    ClaimEdgeCreate,
+    ClaimScopeCondition,
+    ClaimScopeWrite,
+    ClaimUpdate,
+)
+from rka.services.claims import ClaimScopeConflictError, ClaimService
+
+
+PROJECT = "proj_default"
+
+
+async def _claim(db, suffix: str = "main"):
+    entry_id = f"jrn_scope_{suffix}"
+    await db.execute(
+        """INSERT INTO journal
+           (id, project_id, type, content, source, confidence)
+           VALUES (?, ?, 'note', 'Delay was 42 ms.', 'executor', 'tested')""",
+        [entry_id, PROJECT],
+    )
+    await db.commit()
+    return await ClaimService(db, project_id=PROJECT).create(
+        ClaimCreate(
+            source_entry_id=entry_id,
+            claim_type="result",
+            content="Delay was 42 ms.",
+            verified=True,
+            evidence_status="supported",
+        ),
+        actor="executor",
+    )
+
+
+def _condition(value: str = "local testbed") -> ClaimScopeCondition:
+    return ClaimScopeCondition(
+        kind="environment",
+        key="testbed",
+        operator="equals",
+        value=value,
+    )
+
+
+def _complete_scope(
+    expected_revision: int,
+    *,
+    review_status: str = "reviewed",
+    disconfirming_claim_ids: list[str] | None = None,
+) -> ClaimScopeWrite:
+    return ClaimScopeWrite(
+        expected_revision=expected_revision,
+        actor="brain",
+        reason="Reviewed exact operating boundary.",
+        conditions=[_condition()],
+        uncertainty="low",
+        uncertainty_note="Five isolated repetitions.",
+        extension_policy="exact_only",
+        prohibited_extensions=["Do not generalize beyond the local testbed or tested workload."],
+        falsifier_status="applicable",
+        falsifier="Repeated measurements do not reproduce the direction.",
+        disconfirming_claim_ids=disconfirming_claim_ids or [],
+        review_status=review_status,  # type: ignore[arg-type]
+    )
+
+
+def test_condition_and_review_models_reject_ambiguous_boundaries() -> None:
+    with pytest.raises(ValidationError, match="one_of requires"):
+        ClaimScopeCondition(
+            kind="dataset",
+            key="dataset",
+            operator="one_of",
+            value="Dataset A",
+        )
+    with pytest.raises(ValidationError, match="reviewed scope requires"):
+        ClaimScopeWrite(
+            expected_revision=0,
+            actor="brain",
+            reason="Incomplete review must fail.",
+            review_status="reviewed",
+        )
+    with pytest.raises(ValidationError, match="exact_only"):
+        ClaimScopeWrite(
+            expected_revision=0,
+            actor="brain",
+            reason="Contradictory extension policy.",
+            extension_policy="exact_only",
+            allowed_extensions=["all platforms"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_legacy_claim_is_missing_until_versioned_review(db) -> None:
+    claim = await _claim(db)
+    service = ClaimService(db, project_id=PROJECT)
+
+    assert claim.scope_revision == 0
+    assert claim.scope_readiness == "missing"
+    assert claim.scope_contract is None
+    assert claim.scope_findings[0].code == "CLAIM_SCOPE_MISSING"
+
+    draft = await service.append_scope(
+        claim.id,
+        ClaimScopeWrite(
+            expected_revision=0,
+            actor="executor",
+            reason="Preserve preliminary source condition.",
+            conditions=[_condition()],
+            uncertainty="low",
+            falsifier_status="applicable",
+            falsifier="Direction fails to reproduce.",
+        ),
+    )
+    assert draft.current_revision == 1
+    assert draft.scope_readiness == "incomplete"
+    assert draft.current is not None
+    assert draft.current.review_status == "draft"
+
+    reviewed = await service.append_scope(claim.id, _complete_scope(1))
+    assert reviewed.current_revision == 2
+    assert reviewed.scope_readiness == "ready"
+    assert [version.revision for version in reviewed.versions] == [2, 1]
+    assert reviewed.current is not None
+    assert reviewed.current.supersedes_scope_id == reviewed.versions[1].id
+
+
+@pytest.mark.asyncio
+async def test_scope_revision_conflict_and_claim_edit_make_contract_stale(db) -> None:
+    claim = await _claim(db, "stale")
+    service = ClaimService(db, project_id=PROJECT)
+    await service.append_scope(claim.id, _complete_scope(0))
+
+    with pytest.raises(ClaimScopeConflictError, match="revision changed"):
+        await service.append_scope(claim.id, _complete_scope(0))
+
+    updated = await service.update(
+        claim.id,
+        ClaimUpdate(content="Delay was 41 ms."),
+    )
+    assert updated.scope_revision == 1
+    assert updated.scope_readiness == "stale"
+    assert any(finding.code == "CLAIM_SCOPE_STALE" for finding in updated.scope_findings)
+
+
+@pytest.mark.asyncio
+async def test_scope_history_is_immutable_outside_project_deletion(db) -> None:
+    claim = await _claim(db, "immutable")
+    service = ClaimService(db, project_id=PROJECT)
+    history = await service.append_scope(claim.id, _complete_scope(0))
+    scope_id = history.current.id  # type: ignore[union-attr]
+
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        await db.execute(
+            "UPDATE claim_scope_versions SET reason = 'rewrite' WHERE id = ?",
+            [scope_id],
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="project-authorized"):
+        await db.execute(
+            "DELETE FROM claim_scope_versions WHERE id = ?",
+            [scope_id],
+        )
+
+
+@pytest.mark.asyncio
+async def test_reviewed_scope_keeps_contradiction_and_disconfirmation_visible(db) -> None:
+    claim = await _claim(db, "contested")
+    counter = await _claim(db, "counter")
+    service = ClaimService(db, project_id=PROJECT)
+    await service.create_edge(
+        ClaimEdgeCreate(
+            source_claim_id=counter.id,
+            target_claim_id=claim.id,
+            relation="contradicts",
+            confidence=0.9,
+        )
+    )
+    history = await service.append_scope(
+        claim.id,
+        _complete_scope(0, disconfirming_claim_ids=[counter.id]),
+    )
+
+    assert history.scope_readiness == "ready"
+    assert history.current is not None
+    assert history.current.disconfirming_claim_ids == [counter.id]
+    refreshed = await service.get(claim.id)
+    assert refreshed is not None
+    assert refreshed.contradicted is True
+    codes = {finding.code for finding in refreshed.scope_findings}
+    assert "CLAIM_CONTRADICTION_PRESENT" in codes
+    assert "CLAIM_SCOPE_DISCONFIRMING_OBSERVATIONS" in codes
+
+
+@pytest.mark.asyncio
+async def test_scope_rejects_missing_or_self_disconfirming_claims(db) -> None:
+    claim = await _claim(db, "bad_refs")
+    service = ClaimService(db, project_id=PROJECT)
+
+    with pytest.raises(ValueError, match="cannot disconfirm itself"):
+        await service.append_scope(
+            claim.id,
+            _complete_scope(0, disconfirming_claim_ids=[claim.id]),
+        )
+    with pytest.raises(ValueError, match="not available"):
+        await service.append_scope(
+            claim.id,
+            _complete_scope(0, disconfirming_claim_ids=["clm_missing"]),
+        )

--- a/tests/test_services/test_knowledge_pack.py
+++ b/tests/test_services/test_knowledge_pack.py
@@ -19,6 +19,7 @@ from rka.models.literature import LiteratureCreate
 from rka.models.mission import MissionCreate
 from rka.models.project import ProjectCreate
 from rka.services.artifacts import ArtifactService
+from rka.services.claims import ClaimService
 from rka.services.decisions import DecisionService
 from rka.services.knowledge_pack import KnowledgePackService
 from rka.services.literature import LiteratureService
@@ -268,6 +269,17 @@ async def test_knowledge_pack_round_trip_preserves_interpretation_promotion_line
         assert imported_claim["source_entry_id"] == imported.source_id
         assert imported_claim["verified"] == 1
         assert imported_claim["evidence_status"] == "unassessed"
+        assert imported_claim["scope_revision"] == 1
+        imported_scope = await ClaimService(
+            db,
+            project_id=result.project_id,
+        ).get_scope_history(imported.active_claim_id)
+        assert imported_scope is not None
+        assert imported_scope.scope_readiness == "incomplete"
+        assert imported_scope.current is not None
+        assert imported_scope.current.source_candidate_id == imported.id
+        assert imported_scope.current.conditions[0].value == "configured workload"
+        assert imported_scope.current.falsifier_status == "applicable"
         assert await db.fetchall("PRAGMA foreign_key_check") == []
     finally:
         await db.close()

--- a/tests/test_services/test_knowledge_pack_native.py
+++ b/tests/test_services/test_knowledge_pack_native.py
@@ -546,7 +546,7 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
     with zipfile.ZipFile(pack_path) as archive:
         manifest = json.loads(archive.read("manifest.json"))
 
-    assert manifest["pack_format_version"] == PACK_SCHEMA_VERSION == 3
+    assert manifest["pack_format_version"] == PACK_SCHEMA_VERSION == 4
     assert manifest["portability"] == {
         "completed_validation_attestations": "included",
         "excluded_tables": {

--- a/tests/test_services/test_native_manuscript_service.py
+++ b/tests/test_services/test_native_manuscript_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from rka.infra.ids import generate_id
+from rka.models.claim import ClaimScopeCondition, ClaimScopeWrite
 from rka.models.manuscript_native import (
     ManuscriptCheckpointCreate,
     ManuscriptCheckpointResolve,
@@ -16,6 +17,29 @@ from rka.services.manuscript_native import (
     ManuscriptRevisionConflict,
     NativeManuscriptService,
 )
+from rka.services.claims import ClaimService
+
+
+def _reviewed_scope(expected_revision: int = 0) -> ClaimScopeWrite:
+    return ClaimScopeWrite(
+        expected_revision=expected_revision,
+        actor="brain",
+        reason="Test fixture reviewed the bounded operating context.",
+        conditions=[
+            ClaimScopeCondition(
+                kind="environment",
+                key="testbed",
+                operator="equals",
+                value="local evaluated testbed",
+            )
+        ],
+        uncertainty="low",
+        extension_policy="exact_only",
+        prohibited_extensions=["Do not generalize beyond the evaluated testbed."],
+        falsifier_status="applicable",
+        falsifier="Repeated evaluation does not reproduce the direction.",
+        review_status="reviewed",
+    )
 
 
 async def _seed_ready_claim(db, *, project_id: str = "proj_default") -> str:
@@ -37,6 +61,10 @@ async def _seed_ready_claim(db, *, project_id: str = "proj_default") -> str:
         [claim_id, journal_id, project_id],
     )
     await db.commit()
+    await ClaimService(db, project_id=project_id).append_scope(
+        claim_id,
+        _reviewed_scope(),
+    )
     return claim_id
 
 
@@ -818,6 +846,10 @@ async def test_writing_candidates_smooth_claims_through_reviewed_cluster_and_rq(
         )
     await db_with_project.commit()
 
+    claims_service = ClaimService(db_with_project, project_id="proj_default")
+    for claim_id in claim_ids:
+        await claims_service.append_scope(claim_id, _reviewed_scope())
+
     proposal = await service.get_writing_candidates(manuscript.id)
     assert proposal["summary"] == {
         "clusters_total": 1,
@@ -829,6 +861,10 @@ async def test_writing_candidates_smooth_claims_through_reviewed_cluster_and_rq(
     assert candidate["status"] == "candidate"
     assert candidate["ratified_by"] is None
     assert candidate["evidence_ids"] == sorted(claim_ids)
+    assert len(candidate["scope_contract_ids"]) == 2
+    assert candidate["prohibited_wording"] == [
+        "Do not generalize beyond the evaluated testbed."
+    ]
     cluster = proposal["clusters"][0]
     assert cluster["disposition"] == "eligible"
     assert cluster["duplicate_support_groups"] == [sorted(claim_ids)]

--- a/tests/test_services/test_project.py
+++ b/tests/test_services/test_project.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import pytest
 
 from rka.models.project import ProjectCreate
+from rka.models.claim import ClaimCreate, ClaimScopeCondition, ClaimScopeWrite
 from rka.models.interpretation import InterpretationCandidateCreate
+from rka.services.claims import ClaimService
 from rka.services.interpretation import InterpretationService
 from rka.services.project import ProjectService
 
@@ -244,6 +246,70 @@ async def test_confirmed_project_delete_removes_interpretation_history(db) -> No
     ) == []
     assert await db.fetchall(
         "SELECT * FROM interpretation_review_events WHERE project_id = ?",
+        [project_id],
+    ) == []
+    assert await db.fetchall("PRAGMA foreign_key_check") == []
+
+
+@pytest.mark.asyncio
+async def test_confirmed_project_delete_removes_claim_scope_history(db) -> None:
+    svc = ProjectService(db)
+    project_id = "proj_delete_claim_scope"
+    await svc.create_project(
+        ProjectCreate(id=project_id, name="Delete Claim Scope History"),
+        actor="system",
+    )
+    await db.execute(
+        """INSERT INTO journal
+           (id, project_id, type, content, source, confidence)
+           VALUES ('jrn_delete_claim_scope', ?, 'note', ?, 'executor', 'tested')""",
+        [project_id, "The isolated run measured 42 ms."],
+    )
+    await db.commit()
+    claims = ClaimService(db, project_id=project_id)
+    claim = await claims.create(
+        ClaimCreate(
+            source_entry_id="jrn_delete_claim_scope",
+            claim_type="result",
+            content="The isolated run measured 42 ms.",
+            verified=True,
+        ),
+        actor="executor",
+    )
+    await claims.append_scope(
+        claim.id,
+        ClaimScopeWrite(
+            expected_revision=0,
+            actor="brain",
+            reason="Reviewed exact evaluation boundary.",
+            conditions=[
+                ClaimScopeCondition(
+                    kind="environment",
+                    key="run_mode",
+                    operator="equals",
+                    value="isolated",
+                )
+            ],
+            uncertainty="low",
+            extension_policy="exact_only",
+            prohibited_extensions=["concurrent workloads"],
+            falsifier_status="applicable",
+            falsifier="The same isolated run does not reproduce 42 ms.",
+            review_status="reviewed",
+        ),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="project-authorized deletion"):
+        await db.execute(
+            "DELETE FROM claim_scope_versions WHERE claim_id = ?",
+            [claim.id],
+        )
+
+    result = await svc.delete_project(project_id, confirm=True)
+
+    assert result["confirmed"] is True
+    assert await db.fetchall(
+        "SELECT * FROM claim_scope_versions WHERE project_id = ?",
         [project_id],
     ) == []
     assert await db.fetchall("PRAGMA foreign_key_check") == []

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import ResearchHealth from "@/pages/ResearchHealth"
 import ReportContext from "@/pages/ReportContext"
 import ManuscriptWorkbench from "@/pages/ManuscriptWorkbench"
 import InterpretationStaging from "@/pages/InterpretationStaging"
+import ClaimScopeReview from "@/pages/ClaimScopeReview"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -49,6 +50,7 @@ export default function App() {
               <Route path="graph" element={<KnowledgeGraph />} />
               <Route path="research-map" element={<ResearchMap />} />
               <Route path="interpretations" element={<InterpretationStaging />} />
+              <Route path="claim-scopes" element={<ClaimScopeReview />} />
               <Route path="health" element={<ResearchHealth />} />
               <Route path="report-context" element={<ReportContext />} />
               <Route path="workbench" element={<ManuscriptWorkbench />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -157,6 +157,9 @@ import type {
   InterpretationCandidateDetail,
   InterpretationReviewStatus,
   InterpretationTriageRequest,
+  ClaimScopeHistory,
+  ClaimScopeReadiness,
+  ClaimScopeWrite,
 } from "./types"
 
 export const api = {
@@ -398,15 +401,32 @@ export const api = {
     put<EvidenceClusterData>(`/clusters/${clusterId}`, data),
 
   // v2.0: Claims
-  listClaims: (params?: { source_entry_id?: string; cluster_id?: string; claim_type?: string; limit?: number }) => {
+  listClaims: (params?: {
+    source_entry_id?: string
+    cluster_id?: string
+    claim_type?: string
+    limit?: number
+    scope_readiness?: ClaimScopeReadiness
+  }) => {
     const search = new URLSearchParams()
     if (params?.source_entry_id) search.set("source_entry_id", params.source_entry_id)
     if (params?.cluster_id) search.set("cluster_id", params.cluster_id)
     if (params?.claim_type) search.set("claim_type", params.claim_type)
     if (params?.limit) search.set("limit", String(params.limit))
     const qs = search.toString()
-    return get<ClaimData[]>(`/claims${qs ? `?${qs}` : ""}`)
+    return get<ClaimData[]>(`/claims${qs ? `?${qs}` : ""}`).then((claims) => (
+      params?.scope_readiness
+        ? claims.filter((claim) => claim.scope_readiness === params.scope_readiness)
+        : claims
+    ))
   },
+  getClaimScope: (claimId: string) =>
+    get<ClaimScopeHistory>(`/claims/${encodeURIComponent(claimId)}/scope`),
+  appendClaimScope: (claimId: string, data: ClaimScopeWrite) =>
+    post<ClaimScopeHistory>(
+      `/claims/${encodeURIComponent(claimId)}/scope`,
+      data,
+    ),
 
   // M1: reviewable source interpretations. A candidate is not a claim until
   // the explicit, revision-guarded promote action succeeds.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -523,6 +523,7 @@ export interface GraphStats {
   total_nodes: number
   total_edges: number
   edge_counts_by_type: Record<string, number>
+  claim_scope_readiness_counts: Partial<Record<ClaimScopeReadiness, number>>
 }
 
 // ---- Summaries ----
@@ -584,6 +585,99 @@ export interface QASession {
 
 export type ClaimType = "hypothesis" | "evidence" | "method" | "result" | "observation" | "assumption"
 export type ClusterConfidence = "strong" | "moderate" | "emerging" | "contested" | "refuted"
+export type ClaimScopeUncertainty = "none" | "low" | "medium" | "high" | "unknown"
+export type ClaimScopeExtensionPolicy = "exact_only" | "bounded"
+export type ClaimFalsifierStatus = "unknown" | "applicable" | "not_applicable"
+export type ClaimScopeReviewStatus = "draft" | "reviewed"
+export type ClaimScopeReadiness = "missing" | "stale" | "incomplete" | "needs_review" | "ready"
+export type ClaimConditionKind =
+  | "dataset"
+  | "population"
+  | "platform"
+  | "environment"
+  | "threat_model"
+  | "baseline"
+  | "workload"
+  | "metric"
+  | "parameter"
+  | "assumption"
+  | "time_window"
+  | "other"
+export type ClaimConditionOperator =
+  | "equals"
+  | "one_of"
+  | "range"
+  | "at_least"
+  | "at_most"
+  | "present"
+  | "absent"
+  | "described_by"
+
+export interface ClaimScopeCondition {
+  kind: ClaimConditionKind
+  key: string
+  operator: ClaimConditionOperator
+  value: string | number | boolean | Array<string | number | boolean>
+  unit?: string | null
+  note?: string | null
+}
+
+export interface ClaimScopeVersion {
+  id: string
+  claim_id: string
+  project_id: string
+  revision: number
+  claim_content_hash: string
+  conditions: ClaimScopeCondition[]
+  uncertainty: ClaimScopeUncertainty
+  uncertainty_note: string | null
+  extension_policy: ClaimScopeExtensionPolicy | null
+  allowed_extensions: string[]
+  prohibited_extensions: string[]
+  falsifier_status: ClaimFalsifierStatus
+  falsifier: string | null
+  falsifier_rationale: string | null
+  disconfirming_claim_ids: string[]
+  review_status: ClaimScopeReviewStatus
+  created_by: string
+  reason: string
+  source_candidate_id: string | null
+  supersedes_scope_id: string | null
+  created_at: string | null
+}
+
+export interface ClaimScopeFinding {
+  code: string
+  severity: "block" | "warn" | "info"
+  message: string
+}
+
+export interface ClaimScopeHistory {
+  claim_id: string
+  project_id: string
+  current_revision: number
+  scope_readiness: ClaimScopeReadiness
+  findings: ClaimScopeFinding[]
+  current: ClaimScopeVersion | null
+  versions: ClaimScopeVersion[]
+}
+
+export interface ClaimScopeWrite {
+  expected_revision: number
+  actor: "pi" | "brain" | "executor" | "web_ui" | "llm"
+  reason: string
+  conditions: ClaimScopeCondition[]
+  uncertainty: ClaimScopeUncertainty
+  uncertainty_note?: string
+  extension_policy?: ClaimScopeExtensionPolicy
+  allowed_extensions: string[]
+  prohibited_extensions: string[]
+  falsifier_status: ClaimFalsifierStatus
+  falsifier?: string
+  falsifier_rationale?: string
+  disconfirming_claim_ids: string[]
+  review_status: ClaimScopeReviewStatus
+}
 
 export interface Claim {
   id: string
@@ -592,11 +686,17 @@ export interface Claim {
   content: string
   confidence: number
   verified: boolean
+  evidence_status: string
+  contradicted: boolean
   stale: boolean
   source_offset_start: number | null
   source_offset_end: number | null
   source_type?: string | null
   source_actor?: string | null
+  scope_revision: number
+  scope_readiness: ClaimScopeReadiness
+  scope_contract: ClaimScopeVersion | null
+  scope_findings: ClaimScopeFinding[]
   project_id?: string
   created_at?: string | null
   updated_at?: string | null
@@ -826,6 +926,9 @@ export interface ManuscriptEvidenceBinding {
   contradicted?: number | boolean | null
   source_current?: number | boolean | null
   source_is_manuscript?: number | boolean | null
+  scope_readiness?: ClaimScopeReadiness
+  scope_contract?: ClaimScopeVersion | null
+  scope_findings?: ClaimScopeFinding[]
 }
 
 export interface ManuscriptClaimContext {
@@ -935,6 +1038,7 @@ export interface WritingCandidateClaim {
   qualifier_ids: string[]
   counterevidence_ids: string[]
   manuscript_units: string[]
+  scope_contract_ids: string[]
 }
 
 export interface WritingCandidateCluster {
@@ -977,6 +1081,7 @@ export interface ManuscriptWritingCandidates {
       cluster_id: string
       research_question_id: string | null
       representative_claim_ids: string[]
+      scope_contract_ids: string[]
     }
   >
   summary: {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Monitor,
   PanelsTopLeft,
   ListChecks,
+  Scale,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useTheme } from "@/hooks/useTheme"
@@ -58,6 +59,7 @@ const navItems = [
   { to: "/graph", icon: Share2, label: "Knowledge Graph" },
   { to: "/research-map", icon: Map, label: "Research Map" },
   { to: "/interpretations", icon: ListChecks, label: "Interpretation Review" },
+  { to: "/claim-scopes", icon: Scale, label: "Claim Scope Review" },
   { to: "/health", icon: Activity, label: "Research Health" },
   { to: "/report-context", icon: FileSearch, label: "Report Context" },
   { to: "/workbench", icon: PanelsTopLeft, label: "Manuscript Workbench" },

--- a/web/src/hooks/useClaimScopes.ts
+++ b/web/src/hooks/useClaimScopes.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/api/client"
+import type { ClaimScopeWrite } from "@/api/types"
+import { useActiveProjectId } from "@/hooks/useProjectSelection"
+
+export function useClaimScopeQueue() {
+  const projectId = useActiveProjectId()
+  return useQuery({
+    queryKey: ["claim-scope-queue", projectId],
+    queryFn: () => api.listClaims({ limit: 200 }),
+  })
+}
+
+export function useClaimScope(claimId: string | null) {
+  const projectId = useActiveProjectId()
+  return useQuery({
+    queryKey: ["claim-scope", projectId, claimId],
+    queryFn: () => api.getClaimScope(claimId!),
+    enabled: Boolean(claimId),
+  })
+}
+
+export function useAppendClaimScope() {
+  const projectId = useActiveProjectId()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ claimId, data }: { claimId: string; data: ClaimScopeWrite }) =>
+      api.appendClaimScope(claimId, data),
+    onSuccess: (history) => {
+      queryClient.setQueryData(
+        ["claim-scope", projectId, history.claim_id],
+        history,
+      )
+      void queryClient.invalidateQueries({ queryKey: ["claim-scope-queue", projectId] })
+      void queryClient.invalidateQueries({ queryKey: ["research-map", projectId] })
+      void queryClient.invalidateQueries({ queryKey: ["manuscript-workbench", projectId] })
+    },
+  })
+}

--- a/web/src/pages/ClaimScopeReview.tsx
+++ b/web/src/pages/ClaimScopeReview.tsx
@@ -1,0 +1,500 @@
+import { useMemo, useState } from "react"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  History,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Scale,
+  ShieldCheck,
+  Trash2,
+} from "lucide-react"
+import { toast } from "sonner"
+import { ApiError } from "@/api/client"
+import type {
+  Claim,
+  ClaimConditionKind,
+  ClaimConditionOperator,
+  ClaimScopeCondition,
+  ClaimScopeExtensionPolicy,
+  ClaimScopeUncertainty,
+  ClaimFalsifierStatus,
+  ClaimScopeHistory,
+  ClaimScopeReadiness,
+  ClaimScopeReviewStatus,
+} from "@/api/types"
+import {
+  useAppendClaimScope,
+  useClaimScope,
+  useClaimScopeQueue,
+} from "@/hooks/useClaimScopes"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+type ReadinessFilter = "all" | ClaimScopeReadiness
+
+const readinessOrder: ClaimScopeReadiness[] = [
+  "missing",
+  "stale",
+  "incomplete",
+  "needs_review",
+  "ready",
+]
+
+const conditionKinds: ClaimConditionKind[] = [
+  "dataset",
+  "population",
+  "platform",
+  "environment",
+  "threat_model",
+  "baseline",
+  "workload",
+  "metric",
+  "parameter",
+  "assumption",
+  "time_window",
+  "other",
+]
+
+const conditionOperators: ClaimConditionOperator[] = [
+  "equals",
+  "one_of",
+  "range",
+  "at_least",
+  "at_most",
+  "present",
+  "absent",
+  "described_by",
+]
+
+function readinessBadge(readiness: ClaimScopeReadiness) {
+  if (readiness === "ready") return <Badge className="bg-emerald-600 text-white">ready</Badge>
+  if (readiness === "stale") return <Badge variant="destructive">stale</Badge>
+  if (readiness === "needs_review") return <Badge className="bg-amber-500 text-black">needs review</Badge>
+  return <Badge variant="secondary">{readiness.replaceAll("_", " ")}</Badge>
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "time unavailable"
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+export default function ClaimScopeReview() {
+  const queue = useClaimScopeQueue()
+  const [filter, setFilter] = useState<ReadinessFilter>("missing")
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const claims = useMemo(() => queue.data ?? [], [queue.data])
+  const filtered = useMemo(
+    () => claims.filter((claim) => filter === "all" || claim.scope_readiness === filter),
+    [claims, filter],
+  )
+  const activeId = selectedId && filtered.some((claim) => claim.id === selectedId)
+    ? selectedId
+    : filtered[0]?.id ?? null
+  const history = useClaimScope(activeId)
+  const activeClaim = claims.find((claim) => claim.id === activeId) ?? null
+  const counts = useMemo(
+    () => Object.fromEntries([
+      ["all", claims.length],
+      ...readinessOrder.map((state) => [
+        state,
+        claims.filter((claim) => claim.scope_readiness === state).length,
+      ]),
+    ]) as Record<ReadinessFilter, number>,
+    [claims],
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">Claim Scope Review</h1>
+            <Badge variant="outline">M2 contract</Badge>
+          </div>
+          <p className="mt-1 max-w-4xl text-sm text-muted-foreground">
+            Bound canonical research claims before the writer uses them. Scope readiness,
+            scientific support, contradictions, and source grounding remain separate signals.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => void Promise.all([
+            queue.refetch(),
+            activeId ? history.refetch() : Promise.resolve(),
+          ])}
+          disabled={queue.isFetching || history.isFetching}
+        >
+          <RefreshCw className={cn("mr-2 h-4 w-4", (queue.isFetching || history.isFetching) && "animate-spin")} />
+          Refresh queue
+        </Button>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-6">
+        {(["all", ...readinessOrder] as ReadinessFilter[]).map((state) => (
+          <button
+            key={state}
+            type="button"
+            onClick={() => setFilter(state)}
+            className={cn(
+              "rounded-lg border px-3 py-2 text-left transition-colors",
+              filter === state ? "border-primary bg-muted" : "hover:bg-muted/50",
+            )}
+          >
+            <p className="text-xs text-muted-foreground">{state.replaceAll("_", " ")}</p>
+            <p className="mt-1 text-xl font-semibold">{counts[state]}</p>
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[23rem_minmax(0,1fr)]">
+        <Card className="h-fit">
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center justify-between text-sm">
+              <span>Canonical claims</span>
+              <span className="font-normal text-muted-foreground">{filtered.length}</span>
+            </CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Missing and stale contracts are workbench blockers, not hidden defaults.
+            </p>
+          </CardHeader>
+          <CardContent className="max-h-[70vh] space-y-2 overflow-y-auto">
+            {queue.isLoading && <Loading label="Loading claims" />}
+            {queue.error && <ErrorMessage error={queue.error} />}
+            {!queue.isLoading && filtered.length === 0 && (
+              <p className="py-10 text-center text-sm text-muted-foreground">No claims in this state.</p>
+            )}
+            {filtered.map((claim) => (
+              <ClaimButton
+                key={claim.id}
+                claim={claim}
+                selected={claim.id === activeId}
+                onSelect={() => setSelectedId(claim.id)}
+              />
+            ))}
+          </CardContent>
+        </Card>
+
+        {history.isLoading && activeId && <Card><CardContent><Loading label="Loading scope history" /></CardContent></Card>}
+        {history.error && <Card><CardContent className="p-5"><ErrorMessage error={history.error} /></CardContent></Card>}
+        {activeClaim && history.data && (
+          <ClaimScopeDetail
+            key={`${activeClaim.id}:${history.data.current_revision}`}
+            claim={activeClaim}
+            history={history.data}
+          />
+        )}
+        {!activeId && !queue.isLoading && (
+          <Card><CardContent className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+            Select a scope state with claims to review.
+          </CardContent></Card>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Loading({ label }: { label: string }) {
+  return <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> {label}
+  </div>
+}
+
+function ErrorMessage({ error }: { error: Error }) {
+  return <p className="rounded-md border border-red-300 p-3 text-sm text-red-700">{error.message}</p>
+}
+
+function ClaimButton({ claim, selected, onSelect }: { claim: Claim; selected: boolean; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={cn(
+        "w-full rounded-lg border p-3 text-left transition-colors",
+        selected ? "border-primary bg-muted" : "hover:bg-muted/50",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <Badge variant="outline">{claim.claim_type}</Badge>
+        {readinessBadge(claim.scope_readiness)}
+      </div>
+      <p className="mt-2 line-clamp-3 text-sm font-medium leading-5">{claim.content}</p>
+      <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+        <span>scope rev {claim.scope_revision}</span>
+        <span>evidence {claim.evidence_status}</span>
+        {claim.contradicted && <span className="text-red-600">contradicted</span>}
+      </div>
+    </button>
+  )
+}
+
+function ClaimScopeDetail({ claim, history }: { claim: Claim; history: ClaimScopeHistory }) {
+  return (
+    <div className="min-w-0 space-y-4">
+      <Card>
+        <CardHeader className="border-b pb-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                {readinessBadge(history.scope_readiness)}
+                <Badge variant="outline">{claim.claim_type}</Badge>
+                <Badge variant={claim.verified ? "default" : "secondary"}>
+                  source {claim.verified ? "grounded" : "unverified"}
+                </Badge>
+                <Badge variant="outline">evidence {claim.evidence_status}</Badge>
+                {claim.contradicted && <Badge variant="destructive">contradicted</Badge>}
+              </div>
+              <CardTitle className="mt-3 text-lg leading-7">{claim.content}</CardTitle>
+              <code className="mt-2 block break-all text-xs text-muted-foreground">
+                {claim.id} ← {claim.source_entry_id}
+              </code>
+            </div>
+            <code className="rounded bg-muted px-2 py-1 text-xs">scope rev {history.current_revision}</code>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 p-4 lg:grid-cols-2">
+          <section className="space-y-2">
+            <h2 className="flex items-center gap-2 text-sm font-semibold"><Scale className="h-4 w-4" /> Derived readiness</h2>
+            {history.findings.length === 0
+              ? <p className="text-sm text-muted-foreground">No scope findings.</p>
+              : history.findings.map((finding) => (
+                <div key={`${finding.code}:${finding.message}`} className="rounded-md border p-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    {finding.severity === "block" ? <AlertTriangle className="h-4 w-4 text-red-600" /> : <ShieldCheck className="h-4 w-4 text-amber-600" />}
+                    <code className="text-xs">{finding.code}</code>
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{finding.message}</p>
+                </div>
+              ))}
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold">Current applicability boundary</h2>
+            {!history.current && <p className="text-sm text-muted-foreground">No contract exists. Review must supply the boundary; RKA will not infer one.</p>}
+            {history.current && (
+              <div className="space-y-2 text-sm">
+                <p>{history.current.conditions.length} typed condition(s) · {history.current.uncertainty} uncertainty</p>
+                <p>Extension policy: {history.current.extension_policy ?? "unresolved"}</p>
+                <p>Falsifier: {history.current.falsifier_status}</p>
+                <div className="flex flex-wrap gap-1">
+                  {history.current.conditions.map((condition) => (
+                    <Badge key={`${condition.kind}:${condition.key}`} variant="outline">
+                      {condition.kind}:{condition.key} {condition.operator} {String(condition.value)}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 2xl:grid-cols-[minmax(0,1fr)_24rem]">
+        <ScopeEditor claim={claim} history={history} />
+        <ScopeHistory history={history} />
+      </div>
+    </div>
+  )
+}
+
+interface EditableCondition {
+  kind: ClaimConditionKind
+  key: string
+  operator: ClaimConditionOperator
+  value: string
+  unit: string
+}
+
+function lines(value: string) {
+  return value.split("\n").map((item) => item.trim()).filter(Boolean)
+}
+
+function conditionValue(condition: EditableCondition): ClaimScopeCondition["value"] {
+  if (condition.operator === "one_of" || condition.operator === "range") {
+    return condition.value.split(",").map((value) => value.trim()).filter(Boolean)
+  }
+  if (condition.operator === "present" || condition.operator === "absent") return true
+  return condition.value.trim()
+}
+
+function ScopeEditor({ claim, history }: { claim: Claim; history: ClaimScopeHistory }) {
+  const current = history.current
+  const mutation = useAppendClaimScope()
+  const [reviewStatus, setReviewStatus] = useState<ClaimScopeReviewStatus>(current?.review_status ?? "draft")
+  const [reason, setReason] = useState("")
+  const [uncertainty, setUncertainty] = useState<ClaimScopeUncertainty>(current?.uncertainty ?? "unknown")
+  const [uncertaintyNote, setUncertaintyNote] = useState(current?.uncertainty_note ?? "")
+  const [extensionPolicy, setExtensionPolicy] = useState<ClaimScopeExtensionPolicy | "unresolved">(current?.extension_policy ?? "unresolved")
+  const [allowed, setAllowed] = useState((current?.allowed_extensions ?? []).join("\n"))
+  const [prohibited, setProhibited] = useState((current?.prohibited_extensions ?? []).join("\n"))
+  const [falsifierStatus, setFalsifierStatus] = useState<ClaimFalsifierStatus>(current?.falsifier_status ?? "unknown")
+  const [falsifier, setFalsifier] = useState(current?.falsifier ?? "")
+  const [falsifierRationale, setFalsifierRationale] = useState(current?.falsifier_rationale ?? "")
+  const [disconfirming, setDisconfirming] = useState((current?.disconfirming_claim_ids ?? []).join("\n"))
+  const [conditions, setConditions] = useState<EditableCondition[]>(
+    current?.conditions.map((condition) => ({
+      kind: condition.kind,
+      key: condition.key,
+      operator: condition.operator,
+      value: Array.isArray(condition.value) ? condition.value.join(", ") : String(condition.value),
+      unit: condition.unit ?? "",
+    })) ?? [{ kind: "dataset", key: "", operator: "equals", value: "", unit: "" }],
+  )
+
+  const submit = () => {
+    mutation.mutate(
+      {
+        claimId: claim.id,
+        data: {
+          expected_revision: history.current_revision,
+          actor: "web_ui",
+          reason: reason.trim(),
+          conditions: conditions
+            .filter((condition) => condition.key.trim() && (condition.value.trim() || ["present", "absent"].includes(condition.operator)))
+            .map((condition) => ({
+              kind: condition.kind,
+              key: condition.key.trim(),
+              operator: condition.operator,
+              value: conditionValue(condition),
+              unit: condition.unit.trim() || undefined,
+            })),
+          uncertainty,
+          uncertainty_note: uncertaintyNote.trim() || undefined,
+          extension_policy: extensionPolicy === "unresolved" ? undefined : extensionPolicy,
+          allowed_extensions: lines(allowed),
+          prohibited_extensions: lines(prohibited),
+          falsifier_status: falsifierStatus,
+          falsifier: falsifier.trim() || undefined,
+          falsifier_rationale: falsifierRationale.trim() || undefined,
+          disconfirming_claim_ids: lines(disconfirming),
+          review_status: reviewStatus,
+        },
+      },
+      {
+        onSuccess: (updated) => {
+          toast.success(`Scope revision ${updated.current_revision} appended (${updated.scope_readiness})`)
+          setReason("")
+        },
+        onError: (error) => {
+          if (error instanceof ApiError && error.status === 409) {
+            toast.error("This scope changed. Reload before appending another revision.")
+          } else {
+            toast.error(error instanceof Error ? error.message : "Scope update failed")
+          }
+        },
+      },
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-sm"><ShieldCheck className="h-4 w-4" /> Append scope revision</CardTitle>
+        <p className="text-xs text-muted-foreground">Edits create immutable history; they never overwrite prior PI-visible boundaries.</p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="grid gap-4 md:grid-cols-3">
+          <FieldSelect label="Review state" value={reviewStatus} values={["draft", "reviewed"]} onChange={(value) => setReviewStatus(value as ClaimScopeReviewStatus)} />
+          <FieldSelect label="Uncertainty" value={uncertainty} values={["unknown", "none", "low", "medium", "high"]} onChange={(value) => setUncertainty(value as ClaimScopeUncertainty)} />
+          <FieldSelect label="Extension policy" value={extensionPolicy} values={["unresolved", "exact_only", "bounded"]} onChange={(value) => setExtensionPolicy(value as ClaimScopeExtensionPolicy | "unresolved")} />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>Typed applicability conditions</Label>
+            <Button type="button" size="sm" variant="outline" onClick={() => setConditions([...conditions, { kind: "other", key: "", operator: "described_by", value: "", unit: "" }])}>
+              <Plus className="mr-1 h-3.5 w-3.5" /> Add condition
+            </Button>
+          </div>
+          {conditions.map((condition, index) => (
+            <div key={index} className="grid gap-2 rounded-md border p-3 lg:grid-cols-[9rem_1fr_9rem_1fr_6rem_auto]">
+              <CompactSelect value={condition.kind} values={conditionKinds} onChange={(value) => updateCondition(index, { kind: value as ClaimConditionKind })} />
+              <Input aria-label={`Condition ${index + 1} key`} placeholder="key, e.g. evaluation_dataset" value={condition.key} onChange={(event) => updateCondition(index, { key: event.target.value })} />
+              <CompactSelect value={condition.operator} values={conditionOperators} onChange={(value) => updateCondition(index, { operator: value as ClaimConditionOperator })} />
+              <Input aria-label={`Condition ${index + 1} value`} disabled={["present", "absent"].includes(condition.operator)} placeholder={condition.operator === "range" ? "min, max" : "value"} value={condition.value} onChange={(event) => updateCondition(index, { value: event.target.value })} />
+              <Input aria-label={`Condition ${index + 1} unit`} placeholder="unit" value={condition.unit} onChange={(event) => updateCondition(index, { unit: event.target.value })} />
+              <Button type="button" size="icon" variant="ghost" aria-label={`Remove condition ${index + 1}`} onClick={() => setConditions(conditions.filter((_, itemIndex) => itemIndex !== index))}><Trash2 className="h-4 w-4" /></Button>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <TextAreaField label="Allowed extensions (one per line)" value={allowed} onChange={setAllowed} />
+          <TextAreaField label="Prohibited extensions (one per line)" value={prohibited} onChange={setProhibited} />
+          <TextAreaField label="Uncertainty note" value={uncertaintyNote} onChange={setUncertaintyNote} />
+          <TextAreaField label="Disconfirming clm_ ids (one per line)" value={disconfirming} onChange={setDisconfirming} />
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          <FieldSelect label="Falsifier applicability" value={falsifierStatus} values={["unknown", "applicable", "not_applicable"]} onChange={(value) => setFalsifierStatus(value as ClaimFalsifierStatus)} />
+          <TextAreaField label="Falsifier" value={falsifier} onChange={setFalsifier} />
+          <TextAreaField label="Falsifier rationale" value={falsifierRationale} onChange={setFalsifierRationale} />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor={`scope-reason-${claim.id}`}>Revision reason</Label>
+          <Textarea id={`scope-reason-${claim.id}`} value={reason} onChange={(event) => setReason(event.target.value)} placeholder="What source, evaluation, or PI judgment supports this boundary?" />
+        </div>
+        <Button className="w-full" disabled={!reason.trim() || mutation.isPending} onClick={submit}>
+          {mutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+          Append {reviewStatus} revision
+        </Button>
+      </CardContent>
+    </Card>
+  )
+
+  function updateCondition(index: number, patch: Partial<EditableCondition>) {
+    setConditions(conditions.map((condition, itemIndex) => itemIndex === index ? { ...condition, ...patch } : condition))
+  }
+}
+
+function ScopeHistory({ history }: { history: ClaimScopeHistory }) {
+  return (
+    <Card className="h-fit">
+      <CardHeader><CardTitle className="flex items-center gap-2 text-sm"><History className="h-4 w-4" /> Immutable history</CardTitle></CardHeader>
+      <CardContent className="space-y-3">
+        {history.versions.length === 0 && <p className="text-sm text-muted-foreground">No scope revisions.</p>}
+        {history.versions.map((version) => (
+          <div key={version.id} className="border-l-2 pl-3 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium">revision {version.revision}</span>
+              <Badge variant="outline">{version.review_status}</Badge>
+              <span className="text-xs text-muted-foreground">by {version.created_by}</span>
+            </div>
+            <p className="mt-1">{version.reason}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{formatDate(version.created_at)}</p>
+            <code className="mt-1 block break-all text-[10px] text-muted-foreground">{version.id}</code>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function FieldSelect({ label, value, values, onChange }: { label: string; value: string; values: string[]; onChange: (value: string) => void }) {
+  return <div className="space-y-2"><Label>{label}</Label><CompactSelect value={value} values={values} onChange={onChange} /></div>
+}
+
+function CompactSelect({ value, values, onChange }: { value: string; values: readonly string[]; onChange: (value: string) => void }) {
+  return <Select value={value} onValueChange={(next) => next != null && onChange(next)}><SelectTrigger className="w-full"><SelectValue /></SelectTrigger><SelectContent>{values.map((item) => <SelectItem key={item} value={item}>{item.replaceAll("_", " ")}</SelectItem>)}</SelectContent></Select>
+}
+
+function TextAreaField({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return <div className="space-y-2"><Label>{label}</Label><Textarea rows={3} value={value} onChange={(event) => onChange(event.target.value)} /></div>
+}

--- a/web/src/pages/ManuscriptWorkbench.tsx
+++ b/web/src/pages/ManuscriptWorkbench.tsx
@@ -450,7 +450,11 @@ function ScopeView({
             kind: "native claim scope",
             origin: "/api/manuscripts/:id/context",
             derivation: "Latest immutable wording version on the active manuscript claim.",
-            ids: [claim.id, ...claim.evidence.map((item) => item.evidence_claim_id)],
+            ids: [
+              claim.id,
+              ...claim.evidence.map((item) => item.evidence_claim_id),
+              ...claim.evidence.flatMap((item) => item.scope_contract ? [item.scope_contract.id] : []),
+            ],
             status: statusForClaim(claim),
             trace: ["mcl_ version", "scope boundary", "manuscript units"],
           }}
@@ -458,6 +462,13 @@ function ScopeView({
         >
           <p><span className="font-medium text-foreground">Allowed:</span> {claim.allowed_wording ?? "Missing"}</p>
           <p className="mt-1"><span className="font-medium text-foreground">Prohibited:</span> {claim.prohibited_wording.length > 0 ? claim.prohibited_wording.join(" · ") : "Missing, so scope is not ready"}</p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {claim.evidence.map((evidence) => (
+              <Badge key={evidence.evidence_claim_id} variant={evidence.scope_readiness === "ready" ? "default" : "secondary"}>
+                {evidence.evidence_claim_id}: scope {evidence.scope_readiness ?? "missing"}
+              </Badge>
+            ))}
+          </div>
         </TraceCard>
       ))}
       {activeClaims.length === 0 && candidateClaims.map((claim) => (
@@ -470,13 +481,14 @@ function ScopeView({
             kind: "candidate scope",
             origin: "/api/manuscripts/:id/writing-candidates",
             derivation: "Brain-reviewed cluster synthesis; not a native claim or PI ratification.",
-            ids: claim.evidence_ids,
+            ids: [...claim.evidence_ids, ...claim.scope_contract_ids],
             status: claim.prohibited_wording.length ? "Bounded candidate" : "Needs prohibited wording",
           }}
           onInspect={onInspect}
         >
           <p><span className="font-medium text-foreground">Allowed:</span> {claim.allowed_wording}</p>
           <p className="mt-1"><span className="font-medium text-foreground">Prohibited:</span> {claim.prohibited_wording.length ? claim.prohibited_wording.join(" · ") : "Not yet bounded"}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{claim.scope_contract_ids.length} canonical scope contract(s)</p>
         </TraceCard>
       ))}
     </>
@@ -725,7 +737,7 @@ function CandidateClaimCard({
         kind: "writing candidate",
         origin: "/api/manuscripts/:id/writing-candidates",
         derivation: "Current Brain-reviewed cluster bound to an active RQ, with duplicate grouping and admission checks.",
-        ids: [...lineageIds, ...claim.evidence_ids],
+        ids: [...lineageIds, ...claim.evidence_ids, ...claim.scope_contract_ids],
         status: "Provisional",
         trace: ["jrn_", "clm_", lineage?.cluster_id ?? "ecl_", lineage?.research_question_id ?? "RQ", "candidate"],
       }}
@@ -735,6 +747,7 @@ function CandidateClaimCard({
       <div className="mt-2 flex flex-wrap gap-1.5">
         <Badge variant="outline">{claim.claim_type}</Badge>
         <Badge variant="outline">{claim.evidence_ids.length} admitted claims</Badge>
+        <Badge variant="outline">{claim.scope_contract_ids.length} scope contracts</Badge>
         <Badge variant="outline">not ratified</Badge>
       </div>
     </TraceCard>

--- a/web/src/pages/ResearchMap.tsx
+++ b/web/src/pages/ResearchMap.tsx
@@ -731,6 +731,11 @@ function ClaimCard({ claim }: { claim: Claim }) {
               <Badge className={claimTypeColors[claim.claim_type] || ""}>{claim.claim_type}</Badge>
               {claim.verified && <CheckCircle className="h-4 w-4 text-green-500" />}
               {claim.stale && <Badge variant="destructive">stale</Badge>}
+              <Link to="/claim-scopes">
+                <Badge variant={claim.scope_readiness === "ready" ? "default" : "secondary"}>
+                  scope {claim.scope_readiness.replaceAll("_", " ")}
+                </Badge>
+              </Link>
               <span className="text-xs text-muted-foreground">
                 conf: {(claim.confidence * 100).toFixed(0)}%
               </span>
@@ -749,6 +754,7 @@ function ClaimCard({ claim }: { claim: Claim }) {
           )}
           {claim.source_type && <Badge variant="secondary">{claim.source_type}</Badge>}
           {claim.source_actor && <Badge variant="outline">{claim.source_actor}</Badge>}
+          <span>scope rev {claim.scope_revision}</span>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

- add immutable, revision-guarded canonical claim-scope contracts and migration 041
- model typed applicability conditions, uncertainty, allowed/prohibited extensions, falsifiers, disconfirming claims, and review state
- keep scope readiness independent from source grounding, scientific evidence status, contradiction, and freshness
- fail closed in Writer/manuscript admission when scope is missing, incomplete, needs review, or stale
- expose scope history and readiness through REST, MCP, graph, knowledge packs, research map, manuscript workbench, and a dedicated review UI
- record the applicability boundary in ADR 0003 and preserve the experiment/run/result layer as a separately deferred schema

## Validation

- `npm run build`
- `docker compose build rka`
- focused scope/API/MCP/pack/manuscript/project suite: 56 passed
- complete backend suite: 2,844 passed, 1 existing Pydantic warning
- fresh-database Docker smoke: health OK and migration 041 table present
- revision-conflict smoke: stale expected revision rejected with HTTP 409
- disposable browser walkthrough: missing, incomplete, ready, and stale states rendered with exact findings and immutable history; no console errors

## Scope

This is M1 / PR 2 in the dependency-ordered roadmap. PR 3 experiment contracts remain deferred. The next slice after merge is M2 / PR 4 workbench and Context Capsule hardening over the authoritative interpretation and scope contracts.
