### PR TITLE
fix(workbench): complete CPSEval positive-path pilot

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,9 +17,10 @@ milestone must satisfy its exit gate before dependent work is treated as ready.
 
 ## Now
 
-**M0, M1 / PR 1, and M1 / PR 2 are merged. The first M2 / PR 4 workbench
-hardening slice is implemented and fully validated on its feature branch;
-review and merge are the remaining publication gates.** The choice-first Writer delta is reconciled, the authority
+**M0, M1 / PR 1, M1 / PR 2, and the first M2 / PR 4 navigation slice are
+merged. The bounded CPSEval positive-path pilot and responsive-layout repair
+are fully validated on their feature branch; review and merge are the remaining
+publication gates.** The choice-first Writer delta is reconciled, the authority
 and AI boundary is recorded in ADR 0001, and the read-only workbench has been
 walked through with DelaySteer and a full-manuscript control.
 
@@ -50,11 +51,15 @@ detectability through an online database backup. Project isolation passed, and
 the workbench correctly refused to invent scopes or spines: the first two
 projects have no native manuscript, while CPSEval and detectability have native
 manuscripts but empty spines; all four still contain only legacy claims with
-missing canonical scopes. After this slice is merged, the
-immediate target remains **M2 / PR 4**: run a bounded positive-path migration on
-a disposable CPSEval database copy because it already has a native manuscript
-and fewer legacy claims than detectability. No live semantic record will be
-changed for that pilot. PR 3 remains explicitly deferred until the
+missing canonical scopes. The bounded positive path is now complete on a
+disposable CPSEval database copy: one legacy method claim received an exact
+reviewed scope and a one-claim native spine while remaining visibly unverified,
+unassessed, unratified, and checkpoint-blocked. The pilot also exposed and
+closed a narrow-viewport navigation defect. The evidence is recorded in
+[`2026-08-15-cpseval-m2-positive-path.md`](docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md).
+No live semantic record changed. The immediate target remains **M2 / PR 4**:
+freeze the exit evidence with final keyboard/accessibility and explicit
+loading, empty, and capped-count cases. PR 3 remains explicitly deferred until the
 experiment/run/result schema is separately designed and reviewed; the
 workbench must label that missing semantic layer rather than infer experiments
 from journal entries.

--- a/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
+++ b/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
@@ -1,8 +1,9 @@
 # RKA Epistemic Pipeline and Manuscript Drafting Workbench
 
-Status: roadmap design source; M0, M1 PR 1 Interpretation Staging, and M1 PR 2
-Claim Scope Contracts merged; the first M2 PR 4 workbench-hardening slice is
-implemented and fully validated on its feature branch, pending review and merge.
+Status: roadmap design source; M0, M1 PR 1 Interpretation Staging, M1 PR 2
+Claim Scope Contracts, and the first M2 PR 4 navigation slice merged; the
+bounded CPSEval pilot and responsive repair are validated, pending review and
+merge.
 
 Date: 2026-08-14
 
@@ -25,7 +26,7 @@ This plan targets the clean default RKA branch at:
 
 - repository: `infinitywings/rka`
 - branch: `main`
-- commit: `1ef67b6e51cbb50fde60da948df866cdc911478c`
+- commit: `edb1e6f170025a77ddcb5b89038d0e1a34af4857`
 - RKA package version: `2.9.0`
 - latest migration: `041`
 
@@ -1241,7 +1242,7 @@ full-suite, production-build, isolated-container, concurrency, and browser
 acceptance gates.
 
 The active milestone is **M2 / PR 4 Workbench Shell and Context Capsule
-hardening**. The first slice now provides scope-aware capsule summaries,
+hardening**. Its merged navigation slice provides scope-aware capsule summaries,
 URL-resumable stage and review selection, and evidence-to-review trace links.
 Its production build, focused lint, full 2,844-test backend suite, and
 disposable production-browser acceptance path all pass. The evidence is recorded in
@@ -1253,18 +1254,19 @@ path under the new semantics: all canonical scopes are missing, and the two
 existing native manuscripts have empty spines. This is an honest migration
 gate, not a reason to auto-backfill meaning.
 
+The bounded CPSEval pilot is now complete. One exact legacy method claim was
+scoped and connected to a minimal claim-sized native spine only on a disposable
+online database backup. The UI preserved its unverified, unassessed,
+unratified, and checkpoint-blocked state. The same pass exposed and closed a
+narrow-viewport navigation defect. Detailed evidence is recorded in
+[`2026-08-15-cpseval-m2-positive-path.md`](../specs/2026-08-15-cpseval-m2-positive-path.md).
+
 The remaining PR 4 work is:
 
-1. create a disposable database copy for a bounded CPSEval semantic-migration
-   pilot; CPSEval is the recommended smallest case because its native
-   manuscript already exists;
-2. review and scope only the pilot claims needed for a minimal claim-sized
-   spine, preserving every legacy record and uncertainty boundary;
-3. rerun the positive scope-to-spine, trace, impact, and resume path without
-   changing any live semantic record;
-4. close accessibility, narrow-viewport, loading, empty, and partial-count gaps
-   found in that walkthrough;
-5. freeze the M2 exit evidence before any deliberation or mutation UI is
+1. merge the CPSEval pilot evidence and responsive repair;
+2. run the final keyboard/accessibility pass and explicit loading, empty, and
+   capped-count cases;
+3. freeze the M2 exit evidence before any deliberation or mutation UI is
    enabled.
 
 The live pack exporter also emits agentic-branch staleness fields that current

--- a/docs/superpowers/specs/2026-08-14-workbench-scope-navigation-walkthrough.md
+++ b/docs/superpowers/specs/2026-08-14-workbench-scope-navigation-walkthrough.md
@@ -115,16 +115,14 @@ That fail-closed behavior is correct, but a lossless migration design is needed
 in the later intake/hardening milestone before these packs are portable across
 the branches.
 
-## Remaining M2 gate
+## Follow-up M2 gate
 
-A real project cannot yet demonstrate the positive scope-to-spine path because
-the required PI-reviewed semantic records do not exist. The next controlled
-step is to copy the live database online, isolate CPSEval in a disposable
-instance, review a bounded subset of its claims, append canonical scopes, and
-create a minimal claim-sized spine through the normal revision-guarded
-interfaces. CPSEval is the smallest current pilot (81 claims and an existing
-native manuscript), so it is the recommended case.
-
-The disposable pilot must preserve the live database and all live semantic
-records unchanged. It exists to validate the workflow, not to manufacture a
-positive result in the research system.
+The bounded positive scope-to-spine path subsequently passed on an online
+backup of CPSEval. The pilot used one concrete method claim, preserved its
+unverified and unassessed evidence state, appended one exact reviewed scope,
+and created one native manuscript claim and method unit through the normal
+revision-guarded interfaces. It also exposed and closed a narrow-viewport
+navigation defect. See
+[`2026-08-15-cpseval-m2-positive-path.md`](2026-08-15-cpseval-m2-positive-path.md)
+for the isolation evidence, identifiers, browser results, and remaining M2 exit
+checks.

--- a/docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md
+++ b/docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md
@@ -1,0 +1,132 @@
+# M2 CPSEval Positive Scope-to-Spine Pilot
+
+Date: 2026-08-15
+
+Branch: `feature/rka-cpseval-m2-pilot`
+
+Merged-main baseline: `edb1e6f` (PR 72)
+
+## Purpose
+
+Close the real-project admission gate for the read-only manuscript workbench
+without changing live RKA semantics. The pilot asks whether one deliberately
+bounded legacy claim can move through the normal canonical scope and native
+manuscript interfaces while the UI continues to expose every unresolved
+evidence and ratification gate.
+
+## Data isolation
+
+The live RKA `2.8.1` database was opened read-only and copied with SQLite's
+online-backup API. The backup passed `PRAGMA integrity_check` and had SHA-256:
+
+```text
+279cd694f06c2d580ce28eabfc94580d65e7d7f9c9fee38cd1865892644daf21
+```
+
+That snapshot remained unchanged. A second copy was mounted into a disposable
+RKA `2.9.0` container on localhost-only port `19713`; only that copy received
+migrations and semantic writes. Its post-pilot online backup passed the same
+integrity check and had a different SHA-256:
+
+```text
+0932ddc190eb294a92eace53e64f6e0f9ca2d66236407cf9d6bef58e335fc62f
+```
+
+No live container was restarted, and no live semantic record was updated.
+
+## Bounded case
+
+- project: CPSEval (`prj_01KPVB7NHJ0N33C024TD0E6CZ6`);
+- manuscript: ESCAPE (`man_01M00D9BPMA60CN3FXTE86C4W1`);
+- canonical method claim: `clm_01M00DCGGK0WHK6QPTZZF60F4P`;
+- exact source: `jrn_01M00DCGGJCYMGGD79Q2ZNM72S`.
+
+The selected source statement says that the evaluated setup uses two Factory
+IO simulations, Python soft-PLCs, Modbus TCP, and a 20 ms scan cycle (50 Hz).
+It is concrete enough to demonstrate applicability boundaries without
+promoting one of CPSEval's provisional outcome claims.
+
+The pilot intentionally preserved the canonical claim's original independent
+signals:
+
+- `verified = false`;
+- `evidence_status = unassessed`;
+- no Interpretation Staging candidate was invented for the legacy record;
+- no PI ratification or checkpoint resolution was fabricated.
+
+## Normal-interface writes on the disposable copy
+
+1. `GET /api/claims/:id/scope` established scope revision `0` and readiness
+   `missing`.
+2. `POST /api/claims/:id/scope` appended one reviewed, exact-only contract with
+   five typed conditions: two Factory IO simulations, Python soft-PLC,
+   Modbus TCP, 20 ms scan cycle, and 50 Hz sampling.
+3. The contract marked a statistical falsifier `not_applicable` because this is
+   a method/configuration statement; artifact and protocol verification remain
+   the separate correctness gate.
+4. `PUT /api/manuscripts/:id/argument-spine` advanced the manuscript from
+   revision `1` to `2`, adding one active methodological `mcl_` claim and one
+   planned method `mun_`, both bound to the selected `clm_` evidence.
+
+The resulting identifiers were:
+
+- scope contract `csc_01M01Z2TD7F1WZQFFZYZBAP98N`;
+- manuscript claim `mcl_01M01Z2TDEWJW3945DYY2WJ1CN`;
+- manuscript unit `mun_01M01Z2TDFP214ZQ7G5KCYET55`.
+
+## Acceptance result
+
+The scope-to-spine path passed through REST and the production browser:
+
+- canonical scope readiness changed from `missing` to `ready`;
+- the manuscript scope stage exposed the `mcl_`, `clm_`, and `csc_` lineage;
+- the exact claim-scope deep link rendered all five conditions and immutable
+  revision history;
+- browser Back restored `?stage=scope`;
+- the Paper spine stage rendered the one canonical claim at `?stage=spine`;
+- the Outline stage rendered the claim-sized method unit and source claim at
+  `?stage=outline`;
+- the Context Capsule reported 2 RQs, 6 clusters, 81 claims, 80 blocking
+  scopes, 1 ready scope, and 9 relevant semantic changes;
+- the browser console contained no warning or error.
+
+The manuscript correctly remained `BLOCK`. Its four findings were
+`CLAIM_NOT_RATIFIED`, `EVIDENCE_NOT_MANUSCRIPT_READY`, and the unresolved venue
+and outline checkpoints. The scope-review page likewise showed
+`source unverified`, `evidence unassessed`, and
+`CLAIM_EVIDENCE_UNASSESSED`. This is the desired behavior: applicability
+readiness did not become scientific support or drafting readiness.
+
+## Responsive defect and repair
+
+At 390 by 844 pixels, the desktop-only fixed sidebar consumed most of the
+viewport and clipped the workbench. The repair:
+
+- hides the fixed sidebar below the `md` breakpoint;
+- adds an accessible mobile navigation drawer;
+- constrains the header and search to the available width;
+- stacks the manuscript loader on narrow screens;
+- reduces narrow-screen main padding; and
+- makes the first-run banner wrap without forcing horizontal overflow.
+
+The rebuilt production image passed the same CPSEval outline view at 390 by
+844 pixels. The drawer opened from **Open navigation**, exposed the current
+CPSEval context, closed after navigation, and produced no console warning or
+error. The viewport override was reset after testing.
+
+## Verification
+
+- production web build: pass;
+- focused ESLint on the five changed layout/workbench files: pass;
+- production Docker image build: pass;
+- full backend suite: `2,844 passed`, with one existing Pydantic warning;
+- desktop CPSEval scope/spine/outline walkthrough: pass;
+- 390 by 844 responsive and mobile-navigation walkthrough: pass;
+- live backup and post-pilot backup integrity checks: pass.
+
+## Remaining M2 exit work
+
+The real-project positive path and narrow-viewport blocker are closed. Before
+enabling M3 mutation UI, freeze the M2 exit evidence with a final keyboard and
+accessibility pass plus explicit loading, empty, and capped-count cases. Those
+checks must not weaken the epistemic labels demonstrated here.

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -6,11 +6,11 @@ import { FirstRunBanner } from "./FirstRunBanner"
 export function AppLayout() {
   return (
     <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <div className="flex flex-1 flex-col overflow-hidden">
+      <Sidebar className="hidden md:flex" />
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <Header />
         <FirstRunBanner />
-        <main className="flex-1 overflow-auto p-6">
+        <main className="flex-1 overflow-auto p-3 sm:p-6">
           <Outlet />
         </main>
       </div>

--- a/web/src/components/layout/FirstRunBanner.tsx
+++ b/web/src/components/layout/FirstRunBanner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { NavLink } from "react-router-dom"
 import { X, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -9,17 +9,14 @@ import { Button } from "@/components/ui/button"
 const LOCALSTORAGE_KEY = "rka_first_run_banner_dismissed_v2_4"
 
 export function FirstRunBanner() {
-  const [dismissed, setDismissed] = useState<boolean>(true)
-
-  useEffect(() => {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
     try {
-      const stored = window.localStorage.getItem(LOCALSTORAGE_KEY)
-      setDismissed(stored === "true")
+      return window.localStorage.getItem(LOCALSTORAGE_KEY) === "true"
     } catch {
       // localStorage unavailable (private mode); show banner once per session.
-      setDismissed(false)
+      return false
     }
-  }, [])
+  })
 
   const onDismiss = () => {
     setDismissed(true)
@@ -33,9 +30,9 @@ export function FirstRunBanner() {
   if (dismissed) return null
 
   return (
-    <div className="border-b bg-blue-50/50 px-4 py-2 text-xs flex items-center gap-3">
+    <div className="flex items-start gap-2 border-b bg-blue-50/50 px-3 py-2 text-xs sm:items-center sm:gap-3 sm:px-4">
       <Sparkles className="h-4 w-4 text-blue-600 shrink-0" />
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         <span className="font-medium text-blue-900">
           Semantic search is enabled
         </span>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,12 +1,21 @@
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { Search, Circle } from "lucide-react"
+import { Search, Circle, Menu } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Sidebar } from "./Sidebar"
 import { useHealth } from "@/hooks/useProject"
 
 export function Header() {
   const [query, setQuery] = useState("")
+  const [navigationOpen, setNavigationOpen] = useState(false)
   const navigate = useNavigate()
   const { data: health } = useHealth()
 
@@ -19,9 +28,32 @@ export function Header() {
   }
 
   return (
-    <header className="flex h-14 items-center justify-between border-b bg-background px-6">
+    <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background px-3 sm:px-6">
+      <Sheet open={navigationOpen} onOpenChange={setNavigationOpen}>
+        <SheetTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="shrink-0 md:hidden"
+            />
+          }
+        >
+          <Menu className="h-4 w-4" />
+          <span className="sr-only">Open navigation</span>
+        </SheetTrigger>
+        <SheetContent side="left" className="w-72 gap-0 p-0">
+          <SheetTitle className="sr-only">RKA navigation</SheetTitle>
+          <Sidebar
+            className="h-full w-full border-r-0"
+            onNavigate={() => setNavigationOpen(false)}
+          />
+        </SheetContent>
+      </Sheet>
+
       {/* Search */}
-      <form onSubmit={handleSearch} className="flex items-center gap-2 w-full max-w-md">
+      <form onSubmit={handleSearch} className="flex min-w-0 flex-1 items-center gap-2 sm:max-w-md">
         <div className="relative flex-1">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
@@ -35,7 +67,7 @@ export function Header() {
       </form>
 
       {/* Status Indicators */}
-      <div className="flex items-center gap-3">
+      <div className="hidden shrink-0 items-center gap-3 sm:flex">
         {health && (
           <>
             <Badge variant="outline" className="gap-1.5 text-xs">

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -68,7 +68,13 @@ const navItems = [
   { to: "/settings", icon: Settings, label: "Settings" },
 ]
 
-export function Sidebar() {
+export function Sidebar({
+  className,
+  onNavigate,
+}: {
+  className?: string
+  onNavigate?: () => void
+}) {
   const { projectId, setProjectId } = useProjectSelection()
   const { data: project } = useProjectStatus()
   const { data: projects } = useProjects()
@@ -117,7 +123,7 @@ export function Sidebar() {
   }
 
   return (
-    <aside className="flex h-screen w-56 flex-col border-r bg-sidebar">
+    <aside className={cn("flex h-screen w-56 flex-col border-r bg-sidebar", className)}>
       {/* Logo / Project Name */}
       <div className="border-b px-4 py-3">
         <div className="flex items-center gap-2">
@@ -157,7 +163,13 @@ export function Sidebar() {
               224px sidebar and pushing the shrink-0 New/Delete buttons
               off-screen (unclickable) once the Delete button appears on a
               non-default project. */}
-          <Select value={projectId} onValueChange={setProjectId}>
+          <Select
+            value={projectId}
+            onValueChange={(value) => {
+              setProjectId(value)
+              onNavigate?.()
+            }}
+          >
             <SelectTrigger className="h-9 min-w-0 flex-1 text-xs">
               <SelectValue placeholder="Select project" />
             </SelectTrigger>
@@ -199,6 +211,7 @@ export function Sidebar() {
             key={to}
             to={to}
             end={to === "/"}
+            onClick={onNavigate}
             className={({ isActive }) =>
               cn(
                 "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",

--- a/web/src/pages/ManuscriptWorkbench.tsx
+++ b/web/src/pages/ManuscriptWorkbench.tsx
@@ -203,7 +203,11 @@ export default function ManuscriptWorkbench() {
           </p>
         </div>
 
-        <form key={manuscriptId ?? "project-only"} onSubmit={handleLoad} className="flex w-full gap-2 lg:w-[34rem]">
+        <form
+          key={manuscriptId ?? "project-only"}
+          onSubmit={handleLoad}
+          className="flex w-full flex-col gap-2 sm:flex-row lg:w-[34rem]"
+        >
           <Input
             name="manuscript_id"
             defaultValue={manuscriptId ?? ""}


### PR DESCRIPTION
## Summary

- validate a bounded scope-to-spine path on a SQLite-consistent disposable copy of the real CPSEval project
- preserve the selected legacy claim's independent epistemic gates: unverified, evidence unassessed, unratified, and checkpoint-blocked
- document the exact live-copy isolation, REST operations, generated RKA identifiers, browser path, and integrity hashes
- fix the narrow-viewport blocker discovered during the pilot with an accessible mobile navigation drawer and responsive workbench loader/header/banner
- update the roadmap so the remaining M2 gate is final keyboard/accessibility plus explicit loading, empty, and capped-count evidence

## Validation

- production web build: pass
- focused ESLint on the five changed frontend files: pass
- production Docker image build: pass
- full backend suite: `2,844 passed, 1 existing warning`
- desktop CPSEval scope/spine/outline walkthrough: pass
- 390 × 844 responsive and mobile-navigation walkthrough: pass
- browser console: no warnings or errors
- original online backup and post-pilot copy: both `PRAGMA integrity_check = ok`

## Data safety

- live RKA database opened read-only for SQLite online backup
- original backup SHA-256 remained `279cd694f06c2d580ce28eabfc94580d65e7d7f9c9fee38cd1865892644daf21`
- all migrations and semantic writes occurred only in a disposable copy
- no live container restart and no live semantic mutation

## Expected blocked state

The manuscript intentionally remains `BLOCK` with `CLAIM_NOT_RATIFIED`, `EVIDENCE_NOT_MANUSCRIPT_READY`, and unresolved venue/outline checkpoints. A ready applicability scope is not presented as scientific support or drafting readiness.