### PR TITLE
M5 PR 9.1: harden outline and pack integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to RKA are documented here. Format loosely follows
 
 ### Added
 
+- **Portable outline integrity and staleness provenance.** The reserved
+  staleness-resolution schema now round-trips without dropping deployed
+  agentic fields. Knowledge-pack import rekeys resolution and outline-intention
+  references, rejects malformed outline hierarchies, and records attributed
+  outline-profile insert, update, and delete events.
+- **Semantic spine write quieting.** Replaying an unchanged argument spine no
+  longer bumps the manuscript revision, invalidates checkpoints, appends an
+  audit row, or emits delete/reinsert churn. Partial edits update only the
+  affected semantic rows and bindings.
+- **Explicit outline rationale readiness.** Outline responses now expose
+  `rationale_complete`; `checkpoint_ready` remains a deprecated compatibility
+  alias while the workbench uses the accurately named field.
+
 - **Progressive L2-L5 manuscript outline.** Native manuscript units now carry
   pure hierarchy depth, writing rationale, intended reader takeaways, evidence plans,
   and figure/table/citation intentions. Direct and AI-assisted edit, expand,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,9 +33,10 @@ milestone must satisfy its exit gate before dependent work is treated as ready.
 ## Now
 
 **M0 through M4 are complete on `main`. M5 / PR 9 (issue #60), the progressive
-outline and manuscript-unit editor, has passed its independent-audit
-correction gate and is the current review target. It remains draft pending
-refreshed GitHub CI and human review.**
+outline and manuscript-unit editor, merged in PR
+[#80](https://github.com/infinitywings/rka/pull/80); its independent audit and
+resolution record merged in PR [#81](https://github.com/infinitywings/rka/pull/81).
+PR 9.1 integrity hardening is now the active implementation target.**
 PR [#78](https://github.com/infinitywings/rka/pull/78) merged
 the seed-through-contribution dependency; ADR 0008 freezes the evaluation
 contract, and the exact release evidence is recorded in
@@ -47,9 +48,15 @@ implementation plan is
 Its migration, REST/MCP, proposal, workbench, restart, and knowledge-pack gates
 and the correction status of the original acceptance run are recorded in
 [`2026-08-15-workbench-m5-pr9-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m5-pr9-exit-evidence.md).
-The implementation is published for review in draft PR
-[#80](https://github.com/infinitywings/rka/pull/80).
-PR 10 remains dependent on PR 9 review and merge.
+The merged foundation is recorded in PR
+[#80](https://github.com/infinitywings/rka/pull/80), and the PR 9.1 hardening
+contract is
+[`2026-08-17-m5-pr9-1-integrity-hardening.md`](docs/superpowers/plans/2026-08-17-m5-pr9-1-integrity-hardening.md).
+Its migration, pack, semantic-cursor, no-op-write, frontend-build, and
+real-project-derived validation record is
+[`2026-08-17-workbench-m5-pr9-1-exit-evidence.md`](docs/superpowers/specs/2026-08-17-workbench-m5-pr9-1-exit-evidence.md).
+PR 9.2 remains dependent on PR 9.1; PR 10 remains dependent on the typed
+semantic core in PR 9.2.
 The choice-first Writer delta is reconciled, the authority and AI boundary is
 recorded in ADR 0001, the read-only workbench has passed its real-project exit
 gate, and first-class experiment/run/observation/evidence-locator semantics

--- a/docs/superpowers/plans/2026-08-17-m5-pr9-1-integrity-hardening.md
+++ b/docs/superpowers/plans/2026-08-17-m5-pr9-1-integrity-hardening.md
@@ -1,0 +1,58 @@
+# M5 PR 9.1 — Outline and Knowledge-Pack Integrity Hardening
+
+## Outcome
+
+Make the merged progressive-outline foundation safe to move between RKA
+installations and quiet enough to support long manuscripts. The same semantic
+state must survive export/import/rekey, the importer must enforce the same
+hierarchy accepted by the manuscript service, and mechanical no-op rewrites
+must not masquerade as research changes.
+
+## Invariants
+
+1. Knowledge-pack import never silently drops an unknown semantic column.
+2. The reserved agentic staleness-resolution schema is portable and keeps its
+   original migration identity (`030_staleness_resolution.sql`).
+3. Imported outline profiles obey the canonical cycle, parent-depth,
+   parent-before-child, active-parent, and contiguous-subtree rules before the
+   transaction may commit.
+4. Rekeying updates exact and embedded entity IDs in all four outline-intention
+   JSON fields and in staleness-resolution references.
+5. Insert, update, and delete events for outline profiles identify both the
+   manuscript and manuscript unit in the semantic change cursor.
+6. Expansion may intentionally narrow inherited evidence, but every removed
+   support, qualifier, or counterevidence binding is visible in the immutable
+   proposal warning set.
+7. `rationale_complete` names rationale completeness. The historical
+   `checkpoint_ready` field remains a deprecated response alias for one
+   compatibility window and is no longer used by the web workbench.
+8. Replaying an identical spine is a true no-op. A partial edit updates only
+   rows and binding sets whose semantic values changed.
+
+## Compatibility policy
+
+The importer remains strict for genuinely unknown columns. Cross-version
+compatibility is achieved by adopting the already-deployed additive migration,
+not by filtering uploaded rows. Existing agentic databases have migration 030
+recorded and skip it; main-line databases apply it once even if later migration
+numbers are already present. Import rekeying preserves resolution prose and
+rewrites its journal reference.
+
+## Test gates
+
+- fresh and late-application migration-030 coverage, including CHECK values;
+- migration-048 insert/update/delete attribution and idempotent restart;
+- corrupt-pack rollback for cycles, depth inversion, removed parent,
+  child-before-parent order, and non-contiguous subtrees;
+- intention JSON plus staleness-resolution round-trip/rekey;
+- exact no-op and one-field-edit change-event counts;
+- expansion warning parity for all three evidence roles;
+- REST/MCP/projection compatibility for `rationale_complete`;
+- full Python suite, production web build, changed-file lint, and a disposable
+  real-project-derived pack round-trip.
+
+## Non-goals
+
+Typed rhetorical roles, warrants, citation verification, readiness v2, draft
+file synchronization, and embedded LLM orchestration remain PR 9.2 or PR 10
+work. PR 9.1 changes integrity and observability, not manuscript meaning.

--- a/docs/superpowers/specs/2026-08-17-workbench-m5-pr9-1-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-workbench-m5-pr9-1-exit-evidence.md
@@ -1,0 +1,95 @@
+# M5 / PR 9.1 integrity-hardening exit evidence
+
+- Date: 2026-08-17
+- Baseline: `23c9518bdf40ffecbafaca042ad704fa34c0fd86`
+- Branch: `codex/m5-integrity-hardening`
+- Scope: cross-version staleness provenance, knowledge-pack and outline
+  integrity, semantic change attribution, evidence-narrowing disclosure,
+  rationale-readiness naming, and quiet native-spine writes
+- Data safety: the running RKA database and research projects were not
+  modified. Real-project validation used a transactionally consistent SQLite
+  backup copied into `/private/tmp`; migrations, the disposable manuscript,
+  export, and re-import affected only that snapshot.
+
+## Contract exercised
+
+The implementation enforces the PR 9.1 contract recorded in
+[`2026-08-17-m5-pr9-1-integrity-hardening.md`](../plans/2026-08-17-m5-pr9-1-integrity-hardening.md):
+
+- the already-deployed `030_staleness_resolution.sql` identity is restored on
+  main without dropping its five claim and evidence-cluster fields;
+- exact and embedded entity IDs are rekeyed in staleness resolution and all
+  four outline-intention JSON fields;
+- imported outlines use the same cycle, parent-depth, active-parent,
+  parent-before-child, and contiguous-subtree validator as native writes;
+- absent and cross-manuscript outline parents fail during untrusted-pack
+  preflight instead of being silently converted into roots;
+- outline-profile insert, update, and delete events identify their manuscript
+  and unit;
+- expansion warns when a child removes inherited support, qualifier, or
+  counterevidence bindings;
+- `rationale_complete` is the canonical completeness field while the old
+  `checkpoint_ready` value remains a deprecated compatibility alias; and
+- native spine upserts compare individual rows and binding sets, so an exact
+  replay is revision-, checkpoint-, audit-, and cursor-neutral.
+
+## Automated verification
+
+| Gate | Result |
+|---|---|
+| Focused migrations, service, knowledge-pack, REST, and MCP suite | `104 passed in 13.41s` |
+| Exact no-op and one-rationale-edit regression | Passed; no-op emitted no events/audit/revision, one edit changed only its profile plus manuscript revision |
+| Changed Python Ruff lint and format | Passed |
+| Patch whitespace check | Passed |
+| Production TypeScript/Vite build | Passed; 2,421 modules transformed |
+| Changed frontend ESLint | Passed with zero findings |
+| Full Python suite | `3105 passed, 21 skipped, 11 failed in 183.07s` |
+| Untouched-main embedding baseline | Identical 11 failures, 24 passes, and 6 skips across the five failing files |
+
+The 11 full-suite failures are not introduced by this branch. They all concern
+the local sqlite-vector embedding metadata/backfill path. Running those exact
+five files against untouched main commit `23c9518` produced the same 11
+failures. Repository-wide ESLint also retains main's unrelated seven errors
+and two warnings in shared UI, Journal, Research Map, and Settings files; all
+three changed frontend files pass targeted ESLint. The production build keeps
+the repository's existing large-chunk advisory.
+
+## Real-project-derived pack round-trip
+
+A consistent backup of the running RKA database supplied DelaySteer project
+`prj_01KZVF35ESDGKZKTG1D1J59TCF`. On the disposable copy only, current
+migrations were applied and a two-unit L2/L3 native outline was created around
+one actual DelaySteer claim. The outline included the real claim ID inside a
+citation-intention sentence, then the complete project was exported and
+re-imported under a new project ID.
+
+Source and target counts matched exactly:
+
+| Table | Rows |
+|---|---:|
+| journal | 95 |
+| claims | 69 |
+| claim_edges | 70 |
+| evidence_clusters | 13 |
+| decisions | 33 |
+| literature | 60 |
+| manuscripts | 1 |
+| manuscript_claims | 1 |
+| manuscript_units | 2 |
+| manuscript_unit_outline_profiles | 2 |
+| manuscript_claim_evidence | 1 |
+| manuscript_unit_evidence | 1 |
+| manuscript_claim_units | 1 |
+
+The imported L3 unit retained its parent, evidence, and claim bindings; the
+claim ID embedded in citation prose changed to the imported ID; and the target
+project reported zero critical integrity issues. Synthetic round-trip tests
+separately cover non-null staleness-resolution fields because the live
+DelaySteer records currently leave those new fields empty.
+
+## Exit decision
+
+The PR 9.1 feature scope is ready for branch publication and GitHub CI. The
+local environment's embedding and repository-wide ESLint baselines remain
+explicitly unresolved and out of scope; they are not presented as green.
+PR 9.2 remains dependent on this hardening slice.

--- a/rka/db/migrations/030_staleness_resolution.sql
+++ b/rka/db/migrations/030_staleness_resolution.sql
@@ -1,0 +1,38 @@
+-- Migration 030: durable, auditable resolution state for stale claims and
+-- evidence clusters. A resolved item returns to staleness='green' while these
+-- fields preserve its reviewed disposition; audit_log stores the event history.
+--
+-- This migration was first deployed by the agentic runtime and its filename is
+-- already present in those databases. Main deliberately left 030 reserved.
+-- Shipping the original additive schema here makes knowledge packs portable
+-- without dropping semantic fields: agentic databases skip the recorded
+-- migration, while main-line databases apply it exactly once.
+
+ALTER TABLE claims ADD COLUMN staleness_reviewed_at TEXT;
+ALTER TABLE claims ADD COLUMN staleness_verdict TEXT
+    CHECK (staleness_verdict IS NULL OR staleness_verdict IN (
+        'current', 'historical', 'retired', 'superseded', 'retracted', 'dismissed'
+    ));
+ALTER TABLE claims ADD COLUMN staleness_resolution TEXT;
+ALTER TABLE claims ADD COLUMN staleness_resolution_journal_id TEXT;
+ALTER TABLE claims ADD COLUMN staleness_resolved_by TEXT
+    CHECK (staleness_resolved_by IS NULL OR staleness_resolved_by IN (
+        'brain', 'executor', 'pi'
+    ));
+
+ALTER TABLE evidence_clusters ADD COLUMN staleness_reviewed_at TEXT;
+ALTER TABLE evidence_clusters ADD COLUMN staleness_verdict TEXT
+    CHECK (staleness_verdict IS NULL OR staleness_verdict IN (
+        'current', 'historical', 'retired', 'superseded', 'retracted', 'dismissed'
+    ));
+ALTER TABLE evidence_clusters ADD COLUMN staleness_resolution TEXT;
+ALTER TABLE evidence_clusters ADD COLUMN staleness_resolution_journal_id TEXT;
+ALTER TABLE evidence_clusters ADD COLUMN staleness_resolved_by TEXT
+    CHECK (staleness_resolved_by IS NULL OR staleness_resolved_by IN (
+        'brain', 'executor', 'pi'
+    ));
+
+CREATE INDEX IF NOT EXISTS idx_claims_staleness_review
+    ON claims(project_id, staleness, staleness_reviewed_at);
+CREATE INDEX IF NOT EXISTS idx_clusters_staleness_review
+    ON evidence_clusters(project_id, staleness, staleness_reviewed_at);

--- a/rka/db/migrations/048_harden_outline_change_events.sql
+++ b/rka/db/migrations/048_harden_outline_change_events.sql
@@ -1,0 +1,69 @@
+-- Migration 048: make outline-profile changes first-class manuscript events.
+-- requires-table: manuscript_unit_outline_profiles, change_events
+
+DROP TRIGGER IF EXISTS trg_change_manuscript_unit_outline_insert;
+DROP TRIGGER IF EXISTS trg_change_manuscript_unit_outline_update;
+DROP TRIGGER IF EXISTS trg_change_manuscript_unit_outline_delete;
+
+CREATE TRIGGER trg_change_manuscript_unit_outline_insert
+AFTER INSERT ON manuscript_unit_outline_profiles
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id,
+        manuscript_id, manuscript_unit_id, details
+    ) VALUES (
+        NEW.project_id,
+        'manuscript_unit_outline_profiles',
+        'insert',
+        'manuscript_unit',
+        NEW.unit_id,
+        NEW.manuscript_id,
+        NEW.unit_id,
+        json_object(
+            'outline_level', NEW.outline_level,
+            'parent_unit_id', NEW.parent_unit_id
+        )
+    );
+END;
+
+CREATE TRIGGER trg_change_manuscript_unit_outline_update
+AFTER UPDATE ON manuscript_unit_outline_profiles
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id,
+        manuscript_id, manuscript_unit_id, details
+    ) VALUES (
+        NEW.project_id,
+        'manuscript_unit_outline_profiles',
+        'update',
+        'manuscript_unit',
+        NEW.unit_id,
+        NEW.manuscript_id,
+        NEW.unit_id,
+        json_object(
+            'outline_level', NEW.outline_level,
+            'parent_unit_id', NEW.parent_unit_id
+        )
+    );
+END;
+
+CREATE TRIGGER trg_change_manuscript_unit_outline_delete
+AFTER DELETE ON manuscript_unit_outline_profiles
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id,
+        manuscript_id, manuscript_unit_id, details
+    ) VALUES (
+        OLD.project_id,
+        'manuscript_unit_outline_profiles',
+        'delete',
+        'manuscript_unit',
+        OLD.unit_id,
+        OLD.manuscript_id,
+        OLD.unit_id,
+        json_object(
+            'outline_level', OLD.outline_level,
+            'parent_unit_id', OLD.parent_unit_id
+        )
+    );
+END;

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -18,6 +18,7 @@ from rka.models.knowledge_pack import KnowledgePackImportResult
 from rka.models.planning import validate_planning_payload
 from rka.models.semantic_patch import SemanticPatchProposalCreate
 from rka.services.base import BaseService, _now
+from rka.services.outline_integrity import validate_unit_hierarchy
 
 PACK_SCHEMA_VERSION = 7
 PACK_FILE_SUFFIX = ".rka-pack.zip"
@@ -86,6 +87,7 @@ _CRITICAL_INTEGRITY_CATEGORIES: frozenset[str] = frozenset(
         "semantic_patch_proposal_event_head_mismatch",
         "semantic_patch_provider_event_chain_invalid",
         "semantic_patch_payload_invalid",
+        "outline_hierarchy_invalid",
     }
 )
 
@@ -373,7 +375,7 @@ _DIRECT_ID_COLUMNS = {
     ),
     "journal": ("id", "related_mission", "supersedes", "superseded_by"),
     "checkpoints": ("id", "mission_id", "linked_decision_id"),
-    "claims": ("id", "source_entry_id"),
+    "claims": ("id", "source_entry_id", "staleness_resolution_journal_id"),
     "claim_scope_versions": (
         "id",
         "claim_id",
@@ -408,7 +410,11 @@ _DIRECT_ID_COLUMNS = {
         "observation_id",
         "candidate_id",
     ),
-    "evidence_clusters": ("id", "research_question_id"),
+    "evidence_clusters": (
+        "id",
+        "research_question_id",
+        "staleness_resolution_journal_id",
+    ),
     "claim_edges": ("id", "source_claim_id", "target_claim_id", "cluster_id"),
     "decision_options": ("id", "decision_id", "dominated_by"),
     "calibration_outcomes": ("id", "decision_id"),
@@ -619,7 +625,11 @@ _FK_COLUMNS: dict[str, set[str]] = {
         "decision_id",
     },
     "manuscript_units": {"manuscript_id"},
-    "manuscript_unit_outline_profiles": {"unit_id", "manuscript_id"},
+    "manuscript_unit_outline_profiles": {
+        "unit_id",
+        "manuscript_id",
+        "parent_unit_id",
+    },
     "manuscript_claim_evidence": {
         "manuscript_id",
         "manuscript_claim_id",
@@ -664,7 +674,7 @@ _PROSE_TEXT_COLUMNS: dict[str, tuple[str, ...]] = {
     "decisions": ("question", "rationale", "chosen", "abandonment_reason", "options"),
     "missions": ("objective", "context", "tasks", "acceptance_criteria"),
     "literature": ("abstract", "notes"),
-    "claims": ("content",),
+    "claims": ("content", "staleness_resolution"),
     "claim_scope_versions": (
         "uncertainty_note",
         "falsifier",
@@ -696,7 +706,7 @@ _PROSE_TEXT_COLUMNS: dict[str, tuple[str, ...]] = {
     ),
     "evidence_locators": ("label", "locator_value"),
     "claim_evidence_relations": ("review_reason", "revocation_reason"),
-    "evidence_clusters": ("label", "synthesis"),
+    "evidence_clusters": ("label", "synthesis", "staleness_resolution"),
     "checkpoints": ("description",),
     "events": ("summary",),
     "manuscript_claim_versions": ("exact_wording", "allowed_wording"),
@@ -755,6 +765,12 @@ _JSON_ID_COLUMNS = {
     "audit_log": ("details",),
     "reference_validation_attestations": ("full_json_payload",),
     "manuscript_claim_versions": ("prohibited_wording",),
+    "manuscript_unit_outline_profiles": (
+        "evidence_plan",
+        "figure_intentions",
+        "table_intentions",
+        "citation_intentions",
+    ),
     "manuscript_planning_branch_events": ("details",),
     "manuscript_planning_artifact_versions": (
         "payload",
@@ -1487,6 +1503,39 @@ class KnowledgePackService(BaseService):
                     f"project or absent from this pack: {log.get('session_id')!r}"
                 )
 
+        manuscript_units = {
+            str(row["id"]): str(row.get("manuscript_id") or "")
+            for row in tables.get("manuscript_units", [])
+            if row.get("id") and row.get("project_id") == project_id
+        }
+        for profile in tables.get("manuscript_unit_outline_profiles", []):
+            unit_id = str(profile.get("unit_id") or "")
+            manuscript_id = str(profile.get("manuscript_id") or "")
+            if unit_id not in manuscript_units:
+                raise ValueError(
+                    "Knowledge pack outline profile contains a unit outside the "
+                    f"project or absent from this pack: {unit_id!r}"
+                )
+            if manuscript_units[unit_id] != manuscript_id:
+                raise ValueError(
+                    "Knowledge pack outline profile manuscript does not match its unit: "
+                    f"{unit_id!r}"
+                )
+            parent_id = profile.get("parent_unit_id")
+            if parent_id is None:
+                continue
+            parent_id = str(parent_id)
+            if parent_id not in manuscript_units:
+                raise ValueError(
+                    "Knowledge pack outline profile contains a parent outside the "
+                    f"project or absent from this pack: {parent_id!r}"
+                )
+            if manuscript_units[parent_id] != manuscript_id:
+                raise ValueError(
+                    "Knowledge pack outline profile parent belongs to a different manuscript: "
+                    f"{parent_id!r}"
+                )
+
     def _remap_tables(
         self,
         tables: dict[str, list[dict[str, Any]]],
@@ -1722,7 +1771,17 @@ class KnowledgePackService(BaseService):
         if isinstance(value, str):
             if value == source_project_id:
                 return target_project_id
-            return id_map.get(value, value)
+            direct = id_map.get(value)
+            if direct is not None:
+                return direct
+            # JSON intention fields and provider payloads may contain IDs in
+            # explanatory strings rather than as whole scalar values. Rewrite
+            # only tokens present in this pack's id_map, preserving all other
+            # prose byte-for-byte.
+            return _EMBEDDED_ID_RE.sub(
+                lambda match: id_map.get(match.group(0), match.group(0)),
+                value,
+            )
         if isinstance(value, list):
             return [
                 self._rewrite_nested_refs(item, id_map, source_project_id, target_project_id)
@@ -1834,8 +1893,7 @@ class KnowledgePackService(BaseService):
                 dependencies = {
                     str(row[key])
                     for key in dependency_keys
-                    if row.get(key) is not None
-                    and str(row[key]) in remaining
+                    if row.get(key) is not None and str(row[key]) in remaining
                 }
                 if dependencies.issubset(placed):
                     ordered.append(row)
@@ -2148,6 +2206,7 @@ class KnowledgePackService(BaseService):
         "semantic_patch_proposal_event_head_mismatch": "critical",
         "semantic_patch_provider_event_chain_invalid": "critical",
         "semantic_patch_payload_invalid": "critical",
+        "outline_hierarchy_invalid": "critical",
         "claim_count_mismatch": "warning",
     }
 
@@ -2158,6 +2217,66 @@ class KnowledgePackService(BaseService):
         non-blocking by default."""
         return cls._SEVERITY_BY_CATEGORY.get(category, "warning")
 
+    async def _outline_hierarchy_integrity_issues(self, project_id: str) -> list[dict]:
+        rows = await self.db.fetchall(
+            """SELECT u.manuscript_id, u.id AS unit_id, u.local_key,
+                      u.status, u.sequence, p.outline_level,
+                      p.parent_unit_id, parent.local_key AS parent_unit_key
+               FROM manuscript_units AS u
+               LEFT JOIN manuscript_unit_outline_profiles AS p
+                 ON p.unit_id = u.id
+                AND p.manuscript_id = u.manuscript_id
+                AND p.project_id = u.project_id
+               LEFT JOIN manuscript_units AS parent
+                 ON parent.id = p.parent_unit_id
+                AND parent.manuscript_id = p.manuscript_id
+                AND parent.project_id = p.project_id
+               WHERE u.project_id = ?
+               ORDER BY u.manuscript_id, u.sequence, u.local_key, u.id""",
+            [project_id],
+        )
+        by_manuscript: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            parent_key = row.get("parent_unit_key")
+            if row.get("parent_unit_id") and parent_key is None:
+                # Preserve the declared reference so a database created with
+                # foreign-key checks disabled still fails closed here.
+                parent_key = f"__missing_parent__:{row['parent_unit_id']}"
+            by_manuscript.setdefault(str(row["manuscript_id"]), []).append(
+                {
+                    "local_key": str(row["local_key"]),
+                    "status": str(row.get("status") or "planned"),
+                    "sequence": int(row.get("sequence") or 0),
+                    "outline_level": int(row.get("outline_level") or 4),
+                    "parent_unit_key": parent_key,
+                }
+            )
+
+        failures: list[dict[str, str]] = []
+        for manuscript_id, units in by_manuscript.items():
+            try:
+                validate_unit_hierarchy(units)
+            except ValueError as exc:
+                failures.append({"manuscript_id": manuscript_id, "reason": str(exc)})
+                if len(failures) >= 50:
+                    break
+        if not failures:
+            return []
+        category = "outline_hierarchy_invalid"
+        return [
+            {
+                "category": category,
+                "severity": self._severity_for(category),
+                "count": len(failures),
+                "ids": [item["manuscript_id"] for item in failures[:10]],
+                "description": "manuscript outlines that violate the canonical hierarchy",
+                "failures": failures[:10],
+                "fix_action": (
+                    "Repair parent/depth/order relationships through a reviewed spine edit"
+                ),
+            }
+        ]
+
     async def check_integrity(self, project_id: str | None = None) -> list[dict]:
         """Verify knowledge base integrity — check for orphaned edges, missing refs, count mismatches.
 
@@ -2167,6 +2286,7 @@ class KnowledgePackService(BaseService):
         """
         pid = project_id or self.project_id
         issues: list[dict] = []
+        issues.extend(await self._outline_hierarchy_integrity_issues(pid))
 
         source_exists = self._typed_entity_link_endpoint_sql(
             type_column="source_type", id_column="source_id"
@@ -2877,7 +2997,7 @@ class KnowledgePackService(BaseService):
             f"""SELECT binding.id
                 FROM manuscript_planning_evidence_bindings AS binding
                 WHERE binding.project_id = ?
-                  AND NOT ({' OR '.join(binding_clauses)})
+                  AND NOT ({" OR ".join(binding_clauses)})
                 LIMIT 50""",
             [pid],
         )

--- a/rka/services/manuscript_native.py
+++ b/rka/services/manuscript_native.py
@@ -29,6 +29,7 @@ from rka.models.manuscript_native import (
 )
 from rka.services.base import BaseService, _now
 from rka.services.claims import ClaimService
+from rka.services.outline_integrity import validate_unit_hierarchy
 
 
 def _normalized_reference_doi(value: Any) -> str | None:
@@ -349,14 +350,17 @@ class NativeManuscriptService(BaseService):
 
         async with self.db.transaction():
             await self._assert_revision(canonical_id, expected_revision)
-            claim_versions = await self._upsert_claims(canonical_id, claims)
-            unit_ids = await self._upsert_units(canonical_id, units)
-            await self._replace_claim_unit_bindings(
+            claim_versions, claims_changed = await self._upsert_claims(canonical_id, claims)
+            unit_ids, units_changed = await self._upsert_units(canonical_id, units)
+            bindings_changed = await self._replace_claim_unit_bindings(
                 canonical_id,
                 claims,
                 claim_versions=claim_versions,
                 unit_ids=unit_ids,
             )
+            changed = claims_changed or units_changed or bindings_changed
+            if not changed:
+                return await self.get_context(canonical_id)
             await self._invalidate_resolved_checkpoints(
                 canonical_id,
                 kinds={
@@ -2453,89 +2457,7 @@ class NativeManuscriptService(BaseService):
 
     @staticmethod
     def _validate_unit_hierarchy(units: list[dict[str, Any]]) -> None:
-        by_key = {unit["local_key"]: unit for unit in units}
-        for unit in units:
-            parent_key = unit.get("parent_unit_key")
-            if parent_key is None:
-                continue
-            parent = by_key.get(parent_key)
-            if parent is None:
-                raise ValueError(
-                    f"unit {unit['local_key']} references unknown parent {parent_key!r}"
-                )
-            if parent_key == unit["local_key"]:
-                raise ValueError("outline unit cannot be its own parent")
-            if parent.get("status") == "removed" and unit.get("status") != "removed":
-                raise ValueError(f"active unit {unit['local_key']} cannot have a removed parent")
-
-        # Detect graph cycles independently of level validation so malformed
-        # imports receive the precise failure instead of an incidental depth
-        # error from whichever edge happens to be visited first.
-        for unit in units:
-            seen = {unit["local_key"]}
-            cursor = unit
-            while cursor.get("parent_unit_key") is not None:
-                key = str(cursor["parent_unit_key"])
-                if key in seen:
-                    raise ValueError("outline hierarchy contains a cycle")
-                if key not in by_key:
-                    raise ValueError(
-                        f"unit {cursor['local_key']} references unknown parent {key!r}"
-                    )
-                seen.add(key)
-                cursor = by_key[key]
-
-        for unit in units:
-            parent_key = unit.get("parent_unit_key")
-            if parent_key is None:
-                continue
-            parent = by_key[str(parent_key)]
-            if int(parent["outline_level"]) >= int(unit["outline_level"]):
-                raise ValueError(
-                    f"parent {parent_key} must be at a shallower outline depth than "
-                    f"child {unit['local_key']}"
-                )
-
-        active_with_index = [
-            (index, unit)
-            for index, unit in enumerate(units)
-            if unit.get("status") != "removed"
-        ]
-        active = [
-            unit
-            for _index, unit in sorted(
-                active_with_index,
-                key=lambda item: (int(item[1]["sequence"]), item[0]),
-            )
-        ]
-        positions = {unit["local_key"]: index for index, unit in enumerate(active)}
-        active_parents = {
-            unit["local_key"]: unit.get("parent_unit_key") for unit in active
-        }
-
-        def descendants(root: str) -> set[str]:
-            found: set[str] = set()
-            frontier = [root]
-            while frontier:
-                current = frontier.pop()
-                for child, parent in active_parents.items():
-                    if parent == current and child not in found:
-                        found.add(child)
-                        frontier.append(child)
-            return found
-
-        for key, parent_key in active_parents.items():
-            if parent_key is not None and positions[parent_key] >= positions[key]:
-                raise ValueError(
-                    f"outline order must place parent {parent_key!r} before child {key!r}"
-                )
-        for key in positions:
-            nested = descendants(key)
-            if not nested:
-                continue
-            occupied = {positions[key], *(positions[item] for item in nested)}
-            if max(occupied) - min(occupied) + 1 != len(occupied):
-                raise ValueError(f"outline order must keep subtree {key!r} contiguous")
+        validate_unit_hierarchy(units)
 
     @staticmethod
     def _id_list(value: Any, name: str) -> list[str]:
@@ -2560,7 +2482,7 @@ class NativeManuscriptService(BaseService):
         self,
         manuscript_id: str,
         claims: list[dict[str, Any]],
-    ) -> dict[str, tuple[str, int]]:
+    ) -> tuple[dict[str, tuple[str, int]], bool]:
         existing_rows = await self.db.fetchall(
             """SELECT * FROM manuscript_claims
                WHERE manuscript_id = ? AND project_id = ?""",
@@ -2569,6 +2491,7 @@ class NativeManuscriptService(BaseService):
         existing = {row["local_key"]: row for row in existing_rows}
         seen: set[str] = set()
         result: dict[str, tuple[str, int]] = {}
+        changed = False
         for spec in claims:
             local_key = spec["local_key"]
             seen.add(local_key)
@@ -2589,24 +2512,27 @@ class NativeManuscriptService(BaseService):
                     ],
                 )
                 previous_version = 0
+                changed = True
             else:
                 claim_id = row["id"]
                 if row["kind"] != spec["kind"]:
                     raise ValueError(
                         f"claim {local_key} kind is immutable; retire it and create a new local_key"
                     )
-                await self.db.execute(
-                    """UPDATE manuscript_claims
-                       SET state = ?, updated_at = ?
-                       WHERE id = ? AND manuscript_id = ? AND project_id = ?""",
-                    [
-                        spec["state"],
-                        _now(),
-                        claim_id,
-                        manuscript_id,
-                        self.project_id,
-                    ],
-                )
+                if row["state"] != spec["state"]:
+                    await self.db.execute(
+                        """UPDATE manuscript_claims
+                           SET state = ?, updated_at = ?
+                           WHERE id = ? AND manuscript_id = ? AND project_id = ?""",
+                        [
+                            spec["state"],
+                            _now(),
+                            claim_id,
+                            manuscript_id,
+                            self.project_id,
+                        ],
+                    )
+                    changed = True
                 previous_version = await self._latest_claim_version(claim_id) or 0
 
             latest = None
@@ -2640,7 +2566,14 @@ class NativeManuscriptService(BaseService):
                         json.dumps(spec["prohibited_wording"], sort_keys=True),
                     ],
                 )
-            await self._replace_claim_evidence(manuscript_id, claim_id, version, spec["evidence"])
+                changed = True
+            evidence_changed = await self._replace_claim_evidence(
+                manuscript_id,
+                claim_id,
+                version,
+                spec["evidence"],
+            )
+            changed = changed or evidence_changed
             result[local_key] = (claim_id, version)
 
         for local_key, row in existing.items():
@@ -2651,21 +2584,29 @@ class NativeManuscriptService(BaseService):
                        WHERE id = ? AND project_id = ?""",
                     [_now(), row["id"], self.project_id],
                 )
-        return result
+                changed = True
+        return result, changed
 
     async def _upsert_units(
         self,
         manuscript_id: str,
         units: list[dict[str, Any]],
-    ) -> dict[str, str]:
+    ) -> tuple[dict[str, str], bool]:
         existing_rows = await self.db.fetchall(
             """SELECT * FROM manuscript_units
                WHERE manuscript_id = ? AND project_id = ?""",
             [manuscript_id, self.project_id],
         )
         existing = {row["local_key"]: row for row in existing_rows}
+        profile_rows = await self.db.fetchall(
+            """SELECT * FROM manuscript_unit_outline_profiles
+               WHERE manuscript_id = ? AND project_id = ?""",
+            [manuscript_id, self.project_id],
+        )
+        profiles = {row["unit_id"]: row for row in profile_rows}
         seen: set[str] = set()
         result: dict[str, str] = {}
+        changed = False
         for spec in units:
             local_key = spec["local_key"]
             seen.add(local_key)
@@ -2696,32 +2637,80 @@ class NativeManuscriptService(BaseService):
                         *fields,
                     ],
                 )
+                changed = True
             else:
                 unit_id = row["id"]
-                await self.db.execute(
-                    """UPDATE manuscript_units
-                       SET kind = ?, location = ?, title = ?, artifact_ref = ?,
-                           allowed_interpretation = ?,
-                           prohibited_interpretation = ?, sequence = ?,
-                           status = ?, updated_at = ?
-                       WHERE id = ? AND manuscript_id = ? AND project_id = ?""",
-                    [
-                        *fields,
-                        _now(),
-                        unit_id,
-                        manuscript_id,
-                        self.project_id,
-                    ],
-                )
-            await self._replace_unit_evidence(manuscript_id, unit_id, spec["evidence"])
+                current_fields = [
+                    row["kind"],
+                    row["location"],
+                    row.get("title"),
+                    row.get("artifact_ref"),
+                    row.get("allowed_interpretation"),
+                    row.get("prohibited_interpretation"),
+                    int(row["sequence"]),
+                    row["status"],
+                ]
+                if current_fields != fields:
+                    await self.db.execute(
+                        """UPDATE manuscript_units
+                           SET kind = ?, location = ?, title = ?, artifact_ref = ?,
+                               allowed_interpretation = ?,
+                               prohibited_interpretation = ?, sequence = ?,
+                               status = ?, updated_at = ?
+                           WHERE id = ? AND manuscript_id = ? AND project_id = ?""",
+                        [
+                            *fields,
+                            _now(),
+                            unit_id,
+                            manuscript_id,
+                            self.project_id,
+                        ],
+                    )
+                    changed = True
+            evidence_changed = await self._replace_unit_evidence(
+                manuscript_id,
+                unit_id,
+                spec["evidence"],
+            )
+            changed = changed or evidence_changed
             result[local_key] = unit_id
 
         for spec in units:
             unit_id = result[spec["local_key"]]
             parent_key = spec.get("parent_unit_key")
             parent_id = result.get(parent_key) if parent_key else None
-            await self.db.execute(
-                """INSERT INTO manuscript_unit_outline_profiles
+            profile_values = [
+                parent_id,
+                spec["outline_level"],
+                spec["communicative_job"],
+                spec["intended_takeaway"],
+                spec["transition_from_previous"],
+                spec["quick_reader_role"],
+                spec["evidence_plan"],
+                spec["figure_intentions"],
+                spec["table_intentions"],
+                spec["citation_intentions"],
+                spec["blocker"],
+            ]
+            profile = profiles.get(unit_id)
+            current_profile_values = None
+            if profile is not None:
+                current_profile_values = [
+                    profile.get("parent_unit_id"),
+                    int(profile["outline_level"]),
+                    profile.get("communicative_job"),
+                    profile.get("intended_takeaway"),
+                    profile.get("transition_from_previous"),
+                    profile.get("quick_reader_role"),
+                    self._json_loads(profile.get("evidence_plan"), []),
+                    self._json_loads(profile.get("figure_intentions"), []),
+                    self._json_loads(profile.get("table_intentions"), []),
+                    self._json_loads(profile.get("citation_intentions"), []),
+                    profile.get("blocker"),
+                ]
+            if current_profile_values != profile_values:
+                await self.db.execute(
+                    """INSERT INTO manuscript_unit_outline_profiles
                    (unit_id, manuscript_id, project_id, parent_unit_id,
                     outline_level, communicative_job, intended_takeaway,
                     transition_from_previous, quick_reader_role, evidence_plan,
@@ -2741,24 +2730,25 @@ class NativeManuscriptService(BaseService):
                      citation_intentions = excluded.citation_intentions,
                      blocker = excluded.blocker,
                      updated_at = ?""",
-                [
-                    unit_id,
-                    manuscript_id,
-                    self.project_id,
-                    parent_id,
-                    spec["outline_level"],
-                    spec["communicative_job"],
-                    spec["intended_takeaway"],
-                    spec["transition_from_previous"],
-                    spec["quick_reader_role"],
-                    json.dumps(spec["evidence_plan"], sort_keys=True),
-                    json.dumps(spec["figure_intentions"], sort_keys=True),
-                    json.dumps(spec["table_intentions"], sort_keys=True),
-                    json.dumps(spec["citation_intentions"], sort_keys=True),
-                    spec["blocker"],
-                    _now(),
-                ],
-            )
+                    [
+                        unit_id,
+                        manuscript_id,
+                        self.project_id,
+                        parent_id,
+                        spec["outline_level"],
+                        spec["communicative_job"],
+                        spec["intended_takeaway"],
+                        spec["transition_from_previous"],
+                        spec["quick_reader_role"],
+                        json.dumps(spec["evidence_plan"], sort_keys=True),
+                        json.dumps(spec["figure_intentions"], sort_keys=True),
+                        json.dumps(spec["table_intentions"], sort_keys=True),
+                        json.dumps(spec["citation_intentions"], sort_keys=True),
+                        spec["blocker"],
+                        _now(),
+                    ],
+                )
+                changed = True
 
         for local_key, row in existing.items():
             if local_key not in seen and row["status"] != "removed":
@@ -2768,7 +2758,8 @@ class NativeManuscriptService(BaseService):
                        WHERE id = ? AND project_id = ?""",
                     [_now(), row["id"], self.project_id],
                 )
-        return result
+                changed = True
+        return result, changed
 
     async def _replace_claim_evidence(
         self,
@@ -2776,7 +2767,24 @@ class NativeManuscriptService(BaseService):
         claim_id: str,
         version: int,
         evidence: Mapping[str, list[str]],
-    ) -> None:
+    ) -> bool:
+        desired = [
+            (role, evidence_id, ordinal)
+            for role in ("support", "qualifier", "counterevidence")
+            for ordinal, evidence_id in enumerate(evidence[role])
+        ]
+        rows = await self.db.fetchall(
+            """SELECT role, evidence_claim_id, ordinal
+               FROM manuscript_claim_evidence
+               WHERE manuscript_claim_id = ? AND claim_version = ?
+                 AND project_id = ?""",
+            [claim_id, version, self.project_id],
+        )
+        existing = sorted(
+            (str(row["role"]), str(row["evidence_claim_id"]), int(row["ordinal"])) for row in rows
+        )
+        if existing == sorted(desired):
+            return False
         await self.db.execute(
             """DELETE FROM manuscript_claim_evidence
                WHERE manuscript_claim_id = ? AND claim_version = ?
@@ -2800,13 +2808,30 @@ class NativeManuscriptService(BaseService):
                         ordinal,
                     ],
                 )
+        return True
 
     async def _replace_unit_evidence(
         self,
         manuscript_id: str,
         unit_id: str,
         evidence: Mapping[str, list[str]],
-    ) -> None:
+    ) -> bool:
+        desired = [
+            (role, evidence_id, ordinal)
+            for role in ("support", "qualifier", "counterevidence")
+            for ordinal, evidence_id in enumerate(evidence[role])
+        ]
+        rows = await self.db.fetchall(
+            """SELECT role, evidence_claim_id, ordinal
+               FROM manuscript_unit_evidence
+               WHERE unit_id = ? AND project_id = ?""",
+            [unit_id, self.project_id],
+        )
+        existing = sorted(
+            (str(row["role"]), str(row["evidence_claim_id"]), int(row["ordinal"])) for row in rows
+        )
+        if existing == sorted(desired):
+            return False
         await self.db.execute(
             """DELETE FROM manuscript_unit_evidence
                WHERE unit_id = ? AND project_id = ?""",
@@ -2828,6 +2853,7 @@ class NativeManuscriptService(BaseService):
                         ordinal,
                     ],
                 )
+        return True
 
     async def _replace_claim_unit_bindings(
         self,
@@ -2836,15 +2862,11 @@ class NativeManuscriptService(BaseService):
         *,
         claim_versions: Mapping[str, tuple[str, int]],
         unit_ids: Mapping[str, str],
-    ) -> None:
+    ) -> bool:
+        changed = False
         for spec in claims:
             claim_id, version = claim_versions[spec["local_key"]]
-            await self.db.execute(
-                """DELETE FROM manuscript_claim_units
-                   WHERE manuscript_claim_id = ? AND claim_version = ?
-                     AND project_id = ?""",
-                [claim_id, version, self.project_id],
-            )
+            desired = []
             for link in spec["unit_links"]:
                 unit_key = str(link.get("unit_key") or "").strip()
                 relationship = str(link.get("relationship") or "").strip()
@@ -2854,6 +2876,24 @@ class NativeManuscriptService(BaseService):
                     )
                 if relationship not in {"advances", "tests", "bounds", "mentions"}:
                     raise ValueError(f"claim {spec['local_key']} has invalid unit relationship")
+                desired.append((unit_ids[unit_key], relationship))
+            rows = await self.db.fetchall(
+                """SELECT unit_id, relationship
+                   FROM manuscript_claim_units
+                   WHERE manuscript_claim_id = ? AND claim_version = ?
+                     AND project_id = ?""",
+                [claim_id, version, self.project_id],
+            )
+            existing = sorted((str(row["unit_id"]), str(row["relationship"])) for row in rows)
+            if existing == sorted(desired):
+                continue
+            await self.db.execute(
+                """DELETE FROM manuscript_claim_units
+                   WHERE manuscript_claim_id = ? AND claim_version = ?
+                     AND project_id = ?""",
+                [claim_id, version, self.project_id],
+            )
+            for unit_id, relationship in desired:
                 await self.db.execute(
                     """INSERT INTO manuscript_claim_units
                        (manuscript_id, project_id, manuscript_claim_id,
@@ -2864,10 +2904,12 @@ class NativeManuscriptService(BaseService):
                         self.project_id,
                         claim_id,
                         version,
-                        unit_ids[unit_key],
+                        unit_id,
                         relationship,
                     ],
                 )
+            changed = True
+        return changed
 
     async def _find_claim(
         self,

--- a/rka/services/outline.py
+++ b/rka/services/outline.py
@@ -78,6 +78,7 @@ class ManuscriptOutlineService(BaseService):
             checkpoint for checkpoint in context["checkpoints"] if checkpoint["kind"] == "outline"
         ]
         latest_checkpoint = checkpoints[-1] if checkpoints else None
+        rationale_complete = bool(projected) and blocker_count == 0
         return {
             "schema_version": "rka.manuscript-outline/v1",
             "project_id": self.project_id,
@@ -90,12 +91,16 @@ class ManuscriptOutlineService(BaseService):
                 "complete_units": len(projected) - blocker_count,
                 "units_needing_review": blocker_count,
                 "levels": sorted({unit["outline_level"] for unit in projected}),
-                "checkpoint_ready": bool(projected) and blocker_count == 0,
+                "rationale_complete": rationale_complete,
+                # Compatibility alias. This field never represented checkpoint
+                # state; clients should migrate to rationale_complete.
+                "checkpoint_ready": rationale_complete,
             },
             "policy": {
                 "canonical_unit_identity": "mun_",
                 "mutation": "semantic_patch_then_explicit_apply",
                 "checkpoint_resolution": "explicit_pi_decision",
+                "deprecated_fields": {"summary.checkpoint_ready": "summary.rationale_complete"},
                 "file_writes": False,
             },
         }
@@ -137,9 +142,7 @@ class ManuscriptOutlineService(BaseService):
                 "and matching context manifest"
             )
         created_by = actor
-        proposal = await SemanticPatchService(
-            self.db, project_id=self.project_id
-        ).create_proposal(
+        proposal = await SemanticPatchService(self.db, project_id=self.project_id).create_proposal(
             SemanticPatchProposalCreate(
                 origin=data.origin,
                 intent=f"{data.action.capitalize()} the progressive manuscript outline.",
@@ -208,7 +211,8 @@ class ManuscriptOutlineService(BaseService):
         parent_claims: dict[str, list[dict[str, Any]]] = {}
         for claim in claims:
             links = [
-                link for link in claim.get("unit_links", [])
+                link
+                for link in claim.get("unit_links", [])
                 if (link.get("unit_key") or link.get("unit_id")) == parent["unit_id"]
             ]
             if links:
@@ -223,7 +227,9 @@ class ManuscriptOutlineService(BaseService):
         for child in data.children:
             selected_claims = set(child.claim_keys or parent_claims)
             if not selected_claims <= set(parent_claims):
-                raise ValueError("expanded child claim_keys must be a subset of the parent bindings")
+                raise ValueError(
+                    "expanded child claim_keys must be a subset of the parent bindings"
+                )
             selected_evidence: dict[str, list[str]] = {}
             for field in ("support_ids", "qualifier_ids", "counterevidence_ids"):
                 requested = getattr(child, field)
@@ -237,7 +243,8 @@ class ManuscriptOutlineService(BaseService):
                 **{
                     key: value
                     for key, value in parent.items()
-                    if key not in {
+                    if key
+                    not in {
                         "rka_manuscript_unit_id",
                         "evidence",
                         "evidence_ids",
@@ -283,7 +290,7 @@ class ManuscriptOutlineService(BaseService):
                     )
 
         parent_index = units.index(parent)
-        units[parent_index + 1:parent_index + 1] = inserted
+        units[parent_index + 1 : parent_index + 1] = inserted
         return {
             "action": "expand",
             "affected_unit_keys": [parent["unit_id"], *child_keys],
@@ -327,17 +334,28 @@ class ManuscriptOutlineService(BaseService):
             parent[evidence_field] = sorted(
                 {
                     *(parent.get(evidence_field) or []),
-                    *(value for unit in selected.values() for value in unit.get(evidence_field) or []),
+                    *(
+                        value
+                        for unit in selected.values()
+                        for value in unit.get(evidence_field) or []
+                    ),
                 }
             )
         for plan_field in (
-            "evidence_plan", "figure_intentions", "table_intentions", "citation_intentions"
+            "evidence_plan",
+            "figure_intentions",
+            "table_intentions",
+            "citation_intentions",
         ):
             parent[plan_field] = list(
                 dict.fromkeys(
                     [
                         *(parent.get(plan_field) or []),
-                        *(value for unit in selected.values() for value in unit.get(plan_field) or []),
+                        *(
+                            value
+                            for unit in selected.values()
+                            for value in unit.get(plan_field) or []
+                        ),
                     ]
                 )
             )
@@ -345,7 +363,8 @@ class ManuscriptOutlineService(BaseService):
         for claim in claims:
             links = claim.setdefault("unit_links", [])
             inherited = [
-                link for link in links
+                link
+                for link in links
                 if (link.get("unit_key") or link.get("unit_id")) in selected_keys
             ]
             parent_relationships = {
@@ -354,12 +373,12 @@ class ManuscriptOutlineService(BaseService):
                 if (link.get("unit_key") or link.get("unit_id")) == parent["unit_id"]
             }
             for relationship in sorted(
-                {link.get("relationship", "advances") for link in inherited}
-                - parent_relationships
+                {link.get("relationship", "advances") for link in inherited} - parent_relationships
             ):
                 links.append({"unit_key": parent["unit_id"], "relationship": relationship})
             claim["unit_links"] = [
-                link for link in links
+                link
+                for link in links
                 if (link.get("unit_key") or link.get("unit_id")) not in selected_keys
             ]
         for unit in selected.values():
@@ -372,9 +391,7 @@ class ManuscriptOutlineService(BaseService):
             "parent_retained": True,
         }
 
-    def _reorder(
-        self, units: list[dict[str, Any]], data: OutlineProposalRequest
-    ) -> dict[str, Any]:
+    def _reorder(self, units: list[dict[str, Any]], data: OutlineProposalRequest) -> dict[str, Any]:
         active = [unit for unit in units if unit.get("status") != "removed"]
         active_keys = [str(unit["unit_id"]) for unit in active]
         if len(data.ordered_unit_keys) != len(set(data.ordered_unit_keys)):
@@ -386,8 +403,7 @@ class ManuscriptOutlineService(BaseService):
                 f"reorder requires the exact active unit set; missing={missing}, unknown={unknown}"
             )
         old_predecessor = {
-            key: active_keys[index - 1] if index else None
-            for index, key in enumerate(active_keys)
+            key: active_keys[index - 1] if index else None for index, key in enumerate(active_keys)
         }
         by_key = self._unit_map(units)
         reordered = [by_key[key] for key in data.ordered_unit_keys]
@@ -395,7 +411,8 @@ class ManuscriptOutlineService(BaseService):
         removed = [unit for unit in units if unit.get("status") == "removed"]
         units[:] = [*reordered, *removed]
         changed = [
-            key for index, key in enumerate(data.ordered_unit_keys)
+            key
+            for index, key in enumerate(data.ordered_unit_keys)
             if old_predecessor[key] != (data.ordered_unit_keys[index - 1] if index else None)
         ]
         return {

--- a/rka/services/outline_integrity.py
+++ b/rka/services/outline_integrity.py
@@ -1,0 +1,87 @@
+"""Pure hierarchy validation shared by manuscript writes and pack imports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def validate_unit_hierarchy(units: list[dict[str, Any]]) -> None:
+    """Validate one manuscript's canonical flat-tree representation.
+
+    ``local_key`` is the stable node key, ``parent_unit_key`` names another
+    node, and ``sequence`` stores the depth-first flat order. Removed nodes may
+    remain for provenance but cannot parent active nodes.
+    """
+
+    by_key = {unit["local_key"]: unit for unit in units}
+    for unit in units:
+        parent_key = unit.get("parent_unit_key")
+        if parent_key is None:
+            continue
+        parent = by_key.get(parent_key)
+        if parent is None:
+            raise ValueError(f"unit {unit['local_key']} references unknown parent {parent_key!r}")
+        if parent_key == unit["local_key"]:
+            raise ValueError("outline unit cannot be its own parent")
+        if parent.get("status") == "removed" and unit.get("status") != "removed":
+            raise ValueError(f"active unit {unit['local_key']} cannot have a removed parent")
+
+    # Report cycles independently of depth so a corrupt import receives the
+    # causal failure instead of an incidental level error.
+    for unit in units:
+        seen = {unit["local_key"]}
+        cursor = unit
+        while cursor.get("parent_unit_key") is not None:
+            key = str(cursor["parent_unit_key"])
+            if key in seen:
+                raise ValueError("outline hierarchy contains a cycle")
+            if key not in by_key:
+                raise ValueError(f"unit {cursor['local_key']} references unknown parent {key!r}")
+            seen.add(key)
+            cursor = by_key[key]
+
+    for unit in units:
+        parent_key = unit.get("parent_unit_key")
+        if parent_key is None:
+            continue
+        parent = by_key[str(parent_key)]
+        if int(parent["outline_level"]) >= int(unit["outline_level"]):
+            raise ValueError(
+                f"parent {parent_key} must be at a shallower outline depth than "
+                f"child {unit['local_key']}"
+            )
+
+    active_with_index = [
+        (index, unit) for index, unit in enumerate(units) if unit.get("status") != "removed"
+    ]
+    active = [
+        unit
+        for _index, unit in sorted(
+            active_with_index,
+            key=lambda item: (int(item[1]["sequence"]), item[0]),
+        )
+    ]
+    positions = {unit["local_key"]: index for index, unit in enumerate(active)}
+    active_parents = {unit["local_key"]: unit.get("parent_unit_key") for unit in active}
+
+    def descendants(root: str) -> set[str]:
+        found: set[str] = set()
+        frontier = [root]
+        while frontier:
+            current = frontier.pop()
+            for child, parent in active_parents.items():
+                if parent == current and child not in found:
+                    found.add(child)
+                    frontier.append(child)
+        return found
+
+    for key, parent_key in active_parents.items():
+        if parent_key is not None and positions[parent_key] >= positions[key]:
+            raise ValueError(f"outline order must place parent {parent_key!r} before child {key!r}")
+    for key in positions:
+        nested = descendants(key)
+        if not nested:
+            continue
+        occupied = {positions[key], *(positions[item] for item in nested)}
+        if max(occupied) - min(occupied) + 1 != len(occupied):
+            raise ValueError(f"outline order must keep subtree {key!r} contiguous")

--- a/rka/services/semantic_patch.py
+++ b/rka/services/semantic_patch.py
@@ -28,9 +28,7 @@ from rka.services.planning import ManuscriptPlanningService
 SEMANTIC_PATCH_SCHEMA_VERSION = "rka.semantic-patch/v1"
 CONTEXT_MANIFEST_SCHEMA_VERSION = "rka.context-manifest/v1"
 _OPERATION_ADAPTER = TypeAdapter(SemanticPatchOperation)
-_PROPOSAL_STATUSES = {
-    "proposed", "applied", "rejected", "conflicted", "superseded", "expired"
-}
+_PROPOSAL_STATUSES = {"proposed", "applied", "rejected", "conflicted", "superseded", "expired"}
 
 
 class SemanticPatchNotFoundError(ValueError):
@@ -64,9 +62,13 @@ def _semantic_diff(before: Any, after: Any, path: str = "") -> list[dict[str, An
         for key in sorted(set(before) | set(after)):
             child = f"{path}/{key}"
             if key not in before:
-                changes.append({"path": child, "change": "added", "before": None, "after": after[key]})
+                changes.append(
+                    {"path": child, "change": "added", "before": None, "after": after[key]}
+                )
             elif key not in after:
-                changes.append({"path": child, "change": "removed", "before": before[key], "after": None})
+                changes.append(
+                    {"path": child, "change": "removed", "before": before[key], "after": None}
+                )
             else:
                 changes.extend(_semantic_diff(before[key], after[key], child))
         return changes
@@ -101,9 +103,7 @@ def _semantic_diff(before: Any, after: Any, path: str = "") -> list[dict[str, An
                         }
                     )
                 else:
-                    changes.extend(
-                        _semantic_diff(before_items[key], after_items[key], child)
-                    )
+                    changes.extend(_semantic_diff(before_items[key], after_items[key], child))
             return changes
     return [{"path": path or "/", "change": "changed", "before": before, "after": after}]
 
@@ -274,7 +274,9 @@ class SemanticPatchService(BaseService):
                     or manifest["model"] != data.model
                     or manifest["boundary"] != data.boundary
                 ):
-                    raise ValueError("proposal provider boundary does not match its context manifest")
+                    raise ValueError(
+                        "proposal provider boundary does not match its context manifest"
+                    )
                 self._validate_ai_manifest_scope(
                     manifest=manifest,
                     operations=data.operations,
@@ -596,13 +598,14 @@ class SemanticPatchService(BaseService):
                 raise SemanticPatchConflictError("planning artifact version is already stale")
             stored_before = artifact["version"] if artifact else None
             before = self._planning_semantic_snapshot(stored_before)
-            after = self._planning_semantic_snapshot(
-                operation.append.model_dump(mode="json")
-            )
+            after = self._planning_semantic_snapshot(operation.append.model_dump(mode="json"))
             base = {
-                "target": {"type": "planning_artifact", "branch_id": operation.branch_id,
-                           "stage_type": operation.append.stage_type,
-                           "local_key": operation.append.local_key},
+                "target": {
+                    "type": "planning_artifact",
+                    "branch_id": operation.branch_id,
+                    "stage_type": operation.append.stage_type,
+                    "local_key": operation.append.local_key,
+                },
                 "branch_revision": int(branch["revision"]),
                 "artifact_version": previous_version,
                 "fingerprint": _hash(stored_before),
@@ -814,9 +817,13 @@ class SemanticPatchService(BaseService):
         if not claim_ids:
             return
         packet = await EntityResolverService(self.db).resolve_entities(self.project_id, claim_ids)
-        unresolved = [entity_id for entity_id in claim_ids if not packet["entities"][entity_id]["found"]]
+        unresolved = [
+            entity_id for entity_id in claim_ids if not packet["entities"][entity_id]["found"]
+        ]
         if unresolved:
-            raise ValueError("spine references unavailable evidence claims: " + ", ".join(unresolved))
+            raise ValueError(
+                "spine references unavailable evidence claims: " + ", ".join(unresolved)
+            )
 
     @staticmethod
     def _spine_findings(before: dict[str, Any], after: dict[str, Any]) -> list[dict[str, Any]]:
@@ -832,38 +839,80 @@ class SemanticPatchService(BaseService):
             for old_field, new_field, code in checks:
                 removed = sorted(set(left.get(old_field) or []) - set(right["evidence"][new_field]))
                 if removed:
-                    findings.append({
-                        "severity": "warning", "code": code,
-                        "message": f"claim {key} removes {len(removed)} {new_field} binding(s)",
-                        "claim_key": key, "entity_ids": removed,
-                    })
+                    findings.append(
+                        {
+                            "severity": "warning",
+                            "code": code,
+                            "message": f"claim {key} removes {len(removed)} {new_field} binding(s)",
+                            "claim_key": key,
+                            "entity_ids": removed,
+                        }
+                    )
             removed_wording = sorted(
                 set(left.get("prohibited_wording") or []) - set(right["prohibited_wording"])
             )
             if removed_wording:
-                findings.append({
-                    "severity": "warning", "code": "PROHIBITED_WORDING_REMOVED",
-                    "message": f"claim {key} removes wording boundaries",
-                    "claim_key": key, "removed": removed_wording,
-                })
+                findings.append(
+                    {
+                        "severity": "warning",
+                        "code": "PROHIBITED_WORDING_REMOVED",
+                        "message": f"claim {key} removes wording boundaries",
+                        "claim_key": key,
+                        "removed": removed_wording,
+                    }
+                )
             if left.get("allowed_wording") != right.get("allowed_wording"):
-                findings.append({
-                    "severity": "warning", "code": "ALLOWED_WORDING_CHANGED",
-                    "message": f"claim {key} changes its allowed-wording boundary",
-                    "claim_key": key,
-                })
+                findings.append(
+                    {
+                        "severity": "warning",
+                        "code": "ALLOWED_WORDING_CHANGED",
+                        "message": f"claim {key} changes its allowed-wording boundary",
+                        "claim_key": key,
+                    }
+                )
             if left.get("ratified_by") and left.get("text") != right.get("exact_wording"):
-                findings.append({
-                    "severity": "warning", "code": "RATIFIED_WORDING_CHANGED",
-                    "message": (
-                        f"claim {key} has ratified wording; apply appends unratified wording "
-                        "and does not overwrite the ratification"
-                    ),
-                    "claim_key": key, "decision_id": left["ratified_by"],
-                })
+                findings.append(
+                    {
+                        "severity": "warning",
+                        "code": "RATIFIED_WORDING_CHANGED",
+                        "message": (
+                            f"claim {key} has ratified wording; apply appends unratified wording "
+                            "and does not overwrite the ratification"
+                        ),
+                        "claim_key": key,
+                        "decision_id": left["ratified_by"],
+                    }
+                )
         old_units = {item["unit_id"]: item for item in before.get("units", [])}
         new_units = {item["local_key"]: item for item in after.get("units", [])}
         reordered: list[str] = []
+        for key in sorted(set(new_units) - set(old_units)):
+            right = new_units[key]
+            parent_key = right.get("parent_unit_key")
+            parent = old_units.get(parent_key)
+            if parent is None:
+                continue
+            for old_field, role in (
+                ("evidence_ids", "support"),
+                ("qualifier_ids", "qualifier"),
+                ("counterevidence_ids", "counterevidence"),
+            ):
+                removed = sorted(set(parent.get(old_field) or []) - set(right["evidence"][role]))
+                if removed:
+                    findings.append(
+                        {
+                            "severity": "warning",
+                            "code": "INHERITED_UNIT_EVIDENCE_NARROWED",
+                            "message": (
+                                f"new unit {key} narrows {len(removed)} inherited "
+                                f"{role} binding(s) from {parent_key}"
+                            ),
+                            "unit_key": key,
+                            "parent_unit_key": parent_key,
+                            "role": role,
+                            "entity_ids": removed,
+                        }
+                    )
         for key in sorted(set(old_units) & set(new_units)):
             left, right = old_units[key], new_units[key]
             for old_field, role in (
@@ -871,37 +920,41 @@ class SemanticPatchService(BaseService):
                 ("qualifier_ids", "qualifier"),
                 ("counterevidence_ids", "counterevidence"),
             ):
-                removed = sorted(
-                    set(left.get(old_field) or []) - set(right["evidence"][role])
-                )
+                removed = sorted(set(left.get(old_field) or []) - set(right["evidence"][role]))
                 if removed:
-                    findings.append({
-                        "severity": "warning",
-                        "code": "UNIT_EVIDENCE_BINDING_REMOVED",
-                        "message": f"unit {key} removes {len(removed)} {role} binding(s)",
-                        "unit_key": key,
-                        "role": role,
-                        "entity_ids": removed,
-                    })
+                    findings.append(
+                        {
+                            "severity": "warning",
+                            "code": "UNIT_EVIDENCE_BINDING_REMOVED",
+                            "message": f"unit {key} removes {len(removed)} {role} binding(s)",
+                            "unit_key": key,
+                            "role": role,
+                            "entity_ids": removed,
+                        }
+                    )
             if left.get("status") != "removed" and right.get("status") == "removed":
-                findings.append({
-                    "severity": "warning",
-                    "code": "OUTLINE_UNIT_REMOVED",
-                    "message": f"unit {key} will leave the active outline",
-                    "unit_key": key,
-                })
+                findings.append(
+                    {
+                        "severity": "warning",
+                        "code": "OUTLINE_UNIT_REMOVED",
+                        "message": f"unit {key} will leave the active outline",
+                        "unit_key": key,
+                    }
+                )
             if int(left.get("sequence", 0)) != int(right.get("sequence", 0)):
                 reordered.append(key)
         if reordered:
-            findings.append({
-                "severity": "warning",
-                "code": "OUTLINE_ORDER_CHANGED",
-                "message": (
-                    f"{len(reordered)} unit(s) change sequence; review transitions and "
-                    "quick-reader flow before apply"
-                ),
-                "unit_keys": reordered,
-            })
+            findings.append(
+                {
+                    "severity": "warning",
+                    "code": "OUTLINE_ORDER_CHANGED",
+                    "message": (
+                        f"{len(reordered)} unit(s) change sequence; review transitions and "
+                        "quick-reader flow before apply"
+                    ),
+                    "unit_keys": reordered,
+                }
+            )
         return findings
 
     async def _current_operation_base(self, operation: SemanticPatchOperation) -> dict[str, Any]:
@@ -909,16 +962,22 @@ class SemanticPatchService(BaseService):
             planning = ManuscriptPlanningService(self.db, project_id=self.project_id)
             context = await planning.get_branch(operation.branch_id)
             artifact = next(
-                (item for item in context["effective_artifacts"]
-                 if item["stage_type"] == operation.append.stage_type
-                 and item["local_key"] == operation.append.local_key),
+                (
+                    item
+                    for item in context["effective_artifacts"]
+                    if item["stage_type"] == operation.append.stage_type
+                    and item["local_key"] == operation.append.local_key
+                ),
                 None,
             )
             before = artifact["version"] if artifact else None
             return {
-                "target": {"type": "planning_artifact", "branch_id": operation.branch_id,
-                           "stage_type": operation.append.stage_type,
-                           "local_key": operation.append.local_key},
+                "target": {
+                    "type": "planning_artifact",
+                    "branch_id": operation.branch_id,
+                    "stage_type": operation.append.stage_type,
+                    "local_key": operation.append.local_key,
+                },
                 "branch_revision": int(context["branch"]["revision"]),
                 "artifact_version": int(artifact["version"]["version"]) if artifact else 0,
                 "fingerprint": _hash(before),
@@ -951,7 +1010,10 @@ class SemanticPatchService(BaseService):
             result = await ManuscriptPlanningService(
                 self.db, project_id=self.project_id
             ).append_artifact_version(operation.branch_id, operation.append)
-            return {"operation": operation.operation, "branch_revision": result["branch"]["revision"]}
+            return {
+                "operation": operation.operation,
+                "branch_revision": result["branch"]["revision"],
+            }
         manuscript = NativeManuscriptService(self.db, project_id=self.project_id)
         if isinstance(operation, ManuscriptMetadataUpdateOperation):
             fields = {
@@ -989,9 +1051,9 @@ class SemanticPatchService(BaseService):
                 "fingerprint": _hash(context),
                 "snapshot": context,
             }
-        context = await NativeManuscriptService(
-            self.db, project_id=self.project_id
-        ).get_context(target_id)
+        context = await NativeManuscriptService(self.db, project_id=self.project_id).get_context(
+            target_id
+        )
         return {
             "target": {"type": target_type, "id": target_id},
             "revision": int(context["manuscript"]["revision"]),
@@ -1038,14 +1100,27 @@ class SemanticPatchService(BaseService):
                    applied_at = CASE WHEN ? = 'applied' THEN ? ELSE applied_at END,
                    closed_at = ?
                WHERE id = ? AND project_id = ? AND status = ? AND revision = ?""",
-            [status, timestamp, status, timestamp, timestamp,
-             row["id"], self.project_id, row["status"], row["revision"]],
+            [
+                status,
+                timestamp,
+                status,
+                timestamp,
+                timestamp,
+                row["id"],
+                self.project_id,
+                row["status"],
+                row["revision"],
+            ],
         )
         if cursor.rowcount != 1:
             raise SemanticPatchConflictError("proposal changed concurrently")
         await self._insert_event(
-            str(row["id"]), revision=revision, action=status,
-            actor=actor, reason=reason, details=details,
+            str(row["id"]),
+            revision=revision,
+            action=status,
+            actor=actor,
+            reason=reason,
+            details=details,
         )
 
     async def _insert_event(
@@ -1062,6 +1137,14 @@ class SemanticPatchService(BaseService):
             """INSERT INTO semantic_patch_proposal_events
                (id, proposal_id, project_id, proposal_revision, action, actor, reason, details)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            [generate_id("semantic_patch_proposal_event"), proposal_id, self.project_id,
-             revision, action, actor, reason, _canonical_json(details)],
+            [
+                generate_id("semantic_patch_proposal_event"),
+                proposal_id,
+                self.project_id,
+                revision,
+                action,
+                actor,
+                reason,
+                _canonical_json(details),
+            ],
         )

--- a/tests/test_db/test_migration_030.py
+++ b/tests/test_db/test_migration_030.py
@@ -1,0 +1,84 @@
+"""Migration 030 preserves the agentic staleness-resolution contract."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rka.infra.database import Database
+
+
+_RESOLUTION_COLUMNS = {
+    "staleness_reviewed_at",
+    "staleness_verdict",
+    "staleness_resolution",
+    "staleness_resolution_journal_id",
+    "staleness_resolved_by",
+}
+
+
+@pytest.mark.asyncio
+async def test_fresh_schema_contains_staleness_resolution_columns(db) -> None:
+    for table in ("claims", "evidence_clusters"):
+        columns = {row["name"] for row in await db.fetchall(f"PRAGMA table_info({table})")}
+        assert _RESOLUTION_COLUMNS <= columns
+
+    await db.execute(
+        """INSERT INTO journal
+           (id, project_id, type, content, source, confidence)
+           VALUES ('jrn_migration_030', 'proj_default', 'finding',
+                   'Migration source', 'pi', 'verified')"""
+    )
+    await db.execute(
+        """INSERT INTO claims
+           (id, source_entry_id, claim_type, content, project_id)
+           VALUES ('clm_migration_030', 'jrn_migration_030', 'evidence',
+                   'Migration claim', 'proj_default')"""
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+        await db.execute(
+            """UPDATE claims SET staleness_verdict = 'invented'
+               WHERE id = 'clm_migration_030'"""
+        )
+
+
+@pytest.mark.asyncio
+async def test_reserved_030_applies_after_later_main_migrations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = Path(__file__).parents[2] / "rka" / "db" / "migrations"
+    without_030 = tmp_path / "migrations-without-030"
+    without_030.mkdir()
+    for migration in source.glob("*.sql"):
+        if migration.name.startswith("._") or migration.name == "030_staleness_resolution.sql":
+            continue
+        shutil.copy2(migration, without_030 / migration.name)
+
+    monkeypatch.setattr(Database, "_migrations_directory", staticmethod(lambda: without_030))
+    database = Database(str(tmp_path / "late-030.db"))
+    await database.connect()
+    await database.initialize_schema()
+    await database.initialize_phase2_schema()
+    try:
+        before = {row["name"] for row in await database.fetchall("PRAGMA table_info(claims)")}
+        assert "staleness_verdict" not in before
+        assert await database.fetchone(
+            "SELECT filename FROM schema_migrations WHERE filename = ?",
+            ["031_add_claim_evidence_status.sql"],
+        ) == {"filename": "031_add_claim_evidence_status.sql"}
+
+        only_030 = tmp_path / "migration-030-only"
+        only_030.mkdir()
+        shutil.copy2(source / "030_staleness_resolution.sql", only_030)
+        monkeypatch.setattr(Database, "_migrations_directory", staticmethod(lambda: only_030))
+
+        assert await database.run_migrations() == 1
+        after = {row["name"] for row in await database.fetchall("PRAGMA table_info(claims)")}
+        assert _RESOLUTION_COLUMNS <= after
+        assert await database.run_migrations() == 0
+    finally:
+        await database.close()

--- a/tests/test_db/test_migration_048.py
+++ b/tests/test_db/test_migration_048.py
@@ -1,0 +1,69 @@
+"""Migration 048 attributes the complete outline-profile event lifecycle."""
+
+from __future__ import annotations
+
+import pytest
+
+from rka.infra.ids import generate_id
+
+
+@pytest.mark.asyncio
+async def test_outline_profile_events_include_manuscript_unit_and_delete(
+    db_with_project,
+) -> None:
+    manuscript_id = generate_id("manuscript")
+    unit_id = generate_id("manuscript_unit")
+    await db_with_project.execute(
+        """INSERT INTO manuscripts
+           (id, project_id, title, phase, state)
+           VALUES (?, 'proj_default', 'Attributed outline', 'planning', 'active')""",
+        [manuscript_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_units
+           (id, manuscript_id, project_id, local_key, kind, location)
+           VALUES (?, ?, 'proj_default', 'ROOT', 'other', 'outline/root')""",
+        [unit_id, manuscript_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_unit_outline_profiles
+           (unit_id, manuscript_id, project_id, outline_level)
+           VALUES (?, ?, 'proj_default', 2)""",
+        [unit_id, manuscript_id],
+    )
+    await db_with_project.execute(
+        """UPDATE manuscript_unit_outline_profiles
+           SET communicative_job = 'Frame the paper.' WHERE unit_id = ?""",
+        [unit_id],
+    )
+    await db_with_project.execute(
+        "DELETE FROM manuscript_unit_outline_profiles WHERE unit_id = ?",
+        [unit_id],
+    )
+    await db_with_project.commit()
+
+    events = await db_with_project.fetchall(
+        """SELECT operation, manuscript_id, manuscript_unit_id
+           FROM change_events
+           WHERE source_table = 'manuscript_unit_outline_profiles'
+             AND entity_id = ?
+           ORDER BY cursor""",
+        [unit_id],
+    )
+    assert events == [
+        {
+            "operation": operation,
+            "manuscript_id": manuscript_id,
+            "manuscript_unit_id": unit_id,
+        }
+        for operation in ("insert", "update", "delete")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_migration_048_is_recorded_once(db) -> None:
+    assert await db.fetchone(
+        "SELECT filename FROM schema_migrations WHERE filename = ?",
+        ["048_harden_outline_change_events.sql"],
+    ) == {"filename": "048_harden_outline_change_events.sql"}
+    assert await db.run_migrations() == 0

--- a/tests/test_services/test_knowledge_pack_native.py
+++ b/tests/test_services/test_knowledge_pack_native.py
@@ -22,6 +22,7 @@ from rka.models.manuscript_native import (
 )
 from rka.services.knowledge_pack import (
     PACK_SCHEMA_VERSION,
+    KnowledgePackIntegrityError,
     KnowledgePackService,
 )
 from rka.services.manuscript_native import NativeManuscriptService
@@ -65,9 +66,7 @@ async def test_v2_pack_conservatively_backfills_legacy_manuscript_identity(
             [tag, legacy_id],
         )
     await db.commit()
-    project = await db.fetchone(
-        "SELECT * FROM projects WHERE id = 'proj_default'"
-    )
+    project = await db.fetchone("SELECT * FROM projects WHERE id = 'proj_default'")
     journal = await db.fetchone(
         "SELECT * FROM journal WHERE id = ?",
         [legacy_id],
@@ -118,10 +117,13 @@ async def test_v2_pack_conservatively_backfills_legacy_manuscript_identity(
     assert manuscript["abstract"] == "Imported abstract."
     assert manuscript["venue"] == "USENIX Security"
     assert manuscript["phase"] == "drafting"
-    assert await db.fetchall(
-        """SELECT * FROM manuscript_claims
+    assert (
+        await db.fetchall(
+            """SELECT * FROM manuscript_claims
            WHERE project_id = 'proj_legacy_pack'"""
-    ) == []
+        )
+        == []
+    )
 
 
 def _spine(
@@ -138,33 +140,23 @@ def _spine(
                 "status": "active",
                 "text": empirical_wording,
                 "allowed_wording": empirical_wording,
-                "prohibited_wording": [
-                    "The system eliminates every latency source."
-                ],
+                "prohibited_wording": ["The system eliminates every latency source."],
                 "evidence_ids": [evidence_id],
                 "qualifier_ids": [],
                 "counterevidence_ids": [],
-                "unit_links": [
-                    {"unit_key": "R1", "relationship": "tests"}
-                ],
+                "unit_links": [{"unit_key": "R1", "relationship": "tests"}],
             },
             {
                 "claim_id": "C2",
                 "claim_type": "methodological",
                 "status": "candidate",
                 "text": "The workflow separates support from qualifiers.",
-                "allowed_wording": (
-                    "The workflow records support and qualifiers separately."
-                ),
-                "prohibited_wording": [
-                    "The workflow proves that every result is correct."
-                ],
+                "allowed_wording": ("The workflow records support and qualifiers separately."),
+                "prohibited_wording": ["The workflow proves that every result is correct."],
                 "evidence_ids": [],
                 "qualifier_ids": [evidence_id],
                 "counterevidence_ids": [],
-                "unit_links": [
-                    {"unit_key": "M1", "relationship": "advances"}
-                ],
+                "unit_links": [{"unit_key": "M1", "relationship": "advances"}],
             },
         ],
         "units": [
@@ -176,16 +168,12 @@ def _spine(
                 "outline_level": 3,
                 "communicative_job": "Report the bounded latency result.",
                 "intended_takeaway": "The measured configuration reduced latency.",
-                "evidence_plan": ["Bind the measured latency observation."],
-                "figure_intentions": ["Show the latency comparison."],
-                "citation_intentions": ["Cite the benchmark protocol."],
+                "evidence_plan": [f"Bind the measured observation {evidence_id}."],
+                "figure_intentions": [f"Render artifact {artifact_id} with support {evidence_id}."],
+                "citation_intentions": [f"Cite the source of {evidence_id}."],
                 "artifact_ref": artifact_id,
-                "allowed_interpretation": (
-                    "Latency was lower under the measured configuration."
-                ),
-                "prohibited_interpretation": (
-                    "Latency is lower under every configuration."
-                ),
+                "allowed_interpretation": ("Latency was lower under the measured configuration."),
+                "prohibited_interpretation": ("Latency is lower under every configuration."),
                 "evidence_ids": [evidence_id],
                 "sequence": 2,
             },
@@ -196,8 +184,8 @@ def _spine(
                 "outline_level": 2,
                 "communicative_job": "Explain the provenance-aware workflow.",
                 "intended_takeaway": "Support and qualifiers remain distinct.",
-                "evidence_plan": ["Use the workflow qualifier record."],
-                "table_intentions": ["Summarize evidence roles."],
+                "evidence_plan": [f"Use qualifier {evidence_id}."],
+                "table_intentions": [f"Summarize evidence role for {evidence_id}."],
                 "qualifier_ids": [evidence_id],
                 "sequence": 1,
             },
@@ -244,6 +232,21 @@ async def _seed_native_manuscript(db) -> dict[str, str]:
            VALUES (?, ?, 'result', 'Latency was 14 percent lower.',
                    0.9, 1, 'supported', 0, ?)""",
         [evidence_id, source_journal_id, project_id],
+    )
+    await db.execute(
+        """UPDATE claims
+           SET staleness_reviewed_at = '2026-08-17T12:00:00Z',
+               staleness_verdict = 'historical',
+               staleness_resolution = ?,
+               staleness_resolution_journal_id = ?,
+               staleness_resolved_by = 'pi'
+           WHERE id = ? AND project_id = ?""",
+        [
+            f"Bounded by review note {source_journal_id}.",
+            source_journal_id,
+            evidence_id,
+            project_id,
+        ],
     )
     await db.execute(
         """INSERT INTO artifacts
@@ -543,9 +546,9 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
            FROM change_events WHERE project_id = 'proj_default'"""
     )
     assert source_cursor and source_cursor["cursor"] is not None
-    source_context = await NativeManuscriptService(
-        db, project_id="proj_default"
-    ).get_context(source["manuscript_id"])
+    source_context = await NativeManuscriptService(db, project_id="proj_default").get_context(
+        source["manuscript_id"]
+    )
     source_reference_checkpoint = next(
         checkpoint
         for checkpoint in source_context["checkpoints"]
@@ -553,9 +556,7 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
     )
     assert source_reference_checkpoint["dependency_current"] is True
 
-    pack_path, _ = await KnowledgePackService(
-        db, project_id="proj_default"
-    ).export_pack()
+    pack_path, _ = await KnowledgePackService(db, project_id="proj_default").export_pack()
     with zipfile.ZipFile(pack_path) as archive:
         manifest = json.loads(archive.read("manifest.json"))
 
@@ -583,18 +584,20 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
         },
         "validation_job_links_on_import": "cleared",
     }
-    assert not {
-        "change_events",
-        "jobs",
-        "manuscript_migration_issues",
-        "reference_validation_migration_issues",
-    } & manifest["tables"].keys()
+    assert (
+        not {
+            "change_events",
+            "jobs",
+            "manuscript_migration_issues",
+            "reference_validation_migration_issues",
+        }
+        & manifest["tables"].keys()
+    )
     for table in _NATIVE_TABLES:
         assert manifest["table_counts"][table] > 0
 
     version_keys = [
-        (row["claim_id"], row["version"])
-        for row in manifest["tables"]["manuscript_claim_versions"]
+        (row["claim_id"], row["version"]) for row in manifest["tables"]["manuscript_claim_versions"]
     ]
     assert version_keys == sorted(version_keys)
 
@@ -647,10 +650,7 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
         1,
         2,
     ]
-    assert [
-        row["exact_wording"]
-        for row in versions_by_claim[imported_claims["C1"]["id"]]
-    ] == [
+    assert [row["exact_wording"] for row in versions_by_claim[imported_claims["C1"]["id"]]] == [
         "The system reduced latency.",
         "Latency was lower in the measured testbed.",
     ]
@@ -692,22 +692,38 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
                WHERE project_id = 'proj_native_import'"""
         )
     }
-    assert imported_profiles[imported_units["R1"]["id"]]["parent_unit_id"] == (
-        imported_units["M1"]["id"]
+    assert (
+        imported_profiles[imported_units["R1"]["id"]]["parent_unit_id"]
+        == (imported_units["M1"]["id"])
     )
     assert imported_profiles[imported_units["R1"]["id"]]["outline_level"] == 3
-    assert json.loads(
-        imported_profiles[imported_units["R1"]["id"]]["figure_intentions"]
-    ) == ["Show the latency comparison."]
-    assert json.loads(
-        imported_profiles[imported_units["M1"]["id"]]["table_intentions"]
-    ) == ["Summarize evidence roles."]
-
     imported_evidence = await db.fetchone(
-        """SELECT id FROM claims
+        """SELECT * FROM claims
            WHERE project_id = 'proj_native_import'"""
     )
     assert imported_evidence is not None
+    imported_source_journal = await db.fetchone(
+        """SELECT id FROM journal
+           WHERE project_id = 'proj_native_import'
+             AND content = 'Measured 14 percent lower latency.'"""
+    )
+    assert imported_source_journal is not None
+    assert imported_evidence["staleness_reviewed_at"] == "2026-08-17T12:00:00Z"
+    assert imported_evidence["staleness_verdict"] == "historical"
+    assert imported_evidence["staleness_resolved_by"] == "pi"
+    assert imported_evidence["staleness_resolution_journal_id"] == imported_source_journal["id"]
+    assert imported_evidence["staleness_resolution"] == (
+        f"Bounded by review note {imported_source_journal['id']}."
+    )
+    assert json.loads(imported_profiles[imported_units["R1"]["id"]]["figure_intentions"]) == [
+        f"Render artifact {imported_artifact['id']} with support {imported_evidence['id']}."
+    ]
+    assert json.loads(imported_profiles[imported_units["R1"]["id"]]["citation_intentions"]) == [
+        f"Cite the source of {imported_evidence['id']}."
+    ]
+    assert json.loads(imported_profiles[imported_units["M1"]["id"]]["table_intentions"]) == [
+        f"Summarize evidence role for {imported_evidence['id']}."
+    ]
     claim_support = await db.fetchone(
         """SELECT evidence_claim_id, role
            FROM manuscript_claim_evidence
@@ -749,32 +765,20 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
            WHERE project_id = 'proj_native_import'
            ORDER BY created_at, id"""
     )
-    venue_checkpoints = [
-        checkpoint for checkpoint in checkpoints
-        if checkpoint["kind"] == "venue"
-    ]
+    venue_checkpoints = [checkpoint for checkpoint in checkpoints if checkpoint["kind"] == "venue"]
     assert len(venue_checkpoints) == 2
     first_imported = next(
-        checkpoint for checkpoint in venue_checkpoints
-        if checkpoint["status"] == "superseded"
+        checkpoint for checkpoint in venue_checkpoints if checkpoint["status"] == "superseded"
     )
     replacement_imported = next(
-        checkpoint for checkpoint in venue_checkpoints
-        if checkpoint["status"] == "pending"
+        checkpoint for checkpoint in venue_checkpoints if checkpoint["status"] == "pending"
     )
     assert replacement_imported["supersedes_id"] == first_imported["id"]
-    assert first_imported["approved_choice"] == (
-        "The workflow separates support from qualifiers."
-    )
-    outline = next(
-        checkpoint for checkpoint in checkpoints
-        if checkpoint["kind"] == "outline"
-    )
+    assert first_imported["approved_choice"] == ("The workflow separates support from qualifiers.")
+    outline = next(checkpoint for checkpoint in checkpoints if checkpoint["kind"] == "outline")
     assert outline["supersedes_id"] is None
     imported_reference_checkpoint = next(
-        checkpoint
-        for checkpoint in checkpoints
-        if checkpoint["kind"] == "reference_set"
+        checkpoint for checkpoint in checkpoints if checkpoint["kind"] == "reference_set"
     )
     assert imported_reference_checkpoint["status"] == "resolved"
 
@@ -809,14 +813,8 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
     assert imported_reference_validation is not None
     assert imported_reference_validation["id"] != source["validation_id"]
     assert imported_reference_validation["manuscript_id"] == imported_manuscript["id"]
-    assert (
-        imported_reference_validation["canonical_manuscript_id"]
-        == imported_manuscript["id"]
-    )
-    assert (
-        imported_reference_validation["legacy_journal_id"]
-        == imported_legacy["id"]
-    )
+    assert imported_reference_validation["canonical_manuscript_id"] == imported_manuscript["id"]
+    assert imported_reference_validation["legacy_journal_id"] == imported_legacy["id"]
     assert imported_reference_validation["validation_job_id"] is None
     imported_literature = {
         row["title"]: row["id"]
@@ -832,30 +830,16 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
            ORDER BY state, citation_key"""
     )
     assert len(imported_reference_members) == 2
-    imported_by_state = {
-        row["state"]: row for row in imported_reference_members
-    }
+    imported_by_state = {row["state"]: row for row in imported_reference_members}
     assert imported_by_state["active"]["id"] != source["active_reference_id"]
     assert imported_by_state["active"]["citation_key"] == "current2025"
-    assert (
-        imported_by_state["active"]["literature_id"]
-        == imported_literature["Current citation"]
-    )
+    assert imported_by_state["active"]["literature_id"] == imported_literature["Current citation"]
     assert imported_by_state["active"]["retired_at"] is None
-    assert (
-        imported_by_state["retired"]["id"]
-        != source["retired_reference_id"]
-    )
+    assert imported_by_state["retired"]["id"] != source["retired_reference_id"]
     assert imported_by_state["retired"]["citation_key"] == "earlier2024"
-    assert (
-        imported_by_state["retired"]["literature_id"]
-        == imported_literature["Earlier citation"]
-    )
+    assert imported_by_state["retired"]["literature_id"] == imported_literature["Earlier citation"]
     assert imported_by_state["retired"]["retired_at"] is not None
-    assert (
-        imported_reference_validation["literature_id"]
-        == imported_literature["Current citation"]
-    )
+    assert imported_reference_validation["literature_id"] == imported_literature["Current citation"]
     assert json.loads(imported_reference_validation["full_json_payload"]) == {
         "claim_id": imported_claims["C1"]["id"],
         "job_id": "domain-specific-non-worker-value",
@@ -914,3 +898,99 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
                SET overall_verdict = 'warn'
                WHERE project_id = 'proj_native_import'"""
         )
+
+
+def _rewrite_pack_manifest(source: str, destination: Path, mutate) -> None:
+    with zipfile.ZipFile(source) as archive:
+        entries = {name: archive.read(name) for name in archive.namelist()}
+    manifest = json.loads(entries["manifest.json"])
+    mutate(manifest["tables"])
+    entries["manifest.json"] = json.dumps(manifest, indent=2, sort_keys=True).encode()
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, payload in entries.items():
+            archive.writestr(name, payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "corruption",
+    ["cycle", "depth", "removed_parent", "parent_order", "subtree_contiguity"],
+)
+async def test_pack_import_rolls_back_outline_hierarchy_corruption(
+    db_with_project,
+    tmp_path: Path,
+    corruption: str,
+) -> None:
+    db = db_with_project
+    await _seed_native_manuscript(db)
+    pack_path, _ = await KnowledgePackService(db, project_id="proj_default").export_pack()
+    corrupt_path = tmp_path / f"outline-{corruption}.rka-pack.zip"
+
+    def corrupt(tables: dict[str, list[dict]]) -> None:
+        units = {row["local_key"]: row for row in tables["manuscript_units"]}
+        profiles = {row["unit_id"]: row for row in tables["manuscript_unit_outline_profiles"]}
+        parent = units["M1"]
+        child = units["R1"]
+        if corruption == "cycle":
+            profiles[parent["id"]]["parent_unit_id"] = child["id"]
+        elif corruption == "depth":
+            profiles[child["id"]]["outline_level"] = profiles[parent["id"]]["outline_level"]
+        elif corruption == "removed_parent":
+            parent["status"] = "removed"
+        elif corruption == "parent_order":
+            parent["sequence"] = 20
+            child["sequence"] = 10
+        else:
+            sibling = dict(parent)
+            sibling["id"] = generate_id("manuscript_unit")
+            sibling["local_key"] = "OTHER"
+            sibling["location"] = "sections/other.tex"
+            sibling["sequence"] = 20
+            tables["manuscript_units"].append(sibling)
+            sibling_profile = dict(profiles[parent["id"]])
+            sibling_profile["unit_id"] = sibling["id"]
+            sibling_profile["parent_unit_id"] = None
+            tables["manuscript_unit_outline_profiles"].append(sibling_profile)
+            parent["sequence"] = 10
+            child["sequence"] = 30
+
+    _rewrite_pack_manifest(pack_path, corrupt_path, corrupt)
+    target_project = f"proj_outline_{corruption}"
+    with corrupt_path.open("rb") as pack_file:
+        with pytest.raises(KnowledgePackIntegrityError) as excinfo:
+            await KnowledgePackService(db).import_pack(
+                pack_file,
+                project_id=target_project,
+                project_name=f"Outline corruption {corruption}",
+            )
+    assert {issue["category"] for issue in excinfo.value.issues} == {"outline_hierarchy_invalid"}
+    assert await db.fetchone("SELECT id FROM projects WHERE id = ?", [target_project]) is None
+
+
+@pytest.mark.asyncio
+async def test_pack_import_rejects_outline_parent_absent_from_pack(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    db = db_with_project
+    await _seed_native_manuscript(db)
+    pack_path, _ = await KnowledgePackService(db, project_id="proj_default").export_pack()
+    corrupt_path = tmp_path / "outline-missing-parent.rka-pack.zip"
+
+    def corrupt(tables: dict[str, list[dict]]) -> None:
+        units = {row["local_key"]: row for row in tables["manuscript_units"]}
+        profiles = {row["unit_id"]: row for row in tables["manuscript_unit_outline_profiles"]}
+        profiles[units["R1"]["id"]]["parent_unit_id"] = generate_id("manuscript_unit")
+
+    _rewrite_pack_manifest(pack_path, corrupt_path, corrupt)
+    with corrupt_path.open("rb") as pack_file:
+        with pytest.raises(ValueError, match="parent outside the project or absent"):
+            await KnowledgePackService(db).import_pack(
+                pack_file,
+                project_id="proj_outline_missing_parent",
+                project_name="Outline missing parent",
+            )
+    assert (
+        await db.fetchone("SELECT id FROM projects WHERE id = 'proj_outline_missing_parent'")
+        is None
+    )

--- a/tests/test_services/test_native_manuscript_service.py
+++ b/tests/test_services/test_native_manuscript_service.py
@@ -226,9 +226,7 @@ async def test_create_update_and_legacy_alias(db_with_project) -> None:
 async def test_spine_upsert_is_atomic_and_versions_wording(db_with_project) -> None:
     evidence_id = await _seed_ready_claim(db_with_project)
     service = NativeManuscriptService(db_with_project, project_id="proj_default")
-    manuscript = await service.create(
-        ManuscriptCreate(title="Atomic spine", venue="IEEE S&P")
-    )
+    manuscript = await service.create(ManuscriptCreate(title="Atomic spine", venue="IEEE S&P"))
 
     invalid = _spine(evidence_id)
     invalid["claims"][0]["unit_links"][0]["unit_key"] = "missing"
@@ -251,21 +249,92 @@ async def test_spine_upsert_is_atomic_and_versions_wording(db_with_project) -> N
     assert first["manuscript"]["revision"] == 2
     assert first["claims"][0]["version"] == 1
 
+    events_before_noop = await db_with_project.fetchone(
+        "SELECT count(*) AS count FROM change_events WHERE manuscript_id = ?",
+        [manuscript.id],
+    )
+    audits_before_noop = await db_with_project.fetchone(
+        """SELECT count(*) AS count FROM audit_log
+           WHERE entity_type = 'manuscript' AND entity_id = ?""",
+        [manuscript.id],
+    )
+
     same = await service.upsert_argument_spine(
         manuscript.id,
         expected_revision=2,
         spine=_spine(evidence_id),
     )
-    assert same["manuscript"]["revision"] == 3
+    assert same["manuscript"]["revision"] == 2
     assert same["claims"][0]["version"] == 1
+    events_after_noop = await db_with_project.fetchone(
+        "SELECT count(*) AS count FROM change_events WHERE manuscript_id = ?",
+        [manuscript.id],
+    )
+    audits_after_noop = await db_with_project.fetchone(
+        """SELECT count(*) AS count FROM audit_log
+           WHERE entity_type = 'manuscript' AND entity_id = ?""",
+        [manuscript.id],
+    )
+    assert events_after_noop == events_before_noop
+    assert audits_after_noop == audits_before_noop
 
     changed = await service.upsert_argument_spine(
         manuscript.id,
-        expected_revision=3,
+        expected_revision=2,
         spine=_spine(evidence_id, wording="Latency was lower in our testbed."),
     )
-    assert changed["manuscript"]["revision"] == 4
+    assert changed["manuscript"]["revision"] == 3
     assert changed["claims"][0]["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_spine_upsert_emits_only_semantic_profile_change_events(db_with_project) -> None:
+    evidence_id = await _seed_ready_claim(db_with_project)
+    service = NativeManuscriptService(db_with_project, project_id="proj_default")
+    manuscript = await service.create(ManuscriptCreate(title="Quiet spine writes"))
+    await service.upsert_argument_spine(
+        manuscript.id,
+        expected_revision=1,
+        spine=_spine(evidence_id),
+    )
+    before_rows = await db_with_project.fetchall(
+        """SELECT source_table, count(*) AS count
+           FROM change_events
+           WHERE manuscript_id = ?
+           GROUP BY source_table""",
+        [manuscript.id],
+    )
+    before = {row["source_table"]: int(row["count"]) for row in before_rows}
+
+    revised = _spine(evidence_id)
+    revised["units"][0]["communicative_job"] = "Present the bounded latency result."
+    context = await service.upsert_argument_spine(
+        manuscript.id,
+        expected_revision=2,
+        spine=revised,
+    )
+    assert context["manuscript"]["revision"] == 3
+
+    after_rows = await db_with_project.fetchall(
+        """SELECT source_table, count(*) AS count
+           FROM change_events
+           WHERE manuscript_id = ?
+           GROUP BY source_table""",
+        [manuscript.id],
+    )
+    after = {row["source_table"]: int(row["count"]) for row in after_rows}
+    assert after["manuscript_unit_outline_profiles"] == (
+        before.get("manuscript_unit_outline_profiles", 0) + 1
+    )
+    for source_table in (
+        "manuscript_claims",
+        "manuscript_claim_versions",
+        "manuscript_claim_evidence",
+        "manuscript_units",
+        "manuscript_unit_evidence",
+        "manuscript_claim_units",
+    ):
+        assert after.get(source_table, 0) == before.get(source_table, 0)
 
 
 @pytest.mark.asyncio
@@ -273,9 +342,7 @@ async def test_reference_manifest_replacement_is_atomic_and_historical(
     db_with_project,
 ) -> None:
     service = NativeManuscriptService(db_with_project, project_id="proj_default")
-    manuscript = await service.create(
-        ManuscriptCreate(title="Reference replacement")
-    )
+    manuscript = await service.create(ManuscriptCreate(title="Reference replacement"))
     first_literature = await _seed_literature(
         db_with_project,
         title="First study",
@@ -374,15 +441,11 @@ async def test_reference_readiness_uses_latest_exact_bound_validation(
     db_with_project,
 ) -> None:
     service = NativeManuscriptService(db_with_project, project_id="proj_default")
-    manuscript = await service.create(
-        ManuscriptCreate(title="Reference readiness")
-    )
+    manuscript = await service.create(ManuscriptCreate(title="Reference readiness"))
     literature_id = await _seed_literature(db_with_project)
 
     absent = await service.get_readiness(manuscript.id, target_phase="review")
-    assert "REFERENCE_MANIFEST_REQUIRED" in {
-        finding["code"] for finding in absent["findings"]
-    }
+    assert "REFERENCE_MANIFEST_REQUIRED" in {finding["code"] for finding in absent["findings"]}
 
     await service.replace_reference_manifest(
         manuscript.id,
@@ -397,9 +460,7 @@ async def test_reference_readiness_uses_latest_exact_bound_validation(
         ),
     )
     missing = await service.get_readiness(manuscript.id, target_phase="review")
-    assert "REFERENCE_VALIDATION_MISSING" in {
-        finding["code"] for finding in missing["findings"]
-    }
+    assert "REFERENCE_VALIDATION_MISSING" in {finding["code"] for finding in missing["findings"]}
 
     verified_id = await _seed_reference_validation(
         db_with_project,
@@ -426,9 +487,7 @@ async def test_reference_readiness_uses_latest_exact_bound_validation(
         manuscript.id,
         target_phase="review",
     )
-    assert "REFERENCE_NOT_VERIFIED" in {
-        finding["code"] for finding in failed_readiness["findings"]
-    }
+    assert "REFERENCE_NOT_VERIFIED" in {finding["code"] for finding in failed_readiness["findings"]}
 
     mismatched_id = await _seed_reference_validation(
         db_with_project,
@@ -440,9 +499,7 @@ async def test_reference_readiness_uses_latest_exact_bound_validation(
     mismatched = await service.get_reference_manifest(manuscript.id)
     assert mismatched["approved_citation_keys"] == []
     assert mismatched["members"][0]["validation"]["id"] == mismatched_id
-    assert (
-        mismatched["members"][0]["validation"]["identity_matches"] is False
-    )
+    assert mismatched["members"][0]["validation"]["identity_matches"] is False
     mismatch_readiness = await service.get_readiness(
         manuscript.id,
         target_phase="review",
@@ -477,13 +534,11 @@ async def test_ratification_and_checkpoint_readiness(db_with_project) -> None:
     )
     assert ratification.claim_version == 1
 
-    before_checkpoints = await service.get_readiness(
-        manuscript.id, target_phase="drafting"
-    )
+    before_checkpoints = await service.get_readiness(manuscript.id, target_phase="drafting")
     assert before_checkpoints["verdict"] == "BLOCK"
-    assert {
-        finding["code"] for finding in before_checkpoints["findings"]
-    } == {"CHECKPOINT_REQUIRED"}
+    assert {finding["code"] for finding in before_checkpoints["findings"]} == {
+        "CHECKPOINT_REQUIRED"
+    }
 
     revision = 3
     for kind in ("venue", "outline"):
@@ -510,9 +565,7 @@ async def test_ratification_and_checkpoint_readiness(db_with_project) -> None:
         )
         revision += 1
 
-    readiness = await service.get_readiness(
-        manuscript.id, target_phase="drafting"
-    )
+    readiness = await service.get_readiness(manuscript.id, target_phase="drafting")
     assert readiness["verdict"] == "PASS"
     assert readiness["ready"] is True
     assert readiness["findings"] == []
@@ -567,10 +620,7 @@ async def test_projection_omits_superseded_ratification(db_with_project) -> None
     stale = await service.export_spine_projection(manuscript.id)
     assert stale["claims"][0]["ratified_by"] is None
     readiness = await service.get_readiness(manuscript.id)
-    assert any(
-        finding["code"] == "CLAIM_NOT_RATIFIED"
-        for finding in readiness["findings"]
-    )
+    assert any(finding["code"] == "CLAIM_NOT_RATIFIED" for finding in readiness["findings"])
 
 
 @pytest.mark.asyncio
@@ -683,8 +733,7 @@ async def test_canonical_legacy_alias_remains_manuscript_evidence_after_tag_remo
         target_phase="planning",
     )
     assert any(
-        finding["code"] == "EVIDENCE_NOT_MANUSCRIPT_READY"
-        for finding in readiness["findings"]
+        finding["code"] == "EVIDENCE_NOT_MANUSCRIPT_READY" for finding in readiness["findings"]
     )
 
 
@@ -749,10 +798,7 @@ async def test_checkpoint_resolution_requires_paper_writing_decision_and_snapsho
         manuscript.id,
         target_phase="drafting",
     )
-    assert any(
-        finding["code"] == "CHECKPOINT_REQUIRED"
-        for finding in readiness["findings"]
-    )
+    assert any(finding["code"] == "CHECKPOINT_REQUIRED" for finding in readiness["findings"])
 
 
 @pytest.mark.asyncio
@@ -795,9 +841,7 @@ async def test_writing_candidates_smooth_claims_through_reviewed_cluster_and_rq(
     db_with_project,
 ) -> None:
     service = NativeManuscriptService(db_with_project, project_id="proj_default")
-    manuscript = await service.create(
-        ManuscriptCreate(title="Smoothed candidates")
-    )
+    manuscript = await service.create(ManuscriptCreate(title="Smoothed candidates"))
     rq_id = generate_id("decision")
     cluster_id = generate_id("cluster")
     journal_id = generate_id("journal")
@@ -862,9 +906,7 @@ async def test_writing_candidates_smooth_claims_through_reviewed_cluster_and_rq(
     assert candidate["ratified_by"] is None
     assert candidate["evidence_ids"] == sorted(claim_ids)
     assert len(candidate["scope_contract_ids"]) == 2
-    assert candidate["prohibited_wording"] == [
-        "Do not generalize beyond the evaluated testbed."
-    ]
+    assert candidate["prohibited_wording"] == ["Do not generalize beyond the evaluated testbed."]
     cluster = proposal["clusters"][0]
     assert cluster["disposition"] == "eligible"
     assert cluster["duplicate_support_groups"] == [sorted(claim_ids)]
@@ -914,9 +956,7 @@ async def test_checkpoint_snapshots_detect_artifact_and_literature_drift(
     spine = _spine(evidence_id)
     spine["units"][0]["artifact_ref"] = artifact_id
     service = NativeManuscriptService(db_with_project, project_id="proj_default")
-    manuscript = await service.create(
-        ManuscriptCreate(title="Dependency drift", venue="IEEE S&P")
-    )
+    manuscript = await service.create(ManuscriptCreate(title="Dependency drift", venue="IEEE S&P"))
     await service.upsert_argument_spine(
         manuscript.id,
         expected_revision=1,
@@ -985,8 +1025,7 @@ async def test_checkpoint_snapshots_detect_artifact_and_literature_drift(
     current = await service.get_context(manuscript.id)
     current_by_id = {row["id"]: row for row in current["checkpoints"]}
     assert all(
-        current_by_id[checkpoint_id]["dependency_current"]
-        for checkpoint_id in checkpoints.values()
+        current_by_id[checkpoint_id]["dependency_current"] for checkpoint_id in checkpoints.values()
     )
 
     # Projection synchronization and no-op metadata writes must preserve PI
@@ -996,7 +1035,6 @@ async def test_checkpoint_snapshots_detect_artifact_and_literature_drift(
         expected_revision=revision,
         spine=spine,
     )
-    revision += 1
     await service.update(
         manuscript.id,
         ManuscriptUpdate(
@@ -1006,9 +1044,7 @@ async def test_checkpoint_snapshots_detect_artifact_and_literature_drift(
     )
     revision += 1
     after_no_ops = await service.get_context(manuscript.id)
-    no_op_by_id = {
-        row["id"]: row for row in after_no_ops["checkpoints"]
-    }
+    no_op_by_id = {row["id"]: row for row in after_no_ops["checkpoints"]}
     assert all(
         no_op_by_id[checkpoint_id]["status"] == "resolved"
         and no_op_by_id[checkpoint_id]["dependency_current"]
@@ -1037,14 +1073,8 @@ async def test_checkpoint_snapshots_detect_artifact_and_literature_drift(
     await db_with_project.commit()
     after_artifact = await service.get_context(manuscript.id)
     artifact_by_id = {row["id"]: row for row in after_artifact["checkpoints"]}
-    assert (
-        artifact_by_id[checkpoints["table_figure_plan"]]["dependency_current"]
-        is False
-    )
-    assert (
-        artifact_by_id[checkpoints["reference_set"]]["dependency_current"]
-        is True
-    )
+    assert artifact_by_id[checkpoints["table_figure_plan"]]["dependency_current"] is False
+    assert artifact_by_id[checkpoints["reference_set"]]["dependency_current"] is True
 
     await db_with_project.execute(
         """UPDATE literature
@@ -1055,10 +1085,5 @@ async def test_checkpoint_snapshots_detect_artifact_and_literature_drift(
     )
     await db_with_project.commit()
     after_literature = await service.get_context(manuscript.id)
-    literature_by_id = {
-        row["id"]: row for row in after_literature["checkpoints"]
-    }
-    assert (
-        literature_by_id[checkpoints["reference_set"]]["dependency_current"]
-        is False
-    )
+    literature_by_id = {row["id"]: row for row in after_literature["checkpoints"]}
+    assert literature_by_id[checkpoints["reference_set"]]["dependency_current"] is False

--- a/tests/test_services/test_outline.py
+++ b/tests/test_services/test_outline.py
@@ -44,19 +44,21 @@ async def _evidence_claim(db) -> str:
 
 def _spine(evidence_id: str) -> dict:
     return {
-        "claims": [{
-            "claim_id": "C1",
-            "claim_type": "empirical",
-            "status": "active",
-            "text": "The mechanism produced the bounded effect.",
-            "allowed_wording": "The mechanism produced the bounded effect.",
-            "prohibited_wording": ["The mechanism always works."],
-            "evidence_ids": [evidence_id],
-            "unit_links": [
-                {"unit_key": "INTRO", "relationship": "advances"},
-                {"unit_key": "METHOD", "relationship": "advances"},
-            ],
-        }],
+        "claims": [
+            {
+                "claim_id": "C1",
+                "claim_type": "empirical",
+                "status": "active",
+                "text": "The mechanism produced the bounded effect.",
+                "allowed_wording": "The mechanism produced the bounded effect.",
+                "prohibited_wording": ["The mechanism always works."],
+                "evidence_ids": [evidence_id],
+                "unit_links": [
+                    {"unit_key": "INTRO", "relationship": "advances"},
+                    {"unit_key": "METHOD", "relationship": "advances"},
+                ],
+            }
+        ],
         "units": [
             {
                 "unit_id": "INTRO",
@@ -101,11 +103,7 @@ async def _seed_outline(db):
 
 def _evidence_ids_by_role(unit: dict) -> dict[str, list[str]]:
     return {
-        role: sorted(
-            item["evidence_claim_id"]
-            for item in unit["evidence"]
-            if item["role"] == role
-        )
+        role: sorted(item["evidence_claim_id"] for item in unit["evidence"] if item["role"] == role)
         for role in ("support", "qualifier", "counterevidence")
     }
 
@@ -122,6 +120,7 @@ async def test_outline_projection_joins_rationale_claims_and_evidence(db_with_pr
         "complete_units": 2,
         "units_needing_review": 0,
         "levels": [2],
+        "rationale_complete": True,
         "checkpoint_ready": True,
     }
     assert outline["units"][0]["claims"][0]["claim_key"] == "C1"
@@ -239,6 +238,18 @@ async def test_expand_preserves_explicit_binding_narrowing(db_with_project) -> N
         ),
         actor="web_ui",
     )
+    narrowing_findings = [
+        finding
+        for finding in prepared["proposal"]["validation_findings"]
+        if finding["code"] == "INHERITED_UNIT_EVIDENCE_NARROWED"
+    ]
+    assert {
+        (finding["unit_key"], finding["parent_unit_key"], finding["role"]): finding["entity_ids"]
+        for finding in narrowing_findings
+    } == {
+        ("INTRO.NARROW", "INTRO", "support"): [support_ids[1]],
+        ("INTRO.NARROW", "INTRO", "qualifier"): [qualifier_id],
+    }
     await patches.apply_proposal(
         prepared["proposal"]["id"],
         SemanticPatchProposalTransition(
@@ -249,12 +260,8 @@ async def test_expand_preserves_explicit_binding_narrowing(db_with_project) -> N
     )
 
     context = await native.get_context(manuscript.id)
-    narrowed = next(
-        unit for unit in context["units"] if unit["local_key"] == "INTRO.NARROW"
-    )
-    inherited = next(
-        unit for unit in context["units"] if unit["local_key"] == "INTRO.INHERIT"
-    )
+    narrowed = next(unit for unit in context["units"] if unit["local_key"] == "INTRO.NARROW")
+    inherited = next(unit for unit in context["units"] if unit["local_key"] == "INTRO.INHERIT")
     assert _evidence_ids_by_role(narrowed) == {
         "support": [support_ids[0]],
         "qualifier": [],
@@ -281,14 +288,16 @@ async def test_condense_unions_bindings_and_removes_only_selected_descendants(
             action="expand",
             unit_key="INTRO",
             reason="Create one child.",
-            children=[{
-                "local_key": "INTRO.CHILD",
-                "title": "Child",
-                "location": "sections/introduction.tex#child",
-                "communicative_job": "Carry one paragraph job.",
-                "intended_takeaway": "The child preserves the parent promise.",
-                "evidence_plan": ["Use C1 evidence."],
-            }],
+            children=[
+                {
+                    "local_key": "INTRO.CHILD",
+                    "title": "Child",
+                    "location": "sections/introduction.tex#child",
+                    "communicative_job": "Carry one paragraph job.",
+                    "intended_takeaway": "The child preserves the parent promise.",
+                    "evidence_plan": ["Use C1 evidence."],
+                }
+            ],
         ),
         actor="pi",
     )
@@ -320,9 +329,9 @@ async def test_condense_unions_bindings_and_removes_only_selected_descendants(
             expected_revision=1, actor="pi", reason="Approve condensation."
         ),
     )
-    context = await NativeManuscriptService(
-        db_with_project, project_id="proj_default"
-    ).get_context(manuscript_id)
+    context = await NativeManuscriptService(db_with_project, project_id="proj_default").get_context(
+        manuscript_id
+    )
     parent = next(unit for unit in context["units"] if unit["local_key"] == "INTRO")
     child = next(unit for unit in context["units"] if unit["local_key"] == "INTRO.CHILD")
     assert child["status"] == "removed"
@@ -353,15 +362,17 @@ async def test_condense_unions_distinct_child_evidence_into_parent(db_with_proje
             action="expand",
             unit_key="INTRO",
             reason="Create a child with one distinct evidence binding.",
-            children=[{
-                "local_key": "INTRO.CHILD",
-                "title": "Child",
-                "location": "sections/introduction.tex#child",
-                "communicative_job": "Carry the second evidence-backed beat.",
-                "intended_takeaway": "The child uses distinct evidence.",
-                "evidence_plan": ["Use the second support record."],
-                "support_ids": [child_evidence],
-            }],
+            children=[
+                {
+                    "local_key": "INTRO.CHILD",
+                    "title": "Child",
+                    "location": "sections/introduction.tex#child",
+                    "communicative_job": "Carry the second evidence-backed beat.",
+                    "intended_takeaway": "The child uses distinct evidence.",
+                    "evidence_plan": ["Use the second support record."],
+                    "support_ids": [child_evidence],
+                }
+            ],
         ),
         actor="pi",
     )
@@ -405,9 +416,7 @@ async def test_condense_unions_distinct_child_evidence_into_parent(db_with_proje
     context = await native.get_context(manuscript.id)
     parent = next(unit for unit in context["units"] if unit["local_key"] == "INTRO")
     child = next(unit for unit in context["units"] if unit["local_key"] == "INTRO.CHILD")
-    assert _evidence_ids_by_role(parent)["support"] == sorted(
-        [parent_evidence, child_evidence]
-    )
+    assert _evidence_ids_by_role(parent)["support"] == sorted([parent_evidence, child_evidence])
     assert child["status"] == "removed"
 
 
@@ -434,9 +443,7 @@ async def test_reorder_reports_changed_predecessors_without_losing_bindings(
         for finding in prepared["proposal"]["validation_findings"]
     )
 
-    await SemanticPatchService(
-        db_with_project, project_id="proj_default"
-    ).apply_proposal(
+    await SemanticPatchService(db_with_project, project_id="proj_default").apply_proposal(
         prepared["proposal"]["id"],
         SemanticPatchProposalTransition(
             expected_revision=1,
@@ -484,14 +491,16 @@ async def test_reorder_rejects_parent_after_child_and_split_subtree(db_with_proj
             action="expand",
             unit_key="INTRO",
             reason="Create one child for hierarchy-order checks.",
-            children=[{
-                "local_key": "INTRO.CHILD",
-                "title": "Child",
-                "location": "sections/introduction.tex#child",
-                "communicative_job": "Carry one child beat.",
-                "intended_takeaway": "The child remains under its parent.",
-                "evidence_plan": ["Use the inherited support."],
-            }],
+            children=[
+                {
+                    "local_key": "INTRO.CHILD",
+                    "title": "Child",
+                    "location": "sections/introduction.tex#child",
+                    "communicative_job": "Carry one child beat.",
+                    "intended_takeaway": "The child remains under its parent.",
+                    "evidence_plan": ["Use the inherited support."],
+                }
+            ],
         ),
         actor="pi",
     )
@@ -579,9 +588,7 @@ async def test_host_agent_outline_proposal_records_ai_provenance_and_waits_for_p
 async def test_executor_cannot_mislabel_outline_proposal_as_human(db_with_project) -> None:
     manuscript_id, _evidence_id = await _seed_outline(db_with_project)
     with pytest.raises(ValueError, match="must declare their provider origin"):
-        await ManuscriptOutlineService(
-            db_with_project, project_id="proj_default"
-        ).prepare_proposal(
+        await ManuscriptOutlineService(db_with_project, project_id="proj_default").prepare_proposal(
             manuscript_id,
             OutlineProposalRequest(
                 expected_revision=2,
@@ -645,6 +652,7 @@ async def test_applied_outline_edit_supersedes_resolved_outline_checkpoint(
     )
     outline = await outlines.get_outline(manuscript_id)
     assert outline["outline_checkpoint"]["status"] == "superseded"
+    assert outline["summary"]["rationale_complete"] is True
     assert outline["summary"]["checkpoint_ready"] is True
 
 
@@ -678,10 +686,7 @@ async def test_outline_checkpoint_v2_tracks_typed_evidence_bindings(db_with_proj
         expected_revision=3,
         actor="pi",
     )
-    assert (
-        resolved.dependency_snapshot["schema_version"]
-        == "rka.checkpoint-dependencies/v2"
-    )
+    assert resolved.dependency_snapshot["schema_version"] == "rka.checkpoint-dependencies/v2"
 
     spine = await native.export_spine_projection(manuscript_id)
     intro = next(unit for unit in spine["units"] if unit["unit_id"] == "INTRO")

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1011,6 +1011,8 @@ export interface ManuscriptOutline {
     complete_units: number
     units_needing_review: number
     levels: number[]
+    rationale_complete: boolean
+    /** @deprecated Use rationale_complete; this does not report checkpoint state. */
     checkpoint_ready: boolean
   }
   policy: {

--- a/web/src/components/workbench/OutlineEditor.tsx
+++ b/web/src/components/workbench/OutlineEditor.tsx
@@ -182,7 +182,7 @@ export function OutlineEditor({
           <Button
             size="sm"
             variant="outline"
-            disabled={!outline.summary.checkpoint_ready || mutations.createCheckpoint.isPending}
+            disabled={!outline.summary.rationale_complete || mutations.createCheckpoint.isPending}
             onClick={() => void createCheckpoint()}
           >
             <CheckCircle2 className="mr-1 h-4 w-4" /> Create Outline checkpoint

--- a/web/src/pages/ManuscriptWorkbench.tsx
+++ b/web/src/pages/ManuscriptWorkbench.tsx
@@ -113,7 +113,7 @@ function makeStageVerdicts(
     rqs: rqs.length > 0 ? "Ready" : "Blocked",
     contributions: activeClaims.length > 0 ? (readiness?.ready ? "Ready" : "Needs review") : candidateClaims.length > 0 ? "Needs review" : "Blocked",
     evaluation: resultUnits.length > 0 ? "Needs review" : "Blocked",
-    outline: outline?.summary.checkpoint_ready
+    outline: outline?.summary.rationale_complete
       ? checkpointStatusForStage(outline) === "resolved" ? "Ready" : "Needs review"
       : units.length > 0 ? "Needs review" : "Blocked",
   }


### PR DESCRIPTION
## Summary

- restore the deployed migration-030 staleness-resolution schema so agentic and main knowledge packs remain lossless
- enforce native outline hierarchy rules during pack import and rekey exact/embedded IDs in outline intentions and staleness provenance
- attribute outline-profile insert/update/delete events to their manuscript and unit
- disclose evidence narrowing during outline expansion and expose rationale_complete with a deprecated compatibility alias
- make identical spine replays true no-ops and limit partial edits to semantically changed rows/bindings
- update the M5 roadmap, changelog, implementation contract, and exit evidence

## Validation

- focused migration/service/pack/REST/MCP suite: 104 passed
- changed Python Ruff lint + format: passed
- production TypeScript/Vite build: passed (2,421 modules)
- changed frontend ESLint: passed
- disposable DelaySteer-derived pack round-trip: exact key-table counts, embedded outline ID rekeyed, zero critical integrity issues
- full Python suite: 3,105 passed, 21 skipped, 11 failed
  - the same 11 embedding/vector failures reproduce on untouched main commit 23c9518 across the exact five failing files
- repository-wide ESLint retains the same unrelated main baseline of seven errors and two warnings; all changed frontend files pass

Full evidence: docs/superpowers/specs/2026-08-17-workbench-m5-pr9-1-exit-evidence.md

## Safety and scope

The live RKA database was not changed. Real-project validation used a transactionally consistent disposable database snapshot. Typed rhetorical roles, draft-file synchronization, and embedded LLM orchestration remain deferred to PR 9.2 / PR 10.
