### PR TITLE
fix(workbench): close M2 boundary-state and accessibility gates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,10 +17,9 @@ milestone must satisfy its exit gate before dependent work is treated as ready.
 
 ## Now
 
-**M0, M1 / PR 1, M1 / PR 2, and the first M2 / PR 4 navigation slice are
-merged. The bounded CPSEval positive-path pilot and responsive-layout repair
-are fully validated on their feature branch; review and merge are the remaining
-publication gates.** The choice-first Writer delta is reconciled, the authority
+**M0, M1 / PR 1, M1 / PR 2, and the CPSEval-backed M2 / PR 4 workbench are
+complete in the current tree. The next dependency-ordered target is M1 / PR 3
+experiment, run, result, and evidence-locator design.** The choice-first Writer delta is reconciled, the authority
 and AI boundary is recorded in ADR 0001, and the read-only workbench has been
 walked through with DelaySteer and a full-manuscript control.
 
@@ -57,12 +56,15 @@ reviewed scope and a one-claim native spine while remaining visibly unverified,
 unassessed, unratified, and checkpoint-blocked. The pilot also exposed and
 closed a narrow-viewport navigation defect. The evidence is recorded in
 [`2026-08-15-cpseval-m2-positive-path.md`](docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md).
-No live semantic record changed. The immediate target remains **M2 / PR 4**:
-freeze the exit evidence with final keyboard/accessibility and explicit
-loading, empty, and capped-count cases. PR 3 remains explicitly deferred until the
-experiment/run/result schema is separately designed and reviewed; the
-workbench must label that missing semantic layer rather than infer experiments
-from journal entries.
+No live semantic record changed. The final M2 pass adds explicit project-only,
+loading, unavailable, empty, and capped-count states; keyboard stage
+navigation; a skip link; live-region semantics; and a responsive 390 by 844
+check. The evidence is recorded in
+[`2026-08-15-workbench-m2-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m2-exit-evidence.md).
+The immediate target is now **M1 / PR 3**. Its
+experiment/run/result schema must be separately designed and reviewed; the
+workbench must continue to label that missing semantic layer rather than infer
+experiments from journal entries.
 
 ## Dependency map
 

--- a/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
+++ b/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
@@ -1,9 +1,9 @@
 # RKA Epistemic Pipeline and Manuscript Drafting Workbench
 
 Status: roadmap design source; M0, M1 PR 1 Interpretation Staging, M1 PR 2
-Claim Scope Contracts, and the first M2 PR 4 navigation slice merged; the
-bounded CPSEval pilot and responsive repair are validated, pending review and
-merge.
+Claim Scope Contracts, and M2 PR 4 are complete in the current tree. The next
+dependency-ordered target is M1 PR 3 experiment, run, result, and exact
+evidence-locator design.
 
 Date: 2026-08-14
 
@@ -1241,8 +1241,8 @@ through REST, MCP, packs, graph, Writer gating, and the web; and passed its
 full-suite, production-build, isolated-container, concurrency, and browser
 acceptance gates.
 
-The active milestone is **M2 / PR 4 Workbench Shell and Context Capsule
-hardening**. Its merged navigation slice provides scope-aware capsule summaries,
+**M2 / PR 4 Workbench Shell and Context Capsule is complete in the current
+tree.** Its merged navigation slice provides scope-aware capsule summaries,
 URL-resumable stage and review selection, and evidence-to-review trace links.
 Its production build, focused lint, full 2,844-test backend suite, and
 disposable production-browser acceptance path all pass. The evidence is recorded in
@@ -1261,19 +1261,21 @@ unratified, and checkpoint-blocked state. The same pass exposed and closed a
 narrow-viewport navigation defect. Detailed evidence is recorded in
 [`2026-08-15-cpseval-m2-positive-path.md`](../specs/2026-08-15-cpseval-m2-positive-path.md).
 
-The remaining PR 4 work is:
-
-1. merge the CPSEval pilot evidence and responsive repair;
-2. run the final keyboard/accessibility pass and explicit loading, empty, and
-   capped-count cases;
-3. freeze the M2 exit evidence before any deliberation or mutation UI is
-   enabled.
+The CPSEval pilot and responsive repair merged in PR 73. The final M2 branch
+adds and validates project-only, loading, unavailable, empty, and capped-count
+states; Arrow/Home/End plus Enter/Space stage navigation; a skip link; explicit
+live-region semantics; and a 390 by 844 responsive boundary. Detailed evidence
+is recorded in
+[`2026-08-15-workbench-m2-exit-evidence.md`](../specs/2026-08-15-workbench-m2-exit-evidence.md).
+This final branch closes the M2 exit gate.
 
 The live pack exporter also emits agentic-branch staleness fields that current
 `main` cannot import losslessly. The importer correctly rejects those unknown
 semantic columns. Cross-branch pack migration belongs to the intake/hardening
 milestone and must not be solved by dropping them.
 
-PR 3 remains deferred until the experiment/run/result schema is separately
-designed and reviewed. Interpretation candidates and ordinary journal entries
-must not be treated as experiment results in the meantime.
+The next dependency-ordered target is **M1 / PR 3**. Its experiment/run/result
+schema must be separately designed and reviewed before implementation.
+Interpretation candidates and ordinary journal entries must not be treated as
+experiment results in the meantime, and M3 mutation UI remains blocked until
+the substrate is accepted.

--- a/docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md
+++ b/docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md
@@ -124,9 +124,10 @@ error. The viewport override was reset after testing.
 - 390 by 844 responsive and mobile-navigation walkthrough: pass;
 - live backup and post-pilot backup integrity checks: pass.
 
-## Remaining M2 exit work
+## M2 exit follow-up
 
-The real-project positive path and narrow-viewport blocker are closed. Before
-enabling M3 mutation UI, freeze the M2 exit evidence with a final keyboard and
-accessibility pass plus explicit loading, empty, and capped-count cases. Those
-checks must not weaken the epistemic labels demonstrated here.
+The final keyboard/accessibility, loading, empty, capped-count, and responsive
+cases are closed in
+[`2026-08-15-workbench-m2-exit-evidence.md`](2026-08-15-workbench-m2-exit-evidence.md).
+Those checks preserve the epistemic labels demonstrated here. M2 is complete
+when that follow-up branch merges.

--- a/docs/superpowers/specs/2026-08-15-workbench-m2-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-15-workbench-m2-exit-evidence.md
@@ -1,0 +1,111 @@
+# M2 Read-Only Workbench Exit Evidence
+
+Date: 2026-08-15
+
+Branch: `feature/rka-workbench-m2-exit-evidence`
+
+Merged-main baseline: `8b5e4f0` (PR 73)
+
+## Purpose
+
+Close the remaining M2 usability and state-integrity gates before any M3
+deliberation or mutation interface is enabled. This pass asks whether the
+read-only workbench remains truthful and operable when data is loading, absent,
+or capped, and whether a keyboard user can navigate the application and guided
+stage rail without losing URL-resumable state.
+
+## Data isolation
+
+The test server used the production RKA `2.9.0` image on localhost-only port
+`19713` and a new copy of the disposable CPSEval pilot database. The live RKA
+server and database were not restarted or changed. The relevant database
+hashes were:
+
+```text
+live online backup, unchanged:
+279cd694f06c2d580ce28eabfc94580d65e7d7f9c9fee38cd1865892644daf21
+
+post-CPSEval pilot input:
+0932ddc190eb294a92eace53e64f6e0f9ca2d66236407cf9d6bef58e335fc62f
+
+M2 boundary-case fixture:
+2e24fce503e58f85f587a9268e6de054c2a2cc579147ade6b688bdc884b9131f
+```
+
+All three databases passed `PRAGMA integrity_check`. To reach the API's
+200-record claim limit, the fixture added exactly 21 plainly named low-
+confidence, unverified, unassessed claims to the disposable InvarLLM project
+through the normal `POST /api/claims` interface. The project moved from 179 to
+200 claims. These are test-only records and were never written to the live
+database.
+
+## State-integrity changes
+
+- Project-only mode now states that no manuscript is selected and explains how
+  to load a canonical `man_` aggregate.
+- A requested manuscript is labeled `Loading manuscript` while its context is
+  in flight; readiness says it is waiting for context rather than claiming the
+  manuscript is absent.
+- Each stage renders a live loading status for its authoritative dependencies
+  and suppresses empty conclusions until those reads settle.
+- Dependent read failures render an explicit alert instead of a permanent
+  loading label.
+- Review-queue summaries distinguish no records from loading and failure.
+- Reaching the 200-record API limit now says `200 records shown; total unknown`
+  and warns that the displayed counts are not project totals. The UI no longer
+  implies that `200` proves additional records exist.
+
+## Keyboard and accessibility changes
+
+- A first-focus skip link moves focus to the main application landmark.
+- The guided stage rail supports Arrow keys, Home, and End for focus movement.
+- Enter and Space explicitly select the focused stage and preserve the choice
+  in `?stage=...`.
+- Custom evidence cards, queue links, and stage controls expose visible focus
+  rings.
+- The evidence inspector is a polite atomic live region, so a keyboard
+  selection is announced without forcing focus away from the stage control.
+- Loading states use `role=status`; failures use `role=alert`.
+
+## Browser acceptance matrix
+
+| Case | Project / manuscript | Result |
+|---|---|---|
+| Project-only exploration | CPSEval, no manuscript | Explicit project-only status; canonical manuscript fields remain unselected rather than unavailable. |
+| Empty canonical manuscript | detectability / `man_01KTA076RZS52C2T1JPP0D39KT` | `No paper spine yet` and `No native manuscript units` appear only after successful authoritative reads. |
+| Capped claim queue | disposable InvarLLM fixture | `200 blocking scope`, `200 records shown; total unknown`, and the non-total warning render together. |
+| Delayed context | CPSEval / `man_01M00D9BPMA60CN3FXTE86C4W1` through a localhost-only 1.5-second delay proxy | Loading manuscript, readiness-wait, and stage-loading messages render; no empty or unavailable conclusion flashes. The canonical ESCAPE spine replaces them after completion. |
+| Stage keyboard navigation | project-only workbench | Arrow Down focuses Paper spine; Enter selects `?stage=spine`; End focuses Outline; Space selects `?stage=outline`. |
+| Skip navigation | loaded CPSEval manuscript | Activating `Skip to main content` targets `#main-content` and moves focus to the `main` landmark. |
+| Responsive boundary | InvarLLM at 390 by 844 | Mobile navigation replaces the fixed sidebar; project-only and capped-count disclosures remain visible with no horizontal layout blocker. |
+
+## Verification
+
+- focused ESLint on the five changed workbench/layout files: pass;
+- TypeScript and Vite production build: pass;
+- `git diff --check`: pass;
+- production Docker image build: pass;
+- full backend suite in a disposable runner with the checkout mounted
+  read-only: `2,844 passed` in 148.63 seconds;
+- browser acceptance matrix above: pass;
+- disposable fixture integrity check and isolation hashes: pass.
+
+The repository-wide ESLint command still reports the known baseline violations
+in shared `badge`, `button`, and `tabs` components plus `useTheme`, `Journal`,
+`ResearchMap`, and `Settings`. None is introduced by this branch. The full
+backend suite emitted the existing Pydantic forward-reference warning plus the
+expected pytest-cache warning because the checkout was deliberately mounted
+read-only; neither affected test execution.
+
+## Exit decision
+
+This branch closes M2. The read-only workbench now has a real
+positive scope-to-spine path, resumable evidence navigation, responsive layout,
+explicit boundary states, and keyboard-operable stage navigation without
+weakening the separation among applicability, source grounding, scientific
+support, PI ratification, and drafting readiness.
+
+The next dependency-ordered target is **M1 / PR 3**: separately design and
+review first-class experiment, run, result, measurement, metric, baseline,
+condition, and evidence-locator semantics. M3 mutation UI remains blocked until
+that substrate is accepted.

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -6,11 +6,17 @@ import { FirstRunBanner } from "./FirstRunBanner"
 export function AppLayout() {
   return (
     <div className="flex h-screen overflow-hidden">
+      <a
+        href="#main-content"
+        className="fixed left-3 top-3 z-[100] -translate-y-24 rounded-md bg-background px-3 py-2 text-sm font-medium shadow-md ring-2 ring-primary transition-transform focus:translate-y-0"
+      >
+        Skip to main content
+      </a>
       <Sidebar className="hidden md:flex" />
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <Header />
         <FirstRunBanner />
-        <main className="flex-1 overflow-auto p-3 sm:p-6">
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto p-3 outline-none sm:p-6">
           <Outlet />
         </main>
       </div>

--- a/web/src/components/workbench/ContextCapsule.tsx
+++ b/web/src/components/workbench/ContextCapsule.tsx
@@ -4,11 +4,37 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import type { ManuscriptContext, ManuscriptReadiness, ResearchMapData } from "@/api/types"
 
-export interface WorkbenchQueueSummary {
-  total: number
-  attention: number
-  ready: number
-  partial: boolean
+export type WorkbenchQueueSummary =
+  | { state: "loading" }
+  | { state: "error"; message: string }
+  | {
+      state: "ready"
+      shown: number
+      attention: number
+      ready: number
+      limitReached: boolean
+    }
+
+function queueValue(
+  summary: WorkbenchQueueSummary,
+  attentionLabel: string,
+  readyLabel: string,
+) {
+  if (summary.state === "loading") return "Loading review queue"
+  if (summary.state === "error") return "Review queue unavailable"
+  if (summary.shown === 0) return "No records in this view"
+  const counts = `${summary.attention} ${attentionLabel} · ${summary.ready} ${readyLabel}`
+  return summary.limitReached
+    ? `${counts} · ${summary.shown} records shown; total unknown`
+    : counts
+}
+
+function queueDetail(summary: WorkbenchQueueSummary, base: string) {
+  if (summary.state === "error") return `${base} Error: ${summary.message}`
+  if (summary.state === "ready" && summary.limitReached) {
+    return `${base} The API limit was reached, so these counts must not be read as project totals.`
+  }
+  return base
 }
 
 function CapsuleFact({
@@ -45,7 +71,7 @@ function ReviewQueueFact({
   return (
     <Link
       to={to}
-      className="group rounded-md border bg-background/70 px-3 py-2 transition-colors hover:border-primary/40 hover:bg-muted/30"
+      className="group rounded-md border bg-background/70 px-3 py-2 transition-colors hover:border-primary/40 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
@@ -63,32 +89,75 @@ function ReviewQueueFact({
 export function ContextCapsule({
   projectId,
   projectName,
+  projectError,
+  manuscriptRequested,
+  contextLoading,
   context,
   readiness,
+  readinessLoading,
+  readinessError,
   map,
+  mapLoading,
+  mapError,
   impactCount,
   impactPartial,
+  impactError,
   interpretationSummary,
   scopeSummary,
 }: {
   projectId: string
   projectName: string
+  projectError: Error | null
+  manuscriptRequested: boolean
+  contextLoading: boolean
   context?: ManuscriptContext
   readiness?: ManuscriptReadiness
+  readinessLoading: boolean
+  readinessError: Error | null
   map?: ResearchMapData
+  mapLoading: boolean
+  mapError: Error | null
   impactCount: number
   impactPartial: boolean
-  interpretationSummary?: WorkbenchQueueSummary
-  scopeSummary?: WorkbenchQueueSummary
+  impactError: Error | null
+  interpretationSummary: WorkbenchQueueSummary
+  scopeSummary: WorkbenchQueueSummary
 }) {
   const manuscript = context?.manuscript
   const readinessLabel = readiness
     ? readiness.ready
       ? "Ready for drafting"
       : `${readiness.verdict}: ${readiness.findings.length} finding${readiness.findings.length === 1 ? "" : "s"}`
+    : contextLoading
+      ? "Waiting for manuscript context"
+      : readinessError
+        ? "Readiness unavailable"
     : manuscript
-      ? "Readiness loading"
-      : "Pre-manuscript exploration"
+      ? readinessLoading
+        ? "Readiness loading"
+        : "Readiness unavailable"
+      : manuscriptRequested
+        ? "Manuscript unavailable"
+        : "Pre-manuscript exploration"
+  const manuscriptLabel = manuscript
+    ? manuscript.title
+    : contextLoading
+      ? "Loading manuscript"
+      : manuscriptRequested
+        ? "Unavailable"
+        : "Not selected"
+  const manuscriptSource = manuscript
+    ? `/api/manuscripts/${manuscript.id}/context`
+    : manuscriptRequested
+      ? "Canonical context request"
+      : "No canonical man_ aggregate"
+  const mapLabel = map
+    ? `${map.summary.total_rqs} RQs · ${map.summary.total_clusters} clusters · ${map.summary.total_claims} claims`
+    : mapError
+      ? "Research map unavailable"
+      : mapLoading
+        ? "Loading"
+        : "No research map returned"
 
   return (
     <Card className="border-primary/20 bg-gradient-to-r from-primary/[0.04] via-background to-background">
@@ -110,11 +179,15 @@ export function ContextCapsule({
         </div>
 
         <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
-          <CapsuleFact label="Project" value={projectName} source={`/api/status · ${projectId}`} />
+          <CapsuleFact
+            label="Project"
+            value={projectName}
+            source={projectError ? `Error: ${projectError.message}` : `/api/status · ${projectId}`}
+          />
           <CapsuleFact
             label="Manuscript"
-            value={manuscript ? manuscript.title : "Not selected"}
-            source={manuscript ? `/api/manuscripts/${manuscript.id}/context` : "No canonical man_ aggregate"}
+            value={manuscriptLabel}
+            source={manuscriptSource}
           />
           <CapsuleFact
             label="Venue and phase"
@@ -123,28 +196,34 @@ export function ContextCapsule({
           />
           <CapsuleFact
             label="Research map"
-            value={map ? `${map.summary.total_rqs} RQs · ${map.summary.total_clusters} clusters · ${map.summary.total_claims} claims` : "Loading"}
-            source="/api/research-map"
+            value={mapLabel}
+            source={mapError ? `Error: ${mapError.message}` : "/api/research-map"}
           />
-          <CapsuleFact label="Readiness" value={readinessLabel} source="/api/manuscripts/:id/readiness?target_phase=drafting" />
+          <CapsuleFact
+            label="Readiness"
+            value={readinessLabel}
+            source={readinessError ? `Error: ${readinessError.message}` : "/api/manuscripts/:id/readiness?target_phase=drafting"}
+          />
         </div>
 
         <div className="grid gap-2 lg:grid-cols-2">
           <ReviewQueueFact
             label="Interpretation staging"
-            value={interpretationSummary
-              ? `${interpretationSummary.attention} awaiting review · ${interpretationSummary.ready} resolved${interpretationSummary.partial ? ` · first ${interpretationSummary.total}+ records` : ""}`
-              : "Loading review queue"}
-            detail="Source-bounded candidates only; review does not establish scientific support."
+            value={queueValue(interpretationSummary, "awaiting review", "resolved")}
+            detail={queueDetail(
+              interpretationSummary,
+              "Source-bounded candidates only; review does not establish scientific support.",
+            )}
             source="/api/interpretation-candidates?limit=200"
             to="/interpretations?review_status=pending"
           />
           <ReviewQueueFact
             label="Canonical claim scope"
-            value={scopeSummary
-              ? `${scopeSummary.attention} blocking scope · ${scopeSummary.ready} ready${scopeSummary.partial ? ` · first ${scopeSummary.total}+ records` : ""}`
-              : "Loading scope queue"}
-            detail="Applicability only; evidence support, contradictions, and source grounding remain independent."
+            value={queueValue(scopeSummary, "blocking scope", "ready")}
+            detail={queueDetail(
+              scopeSummary,
+              "Applicability only; evidence support, contradictions, and source grounding remain independent.",
+            )}
             source="/api/claims?limit=200"
             to="/claim-scopes?scope=missing"
           />
@@ -160,6 +239,18 @@ export function ContextCapsule({
               <p className="mt-0.5 opacity-80">
                 Derived from <code>/api/manuscripts/:id/impact</code>.
                 {impactPartial ? " The first page is partial; this is not a clean impact result." : ""}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {impactError && (
+          <div role="alert" className="flex items-start gap-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="text-xs">
+              <p className="font-medium">Semantic impact check unavailable.</p>
+              <p className="mt-0.5 opacity-80">
+                No clean-impact conclusion can be drawn. Error: {impactError.message}
               </p>
             </div>
           </div>

--- a/web/src/components/workbench/EvidenceInspector.tsx
+++ b/web/src/components/workbench/EvidenceInspector.tsx
@@ -20,7 +20,7 @@ export interface WorkbenchTraceItem {
 
 export function EvidenceInspector({ item }: { item: WorkbenchTraceItem }) {
   return (
-    <Card className="min-h-40">
+    <Card className="min-h-40" aria-live="polite" aria-atomic="true">
       <CardHeader className="pb-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <CardTitle className="flex items-center gap-2 text-sm">

--- a/web/src/components/workbench/StageRail.tsx
+++ b/web/src/components/workbench/StageRail.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import {
@@ -22,18 +23,54 @@ export function StageRail({
   verdicts: Record<WorkbenchStageId, StageVerdict>
   onSelect: (stage: WorkbenchStageId) => void
 }) {
+  const stageButtons = useRef<Array<HTMLButtonElement | null>>([])
+
+  const moveFocus = (index: number, key: string) => {
+    let nextIndex: number | null = null
+    if (key === "ArrowDown" || key === "ArrowRight") {
+      nextIndex = (index + 1) % WORKBENCH_STAGES.length
+    } else if (key === "ArrowUp" || key === "ArrowLeft") {
+      nextIndex = (index - 1 + WORKBENCH_STAGES.length) % WORKBENCH_STAGES.length
+    } else if (key === "Home") {
+      nextIndex = 0
+    } else if (key === "End") {
+      nextIndex = WORKBENCH_STAGES.length - 1
+    }
+    if (nextIndex === null) return
+    stageButtons.current[nextIndex]?.focus()
+  }
+
   return (
-    <nav aria-label="Manuscript stages" className="space-y-1.5">
+    <nav
+      aria-label="Manuscript stages"
+      aria-describedby="manuscript-stage-keyboard-help"
+      className="space-y-1.5"
+    >
+      <p id="manuscript-stage-keyboard-help" className="sr-only">
+        Use the arrow keys, Home, or End to move between stages. Press Enter or Space to select a stage.
+      </p>
       {WORKBENCH_STAGES.map((stage, index) => {
         const Icon = stage.icon
         const verdict = verdicts[stage.id]
         return (
           <button
             key={stage.id}
+            ref={(node) => { stageButtons.current[index] = node }}
             type="button"
             onClick={() => onSelect(stage.id)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault()
+                onSelect(stage.id)
+                return
+              }
+              if (["ArrowDown", "ArrowRight", "ArrowUp", "ArrowLeft", "Home", "End"].includes(event.key)) {
+                event.preventDefault()
+                moveFocus(index, event.key)
+              }
+            }}
             className={cn(
-              "w-full rounded-lg border px-3 py-2.5 text-left transition-colors",
+              "w-full rounded-lg border px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
               selected === stage.id
                 ? "border-primary bg-primary/5 shadow-sm"
                 : "border-transparent hover:border-border hover:bg-muted/60",

--- a/web/src/pages/ManuscriptWorkbench.tsx
+++ b/web/src/pages/ManuscriptWorkbench.tsx
@@ -68,6 +68,8 @@ const stageDescriptions: Record<WorkbenchStageId, string> = {
   outline: "Claim-sized manuscript units form the read-only outline and preserve file and evidence anchors.",
 }
 
+const WORKBENCH_QUEUE_LIMIT = 200
+
 function statusForClaim(claim: ManuscriptClaimContext): string {
   const currentRatification = claim.ratifications.some(
     (item) =>
@@ -161,25 +163,52 @@ export default function ManuscriptWorkbench() {
 
   const impactCount = impact?.relevant_changes?.length ?? 0
   const interpretationSummary = useMemo(() => {
-    if (!interpretations.data) return undefined
+    if (interpretations.isLoading) return { state: "loading" as const }
+    if (interpretations.error) {
+      return { state: "error" as const, message: interpretations.error.message }
+    }
+    if (!interpretations.data) return { state: "loading" as const }
     const attention = interpretations.data.filter((item) => item.review_status !== "resolved").length
     return {
-      total: interpretations.data.length,
+      state: "ready" as const,
+      shown: interpretations.data.length,
       attention,
       ready: interpretations.data.length - attention,
-      partial: interpretations.data.length >= 200,
+      limitReached: interpretations.data.length >= WORKBENCH_QUEUE_LIMIT,
     }
-  }, [interpretations.data])
+  }, [interpretations.data, interpretations.error, interpretations.isLoading])
   const scopeSummary = useMemo(() => {
-    if (!claimScopes.data) return undefined
+    if (claimScopes.isLoading) return { state: "loading" as const }
+    if (claimScopes.error) {
+      return { state: "error" as const, message: claimScopes.error.message }
+    }
+    if (!claimScopes.data) return { state: "loading" as const }
     const ready = claimScopes.data.filter((claim) => claim.scope_readiness === "ready").length
     return {
-      total: claimScopes.data.length,
+      state: "ready" as const,
+      shown: claimScopes.data.length,
       attention: claimScopes.data.length - ready,
       ready,
-      partial: claimScopes.data.length >= 200,
+      limitReached: claimScopes.data.length >= WORKBENCH_QUEUE_LIMIT,
     }
-  }, [claimScopes.data])
+  }, [claimScopes.data, claimScopes.error, claimScopes.isLoading])
+
+  const stageQueries = (() => {
+    if (!manuscriptId) return []
+    if (["seed", "spine", "scope", "gap", "response"].includes(stage)) {
+      return [workbench.context, workbench.candidates]
+    }
+    if (stage === "contributions") {
+      return [workbench.context, workbench.candidates, workbench.readiness]
+    }
+    if (stage === "evaluation") return [workbench.context]
+    if (stage === "outline") return [workbench.context, workbench.spine]
+    return []
+  })()
+  const stageIsLoading = stageQueries.some((query) => query.isLoading)
+    || (["seed", "landscape", "gap", "rqs"].includes(stage) && researchMap.isLoading)
+  const stageError = stageQueries.map((query) => query.error).find(Boolean)
+    ?? (["seed", "landscape", "gap", "rqs"].includes(stage) ? researchMap.error : null)
 
   const selectStage = (next: WorkbenchStageId) => {
     const params = new URLSearchParams(searchParams)
@@ -232,14 +261,18 @@ export default function ManuscriptWorkbench() {
         </form>
       </div>
 
-      {manuscriptId && workbench.context.isLoading && (
-        <div className="flex h-36 items-center justify-center rounded-lg border">
-          <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading canonical manuscript context
+      {!manuscriptId && (
+        <div role="status" className="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-950 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100">
+          <Info className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>
+            Project-only exploration. Load a canonical <code>man_...</code> identifier to inspect manuscript claims,
+            evidence, readiness, and outline units.
+          </p>
         </div>
       )}
 
       {workbench.context.error && (
-        <div className="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100">
+        <div role="alert" className="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
           <div>
             <p className="font-medium">The manuscript could not be loaded in the selected project.</p>
@@ -250,12 +283,20 @@ export default function ManuscriptWorkbench() {
 
       <ContextCapsule
         projectId={projectId}
-        projectName={project.data?.project_name ?? "Loading project"}
+        projectName={project.data?.project_name ?? (project.error ? "Project unavailable" : "Loading project")}
+        projectError={project.error instanceof Error ? project.error : null}
+        manuscriptRequested={Boolean(manuscriptId)}
+        contextLoading={workbench.context.isLoading}
         context={context}
         readiness={readiness}
+        readinessLoading={workbench.readiness.isLoading}
+        readinessError={workbench.readiness.error instanceof Error ? workbench.readiness.error : null}
         map={researchMap.data}
+        mapLoading={researchMap.isLoading}
+        mapError={researchMap.error instanceof Error ? researchMap.error : null}
         impactCount={impactCount}
         impactPartial={Boolean(impact?.has_more)}
+        impactError={workbench.impact.error instanceof Error ? workbench.impact.error : null}
         interpretationSummary={interpretationSummary}
         scopeSummary={scopeSummary}
       />
@@ -283,6 +324,8 @@ export default function ManuscriptWorkbench() {
             spine={spine}
             candidates={candidates}
             readiness={readiness}
+            isLoading={stageIsLoading}
+            error={stageError instanceof Error ? stageError : null}
             onInspect={(item) => setSelectedTrace({ scopeKey: traceScopeKey, item })}
           />
           <EvidenceInspector
@@ -301,6 +344,8 @@ function StageCanvas({
   spine,
   candidates,
   readiness,
+  isLoading,
+  error,
   onInspect,
 }: {
   stage: WorkbenchStageId
@@ -309,6 +354,8 @@ function StageCanvas({
   spine?: ManuscriptSpine
   candidates?: ManuscriptWritingCandidates
   readiness?: ManuscriptReadiness
+  isLoading: boolean
+  error: Error | null
   onInspect: (item: WorkbenchTraceItem) => void
 }) {
   const stageMeta = WORKBENCH_STAGES.find((item) => item.id === stage)!
@@ -333,6 +380,21 @@ function StageCanvas({
         </p>
       </CardHeader>
       <CardContent className="space-y-3 p-4">
+        {isLoading && (
+          <div role="status" aria-live="polite" className="flex min-h-32 items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading {stageMeta.label.toLowerCase()} data
+          </div>
+        )}
+        {!isLoading && error && (
+          <div role="alert" className="flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-medium">This stage could not load its authoritative data.</p>
+              <p className="mt-1 text-xs opacity-80">{error.message}</p>
+            </div>
+          </div>
+        )}
+        {!isLoading && !error && <>
         {stage === "seed" && (
           <SeedView map={map} candidates={candidates} onInspect={onInspect} />
         )}
@@ -360,6 +422,7 @@ function StageCanvas({
         )}
         {stage === "evaluation" && <EvaluationView units={units} onInspect={onInspect} />}
         {stage === "outline" && <OutlineView units={units} spine={spine} onInspect={onInspect} />}
+        </>}
       </CardContent>
     </Card>
   )
@@ -380,7 +443,8 @@ function TraceCard({
     <button
       type="button"
       onClick={() => onInspect(trace)}
-      className="group w-full rounded-lg border bg-card p-3 text-left transition-colors hover:border-primary/40 hover:bg-muted/25"
+      aria-label={`Inspect evidence for ${title}`}
+      className="group w-full rounded-lg border bg-card p-3 text-left transition-colors hover:border-primary/40 hover:bg-muted/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
     >
       <div className="flex items-start justify-between gap-3">
         <h3 className="text-sm font-semibold">{title}</h3>


### PR DESCRIPTION
## Summary

- distinguish project-only, loading, unavailable, empty, error, and capped workbench states
- add skip navigation, visible focus treatment, live-region semantics, and Arrow/Home/End plus Enter/Space stage controls
- freeze the CPSEval/InvarLLM/detectability browser evidence and advance the roadmap to M1 / PR 3

## Validation

- 2,844 backend tests passed in 148.63 seconds in a disposable runner with the checkout mounted read-only
- focused ESLint passed for all changed web files
- TypeScript and Vite production build passed
- production Docker image build and final localhost smoke test passed
- browser matrix passed for project-only, empty manuscript, delayed loading, 200-row cap disclosure, keyboard navigation, skip focus, and 390 by 844 responsive behavior
- disposable SQLite fixture integrity check passed

## Data safety

All boundary fixtures and semantic writes were confined to disposable database copies. The live RKA service was not restarted and no live semantic record changed.

M2 closes with this PR. M3 mutation UI remains blocked pending the separately reviewed experiment/run/result substrate in #54.

Closes #55