### PR TITLE
feat(writer): add conflict-safe manuscript source sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,9 @@ and proposal-first editing boundary is recorded in
 The typed academic-role, evidence-warrant, citation-use, claim-boundary, and
 proportionate-readiness boundary is recorded in
 [ADR 0010](docs/adr/0010-typed-academic-writing-semantics.md).
+The conflict-safe Markdown/LaTeX source, stable-anchor, recovery, and
+public/private drafting boundary is recorded in
+[ADR 0011](docs/adr/0011-conflict-safe-manuscript-source-synchronization.md).
 
 The roadmap is ordered by dependency, not by invented delivery dates. Every
 milestone must satisfy its exit gate before dependent work is treated as ready.
@@ -42,7 +45,11 @@ resolution record merged in PR [#81](https://github.com/infinitywings/rka/pull/8
 PR 9.1 integrity hardening merged in PR
 [#82](https://github.com/infinitywings/rka/pull/82). PR 9.2, the typed
 academic-writing semantic core ([issue #83](https://github.com/infinitywings/rka/issues/83)),
-is now the active implementation target.**
+merged after independent audit in PR
+[#84](https://github.com/infinitywings/rka/pull/84). **PR 10, conflict-safe
+Markdown/LaTeX source synchronization
+([issue #61](https://github.com/infinitywings/rka/issues/61)), is now the active
+implementation target.**
 PR [#78](https://github.com/infinitywings/rka/pull/78) merged
 the seed-through-contribution dependency; ADR 0008 freezes the evaluation
 contract, and the exact release evidence is recorded in
@@ -66,7 +73,9 @@ PR 9.2 is based on the merged PR 9.1 foundation and is specified in
 Its migration, typed-binding, MCP, workbench, baseline-comparison, and
 real-project-derived pilot evidence is recorded in
 [`2026-08-17-m5-pr9-2-exit-evidence.md`](docs/superpowers/specs/2026-08-17-m5-pr9-2-exit-evidence.md).
-PR 10 remains dependent on this typed semantic core.
+PR 10 is specified in
+[`2026-08-17-m5-pr10-source-sync.md`](docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md)
+and governed by ADR 0011.
 The choice-first Writer delta is reconciled, the authority and AI boundary is
 recorded in ADR 0001, the read-only workbench has passed its real-project exit
 gate, and first-class experiment/run/observation/evidence-locator semantics

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,8 +48,9 @@ academic-writing semantic core ([issue #83](https://github.com/infinitywings/rka
 merged after independent audit in PR
 [#84](https://github.com/infinitywings/rka/pull/84). **PR 10, conflict-safe
 Markdown/LaTeX source synchronization
-([issue #61](https://github.com/infinitywings/rka/issues/61)), is now the active
-implementation target.**
+([issue #61](https://github.com/infinitywings/rka/issues/61)), now has an
+implementation candidate and passed its automated and browser exit gates; its
+exact commit remains subject to the required independent audit before merge.**
 PR [#78](https://github.com/infinitywings/rka/pull/78) merged
 the seed-through-contribution dependency; ADR 0008 freezes the evaluation
 contract, and the exact release evidence is recorded in
@@ -75,7 +76,10 @@ real-project-derived pilot evidence is recorded in
 [`2026-08-17-m5-pr9-2-exit-evidence.md`](docs/superpowers/specs/2026-08-17-m5-pr9-2-exit-evidence.md).
 PR 10 is specified in
 [`2026-08-17-m5-pr10-source-sync.md`](docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md)
-and governed by ADR 0011.
+and governed by ADR 0011. Its migration, source-security, recovery,
+authorization, workbench, responsive-browser, and restart evidence is recorded
+in
+[`2026-08-17-m5-pr10-exit-evidence.md`](docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md).
 The choice-first Writer delta is reconciled, the authority and AI boundary is
 recorded in ADR 0001, the read-only workbench has passed its real-project exit
 gate, and first-class experiment/run/observation/evidence-locator semantics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,10 @@ services:
     build: .
     container_name: rka-server
     ports:
-      - "9712:9712"
+      # Keep the unauthenticated local dashboard/API off the LAN. The server
+      # still listens on all interfaces inside the container so Docker health
+      # checks and the worker can reach it.
+      - "127.0.0.1:9712:9712"
     volumes:
       - rka-data:/data
     environment:

--- a/docs/TECHNICAL_REFERENCE.md
+++ b/docs/TECHNICAL_REFERENCE.md
@@ -86,6 +86,8 @@ Core runtime settings use the `RKA_` prefix. Common settings include:
 | `RKA_HOST` | `127.0.0.1` | API bind address outside Docker. |
 | `RKA_PORT` | `9712` | API port. |
 | `RKA_DB_PATH` | `rka.db` | Database path outside the default Docker deployment. |
+| `RKA_MANUSCRIPT_WORKSPACE_ROOTS` | empty | `os.pathsep`-separated allowlist for local Markdown/LaTeX source access; an empty value disables source synchronization. |
+| `RKA_MANUSCRIPT_SOURCE_MAX_BYTES` | `2097152` | Maximum UTF-8 bytes accepted for one synchronized manuscript source file. |
 | `RKA_SKILL_TOOLS` | unset | Promote ChatGPT skill-adapter tools on the connector surface. |
 | `RKA_LEGACY_TOOLS` | unset | Restore the compatibility always-on tool surface when required. |
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -654,6 +654,16 @@ database, and atomically replaces the file. If an external editor changed the
 file, the proposal becomes conflicted and neither version is overwritten. RKA
 never performs a Git operation for source synchronization.
 
+For an existing file, Apply also keeps the exact displaced inode at a hidden
+`.rka-source-*.recovery` name beside that file. This preserves writes made later
+through an editor descriptor opened before Apply. These source-adjacent files
+are intentionally not deleted automatically, including when the RKA project is
+deleted. Project-deletion preview and result list deterministic candidate paths
+under `retained_workspace_artifacts`; inspect them after all editors are closed,
+then remove only artifacts you have deliberately verified are no longer needed.
+Managed recovery beneath the RKA data directory is still removed by confirmed
+project deletion.
+
 The adjacent **Quick reader** view shows the ordered argument path and anchor
 health. **Reviewer risk (private)** shows prohibited wording, qualifiers,
 counterevidence, and citation-verification warnings. Private risk material is

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -620,6 +620,45 @@ plan, create an Outline checkpoint. Only a separate PI decision can resolve
 that checkpoint. A proposal, AI recommendation, or edited local outline file
 never ratifies itself.
 
+### 15.5 — Synchronizing Markdown and LaTeX source
+
+The Outline stage can open local `.md`, `.markdown`, and `.tex` files beneath a
+native manuscript's `workspace_ref`. This is opt-in: the workspace must also be
+beneath one of the roots in `RKA_MANUSCRIPT_WORKSPACE_ROOTS`. RKA rejects
+hidden paths, traversal, symlinks, special files, oversized content, and files
+outside that explicit allowlist. Source content is available only to the local
+web interface and is not added to the MCP tool surface. The bundled Docker
+configuration publishes the dashboard/API only on `127.0.0.1`; do not expose
+the unauthenticated REST port to a LAN or public interface.
+
+Use stable unit-range comments to connect public prose to native manuscript
+units:
+
+```markdown
+<!-- rka:unit mun_... begin -->
+Public manuscript prose.
+<!-- rka:provenance claim=mcl_... evidence=clm_... citation=Smith2026 -->
+<!-- rka:unit mun_... end -->
+```
+
+LaTeX uses the equivalent `% rka:unit ... begin/end` and
+`% rka:provenance ...` comments. The diagnostics verify that IDs and citation
+keys are currently bound to that unit; the comment is an auditable link, not
+proof that the prose accurately represents the evidence.
+
+Editing remains prepare-then-apply. Preparing stores an immutable candidate
+without touching the file. Open **Review source diff** to compare the current
+and proposed text; only then is the apply action available. Apply rechecks the
+exact SHA-256 base, saves managed recovery metadata beside the active RKA
+database, and atomically replaces the file. If an external editor changed the
+file, the proposal becomes conflicted and neither version is overwritten. RKA
+never performs a Git operation for source synchronization.
+
+The adjacent **Quick reader** view shows the ordered argument path and anchor
+health. **Reviewer risk (private)** shows prohibited wording, qualifiers,
+counterevidence, and citation-verification warnings. Private risk material is
+planning context and is never inserted into public source automatically.
+
 ---
 
 ## Chapter 16: MCP Tools Quick Reference
@@ -811,6 +850,8 @@ Studio model for a schema-constrained, unapplied semantic proposal:
 | `RKA_WORKBENCH_LM_STUDIO_BASE_URL` | Docker: `http://host.docker.internal:1234/v1`; non-Docker: `http://127.0.0.1:1234/v1` | Local-machine OpenAI-compatible endpoint |
 | `RKA_WORKBENCH_LM_STUDIO_MODEL` | empty | Exact served model ID; required to use the adapter |
 | `RKA_WORKBENCH_LM_STUDIO_TIMEOUT` | `120` | Request timeout in seconds (1–600) |
+| `RKA_MANUSCRIPT_WORKSPACE_ROOTS` | empty (source access disabled) | `os.pathsep`-separated allowlist of local manuscript workspace roots |
+| `RKA_MANUSCRIPT_SOURCE_MAX_BYTES` | `2097152` | Maximum UTF-8 bytes per synchronized source file (up to 20 MiB) |
 
 This adapter is not a background enrichment engine. It receives an explicit
 context manifest, records provider-call provenance, cannot use credentials or
@@ -818,6 +859,25 @@ a non-local URL, never falls back to cloud, and never applies its own output.
 The manifest must disclose every target and referenced evidence entity. A
 target revision change during generation, an undisclosed target, or an
 undisclosed evidence binding causes the proposal to fail closed.
+
+For a Docker deployment, explicitly mount only the parent directories that
+contain manuscripts you want RKA to edit, then allowlist the corresponding
+container paths. For example, add this opt-in override rather than granting the
+container access to an entire home directory:
+
+```yaml
+services:
+  rka:
+    volumes:
+      - /absolute/host/path/to/papers:/manuscripts:rw
+    environment:
+      RKA_MANUSCRIPT_WORKSPACE_ROOTS: /manuscripts
+```
+
+Set each manuscript's `workspace_ref` to its container-visible directory, such
+as `/manuscripts/example-paper`. Multiple roots use the host platform's path
+separator (`:` on macOS/Linux). Recreate the RKA service after changing mounts
+or environment settings.
 
 ---
 

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -128,13 +128,16 @@ also drop the redundant hidden name because the same inode remains public.
 Recovery classification is bounded: an oversized retained regular inode is
 reported as `oversized` without reading it into memory, retained in place, and
 does not prevent Apply conflict, Reject, or Supersede from reaching a durable
-terminal state. Symlinks and non-regular recovery objects still fail closed.
+terminal state. An unreadable, symlinked, or non-regular hidden recovery object
+is classified as `unsafe`, retained in place, and never exchanged into the
+public manuscript path; after the source-directory fsync, Apply records a
+terminal restart-era conflict.
 
 Source events separate the durable naming fact from a mutable byte
 classification. `source_recovery_state` says only whether a recovery name was
 retained, missing, or not checked. `source_recovery_last_observed` records the
 last bounded observation (`reviewed_base`, `proposal`, `unclassified`,
-`oversized`, or `missing`) immediately before the transition. It is not a
+`oversized`, `unsafe`, or `missing`) immediately before the transition. It is not a
 promise that a still-open external descriptor cannot change those bytes later;
 the retained path is the durable audit handle. `retained_source_path` is generic;
 `displaced_source_path` is populated only when an original target actually

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -1,0 +1,173 @@
+# ADR 0011: Conflict-safe manuscript source synchronization
+
+- Status: accepted for M5 / PR 10 implementation
+- Date: 2026-08-17
+- Baseline: `infinitywings/rka` `main` merge `116f76b`
+- Scope: Markdown/LaTeX authoring files, stable manuscript-unit anchors,
+  recoverable optimistic writes, provenance diagnostics, and public/private
+  drafting views
+
+## Context
+
+RKA now owns a ratified manuscript aggregate: exact claim versions, claim
+boundaries, typed evidence uses, typed citation intentions, progressive `mun_`
+units, checkpoints, and readiness. Researchers still write the paper in normal
+Markdown or LaTeX files. PR 10 must connect those files to RKA without making
+either a second semantic authority or an unsafe remote filesystem API.
+
+Source files also have a transaction boundary that SQLite cannot roll back. A
+semantic-patch transaction therefore cannot safely include a file replacement.
+The authoring path needs its own proposal ledger and recovery protocol while
+retaining the same propose, inspect, explicitly apply, conflict, and audit
+experience for human and AI edits.
+
+## Decision
+
+### 1. Preserve the four-layer authority model
+
+- RKA remains authoritative for research evidence and manuscript semantics.
+- Markdown and LaTeX remain authoritative only for public prose and layout.
+- A source-edit proposal is a candidate authoring change, not evidence, a
+  claim, a checkpoint, or a manuscript revision.
+- Writing a file never changes claim wording, bindings, ratification, unit
+  status, or readiness. Those changes continue through semantic proposals.
+- An external editor may change a source file. RKA detects and reports that
+  change; it does not overwrite it or infer a semantic update.
+
+### 2. Use one source-proposal path for human and AI edits
+
+Human and AI source changes use one immutable source-edit proposal envelope.
+It records manuscript, relative path, source format, exact base hash, proposed
+content and hash, origin/provider boundary, reason, validation findings, and
+status. Creating a proposal does not touch the file. Only a PI or local web
+user may apply or reject it.
+
+The source ledger is intentionally separate from the semantic-patch ledger.
+This avoids pretending that a filesystem replacement is part of a rollbackable
+SQLite transaction. AI proposals still require a matching immutable Context
+Capsule and may not self-apply. Direct API calls do not create a parallel write
+path.
+
+### 3. Resolve files only inside explicit allowlisted roots
+
+`manuscripts.workspace_ref` selects a workspace, but it grants no authority by
+itself. The server must also be configured with one or more
+`RKA_MANUSCRIPT_WORKSPACE_ROOTS`. A source path must:
+
+- be a normalized POSIX-relative path ending in `.md`, `.markdown`, or `.tex`;
+- resolve below both the selected workspace and an allowlisted root;
+- contain no symlink component;
+- avoid `.git`, `.rka`, hidden recovery data, traversal, and special files;
+- satisfy bounded UTF-8 file and request sizes.
+
+An unconfigured, missing, foreign, or unsafe workspace fails closed. Source
+content is never exposed through MCP in PR 10; it is a local web/REST surface.
+
+### 4. Make every replacement optimistic, atomic, and recoverable
+
+Apply re-reads the file and compares its SHA-256 hash with the proposal's base
+hash. A missing file is represented by the explicit sentinel `null`; an empty
+file has the normal SHA-256 of empty bytes. Any mismatch marks the proposal
+`conflicted`, preserves both versions, and performs no file write.
+
+For a matching base, apply:
+
+1. writes a recovery copy and manifest beneath RKA's persistent `data_dir`;
+2. fsyncs the recovery file and manifest;
+3. writes the proposed bytes to a same-directory temporary regular file;
+4. preserves the existing regular-file mode when applicable;
+5. fsyncs and atomically replaces the target with `os.replace`;
+6. fsyncs the containing directory;
+7. records the applied event with before, after, and recovery hashes.
+
+The recovery manifest is durable even if the database event cannot be
+committed after replacement. The service never runs `git add`, commit, reset,
+checkout, merge, or push.
+
+### 5. Use explicit, stable `mun_` range anchors
+
+Anchors are comments that normal Markdown and LaTeX renderers ignore:
+
+```markdown
+<!-- rka:unit mun_... begin -->
+Public prose.
+<!-- rka:unit mun_... end -->
+```
+
+```tex
+% rka:unit mun_... begin
+Public prose.
+% rka:unit mun_... end
+```
+
+The parser requires a unique, balanced, non-nested range per `mun_` in a file.
+It validates that every unit belongs to the selected manuscript and reports a
+content hash for the anchored region. Line numbers are diagnostic only; the
+stable identity is the explicit `mun_` token. Duplicate, foreign, nested,
+unbalanced, or removed-unit anchors are blocking findings for apply.
+
+### 6. Treat provenance comments as verifiable links, not trusted evidence
+
+An anchored unit may contain hidden comments such as:
+
+```markdown
+<!-- rka:provenance claim=mcl_... evidence=clm_... citation=Smith2026 -->
+```
+
+The service parses identifiers, then verifies them against that unit's current
+claim links, typed evidence uses, and citation uses. Unknown, foreign, stale, or
+unbound references are findings. A valid comment proves only that the prose
+declares a link to a current RKA object; it does not prove the prose accurately
+expresses that object. That judgment remains review work.
+
+### 7. Keep public prose and private reviewer risk structurally separate
+
+The source editor displays three distinct projections:
+
+- **Draft source:** editable public Markdown/LaTeX plus a non-authoritative
+  preview;
+- **Quick reader:** current unit order, communicative job, takeaway, and
+  quick-reader role, with anchor health;
+- **Reviewer risk (private):** prohibited wording, qualifiers,
+  counterevidence, unresolved citation verification, and unallocated adverse
+  evidence.
+
+Private material is never inserted into source content by projection or apply.
+The UI labels it private planning context. The draft editor can link to those
+records for review without copying them into public prose.
+
+### 8. Project source impact without changing semantic readiness
+
+The source projection joins current file anchors to `mun_` units and current
+semantic bindings. It reports missing anchors, externally changed files,
+unverified provenance comments, and upstream RKA impact for anchored units.
+Source-file currency is an authoring diagnostic, not a semantic readiness gate
+and does not invalidate PI checkpoints by itself.
+
+## Consequences
+
+- Researchers can use normal editors alongside the workbench without silent
+  overwrites.
+- RKA can navigate from prose ranges to exact units, claims, evidence, and
+  citations while keeping the limits of that link visible.
+- Candidate prose is reviewable and auditable without being promoted to
+  semantic truth.
+- Filesystem and database failure cannot be made perfectly atomic; the durable
+  recovery-before-replace protocol makes the partial state observable and
+  repairable.
+- Deployments must explicitly mount and allowlist manuscript workspaces.
+
+## PR 10 exit gate
+
+- migration applies on fresh, upgraded, and restarted databases;
+- path traversal, symlink, special-file, size, encoding, and foreign-project
+  attempts fail closed;
+- human and AI edits use the same proposal service and only PI/web may apply;
+- an external edit produces a durable conflict and leaves the file untouched;
+- applied writes are atomic, mode-preserving, and recoverable;
+- Markdown and LaTeX anchors round-trip and invalid anchors are actionable;
+- provenance comments are checked against current typed bindings;
+- source, quick-reader, and private-risk views remain distinct;
+- no source action invokes Git;
+- focused, full, build/lint, restart, browser, and disposable real-project
+  validations pass.

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -62,6 +62,9 @@ itself. The server must also be configured with one or more
 
 An unconfigured, missing, foreign, or unsafe workspace fails closed. Source
 content is never exposed through MCP in PR 10; it is a local web/REST surface.
+The bundled Docker deployment binds the unauthenticated dashboard/API port to
+host loopback. Remote access requires a separately reviewed authentication and
+transport boundary; changing `X-RKA-Actor` is provenance, not authentication.
 
 ### 4. Make every replacement optimistic, atomic, and recoverable
 
@@ -72,7 +75,8 @@ file has the normal SHA-256 of empty bytes. Any mismatch marks the proposal
 
 For a matching base, apply:
 
-1. writes a recovery copy and manifest beneath RKA's persistent `data_dir`;
+1. writes a recovery copy and manifest beneath the managed storage directory
+   beside the active RKA database;
 2. fsyncs the recovery file and manifest;
 3. writes the proposed bytes to a same-directory temporary regular file;
 4. preserves the existing regular-file mode when applicable;

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -84,14 +84,26 @@ For a matching base, apply:
 1. re-reads after asynchronous validation and requires the same base hash;
 2. writes a recovery copy and manifest beneath the managed storage directory
    beside the active RKA database;
-3. fsyncs the recovery file and manifest;
-4. writes the proposed bytes to a same-directory temporary regular file;
-5. preserves the existing regular-file mode and fsyncs the temporary file;
-6. re-reads synchronously immediately before replacement and again requires the
-   same base hash;
-7. atomically replaces the target with `os.replace`;
-8. fsyncs the containing directory;
-9. records the applied event with before, after, and recovery hashes.
+3. fsyncs the recovery file, manifest, leaf directory, and every newly ensured
+   ancestor edge so a fresh recovery hierarchy is durable;
+4. writes the proposed bytes to a deterministic same-directory swap file,
+   preserves the existing regular-file mode, fsyncs the file, and fsyncs its
+   containing directory;
+5. for an existing target, atomically exchanges the target and swap names,
+   hashes the exact displaced target, and restores that displaced object by a
+   second exchange if it is not the reviewed base;
+6. for a missing target, installs the proposed inode with a no-clobber hard link
+   so a file that appears at the commit point wins and is never overwritten;
+7. removes the validated displaced/swap name and fsyncs the source directory;
+8. records the applied event with before, after, and recovery hashes.
+
+The name-exchange primitive is `renameatx_np(..., RENAME_SWAP)` on macOS and
+`renameat2(..., RENAME_EXCHANGE)` on Linux. A deployment without an atomic
+exchange primitive fails closed instead of falling back to a check-then-rename
+sequence. A deterministic swap left by a crash is reconciled before the ledger
+can become `applied`: the service either finishes cleanup and repeats the source
+directory fsync, or restores the exact displaced external object and records a
+conflict.
 
 The recovery manifest is durable even if the database event cannot be
 committed after replacement. The service never runs `git add`, commit, reset,
@@ -166,8 +178,8 @@ and does not invalidate PI checkpoints by itself.
 - Candidate prose is reviewable and auditable without being promoted to
   semantic truth.
 - Filesystem and database failure cannot be made perfectly atomic; the durable
-  recovery-before-replace protocol makes the partial state observable and
-  repairable.
+  recovery-before-exchange protocol and deterministic swap make every expected
+  partial naming state observable and repairable.
 - Deployments must explicitly mount and allowlist manuscript workspaces.
 
 ## PR 10 exit gate

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -77,7 +77,13 @@ or Supersede cannot record a false terminal state.
 Apply re-reads the file and compares its SHA-256 hash with the proposal's base
 hash. A missing file is represented by the explicit sentinel `null`; an empty
 file has the normal SHA-256 of empty bytes. Any mismatch marks the proposal
-`conflicted`, preserves both versions, and performs no file write.
+`conflicted` and preserves both versions. A mismatch found before the commit
+point performs no exchange. A mismatch discovered by inspecting the exact
+displaced object after exchange triggers an immediate reverse exchange; the
+proposal can therefore be transiently observable to another local reader, but
+the final public target is restored before the conflict becomes terminal.
+Conflict events distinguish an observed exchange, no observed exchange, and a
+recovery-era state where an earlier exchange is possible but no longer provable.
 
 For a matching base, apply:
 
@@ -94,8 +100,12 @@ For a matching base, apply:
    second exchange if it is not the reviewed base;
 6. for a missing target, installs the proposed inode with a no-clobber hard link
    so a file that appears at the commit point wins and is never overwritten;
-7. removes the validated displaced/swap name and fsyncs the source directory;
-8. records the applied event with before, after, and recovery hashes.
+7. for an existing target, retains the exact displaced inode at its deterministic
+   hidden recovery name so writes through an editor descriptor opened before
+   exchange cannot be destroyed by unlink; for a missing target, removes the
+   redundant proposal hard link;
+8. fsyncs the source directory and records the applied event with before, after,
+   recovery, and retained-displaced paths.
 
 The name-exchange primitive is `renameatx_np(..., RENAME_SWAP)` on macOS and
 `renameat2(..., RENAME_EXCHANGE)` on Linux. A deployment without an atomic
@@ -103,7 +113,11 @@ exchange primitive fails closed instead of falling back to a check-then-rename
 sequence. A deterministic swap left by a crash is reconciled before the ledger
 can become `applied`: the service either finishes cleanup and repeats the source
 directory fsync, or restores the exact displaced external object and records a
-conflict.
+conflict. A retry that sees the restored external target with valid recovery
+metadata likewise removes only a verified proposal-byte swap and repeats the
+source-directory fsync before the ledger can become terminally `conflicted`;
+Reject and Supersede share the same guard. An unexpected swap fails closed and
+remains available for inspection.
 
 The recovery manifest is durable even if the database event cannot be
 committed after replacement. The service never runs `git add`, commit, reset,
@@ -177,6 +191,10 @@ and does not invalidate PI checkpoints by itself.
   citations while keeping the limits of that link visible.
 - Candidate prose is reviewable and auditable without being promoted to
   semantic truth.
+- Each successful existing-file Apply retains one hidden displaced-inode
+  recovery artifact next to the source. This deliberate storage cost is what
+  preserves late writes through pre-opened editor descriptors; PR 10 never
+  deletes those artifacts automatically.
 - Filesystem and database failure cannot be made perfectly atomic; the durable
   recovery-before-exchange protocol and deterministic swap make every expected
   partial naming state observable and repairable.
@@ -188,7 +206,9 @@ and does not invalidate PI checkpoints by itself.
 - path traversal, symlink, special-file, size, encoding, and foreign-project
   attempts fail closed;
 - human and AI edits use the same proposal service and only PI/web may apply;
-- an external edit produces a durable conflict and leaves the file untouched;
+- an external edit produces a durable conflict and restores the exact external
+  target before the ledger becomes terminal, even if a transient exchange was
+  observable;
 - same-file apply/reject/supersede races yield rather than blocking the event
   loop and cannot produce a file/ledger terminal-state mismatch;
 - applied writes are atomic, mode-preserving, and recoverable;

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -125,6 +125,20 @@ can become terminally `conflicted`; Reject and Supersede share the same guard.
 Only a swap freshly created and still owned by the current pre-exchange
 invocation may be unlinked automatically. A missing-file hard-link install may
 also drop the redundant hidden name because the same inode remains public.
+Recovery classification is bounded: an oversized retained regular inode is
+reported as `oversized` without reading it into memory, retained in place, and
+does not prevent Apply conflict, Reject, or Supersede from reaching a durable
+terminal state. Symlinks and non-regular recovery objects still fail closed.
+
+Source events separate the durable naming fact from a mutable byte
+classification. `source_recovery_state` says only whether a recovery name was
+retained, missing, or not checked. `source_recovery_last_observed` records the
+last bounded observation (`reviewed_base`, `proposal`, `unclassified`,
+`oversized`, or `missing`) immediately before the transition. It is not a
+promise that a still-open external descriptor cannot change those bytes later;
+the retained path is the durable audit handle. `retained_source_path` is generic;
+`displaced_source_path` is populated only when an original target actually
+existed, never for a redundant proposal hard link from missing-file recovery.
 
 The recovery manifest is durable even if the database event cannot be
 committed after replacement. The service never runs `git add`, commit, reset,

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -68,6 +68,12 @@ transport boundary; changing `X-RKA-Actor` is provenance, not authentication.
 
 ### 4. Make every replacement optimistic, atomic, and recoverable
 
+Create, apply, reject, and supersede share a per-file advisory lock. Lock
+acquisition uses nonblocking retries that yield to the async event loop, and the
+lock remains held through the database terminal transition. A crash-applied
+file with valid recovery metadata must be reconciled by retrying Apply; Reject
+or Supersede cannot record a false terminal state.
+
 Apply re-reads the file and compares its SHA-256 hash with the proposal's base
 hash. A missing file is represented by the explicit sentinel `null`; an empty
 file has the normal SHA-256 of empty bytes. Any mismatch marks the proposal
@@ -75,14 +81,17 @@ file has the normal SHA-256 of empty bytes. Any mismatch marks the proposal
 
 For a matching base, apply:
 
-1. writes a recovery copy and manifest beneath the managed storage directory
+1. re-reads after asynchronous validation and requires the same base hash;
+2. writes a recovery copy and manifest beneath the managed storage directory
    beside the active RKA database;
-2. fsyncs the recovery file and manifest;
-3. writes the proposed bytes to a same-directory temporary regular file;
-4. preserves the existing regular-file mode when applicable;
-5. fsyncs and atomically replaces the target with `os.replace`;
-6. fsyncs the containing directory;
-7. records the applied event with before, after, and recovery hashes.
+3. fsyncs the recovery file and manifest;
+4. writes the proposed bytes to a same-directory temporary regular file;
+5. preserves the existing regular-file mode and fsyncs the temporary file;
+6. re-reads synchronously immediately before replacement and again requires the
+   same base hash;
+7. atomically replaces the target with `os.replace`;
+8. fsyncs the containing directory;
+9. records the applied event with before, after, and recovery hashes.
 
 The recovery manifest is durable even if the database event cannot be
 committed after replacement. The service never runs `git add`, commit, reset,
@@ -168,6 +177,8 @@ and does not invalidate PI checkpoints by itself.
   attempts fail closed;
 - human and AI edits use the same proposal service and only PI/web may apply;
 - an external edit produces a durable conflict and leaves the file untouched;
+- same-file apply/reject/supersede races yield rather than blocking the event
+  loop and cannot produce a file/ledger terminal-state mismatch;
 - applied writes are atomic, mode-preserving, and recoverable;
 - Markdown and LaTeX anchors round-trip and invalid anchors are actionable;
 - provenance comments are checked against current typed bindings;

--- a/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
+++ b/docs/adr/0011-conflict-safe-manuscript-source-synchronization.md
@@ -96,8 +96,9 @@ For a matching base, apply:
    preserves the existing regular-file mode, fsyncs the file, and fsyncs its
    containing directory;
 5. for an existing target, atomically exchanges the target and swap names,
-   hashes the exact displaced target, and restores that displaced object by a
-   second exchange if it is not the reviewed base;
+   verifies both the installed proposal and the exact displaced target, and
+   restores the prior target by a second exchange if either boundary object
+   differs from its reviewed hash;
 6. for a missing target, installs the proposed inode with a no-clobber hard link
    so a file that appears at the commit point wins and is never overwritten;
 7. for an existing target, retains the exact displaced inode at its deterministic
@@ -113,11 +114,17 @@ exchange primitive fails closed instead of falling back to a check-then-rename
 sequence. A deterministic swap left by a crash is reconciled before the ledger
 can become `applied`: the service either finishes cleanup and repeats the source
 directory fsync, or restores the exact displaced external object and records a
-conflict. A retry that sees the restored external target with valid recovery
-metadata likewise removes only a verified proposal-byte swap and repeats the
-source-directory fsync before the ledger can become terminally `conflicted`;
-Reject and Supersede share the same guard. An unexpected swap fails closed and
-remains available for inspection.
+conflict. Recovery classification runs before any fresh replacement, including
+when the public target has returned to base-equivalent bytes. A retry that sees
+an external or base-equivalent target with valid recovery metadata retains any
+pre-existing deterministic recovery inode, whether it currently contains
+proposal, reviewed-base, or unclassified bytes. This also protects a descriptor
+opened while proposal bytes were transiently public during a rolled-back
+exchange. The service then repeats the source-directory fsync before the ledger
+can become terminally `conflicted`; Reject and Supersede share the same guard.
+Only a swap freshly created and still owned by the current pre-exchange
+invocation may be unlinked automatically. A missing-file hard-link install may
+also drop the redundant hidden name because the same inode remains public.
 
 The recovery manifest is durable even if the database event cannot be
 committed after replacement. The service never runs `git add`, commit, reset,
@@ -194,7 +201,10 @@ and does not invalidate PI checkpoints by itself.
 - Each successful existing-file Apply retains one hidden displaced-inode
   recovery artifact next to the source. This deliberate storage cost is what
   preserves late writes through pre-opened editor descriptors; PR 10 never
-  deletes those artifacts automatically.
+  deletes those artifacts automatically. Project-deletion preview and result
+  enumerate their deterministic candidate paths before deleting the RKA ledger;
+  cleanup remains a deliberate researcher action after all editor descriptors
+  are closed.
 - Filesystem and database failure cannot be made perfectly atomic; the durable
   recovery-before-exchange protocol and deterministic swap make every expected
   partial naming state observable and repairable.

--- a/docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md
+++ b/docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md
@@ -1,6 +1,7 @@
 # M5 PR 10 implementation plan: manuscript source synchronization
 
 - Date: 2026-08-17
+- Status: implementation candidate complete; independent audit pending
 - Tracking issue: #61
 - Depends on: merged PR #84 / typed academic-writing core
 - Design authority: ADR 0011

--- a/docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md
+++ b/docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md
@@ -1,0 +1,90 @@
+# M5 PR 10 implementation plan: manuscript source synchronization
+
+- Date: 2026-08-17
+- Tracking issue: #61
+- Depends on: merged PR #84 / typed academic-writing core
+- Design authority: ADR 0011
+
+## Goal
+
+Add a narrow local authoring workbench for Markdown and LaTeX that keeps prose
+linked to RKA's ratified manuscript units while preventing stale overwrites,
+unsafe path access, accidental publication of private risk material, and
+automatic Git mutation.
+
+## Slice A: source proposal and recovery substrate
+
+1. Add migration 050 with immutable source-edit proposals and append-only
+   transition events.
+2. Add typed request/response models and new ID prefixes.
+3. Add configured workspace-root and recovery-root policy to `RKAConfig`.
+4. Implement strict path resolution, bounded UTF-8 reads, SHA-256 currency,
+   recovery manifests, same-directory atomic replacement, and directory fsync.
+5. Mark a proposal conflicted when the current file hash differs; retain the
+   proposed content and current hash in the event ledger.
+
+Gate: unit tests prove no write before apply, exact replay/conflict behavior,
+recovery-before-replace, mode preservation, and no Git subprocess path.
+
+## Slice B: anchors, provenance, and projections
+
+1. Parse balanced Markdown/LaTeX `mun_` ranges without nesting or overlap.
+2. Resolve anchor unit IDs against the selected manuscript and report region
+   hashes and line diagnostics.
+3. Parse hidden provenance comments and verify claim, evidence, and citation
+   references against current unit bindings.
+4. Project source files, anchor health, quick-reader flow, and private reviewer
+   risk without mutating semantic readiness.
+5. Include source proposal/event tables in project deletion and integrity
+   checks. Keep file content out of KnowledgePack export; export only an
+   explicit omission warning because workspace files and recovery data are
+   installation-local.
+
+Gate: Markdown and LaTeX round trips, malformed/foreign anchor rejection,
+binding mismatch diagnostics, project isolation, deletion, and pack omission
+tests pass.
+
+## Slice C: REST and local workbench
+
+1. Add local REST endpoints to list/read source files, create/get/list source
+   proposals, and explicitly apply/reject them.
+2. Restrict source reads and proposal transitions to the local web transport;
+   do not expose source content in the MCP operation registry.
+3. Add a `SourceSyncPanel` to the Outline stage with file selector, source and
+   preview split view, hash/currency state, anchor/provenance diagnostics, and
+   a prepare-then-apply flow.
+4. Add separate Quick reader and Reviewer risk tabs. Reviewer risk is visibly
+   private and cannot populate the source editor automatically.
+5. Preserve unsent edits when a background refetch notices an external file
+   change; require compare/reload or a new proposal.
+
+Gate: keyboard navigation, labels, readable conflict/recovery messages,
+responsive layout, production build, changed-file lint, and browser console
+health pass.
+
+## Slice D: release evidence
+
+1. Run migration fresh/upgrade/restart tests.
+2. Run service, REST, authorization, project-scope, and security tests.
+3. Run MCP drift tests to prove the surface did not accidentally expand.
+4. Run the complete Python suite and production web build/lint.
+5. Use a disposable copy of a mature manuscript workspace to demonstrate:
+   - one Markdown and one LaTeX anchor;
+   - verified support and citation provenance;
+   - a private qualifier/counterevidence risk;
+   - a successful apply and recovery artifact;
+   - an external-edit conflict with no overwrite;
+   - restart persistence and zero Git mutation.
+6. Request an independent code and workflow audit, correct findings, and only
+   then merge.
+
+## Deliberate non-goals
+
+- Word or rich-text round trips;
+- LaTeX macro expansion or compilation;
+- automatic prose generation or semantic promotion;
+- three-way merge automation (PR 10 preserves both versions and supports
+  explicit rebase; it does not guess a merge);
+- automatic Git operations;
+- MCP exposure of arbitrary source files;
+- source inbox/repository/URL ingestion, which remains PR 11.

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -1,0 +1,119 @@
+# M5 PR 10 Exit Evidence: Conflict-Safe Manuscript Source Synchronization
+
+Date: 2026-08-17
+Baseline: `main` at `116f76b`
+Implementation branch: `codex/m5-source-sync`
+Tracking issue: #61
+Design authority: ADR 0011
+
+## Scope exercised
+
+- Migration 050 on a fresh database, after restart, and as a late migration over
+  existing manuscript records.
+- Immutable source proposals and append-only proposal events with project-scoped
+  foreign keys and deletion authorization.
+- Explicitly allowlisted Markdown/LaTeX workspace reads with traversal,
+  symlink, special-file, UTF-8, and size-boundary checks.
+- Balanced `mun_` source ranges and exact claim, evidence, and citation
+  provenance validation against current manuscript bindings.
+- Prepare, review, apply, reject, hash-conflict, crash-recovery, mode-preserving
+  atomic replacement, and durable recovery manifests without Git operations.
+- Quick-reader source ranges and a separate private reviewer-risk projection for
+  boundaries, qualifiers, counterevidence, and citation-verification warnings.
+- Local-web-only REST authorization; arbitrary manuscript source content is not
+  added to the MCP surface or portable KnowledgePack payloads. The bundled
+  Docker port is now host-loopback-only so this unauthenticated surface is not
+  published to the LAN by default.
+- Project deletion removes source-ledger rows and managed recovery data while
+  failing closed on a replaced recovery-directory symlink.
+- Responsive workbench controls for file selection, public source editing,
+  preview, diagnostics, external-change detection, and explicit review/apply.
+
+## Disposable end-to-end pilot
+
+A disposable project, manuscript, workspace, and database under
+`/private/tmp/rka-source-pilot` exercised the production web build against a
+loopback-only RKA server. The pilot contained:
+
+- one Markdown file and one LaTeX file with stable `mun_` anchors;
+- one unit-bound manuscript claim, verified support, private qualifier,
+  private counterevidence, and a self-attested citation;
+- valid hidden provenance for the public source;
+- a deliberately private prohibited-wording boundary.
+
+The browser workbench demonstrated that:
+
+1. Preparing `msp_01M08QHN6FPMV6DK6KRPTCKG80` left `main.md` at its original
+   SHA-256 and status `proposed`.
+2. Reloading the workbench showed only `Review source diff`; no Apply control was
+   available until the full current/proposed source was loaded for review.
+3. Explicit Apply atomically replaced the file, advanced the proposal to
+   revision 2 / `applied`, and retained `before.bin` plus a versioned recovery
+   manifest. The applied event records `git_operation: false`.
+4. Restarting the server preserved the applied proposal, both transition events,
+   the recovery path, and the full reviewed content.
+5. The Quick reader linked the canonical unit to both Markdown and LaTeX ranges.
+   The private tab showed the claim boundary, qualifier, counterevidence, and
+   stale citation warning without placing them in the public editor.
+6. An external edit made after an unsent browser change produced the explicit
+   conflict banner and preserved the unique unsent draft text. Reload remained
+   a separate user action; no overwrite occurred.
+7. A 390x844 responsive check initially exposed a narrow tab/header overflow.
+   The panel was corrected with wrapping, minimum-width, and mobile-select rules,
+   then visually rechecked successfully.
+8. The final browser console contained no warnings or errors.
+
+The pilot workspace is disposable and is not part of the repository. It did not
+touch a live research project or invoke a model.
+
+## Automated evidence
+
+| Gate | Result |
+| --- | --- |
+| Migration/source/API/project/pack corrective suite (command below) | **38 passed** |
+| MCP schema/model-drift suite (command below) | **994 passed** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,171 passed in 225.33s** |
+| Changed Python files: Ruff | **Passed** |
+| Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
+| Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
+| Docker Compose validation: `docker compose config --quiet` | **Passed** |
+| Web production build: `(cd web && npm run build)` | **Passed**; existing large-chunk warning remains |
+| Changed web files: ESLint | **Passed** |
+| Browser prepare/review/apply/restart/conflict/private-risk pilot | **Passed** |
+
+Corrective suite command:
+
+```text
+.venv/bin/python -m pytest -q tests/test_db/test_migration_050.py tests/test_services/test_manuscript_source.py tests/test_api/test_manuscript_sources.py tests/test_services/test_project.py tests/test_services/test_knowledge_pack_native.py
+```
+
+MCP schema/model-drift command:
+
+```text
+.venv/bin/python -m pytest -q tests/test_mcp/test_v270_model_drift.py tests/test_mcp/test_mcp_tool_surface.py tests/test_mcp/test_native_manuscript_operations.py
+```
+
+Ruff command:
+
+```text
+.venv/bin/python -m ruff check rka/api/app.py rka/api/deps.py rka/api/routes/manuscript_sources.py rka/config.py rka/infra/ids.py rka/models/manuscript_source.py rka/services/knowledge_pack.py rka/services/manuscript_source.py rka/services/project.py tests/test_api/test_manuscript_sources.py tests/test_db/test_migration_050.py tests/test_services/test_knowledge_pack_native.py tests/test_services/test_manuscript_source.py tests/test_services/test_project.py
+```
+
+Changed-web ESLint command:
+
+```text
+cd web && npx eslint src/api/client.ts src/api/types.ts src/components/workbench/SourceSyncPanel.tsx src/hooks/useManuscriptSources.ts src/pages/ManuscriptWorkbench.tsx
+```
+
+The disposable virtual environment uses the repository-locked
+`sqlite-vec==0.1.6`; no temporary dependency override was needed for the final
+full-suite result.
+
+## Review interpretation
+
+These checks establish the implementation candidate's source-synchronization
+contract, local security boundary, crash/conflict behavior, and workbench
+interaction. They do not establish support for arbitrary LaTeX macro expansion,
+Word round trips, automatic three-way merging, or automatic prose generation;
+those remain deliberate non-goals. The candidate remains unmerged until an
+independent audit reviews the exact commit and any findings are corrected.

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -16,16 +16,18 @@ Design authority: ADR 0011
   symlink, special-file, UTF-8, and size-boundary checks.
 - Balanced `mun_` source ranges and exact claim, evidence, and citation
   provenance validation against current manuscript bindings.
-- Prepare, review, apply, reject, hash-conflict, crash-recovery, mode-preserving
-  atomic replacement, and durable recovery manifests without Git operations.
+- Prepare, review, apply, reject, supersede, hash-conflict, crash-recovery,
+  nonblocking same-file transition serialization, mode-preserving atomic
+  replacement, and durable recovery manifests without Git operations.
 - Quick-reader source ranges and a separate private reviewer-risk projection for
   boundaries, qualifiers, counterevidence, and citation-verification warnings.
 - Local-web-only REST authorization; arbitrary manuscript source content is not
   added to the MCP surface or portable KnowledgePack payloads. The bundled
   Docker port is now host-loopback-only so this unauthenticated surface is not
   published to the LAN by default.
-- Project deletion removes source-ledger rows and managed recovery data while
-  failing closed on a replaced recovery-directory symlink.
+- Project deletion removes chained source-proposal histories, ledger rows, and
+  managed recovery data while failing closed on a replaced recovery-directory
+  symlink.
 - Responsive workbench controls for file selection, public source editing,
   preview, diagnostics, external-change detection, and explicit review/apply.
 
@@ -55,9 +57,11 @@ The browser workbench demonstrated that:
 5. The Quick reader linked the canonical unit to both Markdown and LaTeX ranges.
    The private tab showed the claim boundary, qualifier, counterevidence, and
    stale citation warning without placing them in the public editor.
-6. An external edit made after an unsent browser change produced the explicit
-   conflict banner and preserved the unique unsent draft text. Reload remained
-   a separate user action; no overwrite occurred.
+6. An external edit made after an unsent browser change was detected by the
+   active workbench's ten-second source poll without pressing the manual check
+   button. The explicit conflict banner appeared, Prepare disabled, and the
+   unique unsent draft remained intact. Reload remained a separate user action;
+   no overwrite occurred.
 7. A 390x844 responsive check initially exposed a narrow tab/header overflow.
    The panel was corrected with wrapping, minimum-width, and mobile-select rules,
    then visually rechecked successfully.
@@ -70,16 +74,16 @@ touch a live research project or invoke a model.
 
 | Gate | Result |
 | --- | --- |
-| Migration/source/API/project/pack corrective suite (command below) | **38 passed** |
+| Migration/source/API/project/pack corrective suite (command below) | **46 passed** |
 | MCP schema/model-drift suite (command below) | **994 passed** |
-| Full Python suite: `.venv/bin/python -m pytest -q` | **3,171 passed in 225.33s** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,179 passed in 260.88s** |
 | Changed Python files: Ruff | **Passed** |
 | Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
 | Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
 | Docker Compose validation: `docker compose config --quiet` | **Passed** |
 | Web production build: `(cd web && npm run build)` | **Passed**; existing large-chunk warning remains |
 | Changed web files: ESLint | **Passed** |
-| Browser prepare/review/apply/restart/conflict/private-risk pilot | **Passed** |
+| Browser prepare/review/apply/restart/automatic-conflict/private-risk pilot | **Passed** |
 
 Corrective suite command:
 
@@ -108,6 +112,30 @@ cd web && npx eslint src/api/client.ts src/api/types.ts src/components/workbench
 The disposable virtual environment uses the repository-locked
 `sqlite-vec==0.1.6`; no temporary dependency override was needed for the final
 full-suite result.
+
+## Independent-audit corrections
+
+The first exact-commit audit kept the candidate in draft and identified
+same-file event-loop blocking, terminal-transition races, a late external-edit
+overwrite window, deletion failure for supersession chains, omitted unallocated
+adverse evidence, and a UI guard that depended on manual refresh. The corrected
+candidate adds deterministic regression coverage for:
+
+- two concurrent same-file applies completing without event-loop deadlock;
+- apply racing reject and supersede after the filesystem commit point;
+- a late external edit injected after durable recovery but before replacement;
+- database interruption after replace and failure between replace and directory
+  fsync, both reconciled by retrying Apply;
+- rejection of a crash-applied proposal until Apply reconciles the ledger;
+- deletion of a service-created three-proposal supersession history;
+- private projection of unallocated claim-level qualifier and counterevidence;
+- direct invalid-UTF-8 and configured-size-limit reads; and
+- an automatic background source refetch preserving a dirty browser draft and
+  disabling Prepare.
+
+The browser pilot remains complementary disposable evidence rather than a
+committed test artifact. The concurrency, recovery, deletion, and risk
+semantics above are established by committed deterministic tests.
 
 ## Review interpretation
 

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -18,7 +18,8 @@ Design authority: ADR 0011
   provenance validation against current manuscript bindings.
 - Prepare, review, apply, reject, supersede, hash-conflict, crash-recovery,
   nonblocking same-file transition serialization, mode-preserving atomic
-  replacement, and durable recovery manifests without Git operations.
+  exchange, durable managed manifests, and retained displaced-inode recovery
+  without Git operations.
 - Quick-reader source ranges and a separate private reviewer-risk projection for
   boundaries, qualifiers, counterevidence, and citation-verification warnings.
 - Local-web-only REST authorization; arbitrary manuscript source content is not
@@ -74,9 +75,9 @@ touch a live research project or invoke a model.
 
 | Gate | Result |
 | --- | --- |
-| Migration/source/API/project/pack corrective suite (command below) | **54 passed** |
+| Migration/source/API/project/pack corrective suite (command below) | **60 passed** |
 | MCP schema/model-drift suite (command below) | **994 passed** |
-| Full Python suite: `.venv/bin/python -m pytest -q` | **3,187 passed in 209.99s** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,193 passed in 209.03s** |
 | Changed Python files: Ruff | **Passed** |
 | Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
 | Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
@@ -125,6 +126,9 @@ candidate adds deterministic regression coverage for:
 - apply racing reject and supersede after the filesystem commit point;
 - a late external edit injected at the final atomic-exchange call, with the exact
   displaced external object restored instead of overwritten;
+- an editor descriptor opened before Apply writing after displaced-byte
+  validation, with that exact inode still linked at the recorded hidden recovery
+  path after the public target and ledger become applied;
 - missing-file creation with a no-clobber hard link, including an external file
   appearing at the commit point;
 - database interruption after exchange, interrupted exchange with the reviewed
@@ -133,6 +137,10 @@ candidate adds deterministic regression coverage for:
 - restoration of an external object retained by a crash-interrupted exchange;
 - retry of every recovery-ancestor directory-fsync barrier and the failed source
   directory fsync before the ledger may become applied;
+- retry of a failed rollback-directory fsync before Apply may record conflict,
+  plus the same durable cleanup guard for Reject and Supersede;
+- cleanup of only a known proposal-byte swap before terminal conflict, with an
+  unexpected swap preserved and the ledger left open;
 - rejection of a crash-applied proposal until Apply reconciles the ledger;
 - deletion of a service-created three-proposal supersession history;
 - private projection of unallocated claim-level qualifier and counterevidence;

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -57,11 +57,11 @@ The browser workbench demonstrated that:
 5. The Quick reader linked the canonical unit to both Markdown and LaTeX ranges.
    The private tab showed the claim boundary, qualifier, counterevidence, and
    stale citation warning without placing them in the public editor.
-6. An external edit made after an unsent browser change was detected by the
-   active workbench's ten-second source poll without pressing the manual check
-   button. The explicit conflict banner appeared, Prepare disabled, and the
-   unique unsent draft remained intact. Reload remained a separate user action;
-   no overwrite occurred.
+6. A clean editor adopted an external source change through the ten-second poll
+   without a manual check. After a keyboard-entered unsent draft, the next
+   external edit updated the displayed source hash but preserved the draft,
+   raised the explicit conflict banner, and disabled Prepare. Reload remained a
+   separate user action; no overwrite occurred.
 7. A 390x844 responsive check initially exposed a narrow tab/header overflow.
    The panel was corrected with wrapping, minimum-width, and mobile-select rules,
    then visually rechecked successfully.
@@ -74,9 +74,9 @@ touch a live research project or invoke a model.
 
 | Gate | Result |
 | --- | --- |
-| Migration/source/API/project/pack corrective suite (command below) | **46 passed** |
+| Migration/source/API/project/pack corrective suite (command below) | **54 passed** |
 | MCP schema/model-drift suite (command below) | **994 passed** |
-| Full Python suite: `.venv/bin/python -m pytest -q` | **3,179 passed in 260.88s** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,187 passed in 209.99s** |
 | Changed Python files: Ruff | **Passed** |
 | Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
 | Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
@@ -123,15 +123,22 @@ candidate adds deterministic regression coverage for:
 
 - two concurrent same-file applies completing without event-loop deadlock;
 - apply racing reject and supersede after the filesystem commit point;
-- a late external edit injected after durable recovery but before replacement;
-- database interruption after replace and failure between replace and directory
-  fsync, both reconciled by retrying Apply;
+- a late external edit injected at the final atomic-exchange call, with the exact
+  displaced external object restored instead of overwritten;
+- missing-file creation with a no-clobber hard link, including an external file
+  appearing at the commit point;
+- database interruption after exchange, interrupted exchange with the reviewed
+  base retained at the deterministic swap name, and failure between cleanup and
+  source-directory fsync, all reconciled by retrying Apply;
+- restoration of an external object retained by a crash-interrupted exchange;
+- retry of every recovery-ancestor directory-fsync barrier and the failed source
+  directory fsync before the ledger may become applied;
 - rejection of a crash-applied proposal until Apply reconciles the ledger;
 - deletion of a service-created three-proposal supersession history;
 - private projection of unallocated claim-level qualifier and counterevidence;
 - direct invalid-UTF-8 and configured-size-limit reads; and
-- an automatic background source refetch preserving a dirty browser draft and
-  disabling Prepare.
+- an automatic clean-editor reload followed by a background refetch preserving
+  a dirty browser draft and disabling Prepare.
 
 The browser pilot remains complementary disposable evidence rather than a
 committed test artifact. The concurrency, recovery, deletion, and risk

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -75,9 +75,9 @@ touch a live research project or invoke a model.
 
 | Gate | Result |
 | --- | --- |
-| Migration/source/API/project/pack corrective suite (command below) | **72 passed** |
+| Migration/source/API/project/pack corrective suite (command below) | **75 passed** |
 | MCP schema/model-drift suite (command below) | **994 passed** |
-| Full Python suite: `.venv/bin/python -m pytest -q` | **3,205 passed in 211.26s** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,208 passed in 321.37s** |
 | Changed Python files: Ruff | **Passed** |
 | Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
 | Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
@@ -145,6 +145,10 @@ candidate adds deterministic regression coverage for:
 - bounded classification of an oversized retained regular inode through Apply,
   Reject, and Supersede, without loading it into memory or leaving the proposal
   permanently open;
+- retention and terminal conflict for unreadable, symlinked, FIFO, or directory
+  recovery objects without ever exchanging them into the public manuscript path;
+- explicit successor creation after an unsafe-object conflict, while the retained
+  object remains available for inspection;
 - separate event fields for durable retention state and the last observed byte
   classification, so a late descriptor write is not mislabeled as immutable
   reviewed-base content;

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -75,9 +75,9 @@ touch a live research project or invoke a model.
 
 | Gate | Result |
 | --- | --- |
-| Migration/source/API/project/pack corrective suite (command below) | **69 passed** |
+| Migration/source/API/project/pack corrective suite (command below) | **72 passed** |
 | MCP schema/model-drift suite (command below) | **994 passed** |
-| Full Python suite: `.venv/bin/python -m pytest -q` | **3,202 passed in 251.74s** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,205 passed in 211.26s** |
 | Changed Python files: Ruff | **Passed** |
 | Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
 | Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
@@ -142,6 +142,16 @@ candidate adds deterministic regression coverage for:
 - retention of every pre-existing deterministic recovery inode before terminal
   conflict, including proposal, reviewed-base, and unclassified content, with
   the source directory fsynced and retained path recorded as the ledger closes;
+- bounded classification of an oversized retained regular inode through Apply,
+  Reject, and Supersede, without loading it into memory or leaving the proposal
+  permanently open;
+- separate event fields for durable retention state and the last observed byte
+  classification, so a late descriptor write is not mislabeled as immutable
+  reviewed-base content;
+- a generic retained-source path for crash-left proposal hard links while
+  reserving `displaced_source_path` for an original target that actually existed;
+- a post-unlink source-directory fsync when a fresh pre-exchange swap is cleaned
+  after a missing-target collision;
 - restart classification before any fresh replacement when a valid recovery
   manifest and retained inode exist, including a public target whose bytes have
   returned to the reviewed base;

--- a/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
+++ b/docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md
@@ -75,9 +75,9 @@ touch a live research project or invoke a model.
 
 | Gate | Result |
 | --- | --- |
-| Migration/source/API/project/pack corrective suite (command below) | **60 passed** |
+| Migration/source/API/project/pack corrective suite (command below) | **69 passed** |
 | MCP schema/model-drift suite (command below) | **994 passed** |
-| Full Python suite: `.venv/bin/python -m pytest -q` | **3,193 passed in 209.03s** |
+| Full Python suite: `.venv/bin/python -m pytest -q` | **3,202 passed in 251.74s** |
 | Changed Python files: Ruff | **Passed** |
 | Python compile check: `.venv/bin/python -m compileall -q rka` | **Passed** |
 | Git whitespace/error check: `git diff --check 116f76b --` | **Passed** |
@@ -138,11 +138,20 @@ candidate adds deterministic regression coverage for:
 - retry of every recovery-ancestor directory-fsync barrier and the failed source
   directory fsync before the ledger may become applied;
 - retry of a failed rollback-directory fsync before Apply may record conflict,
-  plus the same durable cleanup guard for Reject and Supersede;
-- cleanup of only a known proposal-byte swap before terminal conflict, with an
-  unexpected swap preserved and the ledger left open;
+  plus the same durable recovery guard for Reject and Supersede;
+- retention of every pre-existing deterministic recovery inode before terminal
+  conflict, including proposal, reviewed-base, and unclassified content, with
+  the source directory fsynced and retained path recorded as the ledger closes;
+- restart classification before any fresh replacement when a valid recovery
+  manifest and retained inode exist, including a public target whose bytes have
+  returned to the reviewed base;
+- boundary verification of both installed proposal and displaced target, with a
+  mutated proposal inode restored to its hidden recovery name instead of being
+  unlinked;
 - rejection of a crash-applied proposal until Apply reconciles the ledger;
-- deletion of a service-created three-proposal supersession history;
+- deletion of a service-created three-proposal supersession history, plus
+  explicit preview/result reporting of source-adjacent recovery candidates that
+  are intentionally not auto-deleted;
 - private projection of unallocated claim-level qualifier and counterevidence;
 - direct invalid-UTF-8 and configured-size-limit reads; and
 - an automatic clean-editor reload followed by a background refetch preserving

--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -29,6 +29,7 @@ from rka.api.routes import (
     literature as literature_routes,
     llm as llm_routes,
     manuscripts as manuscripts_routes,
+    manuscript_sources as manuscript_source_routes,
     missions as missions_routes,
     notes as notes_routes,
     project as project_routes,
@@ -298,6 +299,11 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
     app.include_router(project_routes.router, prefix="/api", tags=["project"])
     app.include_router(notes_routes.router, prefix="/api", tags=["notes"])
     app.include_router(manuscripts_routes.router, prefix="/api", tags=["manuscripts"])
+    app.include_router(
+        manuscript_source_routes.router,
+        prefix="/api",
+        tags=["manuscript-sources"],
+    )
     app.include_router(decisions_routes.router, prefix="/api", tags=["decisions"])
     app.include_router(literature_routes.router, prefix="/api", tags=["literature"])
     app.include_router(missions_routes.router, prefix="/api", tags=["missions"])

--- a/rka/api/deps.py
+++ b/rka/api/deps.py
@@ -41,6 +41,7 @@ from rka.services.interpretation import InterpretationService
 from rka.services.experiments import ExperimentService
 from rka.services.planning import ManuscriptPlanningService
 from rka.services.semantic_patch import SemanticPatchService
+from rka.services.manuscript_source import ManuscriptSourceService
 
 logger = logging.getLogger(__name__)
 
@@ -449,6 +450,14 @@ def get_scoped_semantic_patch_service(
     db: Database = Depends(get_db),
 ) -> SemanticPatchService:
     return SemanticPatchService(db, project_id=project_id)
+
+
+def get_scoped_manuscript_source_service(
+    config: RKAConfig = Depends(get_config),
+    project_id: str = Depends(require_project),
+    db: Database = Depends(get_db),
+) -> ManuscriptSourceService:
+    return ManuscriptSourceService(db, config=config, project_id=project_id)
 
 
 def get_scoped_cluster_service(

--- a/rka/api/routes/manuscript_sources.py
+++ b/rka/api/routes/manuscript_sources.py
@@ -1,0 +1,146 @@
+"""Local-only manuscript Markdown/LaTeX source synchronization routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from rka.api.deps import get_scoped_manuscript_source_service, get_transport_actor
+from rka.models.manuscript_source import (
+    ManuscriptSourcePath,
+    ManuscriptSourceProposalCreate,
+    ManuscriptSourceProposalTransition,
+)
+from rka.services.manuscript_native import ManuscriptNotFoundError
+from rka.services.manuscript_source import (
+    ManuscriptSourceConflictError,
+    ManuscriptSourceNotFoundError,
+    ManuscriptSourceSecurityError,
+    ManuscriptSourceService,
+)
+
+
+router = APIRouter()
+
+
+def _require_web_actor(actor: str) -> None:
+    if actor != "web_ui":
+        raise HTTPException(
+            status_code=403,
+            detail="manuscript source content is restricted to the local web transport",
+        )
+
+
+def _raise_source_error(exc: Exception) -> None:
+    if isinstance(exc, (ManuscriptNotFoundError, ManuscriptSourceNotFoundError)):
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if isinstance(exc, ManuscriptSourceConflictError):
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if isinstance(exc, ManuscriptSourceSecurityError):
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/manuscripts/{manuscript_id}/source")
+async def get_manuscript_source_overview(
+    manuscript_id: str,
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> dict:
+    _require_web_actor(actor)
+    try:
+        return await service.get_overview(manuscript_id)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)
+
+
+@router.post("/manuscripts/{manuscript_id}/source/read")
+async def read_manuscript_source_file(
+    manuscript_id: str,
+    data: ManuscriptSourcePath,
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> dict:
+    _require_web_actor(actor)
+    try:
+        return await service.read_file(manuscript_id, data.relative_path)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)
+
+
+@router.post("/manuscripts/{manuscript_id}/source/proposals", status_code=201)
+async def create_manuscript_source_proposal(
+    manuscript_id: str,
+    data: ManuscriptSourceProposalCreate,
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> dict:
+    _require_web_actor(actor)
+    if data.created_by != "web_ui":
+        raise HTTPException(
+            status_code=403,
+            detail="local web source proposals must be attributed to web_ui",
+        )
+    try:
+        return await service.create_proposal(manuscript_id, data)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)
+
+
+@router.get("/manuscripts/{manuscript_id}/source/proposals")
+async def list_manuscript_source_proposals(
+    manuscript_id: str,
+    status: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> list[dict]:
+    _require_web_actor(actor)
+    try:
+        return await service.list_proposals(manuscript_id, status=status, limit=limit)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)
+
+
+@router.get("/manuscript-source-proposals/{proposal_id}")
+async def get_manuscript_source_proposal(
+    proposal_id: str,
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> dict:
+    _require_web_actor(actor)
+    try:
+        return await service.get_proposal(proposal_id)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)
+
+
+@router.post("/manuscript-source-proposals/{proposal_id}/apply")
+async def apply_manuscript_source_proposal(
+    proposal_id: str,
+    data: ManuscriptSourceProposalTransition,
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> dict:
+    _require_web_actor(actor)
+    if data.actor != "web_ui":
+        raise HTTPException(status_code=403, detail="local web apply requires actor=web_ui")
+    try:
+        return await service.apply_proposal(proposal_id, data)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)
+
+
+@router.post("/manuscript-source-proposals/{proposal_id}/reject")
+async def reject_manuscript_source_proposal(
+    proposal_id: str,
+    data: ManuscriptSourceProposalTransition,
+    actor: str = Depends(get_transport_actor),
+    service: ManuscriptSourceService = Depends(get_scoped_manuscript_source_service),
+) -> dict:
+    _require_web_actor(actor)
+    if data.actor != "web_ui":
+        raise HTTPException(status_code=403, detail="local web reject requires actor=web_ui")
+    try:
+        return await service.reject_proposal(proposal_id, data)
+    except (ValueError, OSError, UnicodeError) as exc:
+        _raise_source_error(exc)

--- a/rka/config.py
+++ b/rka/config.py
@@ -82,6 +82,22 @@ class RKAConfig(BaseSettings):
         description="LM Studio proposal request timeout in seconds",
     )
 
+    # Manuscript source synchronization is deliberately opt-in. A
+    # manuscript.workspace_ref never grants filesystem authority on its own;
+    # it must resolve below one of these os.pathsep-separated roots.
+    manuscript_workspace_roots: str = Field(
+        default="",
+        description=(
+            "os.pathsep-separated allowlist of local manuscript workspace roots"
+        ),
+    )
+    manuscript_source_max_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=1,
+        le=20 * 1024 * 1024,
+        description="Maximum UTF-8 bytes in one synchronized manuscript source file",
+    )
+
     # Embeddings — v2.4.0 (Mission D) flips the default to ON. Persistent
     # backend config lives at /data/embedding_config.json; this env var
     # remains the master enable/disable switch for the in-process

--- a/rka/db/migrations/050_add_manuscript_source_sync.sql
+++ b/rka/db/migrations/050_add_manuscript_source_sync.sql
@@ -1,0 +1,112 @@
+-- Migration 050: conflict-safe manuscript source proposal and recovery ledger.
+-- requires-table: projects, manuscripts, semantic_patch_context_manifests, change_events, project_deletion_authorizations
+
+CREATE TABLE IF NOT EXISTS manuscript_source_proposals (
+    id TEXT PRIMARY KEY CHECK (substr(id, 1, 4) = 'msp_' AND length(id) > 4),
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+    manuscript_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'proposed' CHECK (status IN ('proposed', 'applied', 'rejected', 'conflicted', 'superseded', 'expired')),
+    revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+    origin TEXT NOT NULL CHECK (origin IN ('human', 'host_agent', 'lm_studio')),
+    relative_path TEXT NOT NULL CHECK (length(trim(relative_path)) > 0),
+    source_format TEXT NOT NULL CHECK (source_format IN ('markdown', 'latex')),
+    base_content_hash TEXT CHECK (base_content_hash IS NULL OR length(base_content_hash) = 64),
+    proposed_content TEXT NOT NULL,
+    proposed_content_hash TEXT NOT NULL CHECK (length(proposed_content_hash) = 64),
+    created_by TEXT NOT NULL CHECK (created_by IN ('pi', 'brain', 'executor', 'web_ui')),
+    reason TEXT NOT NULL CHECK (length(trim(reason)) > 0),
+    validation_findings TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(validation_findings) AND json_type(validation_findings) = 'array'),
+    context_manifest_id TEXT,
+    provider TEXT,
+    model TEXT,
+    boundary TEXT NOT NULL CHECK (boundary IN ('none', 'host_conversation', 'local_loopback')),
+    supersedes_proposal_id TEXT,
+    recovery_manifest_path TEXT,
+    applied_at TEXT,
+    closed_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE (id, project_id),
+    FOREIGN KEY (manuscript_id, project_id) REFERENCES manuscripts(id, project_id) ON DELETE RESTRICT,
+    FOREIGN KEY (context_manifest_id, project_id) REFERENCES semantic_patch_context_manifests(id, project_id) ON DELETE RESTRICT,
+    FOREIGN KEY (supersedes_proposal_id, project_id) REFERENCES manuscript_source_proposals(id, project_id) ON DELETE RESTRICT,
+    CHECK ((origin = 'human' AND context_manifest_id IS NULL AND provider IS NULL AND model IS NULL AND boundary = 'none')
+        OR (origin <> 'human' AND context_manifest_id IS NOT NULL AND provider IS NOT NULL AND model IS NOT NULL AND boundary <> 'none'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_source_proposals_project
+    ON manuscript_source_proposals(project_id, manuscript_id, status, updated_at DESC, id);
+
+CREATE TABLE IF NOT EXISTS manuscript_source_events (
+    id TEXT PRIMARY KEY CHECK (substr(id, 1, 4) = 'mse_' AND length(id) > 4),
+    proposal_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    proposal_revision INTEGER NOT NULL CHECK (proposal_revision >= 1),
+    action TEXT NOT NULL CHECK (action IN ('proposed', 'applied', 'rejected', 'conflicted', 'superseded', 'expired')),
+    actor TEXT NOT NULL CHECK (actor IN ('pi', 'brain', 'executor', 'web_ui', 'system')),
+    reason TEXT NOT NULL CHECK (length(trim(reason)) > 0),
+    details TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(details) AND json_type(details) = 'object'),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE (id, project_id),
+    UNIQUE (proposal_id, proposal_revision),
+    FOREIGN KEY (proposal_id, project_id) REFERENCES manuscript_source_proposals(id, project_id) ON DELETE RESTRICT
+);
+
+CREATE TRIGGER IF NOT EXISTS trg_manuscript_source_events_no_update
+BEFORE UPDATE ON manuscript_source_events BEGIN
+    SELECT RAISE(ABORT, 'manuscript source events are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_manuscript_source_proposals_validate_update
+BEFORE UPDATE ON manuscript_source_proposals
+WHEN NEW.id IS NOT OLD.id OR NEW.project_id IS NOT OLD.project_id
+ OR NEW.manuscript_id IS NOT OLD.manuscript_id OR NEW.origin IS NOT OLD.origin
+ OR NEW.relative_path IS NOT OLD.relative_path OR NEW.source_format IS NOT OLD.source_format
+ OR NEW.base_content_hash IS NOT OLD.base_content_hash
+ OR NEW.proposed_content IS NOT OLD.proposed_content
+ OR NEW.proposed_content_hash IS NOT OLD.proposed_content_hash
+ OR NEW.created_by IS NOT OLD.created_by OR NEW.reason IS NOT OLD.reason
+ OR NEW.validation_findings IS NOT OLD.validation_findings
+ OR NEW.context_manifest_id IS NOT OLD.context_manifest_id OR NEW.provider IS NOT OLD.provider
+ OR NEW.model IS NOT OLD.model OR NEW.boundary IS NOT OLD.boundary
+ OR NEW.supersedes_proposal_id IS NOT OLD.supersedes_proposal_id OR NEW.created_at IS NOT OLD.created_at
+ OR NEW.revision <> OLD.revision + 1
+ OR NOT (
+     (OLD.status = 'proposed'
+      AND NEW.status IN ('applied', 'rejected', 'conflicted', 'superseded', 'expired'))
+     OR (OLD.status = 'conflicted' AND NEW.status = 'superseded')
+ )
+ OR NEW.closed_at IS NULL OR NEW.closed_at IS NOT NEW.updated_at
+ OR (NEW.status = 'applied'
+     AND (NEW.applied_at IS NULL OR NEW.applied_at IS NOT NEW.updated_at
+          OR NEW.recovery_manifest_path IS NULL))
+ OR (NEW.status <> 'applied'
+     AND (NEW.applied_at IS NOT OLD.applied_at
+          OR NEW.recovery_manifest_path IS NOT OLD.recovery_manifest_path))
+BEGIN
+    SELECT RAISE(ABORT, 'manuscript source proposal content is immutable and only open records may transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_manuscript_source_rows_no_delete_proposal
+BEFORE DELETE ON manuscript_source_proposals
+WHEN NOT EXISTS (SELECT 1 FROM project_deletion_authorizations WHERE project_id = OLD.project_id)
+BEGIN SELECT RAISE(ABORT, 'manuscript source proposals require project-authorized deletion'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_manuscript_source_rows_no_delete_event
+BEFORE DELETE ON manuscript_source_events
+WHEN NOT EXISTS (SELECT 1 FROM project_deletion_authorizations WHERE project_id = OLD.project_id)
+BEGIN SELECT RAISE(ABORT, 'manuscript source events require project-authorized deletion'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_change_manuscript_source_proposals_insert
+AFTER INSERT ON manuscript_source_proposals BEGIN
+    INSERT INTO change_events (project_id, source_table, operation, entity_type, entity_id, manuscript_id, details)
+    VALUES (NEW.project_id, 'manuscript_source_proposals', 'insert', 'manuscript_source_proposal', NEW.id, NEW.manuscript_id,
+            json_object('status', NEW.status, 'revision', NEW.revision, 'relative_path', NEW.relative_path));
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_change_manuscript_source_proposals_update
+AFTER UPDATE ON manuscript_source_proposals BEGIN
+    INSERT INTO change_events (project_id, source_table, operation, entity_type, entity_id, manuscript_id, details)
+    VALUES (NEW.project_id, 'manuscript_source_proposals', 'update', 'manuscript_source_proposal', NEW.id, NEW.manuscript_id,
+            json_object('status', NEW.status, 'revision', NEW.revision, 'relative_path', NEW.relative_path));
+END;

--- a/rka/db/migrations/050_add_manuscript_source_sync.sql
+++ b/rka/db/migrations/050_add_manuscript_source_sync.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS manuscript_source_proposals (
     UNIQUE (id, project_id),
     FOREIGN KEY (manuscript_id, project_id) REFERENCES manuscripts(id, project_id) ON DELETE RESTRICT,
     FOREIGN KEY (context_manifest_id, project_id) REFERENCES semantic_patch_context_manifests(id, project_id) ON DELETE RESTRICT,
-    FOREIGN KEY (supersedes_proposal_id, project_id) REFERENCES manuscript_source_proposals(id, project_id) ON DELETE RESTRICT,
+    FOREIGN KEY (supersedes_proposal_id, project_id) REFERENCES manuscript_source_proposals(id, project_id) ON DELETE CASCADE,
     CHECK ((origin = 'human' AND context_manifest_id IS NULL AND provider IS NULL AND model IS NULL AND boundary = 'none')
         OR (origin <> 'human' AND context_manifest_id IS NOT NULL AND provider IS NOT NULL AND model IS NOT NULL AND boundary <> 'none'))
 );

--- a/rka/infra/ids.py
+++ b/rka/infra/ids.py
@@ -67,6 +67,8 @@ _PREFIXES = {
     "semantic_patch_proposal_event": "spe",
     "semantic_patch_provider_call": "spc",
     "semantic_patch_provider_event": "pce",
+    "manuscript_source_proposal": "msp",
+    "manuscript_source_event": "mse",
 }
 
 

--- a/rka/models/manuscript_source.py
+++ b/rka/models/manuscript_source.py
@@ -1,0 +1,90 @@
+"""Typed contracts for conflict-safe Markdown/LaTeX source synchronization."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from rka.models.semantic_patch import ProposalOrigin, ProviderBoundary
+
+
+SourceFormat = Literal["markdown", "latex"]
+SourceProposalStatus = Literal[
+    "proposed", "applied", "rejected", "conflicted", "superseded", "expired"
+]
+SourceProposalActor = Literal["pi", "brain", "executor", "web_ui"]
+SourceProposalReviewer = Literal["pi", "web_ui"]
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ManuscriptSourcePath(_ClosedModel):
+    relative_path: str = Field(min_length=1, max_length=4096)
+
+    @field_validator("relative_path")
+    @classmethod
+    def normalize_path(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("relative_path must not be blank")
+        return value
+
+
+class ManuscriptSourceProposalCreate(ManuscriptSourcePath):
+    origin: ProposalOrigin
+    expected_content_hash: str | None = Field(
+        default=None,
+        pattern=r"^[0-9a-fA-F]{64}$",
+        description="SHA-256 of the current file, or null only when it must be absent.",
+    )
+    content: str = Field(max_length=20 * 1024 * 1024)
+    created_by: SourceProposalActor
+    reason: str = Field(min_length=1, max_length=10_000)
+    provider: str | None = Field(default=None, max_length=500)
+    model: str | None = Field(default=None, max_length=500)
+    boundary: ProviderBoundary = "none"
+    context_manifest_id: str | None = Field(default=None, max_length=128)
+    supersedes_proposal_id: str | None = Field(default=None, max_length=128)
+
+    @model_validator(mode="after")
+    def validate_origin(self):
+        self.reason = self.reason.strip()
+        self.provider = self.provider.strip() if self.provider else None
+        self.model = self.model.strip() if self.model else None
+        self.context_manifest_id = (
+            self.context_manifest_id.strip() if self.context_manifest_id else None
+        )
+        self.supersedes_proposal_id = (
+            self.supersedes_proposal_id.strip() if self.supersedes_proposal_id else None
+        )
+        if self.expected_content_hash:
+            self.expected_content_hash = self.expected_content_hash.lower()
+        if not self.reason:
+            raise ValueError("reason must not be blank")
+        if self.origin == "human":
+            if self.provider or self.model or self.boundary != "none" or self.context_manifest_id:
+                raise ValueError("human proposals cannot declare an AI provider boundary")
+        else:
+            if not self.provider or not self.model or not self.context_manifest_id:
+                raise ValueError("AI proposals require provider, model, and context_manifest_id")
+            expected = "host_conversation" if self.origin == "host_agent" else "local_loopback"
+            if self.boundary != expected:
+                raise ValueError(f"{self.origin} proposals require boundary={expected!r}")
+        return self
+
+
+class ManuscriptSourceProposalTransition(_ClosedModel):
+    expected_revision: int = Field(ge=1)
+    actor: SourceProposalReviewer
+    reason: str = Field(min_length=1, max_length=10_000)
+
+    @field_validator("reason")
+    @classmethod
+    def normalize_reason(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("reason must not be blank")
+        return value

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -46,6 +46,14 @@ _PORTABILITY_EXCLUSIONS: dict[str, str] = {
         "Diagnostics from source-installation reference-validation migration, "
         "not portable manuscript semantic state."
     ),
+    "manuscript_source_proposals": (
+        "Candidate source text, local workspace paths, and recovery state are "
+        "installation-local authoring data; export the manuscript files separately."
+    ),
+    "manuscript_source_events": (
+        "Source-file apply and recovery events refer to installation-local paths "
+        "and are omitted with their source proposals."
+    ),
 }
 
 
@@ -189,6 +197,8 @@ _TABLE_CATEGORIES: dict[str, list[str]] = {
         "jobs",
         "manuscript_migration_issues",
         "reference_validation_migration_issues",
+        "manuscript_source_proposals",
+        "manuscript_source_events",
         "project_deletion_authorizations",
         "kv_store",
         "embedding_metadata",

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -58,7 +58,7 @@ class ManuscriptSourceConflictError(ValueError):
         self,
         message: str,
         *,
-        transient_exchange: bool = False,
+        transient_exchange: bool | None = False,
         recovery_state: str | None = None,
     ):
         super().__init__(message)
@@ -1201,7 +1201,11 @@ class ManuscriptSourceService(BaseService):
         current_hash = _sha256(current) if current is not None else None
         recovery_path = self._recovery_manifest_path(row)
         has_valid_recovery = self._valid_recovery_manifest(recovery_path, row)
-        if current_hash == row["proposed_content_hash"] and has_valid_recovery:
+        if (
+            row["status"] == "proposed"
+            and current_hash == row["proposed_content_hash"]
+            and has_valid_recovery
+        ):
             raise ManuscriptSourceConflictError(
                 "proposal content is already on disk with valid recovery metadata; "
                 f"retry apply to reconcile the ledger before {action}"
@@ -1616,22 +1620,22 @@ class ManuscriptSourceService(BaseService):
                     validate_utf8=False,
                 )
             except (OSError, ValueError, ManuscriptSourceSecurityError) as exc:
-                # The deterministic swap name can only contain the object that
-                # was about to replace the target or the exact target displaced
-                # by the exchange. Restore the latter even when it cannot be
-                # decoded or bounded safely enough to inspect.
-                try:
-                    self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
-                    os.fsync(parent_fd)
-                except Exception as rollback_error:
-                    raise ManuscriptSourceSecurityError(
-                        "interrupted source exchange could not be reconciled safely"
-                    ) from rollback_error
+                # Never promote an unreadable, symlinked, or non-regular hidden
+                # recovery object into the public manuscript path. Preserve the
+                # current regular proposal and the unsafe object, then durably
+                # terminalize as a restart-era conflict.
+                swap_state = self._classify_source_swap_at(
+                    parent_fd,
+                    swap_name,
+                    expected_content_hash=expected_content_hash,
+                    proposed_content_hash=proposed_content_hash,
+                )
+                os.fsync(parent_fd)
                 raise ManuscriptSourceConflictError(
-                    "an unsafe external source version was restored after an "
+                    "an unclassifiable hidden recovery state was retained after an "
                     "interrupted replacement",
-                    transient_exchange=True,
-                    recovery_state="retained_proposal",
+                    transient_exchange=None,
+                    recovery_state=self._retention_state_from_swap_state(swap_state),
                 ) from exc
 
             if displaced is None:
@@ -1730,6 +1734,8 @@ class ManuscriptSourceService(BaseService):
                 missing_ok=True,
                 validate_utf8=False,
             )
+        except (OSError, ManuscriptSourceSecurityError):
+            return "unsafe"
         except ValueError as exc:
             if "exceeds configured size limit" not in str(exc):
                 raise
@@ -1751,6 +1757,7 @@ class ManuscriptSourceService(BaseService):
             "reviewed_base": "retained_base",
             "unclassified": "retained_unclassified",
             "oversized": "retained_oversized",
+            "unsafe": "retained_unsafe",
         }[swap_state]
 
     def _source_recovery_event_details(
@@ -1765,6 +1772,7 @@ class ManuscriptSourceService(BaseService):
             "retained_base": "reviewed_base",
             "retained_unclassified": "unclassified",
             "retained_oversized": "oversized",
+            "retained_unsafe": "unsafe",
         }[recovery_state]
         retained = bool(recovery_state and recovery_state.startswith("retained_"))
         return {

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import ctypes
+import errno
 import fcntl
 import hashlib
 import json
 import os
 import re
 import stat
+import sys
 from collections import Counter, defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path, PurePosixPath
@@ -706,6 +709,23 @@ class ManuscriptSourceService(BaseService):
                 if current_hash == proposed_hash and self._valid_recovery_manifest(
                     recovery_path, row
                 ):
+                    try:
+                        self._reconcile_replaced_source(
+                            workspace,
+                            relative_path,
+                            proposal_id=str(row["id"]),
+                            expected_content_hash=row["base_content_hash"],
+                            proposed_content_hash=proposed_hash,
+                        )
+                    except ManuscriptSourceConflictError:
+                        latest, _ = self._read_current(workspace, relative_path)
+                        latest_hash = _sha256(latest) if latest is not None else None
+                        await self._mark_conflicted(
+                            row,
+                            data,
+                            current_content_hash=latest_hash,
+                        )
+                        raise
                     await self._complete_applied_transition(
                         row,
                         data,
@@ -750,6 +770,7 @@ class ManuscriptSourceService(BaseService):
                     relative_path,
                     proposed,
                     mode,
+                    proposal_id=str(row["id"]),
                     expected_content_hash=row["base_content_hash"],
                 )
             except ManuscriptSourceConflictError:
@@ -961,36 +982,49 @@ class ManuscriptSourceService(BaseService):
         normalized, _ = self._normalize_source_path(relative_path)
         parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
         try:
-            try:
-                file_fd = os.open(
-                    name,
-                    os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
-                    dir_fd=parent_fd,
-                )
-            except FileNotFoundError:
-                return None, None
-            try:
-                file_stat = os.fstat(file_fd)
-                if not stat.S_ISREG(file_stat.st_mode):
-                    raise ManuscriptSourceSecurityError("source target is not a regular file")
-                if file_stat.st_size > self.config.manuscript_source_max_bytes:
-                    raise ValueError("manuscript source file exceeds configured size limit")
-                chunks = []
-                remaining = self.config.manuscript_source_max_bytes + 1
-                while remaining > 0:
-                    chunk = os.read(file_fd, min(64 * 1024, remaining))
-                    if not chunk:
-                        break
-                    chunks.append(chunk)
-                    remaining -= len(chunk)
-                value = b"".join(chunks)
-                self._assert_size(value)
-                self._decode(value)
-                return value, stat.S_IMODE(file_stat.st_mode)
-            finally:
-                os.close(file_fd)
+            return self._read_source_entry_at(parent_fd, name, missing_ok=True)
         finally:
             os.close(parent_fd)
+
+    def _read_source_entry_at(
+        self,
+        directory_fd: int,
+        name: str,
+        *,
+        missing_ok: bool,
+        validate_utf8: bool = True,
+    ) -> tuple[bytes | None, int | None]:
+        try:
+            file_fd = os.open(
+                name,
+                os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            if missing_ok:
+                return None, None
+            raise
+        try:
+            file_stat = os.fstat(file_fd)
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise ManuscriptSourceSecurityError("source target is not a regular file")
+            if file_stat.st_size > self.config.manuscript_source_max_bytes:
+                raise ValueError("manuscript source file exceeds configured size limit")
+            chunks = []
+            remaining = self.config.manuscript_source_max_bytes + 1
+            while remaining > 0:
+                chunk = os.read(file_fd, min(64 * 1024, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            value = b"".join(chunks)
+            self._assert_size(value)
+            if validate_utf8:
+                self._decode(value)
+            return value, stat.S_IMODE(file_stat.st_mode)
+        finally:
+            os.close(file_fd)
 
     @staticmethod
     def _open_parent_fd(workspace: Path, relative_path: PurePosixPath) -> tuple[int, str]:
@@ -1126,6 +1160,11 @@ class ManuscriptSourceService(BaseService):
                         os.mkdir(component, mode=0o700, dir_fd=current_fd)
                     except FileExistsError:
                         pass
+                    # Persist every hierarchy edge, including an edge whose
+                    # preceding fsync failed and is being retried. Merely
+                    # fsyncing the leaf cannot make newly created ancestors
+                    # durable across a power loss.
+                    os.fsync(current_fd)
                 try:
                     next_fd = os.open(component, flags, dir_fd=current_fd)
                 except OSError as exc:
@@ -1315,48 +1354,249 @@ class ManuscriptSourceService(BaseService):
         value: bytes,
         previous_mode: int | None,
         *,
+        proposal_id: str,
         expected_content_hash: str | None,
     ) -> None:
         normalized, _ = self._normalize_source_path(relative_path)
         parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
-        temp_name = f".{name}.rka-{generate_id('manuscript_source_proposal')}"
-        temp_fd = None
+        swap_name = self._source_swap_name(proposal_id)
+        exchanged = False
+        try:
+            self._prepare_source_swap(
+                parent_fd,
+                swap_name,
+                value,
+                previous_mode if previous_mode is not None else 0o644,
+            )
+
+            if expected_content_hash is None:
+                try:
+                    os.link(
+                        swap_name,
+                        name,
+                        src_dir_fd=parent_fd,
+                        dst_dir_fd=parent_fd,
+                        follow_symlinks=False,
+                    )
+                except FileExistsError as exc:
+                    raise ManuscriptSourceConflictError(
+                        "source appeared immediately before creation; current and "
+                        "proposed versions were preserved"
+                    ) from exc
+                os.unlink(swap_name, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+                return
+
+            try:
+                self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+            except OSError as exc:
+                if exc.errno in {errno.ENOENT, errno.ENOTDIR}:
+                    raise ManuscriptSourceConflictError(
+                        "source changed immediately before replacement; current and "
+                        "proposed versions were preserved"
+                    ) from exc
+                raise
+            exchanged = True
+            try:
+                displaced, _ = self._read_source_entry_at(
+                    parent_fd,
+                    swap_name,
+                    missing_ok=False,
+                    validate_utf8=False,
+                )
+            except (OSError, ValueError, ManuscriptSourceSecurityError) as exc:
+                raise ManuscriptSourceConflictError(
+                    "source became unsafe immediately before replacement; the exact "
+                    "displaced version will be restored"
+                ) from exc
+            assert displaced is not None
+            if _sha256(displaced) != expected_content_hash:
+                raise ManuscriptSourceConflictError(
+                    "source changed immediately before replacement; the exact "
+                    "displaced version will be restored"
+                )
+
+            os.unlink(swap_name, dir_fd=parent_fd)
+            exchanged = False
+            os.fsync(parent_fd)
+        except Exception:
+            if exchanged:
+                try:
+                    self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+                    exchanged = False
+                    os.unlink(swap_name, dir_fd=parent_fd)
+                    os.fsync(parent_fd)
+                except Exception as rollback_error:
+                    raise ManuscriptSourceSecurityError(
+                        "source exchange failed and could not be rolled back safely"
+                    ) from rollback_error
+            raise
+        finally:
+            # Before an exchange the swap contains only proposal bytes and is
+            # safe to remove. If rollback itself failed, `exchanged` remains
+            # true and both names are deliberately retained for recovery.
+            if not exchanged:
+                try:
+                    os.unlink(swap_name, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    pass
+            os.close(parent_fd)
+
+    def _reconcile_replaced_source(
+        self,
+        workspace: Path,
+        relative_path: str,
+        *,
+        proposal_id: str,
+        expected_content_hash: str | None,
+        proposed_content_hash: str,
+    ) -> None:
+        """Finish a crash-interrupted replacement before updating its ledger."""
+        normalized, _ = self._normalize_source_path(relative_path)
+        parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
+        swap_name = self._source_swap_name(proposal_id)
+        try:
+            try:
+                displaced, _ = self._read_source_entry_at(
+                    parent_fd,
+                    swap_name,
+                    missing_ok=True,
+                    validate_utf8=False,
+                )
+            except (OSError, ValueError, ManuscriptSourceSecurityError) as exc:
+                # The deterministic swap name can only contain the object that
+                # was about to replace the target or the exact target displaced
+                # by the exchange. Restore the latter even when it cannot be
+                # decoded or bounded safely enough to inspect.
+                try:
+                    self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+                    os.unlink(swap_name, dir_fd=parent_fd)
+                    os.fsync(parent_fd)
+                except Exception as rollback_error:
+                    raise ManuscriptSourceSecurityError(
+                        "interrupted source exchange could not be reconciled safely"
+                    ) from rollback_error
+                raise ManuscriptSourceConflictError(
+                    "an unsafe external source version was restored after an "
+                    "interrupted replacement"
+                ) from exc
+
+            if displaced is None:
+                # The rename/link and cleanup completed, but a previous source
+                # directory fsync or the SQLite transition may have failed.
+                os.fsync(parent_fd)
+                return
+
+            displaced_hash = _sha256(displaced)
+            if expected_content_hash is None or displaced_hash == proposed_content_hash:
+                # Missing-file creation leaves a second hard link until cleanup;
+                # an identical proposed swap is also safe to discard.
+                os.unlink(swap_name, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+                return
+            if displaced_hash == expected_content_hash:
+                # Exchange completed and the exact reviewed base is retained at
+                # the swap name. Recovery is already durable, so finish cleanup.
+                os.unlink(swap_name, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+                return
+
+            # An external editor won the race immediately before the exchange.
+            # Restore that exact displaced inode and leave the proposal conflicted.
+            self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+            os.unlink(swap_name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
+            raise ManuscriptSourceConflictError(
+                "an external source version was restored after an interrupted replacement"
+            )
+        finally:
+            os.close(parent_fd)
+
+    @staticmethod
+    def _source_swap_name(proposal_id: str) -> str:
+        return f".rka-source-{_sha256(proposal_id.encode())[:32]}.swap"
+
+    def _prepare_source_swap(
+        self,
+        parent_fd: int,
+        swap_name: str,
+        value: bytes,
+        mode: int,
+    ) -> None:
         try:
             temp_fd = os.open(
-                temp_name,
+                swap_name,
                 os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
                 0o600,
                 dir_fd=parent_fd,
             )
-            view = memoryview(value)
-            while view:
-                written = os.write(temp_fd, view)
-                view = view[written:]
-            os.fchmod(temp_fd, previous_mode if previous_mode is not None else 0o644)
-            os.fsync(temp_fd)
-            os.close(temp_fd)
-            temp_fd = None
-
-            # This is the last synchronous observation before replacement. The
-            # recovery copy was written from the same expected version, so a
-            # mismatch preserves both the external file and the proposal.
-            current, _ = self._read_current(workspace, normalized)
-            current_hash = _sha256(current) if current is not None else None
-            if current_hash != expected_content_hash:
-                raise ManuscriptSourceConflictError(
-                    "source changed immediately before replacement; current and "
-                    "proposed versions were preserved"
+        except FileExistsError:
+            existing, _ = self._read_source_entry_at(
+                parent_fd,
+                swap_name,
+                missing_ok=False,
+                validate_utf8=False,
+            )
+            assert existing is not None
+            if _sha256(existing) != _sha256(value):
+                raise ManuscriptSourceSecurityError(
+                    "existing source swap does not match this proposal"
                 )
-            os.replace(temp_name, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
-            os.fsync(parent_fd)
-        finally:
-            if temp_fd is not None:
-                os.close(temp_fd)
+        else:
             try:
-                os.unlink(temp_name, dir_fd=parent_fd)
-            except FileNotFoundError:
-                pass
-            os.close(parent_fd)
+                view = memoryview(value)
+                while view:
+                    written = os.write(temp_fd, view)
+                    view = view[written:]
+                os.fchmod(temp_fd, mode)
+                os.fsync(temp_fd)
+            finally:
+                os.close(temp_fd)
+        # Make the proposed swap name durable before exchanging it. A crash can
+        # then leave either the pre- or post-exchange naming state, both recoverable.
+        os.fsync(parent_fd)
+
+    @staticmethod
+    def _atomic_exchange_at(
+        old_directory_fd: int,
+        old_name: str,
+        new_directory_fd: int,
+        new_name: str,
+    ) -> None:
+        """Atomically exchange two names or fail closed on unsupported platforms."""
+        libc = ctypes.CDLL(None, use_errno=True)
+        if sys.platform == "darwin":
+            function_name = "renameatx_np"
+        elif sys.platform.startswith("linux"):
+            function_name = "renameat2"
+        else:
+            raise ManuscriptSourceSecurityError(
+                "atomic source exchange is unsupported on this platform"
+            )
+        try:
+            exchange = getattr(libc, function_name)
+        except AttributeError as exc:
+            raise ManuscriptSourceSecurityError(
+                "atomic source exchange is unavailable; refusing an unsafe replacement"
+            ) from exc
+        exchange.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        exchange.restype = ctypes.c_int
+        result = exchange(
+            old_directory_fd,
+            os.fsencode(old_name),
+            new_directory_fd,
+            os.fsencode(new_name),
+            0x2,
+        )
+        if result != 0:
+            error_number = ctypes.get_errno()
+            raise OSError(error_number, os.strerror(error_number))
 
     async def _require_proposal_row(self, proposal_id: str) -> dict[str, Any]:
         row = await self.db.fetchone(

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import fcntl
 import hashlib
 import json
@@ -9,6 +10,7 @@ import os
 import re
 import stat
 from collections import Counter, defaultdict
+from contextlib import asynccontextmanager
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
@@ -184,11 +186,19 @@ class ManuscriptSourceService(BaseService):
             self.db, project_id=self.project_id
         ).get_context(manuscript["id"])
         claims = {claim["id"]: claim for claim in context["claims"]}
+        active_units = [unit for unit in context["units"] if unit["status"] != "removed"]
+        allocated_adverse_by_role = {
+            role: {
+                str(binding["evidence_claim_id"])
+                for unit in active_units
+                for binding in unit.get("evidence", [])
+                if binding.get("role") == role
+            }
+            for role in ("qualifier", "counterevidence")
+        }
         quick_reader = []
         private_risks: list[dict[str, Any]] = []
-        for unit in sorted(context["units"], key=lambda value: (value["sequence"], value["id"])):
-            if unit["status"] == "removed":
-                continue
+        for unit in sorted(active_units, key=lambda value: (value["sequence"], value["id"])):
             unit_claims = [
                 claim
                 for claim in claims.values()
@@ -217,6 +227,26 @@ class ManuscriptSourceService(BaseService):
                             "message": "Prohibited wording is private review context, not draft prose.",
                         }
                     )
+                for binding in claim.get("evidence", []):
+                    role = binding.get("role")
+                    evidence_claim_id = str(binding.get("evidence_claim_id"))
+                    if (
+                        role in allocated_adverse_by_role
+                        and evidence_claim_id not in allocated_adverse_by_role[role]
+                    ):
+                        private_risks.append(
+                            {
+                                "kind": f"unallocated_{role}",
+                                "unit_id": unit["id"],
+                                "claim_id": claim["id"],
+                                "evidence_claim_id": evidence_claim_id,
+                                "content": binding.get("content"),
+                                "message": (
+                                    "Claim-level adverse evidence is not allocated to an "
+                                    "active manuscript unit and requires deliberate treatment."
+                                ),
+                            }
+                        )
             for binding in unit.get("evidence", []):
                 if binding["role"] in {"qualifier", "counterevidence"}:
                     private_risks.append(
@@ -498,93 +528,104 @@ class ManuscriptSourceService(BaseService):
         relative_path, source_format = self._normalize_source_path(data.relative_path)
         proposed = data.content.encode("utf-8")
         self._assert_size(proposed)
-        current, _ = self._read_current(workspace, relative_path)
-        current_hash = _sha256(current) if current is not None else None
-        if current_hash != data.expected_content_hash:
-            raise ManuscriptSourceConflictError(
-                f"source hash conflict: expected {data.expected_content_hash!r}, found {current_hash!r}"
+        async with self._source_lock(manuscript["id"], relative_path):
+            current, _ = self._read_current(workspace, relative_path)
+            current_hash = _sha256(current) if current is not None else None
+            if current_hash != data.expected_content_hash:
+                raise ManuscriptSourceConflictError(
+                    "source hash conflict: "
+                    f"expected {data.expected_content_hash!r}, found {current_hash!r}"
+                )
+            proposed_hash = _sha256(proposed)
+            if proposed_hash == current_hash:
+                raise ValueError("source proposal has no content changes")
+            inspection = await self.inspect_content(
+                manuscript["id"], relative_path, source_format, data.content
             )
-        proposed_hash = _sha256(proposed)
-        if proposed_hash == current_hash:
-            raise ValueError("source proposal has no content changes")
-        inspection = await self.inspect_content(
-            manuscript["id"], relative_path, source_format, data.content
-        )
-        if any(item["severity"] == "error" for item in inspection["findings"]):
-            raise ValueError("source proposal contains blocking anchor or provenance findings")
+            if any(item["severity"] == "error" for item in inspection["findings"]):
+                raise ValueError(
+                    "source proposal contains blocking anchor or provenance findings"
+                )
 
-        proposal_id = generate_id("manuscript_source_proposal")
-        async with self.db.transaction():
-            context_manifest_id = None
-            if data.origin != "human":
-                await self._validate_ai_context(
-                    manuscript,
-                    str(data.context_manifest_id),
-                    origin=data.origin,
-                    provider=str(data.provider),
-                    model=str(data.model),
-                    boundary=data.boundary,
-                )
-                context_manifest_id = data.context_manifest_id
-            if data.supersedes_proposal_id:
-                previous = await self._require_proposal_row(data.supersedes_proposal_id)
-                if previous["status"] not in {"proposed", "conflicted"}:
-                    raise ManuscriptSourceConflictError(
-                        "only proposed or conflicted source proposals may be superseded"
+            proposal_id = generate_id("manuscript_source_proposal")
+            async with self.db.transaction():
+                context_manifest_id = None
+                if data.origin != "human":
+                    await self._validate_ai_context(
+                        manuscript,
+                        str(data.context_manifest_id),
+                        origin=data.origin,
+                        provider=str(data.provider),
+                        model=str(data.model),
+                        boundary=data.boundary,
                     )
-                if (
-                    previous["manuscript_id"] != manuscript["id"]
-                    or previous["relative_path"] != relative_path
-                ):
-                    raise ValueError("a source proposal may supersede only the same file")
-                await self._transition_row(
-                    previous,
-                    status="superseded",
-                    actor=data.created_by,
-                    reason=f"Superseded by {proposal_id}: {data.reason}",
-                    details={"superseded_by": proposal_id},
+                    context_manifest_id = data.context_manifest_id
+                if data.supersedes_proposal_id:
+                    previous = await self._require_proposal_row(
+                        data.supersedes_proposal_id
+                    )
+                    if previous["status"] not in {"proposed", "conflicted"}:
+                        raise ManuscriptSourceConflictError(
+                            "only proposed or conflicted source proposals may be superseded"
+                        )
+                    if (
+                        previous["manuscript_id"] != manuscript["id"]
+                        or previous["relative_path"] != relative_path
+                    ):
+                        raise ValueError(
+                            "a source proposal may supersede only the same file"
+                        )
+                    self._assert_not_written_before_close(
+                        previous, workspace, action="supersede"
+                    )
+                    await self._transition_row(
+                        previous,
+                        status="superseded",
+                        actor=data.created_by,
+                        reason=f"Superseded by {proposal_id}: {data.reason}",
+                        details={"superseded_by": proposal_id},
+                    )
+                await self.db.execute(
+                    """INSERT INTO manuscript_source_proposals
+                       (id, project_id, manuscript_id, origin, relative_path,
+                        source_format, base_content_hash, proposed_content,
+                        proposed_content_hash, created_by, reason,
+                        validation_findings, context_manifest_id, provider, model,
+                        boundary, supersedes_proposal_id)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    [
+                        proposal_id,
+                        self.project_id,
+                        manuscript["id"],
+                        data.origin,
+                        relative_path,
+                        source_format,
+                        current_hash,
+                        data.content,
+                        proposed_hash,
+                        data.created_by,
+                        data.reason,
+                        _canonical_json(inspection["findings"]),
+                        context_manifest_id,
+                        data.provider,
+                        data.model,
+                        data.boundary,
+                        data.supersedes_proposal_id,
+                    ],
                 )
-            await self.db.execute(
-                """INSERT INTO manuscript_source_proposals
-                   (id, project_id, manuscript_id, origin, relative_path,
-                    source_format, base_content_hash, proposed_content,
-                    proposed_content_hash, created_by, reason,
-                    validation_findings, context_manifest_id, provider, model,
-                    boundary, supersedes_proposal_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                [
+                await self._insert_event(
                     proposal_id,
-                    self.project_id,
-                    manuscript["id"],
-                    data.origin,
-                    relative_path,
-                    source_format,
-                    current_hash,
-                    data.content,
-                    proposed_hash,
-                    data.created_by,
-                    data.reason,
-                    _canonical_json(inspection["findings"]),
-                    context_manifest_id,
-                    data.provider,
-                    data.model,
-                    data.boundary,
-                    data.supersedes_proposal_id,
-                ],
-            )
-            await self._insert_event(
-                proposal_id,
-                revision=1,
-                action="proposed",
-                actor=data.created_by,
-                reason=data.reason,
-                details={
-                    "relative_path": relative_path,
-                    "base_content_hash": current_hash,
-                    "proposed_content_hash": proposed_hash,
-                    "finding_count": len(inspection["findings"]),
-                },
-            )
+                    revision=1,
+                    action="proposed",
+                    actor=data.created_by,
+                    reason=data.reason,
+                    details={
+                        "relative_path": relative_path,
+                        "base_content_hash": current_hash,
+                        "proposed_content_hash": proposed_hash,
+                        "finding_count": len(inspection["findings"]),
+                    },
+                )
         return await self.get_proposal(proposal_id)
 
     async def get_proposal(self, proposal_id: str) -> dict[str, Any]:
@@ -652,9 +693,7 @@ class ManuscriptSourceService(BaseService):
         self._assert_open(row, data.expected_revision)
         manuscript, workspace = await self._resolve_workspace(row["manuscript_id"])
         relative_path, _ = self._normalize_source_path(row["relative_path"])
-        lock_fd = self._open_lock_fd(manuscript["id"], relative_path)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        async with self._source_lock(manuscript["id"], relative_path):
             row = await self._require_proposal_row(proposal_id)
             self._assert_open(row, data.expected_revision)
             current, mode = self._read_current(workspace, relative_path)
@@ -674,22 +713,11 @@ class ManuscriptSourceService(BaseService):
                         recovered_after_restart=True,
                     )
                     return await self.get_proposal(proposal_id)
-                async with self.db.transaction():
-                    row = await self._require_proposal_row(proposal_id)
-                    self._assert_open(row, data.expected_revision)
-                    await self._transition_row(
-                        row,
-                        status="conflicted",
-                        actor=data.actor,
-                        reason=data.reason,
-                        details={
-                            "relative_path": relative_path,
-                            "expected_content_hash": row["base_content_hash"],
-                            "current_content_hash": current_hash,
-                            "proposed_content_hash": proposed_hash,
-                            "file_written": False,
-                        },
-                    )
+                await self._mark_conflicted(
+                    row,
+                    data,
+                    current_content_hash=current_hash,
+                )
                 raise ManuscriptSourceConflictError(
                     "source changed after proposal creation; current and proposed versions were preserved"
                 )
@@ -699,19 +727,46 @@ class ManuscriptSourceService(BaseService):
             )
             if any(item["severity"] == "error" for item in inspection["findings"]):
                 raise ValueError("source proposal no longer passes anchor/provenance validation")
+
+            # Validation awaits database reads. Re-read afterwards so an editor
+            # change during that await is never recovered as the wrong base.
+            current, mode = self._read_current(workspace, relative_path)
+            current_hash = _sha256(current) if current is not None else None
+            if current_hash != row["base_content_hash"]:
+                await self._mark_conflicted(
+                    row,
+                    data,
+                    current_content_hash=current_hash,
+                )
+                raise ManuscriptSourceConflictError(
+                    "source changed during proposal validation; current and proposed "
+                    "versions were preserved"
+                )
+
             self._write_recovery(row, current, mode, recovery_path)
-            self._atomic_replace(workspace, relative_path, proposed, mode)
+            try:
+                self._atomic_replace(
+                    workspace,
+                    relative_path,
+                    proposed,
+                    mode,
+                    expected_content_hash=row["base_content_hash"],
+                )
+            except ManuscriptSourceConflictError:
+                latest, _ = self._read_current(workspace, relative_path)
+                latest_hash = _sha256(latest) if latest is not None else None
+                await self._mark_conflicted(
+                    row,
+                    data,
+                    current_content_hash=latest_hash,
+                )
+                raise
             await self._complete_applied_transition(
                 row,
                 data,
                 recovery_path,
                 recovered_after_restart=False,
             )
-        finally:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            finally:
-                os.close(lock_fd)
         return await self.get_proposal(proposal_id)
 
     async def reject_proposal(
@@ -719,17 +774,49 @@ class ManuscriptSourceService(BaseService):
         proposal_id: str,
         data: ManuscriptSourceProposalTransition,
     ) -> dict[str, Any]:
-        async with self.db.transaction():
+        row = await self._require_proposal_row(proposal_id)
+        self._assert_open(row, data.expected_revision)
+        manuscript, workspace = await self._resolve_workspace(row["manuscript_id"])
+        relative_path, _ = self._normalize_source_path(row["relative_path"])
+        async with self._source_lock(manuscript["id"], relative_path):
             row = await self._require_proposal_row(proposal_id)
             self._assert_open(row, data.expected_revision)
+            self._assert_not_written_before_close(row, workspace, action="reject")
+            async with self.db.transaction():
+                row = await self._require_proposal_row(proposal_id)
+                self._assert_open(row, data.expected_revision)
+                await self._transition_row(
+                    row,
+                    status="rejected",
+                    actor=data.actor,
+                    reason=data.reason,
+                    details={},
+                )
+        return await self.get_proposal(proposal_id)
+
+    async def _mark_conflicted(
+        self,
+        row: Mapping[str, Any],
+        data: ManuscriptSourceProposalTransition,
+        *,
+        current_content_hash: str | None,
+    ) -> None:
+        async with self.db.transaction():
+            current = await self._require_proposal_row(str(row["id"]))
+            self._assert_open(current, data.expected_revision)
             await self._transition_row(
-                row,
-                status="rejected",
+                current,
+                status="conflicted",
                 actor=data.actor,
                 reason=data.reason,
-                details={},
+                details={
+                    "relative_path": row["relative_path"],
+                    "expected_content_hash": row["base_content_hash"],
+                    "current_content_hash": current_content_hash,
+                    "proposed_content_hash": row["proposed_content_hash"],
+                    "file_written": False,
+                },
             )
-        return await self.get_proposal(proposal_id)
 
     async def _complete_applied_transition(
         self,
@@ -965,6 +1052,43 @@ class ManuscriptSourceService(BaseService):
         finally:
             os.close(directory_fd)
 
+    @asynccontextmanager
+    async def _source_lock(self, manuscript_id: str, relative_path: str):
+        """Serialize same-file state transitions without blocking the event loop."""
+        lock_fd = self._open_lock_fd(manuscript_id, relative_path)
+        try:
+            while True:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    await asyncio.sleep(0.01)
+            yield
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(lock_fd)
+
+    def _assert_not_written_before_close(
+        self,
+        row: Mapping[str, Any],
+        workspace: Path,
+        *,
+        action: str,
+    ) -> None:
+        """Keep a crash-applied proposal open until Apply reconciles its ledger."""
+        current, _ = self._read_current(workspace, str(row["relative_path"]))
+        current_hash = _sha256(current) if current is not None else None
+        recovery_path = self._recovery_manifest_path(row)
+        if current_hash == row["proposed_content_hash"] and self._valid_recovery_manifest(
+            recovery_path, row
+        ):
+            raise ManuscriptSourceConflictError(
+                "proposal content is already on disk with valid recovery metadata; "
+                f"retry apply to reconcile the ledger before {action}"
+            )
+
     def _recovery_components(self, row: Mapping[str, Any]) -> tuple[str, str, str]:
         components = (
             self.project_id,
@@ -1190,6 +1314,8 @@ class ManuscriptSourceService(BaseService):
         relative_path: str,
         value: bytes,
         previous_mode: int | None,
+        *,
+        expected_content_hash: str | None,
     ) -> None:
         normalized, _ = self._normalize_source_path(relative_path)
         parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
@@ -1210,6 +1336,17 @@ class ManuscriptSourceService(BaseService):
             os.fsync(temp_fd)
             os.close(temp_fd)
             temp_fd = None
+
+            # This is the last synchronous observation before replacement. The
+            # recovery copy was written from the same expected version, so a
+            # mismatch preserves both the external file and the proposal.
+            current, _ = self._read_current(workspace, normalized)
+            current_hash = _sha256(current) if current is not None else None
+            if current_hash != expected_content_hash:
+                raise ManuscriptSourceConflictError(
+                    "source changed immediately before replacement; current and "
+                    "proposed versions were preserved"
+                )
             os.replace(temp_name, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
             os.fsync(parent_fd)
         finally:

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -54,9 +54,16 @@ class ManuscriptSourceNotFoundError(ValueError):
 class ManuscriptSourceConflictError(ValueError):
     """The proposal or file optimistic guard is stale."""
 
-    def __init__(self, message: str, *, transient_exchange: bool = False):
+    def __init__(
+        self,
+        message: str,
+        *,
+        transient_exchange: bool = False,
+        recovery_state: str | None = None,
+    ):
         super().__init__(message)
         self.transient_exchange = transient_exchange
+        self.recovery_state = recovery_state
 
 
 class ManuscriptSourceSecurityError(ValueError):
@@ -582,7 +589,7 @@ class ManuscriptSourceService(BaseService):
                         raise ValueError(
                             "a source proposal may supersede only the same file"
                         )
-                    self._assert_not_written_before_close(
+                    close_details = self._assert_not_written_before_close(
                         previous, workspace, action="supersede"
                     )
                     await self._transition_row(
@@ -590,7 +597,7 @@ class ManuscriptSourceService(BaseService):
                         status="superseded",
                         actor=data.created_by,
                         reason=f"Superseded by {proposal_id}: {data.reason}",
-                        details={"superseded_by": proposal_id},
+                        details={"superseded_by": proposal_id, **close_details},
                     )
                 await self.db.execute(
                     """INSERT INTO manuscript_source_proposals
@@ -708,12 +715,12 @@ class ManuscriptSourceService(BaseService):
             proposed = row["proposed_content"].encode("utf-8")
             proposed_hash = _sha256(proposed)
             recovery_path = self._recovery_manifest_path(row)
+            has_valid_recovery = self._valid_recovery_manifest(recovery_path, row)
 
-            if current_hash != row["base_content_hash"]:
-                has_valid_recovery = self._valid_recovery_manifest(recovery_path, row)
-                if current_hash == proposed_hash and has_valid_recovery:
+            if has_valid_recovery:
+                if current_hash == proposed_hash:
                     try:
-                        self._reconcile_replaced_source(
+                        recovery_state = self._reconcile_replaced_source(
                             workspace,
                             relative_path,
                             proposal_id=str(row["id"]),
@@ -728,6 +735,7 @@ class ManuscriptSourceService(BaseService):
                             data,
                             current_content_hash=latest_hash,
                             transient_exchange=exc.transient_exchange,
+                            recovery_state=exc.recovery_state,
                         )
                         raise
                     await self._complete_applied_transition(
@@ -735,24 +743,49 @@ class ManuscriptSourceService(BaseService):
                         data,
                         recovery_path,
                         recovered_after_restart=True,
+                        source_recovery_state=recovery_state,
                     )
                     return await self.get_proposal(proposal_id)
-                if has_valid_recovery:
+                swap_state = self._source_swap_state(
+                    workspace,
+                    relative_path,
+                    proposal_id=str(row["id"]),
+                    expected_content_hash=row["base_content_hash"],
+                    proposed_content_hash=proposed_hash,
+                )
+                if not (
+                    current_hash == row["base_content_hash"]
+                    and swap_state == "missing"
+                ):
                     # A previous attempt may have restored an external object
-                    # but failed the rollback directory fsync. Do not close the
-                    # ledger until that naming state (and any proposal-only swap
-                    # cleanup) is durably committed.
-                    self._finalize_conflicted_source_state(
+                    # or retained a displaced inode but failed before the ledger
+                    # transition. Preserve every pre-existing recovery object,
+                    # fsync its naming state, and durably close as conflicted.
+                    recovery_state = self._finalize_conflicted_source_state(
                         workspace,
                         relative_path,
                         proposal_id=str(row["id"]),
+                        expected_content_hash=row["base_content_hash"],
                         proposed_content_hash=proposed_hash,
                     )
+                    await self._mark_conflicted(
+                        row,
+                        data,
+                        current_content_hash=current_hash,
+                        transient_exchange=None,
+                        recovery_state=recovery_state,
+                    )
+                    raise ManuscriptSourceConflictError(
+                        "source changed after a recoverable apply attempt; current, "
+                        "proposed, and retained versions were preserved"
+                    )
+
+            if current_hash != row["base_content_hash"]:
                 await self._mark_conflicted(
                     row,
                     data,
                     current_content_hash=current_hash,
-                    transient_exchange=None if has_valid_recovery else False,
+                    transient_exchange=False,
                 )
                 raise ManuscriptSourceConflictError(
                     "source changed after proposal creation; current and proposed versions were preserved"
@@ -797,6 +830,7 @@ class ManuscriptSourceService(BaseService):
                     data,
                     current_content_hash=latest_hash,
                     transient_exchange=exc.transient_exchange,
+                    recovery_state=exc.recovery_state,
                 )
                 raise
             await self._complete_applied_transition(
@@ -804,6 +838,11 @@ class ManuscriptSourceService(BaseService):
                 data,
                 recovery_path,
                 recovered_after_restart=False,
+                source_recovery_state=(
+                    "retained_base"
+                    if row["base_content_hash"] is not None
+                    else "missing"
+                ),
             )
         return await self.get_proposal(proposal_id)
 
@@ -819,7 +858,9 @@ class ManuscriptSourceService(BaseService):
         async with self._source_lock(manuscript["id"], relative_path):
             row = await self._require_proposal_row(proposal_id)
             self._assert_open(row, data.expected_revision)
-            self._assert_not_written_before_close(row, workspace, action="reject")
+            close_details = self._assert_not_written_before_close(
+                row, workspace, action="reject"
+            )
             async with self.db.transaction():
                 row = await self._require_proposal_row(proposal_id)
                 self._assert_open(row, data.expected_revision)
@@ -828,7 +869,7 @@ class ManuscriptSourceService(BaseService):
                     status="rejected",
                     actor=data.actor,
                     reason=data.reason,
-                    details={},
+                    details=close_details,
                 )
         return await self.get_proposal(proposal_id)
 
@@ -839,6 +880,7 @@ class ManuscriptSourceService(BaseService):
         *,
         current_content_hash: str | None,
         transient_exchange: bool | None = False,
+        recovery_state: str | None = None,
     ) -> None:
         async with self.db.transaction():
             current = await self._require_proposal_row(str(row["id"]))
@@ -863,6 +905,13 @@ class ManuscriptSourceService(BaseService):
                         else "not_observed"
                     ),
                     "final_target_preserved": True,
+                    "source_recovery_state": recovery_state,
+                    "retained_source_path": (
+                        self._retained_source_relative_path(row)
+                        if recovery_state
+                        in {"retained_base", "retained_proposal", "retained_unclassified"}
+                        else None
+                    ),
                 },
             )
 
@@ -873,6 +922,7 @@ class ManuscriptSourceService(BaseService):
         recovery_path: Path,
         *,
         recovered_after_restart: bool,
+        source_recovery_state: str,
     ) -> None:
         recovery_relative = recovery_path.relative_to(
             Path(self.db.db_path).resolve().parent
@@ -892,9 +942,10 @@ class ManuscriptSourceService(BaseService):
                     "recovery_manifest_path": recovery_relative,
                     "displaced_source_path": (
                         self._retained_source_relative_path(row)
-                        if row["base_content_hash"] is not None
+                        if source_recovery_state.startswith("retained_")
                         else None
                     ),
+                    "source_recovery_state": source_recovery_state,
                     "recovered_after_restart": recovered_after_restart,
                     "git_operation": False,
                 },
@@ -910,7 +961,7 @@ class ManuscriptSourceService(BaseService):
         provider: str,
         model: str,
         boundary: str,
-    ) -> None:
+    ) -> str:
         row = await self.db.fetchone(
             """SELECT * FROM semantic_patch_context_manifests
                WHERE id = ? AND project_id = ?""",
@@ -1142,7 +1193,7 @@ class ManuscriptSourceService(BaseService):
         workspace: Path,
         *,
         action: str,
-    ) -> None:
+    ) -> dict[str, Any]:
         """Keep a crash-applied proposal open until Apply reconciles its ledger."""
         current, _ = self._read_current(workspace, str(row["relative_path"]))
         current_hash = _sha256(current) if current is not None else None
@@ -1154,12 +1205,23 @@ class ManuscriptSourceService(BaseService):
                 f"retry apply to reconcile the ledger before {action}"
             )
         if has_valid_recovery:
-            self._finalize_conflicted_source_state(
+            recovery_state = self._finalize_conflicted_source_state(
                 workspace,
                 str(row["relative_path"]),
                 proposal_id=str(row["id"]),
+                expected_content_hash=row["base_content_hash"],
                 proposed_content_hash=str(row["proposed_content_hash"]),
             )
+            return {
+                "source_recovery_state": recovery_state,
+                "retained_source_path": (
+                    self._retained_source_relative_path(row)
+                    if recovery_state
+                    in {"retained_base", "retained_proposal", "retained_unclassified"}
+                    else None
+                ),
+            }
+        return {}
 
     def _recovery_components(self, row: Mapping[str, Any]) -> tuple[str, str, str]:
         components = (
@@ -1404,14 +1466,17 @@ class ManuscriptSourceService(BaseService):
         parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
         swap_name = self._source_swap_name(proposal_id)
         exchanged = False
-        retain_swap = False
+        proposal_swap_owned = False
         try:
-            self._prepare_source_swap(
+            proposal_swap_owned = self._prepare_source_swap(
                 parent_fd,
                 swap_name,
                 value,
                 previous_mode if previous_mode is not None else 0o644,
             )
+            # Cleanup is safe only after preparation proves that this name
+            # contains the immutable proposal bytes. A pre-existing retained
+            # base or external inode must never be removed by this invocation.
 
             if expected_content_hash is None:
                 try:
@@ -1425,9 +1490,13 @@ class ManuscriptSourceService(BaseService):
                 except FileExistsError as exc:
                     raise ManuscriptSourceConflictError(
                         "source appeared immediately before creation; current and "
-                        "proposed versions were preserved"
+                        "proposed versions were preserved",
+                        recovery_state=(
+                            None if proposal_swap_owned else "retained_proposal"
+                        ),
                     ) from exc
                 os.unlink(swap_name, dir_fd=parent_fd)
+                proposal_swap_owned = False
                 os.fsync(parent_fd)
                 return
 
@@ -1437,10 +1506,34 @@ class ManuscriptSourceService(BaseService):
                 if exc.errno in {errno.ENOENT, errno.ENOTDIR}:
                     raise ManuscriptSourceConflictError(
                         "source changed immediately before replacement; current and "
-                        "proposed versions were preserved"
+                        "proposed versions were preserved",
+                        recovery_state=(
+                            None if proposal_swap_owned else "retained_proposal"
+                        ),
                     ) from exc
                 raise
             exchanged = True
+            proposal_swap_owned = False
+            try:
+                installed, _ = self._read_source_entry_at(
+                    parent_fd,
+                    name,
+                    missing_ok=False,
+                    validate_utf8=False,
+                )
+            except (OSError, ValueError, ManuscriptSourceSecurityError) as exc:
+                raise ManuscriptSourceConflictError(
+                    "installed source became unsafe at the replacement boundary; "
+                    "the prior target will be restored",
+                    transient_exchange=True,
+                ) from exc
+            assert installed is not None
+            if _sha256(installed) != _sha256(value):
+                raise ManuscriptSourceConflictError(
+                    "proposal swap changed at the replacement boundary; the prior "
+                    "target will be restored",
+                    transient_exchange=True,
+                )
             try:
                 displaced, _ = self._read_source_entry_at(
                     parent_fd,
@@ -1466,26 +1559,38 @@ class ManuscriptSourceService(BaseService):
             # name. An editor that opened the original target before exchange
             # can still write through that descriptor; retaining the inode is
             # the only way to ensure those later bytes remain recoverable.
-            retain_swap = True
             exchanged = False
             os.fsync(parent_fd)
-        except Exception:
+        except Exception as original_error:
             if exchanged:
                 try:
                     self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
                     exchanged = False
-                    os.unlink(swap_name, dir_fd=parent_fd)
+                    restored_swap, _ = self._read_source_entry_at(
+                        parent_fd,
+                        swap_name,
+                        missing_ok=False,
+                        validate_utf8=False,
+                    )
+                    assert restored_swap is not None
+                    rollback_state = (
+                        "retained_proposal"
+                        if _sha256(restored_swap) == _sha256(value)
+                        else "retained_unclassified"
+                    )
                     os.fsync(parent_fd)
+                    if isinstance(original_error, ManuscriptSourceConflictError):
+                        original_error.recovery_state = rollback_state
                 except Exception as rollback_error:
                     raise ManuscriptSourceSecurityError(
                         "source exchange failed and could not be rolled back safely"
                     ) from rollback_error
             raise
         finally:
-            # Before an exchange the swap contains only proposal bytes and is
-            # safe to remove. If rollback itself failed, `exchanged` remains
-            # true and both names are deliberately retained for recovery.
-            if not exchanged and not retain_swap:
+            # Remove only a name positively classified as this operation's
+            # immutable proposal bytes. If preparation rejected a pre-existing
+            # retained or unknown inode, ownership remains false.
+            if proposal_swap_owned:
                 try:
                     os.unlink(swap_name, dir_fd=parent_fd)
                 except FileNotFoundError:
@@ -1520,7 +1625,6 @@ class ManuscriptSourceService(BaseService):
                 # decoded or bounded safely enough to inspect.
                 try:
                     self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
-                    os.unlink(swap_name, dir_fd=parent_fd)
                     os.fsync(parent_fd)
                 except Exception as rollback_error:
                     raise ManuscriptSourceSecurityError(
@@ -1530,36 +1634,38 @@ class ManuscriptSourceService(BaseService):
                     "an unsafe external source version was restored after an "
                     "interrupted replacement",
                     transient_exchange=True,
+                    recovery_state="retained_proposal",
                 ) from exc
 
             if displaced is None:
                 # The rename/link and cleanup completed, but a previous source
                 # directory fsync or the SQLite transition may have failed.
                 os.fsync(parent_fd)
-                return
+                return "missing"
 
             displaced_hash = _sha256(displaced)
             if expected_content_hash is None or displaced_hash == proposed_content_hash:
-                # Missing-file creation leaves a second hard link until cleanup;
-                # an identical proposed swap is also safe to discard.
-                os.unlink(swap_name, dir_fd=parent_fd)
+                # A restart cannot prove that a pre-existing proposal-valued
+                # inode has no descriptor opened while it was public. Retain
+                # the deterministic name; normal missing-file creation removes
+                # its redundant link before returning from the original call.
                 os.fsync(parent_fd)
-                return
+                return "retained_proposal"
             if displaced_hash == expected_content_hash:
                 # Exchange completed and the exact reviewed base is retained at
                 # the hidden recovery name. Keep that inode linked permanently:
                 # a pre-opened editor descriptor may still write through it.
                 os.fsync(parent_fd)
-                return
+                return "retained_base"
 
             # An external editor won the race immediately before the exchange.
             # Restore that exact displaced inode and leave the proposal conflicted.
             self._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
-            os.unlink(swap_name, dir_fd=parent_fd)
             os.fsync(parent_fd)
             raise ManuscriptSourceConflictError(
                 "an external source version was restored after an interrupted replacement",
                 transient_exchange=True,
+                recovery_state="retained_proposal",
             )
         finally:
             os.close(parent_fd)
@@ -1570,9 +1676,10 @@ class ManuscriptSourceService(BaseService):
         relative_path: str,
         *,
         proposal_id: str,
+        expected_content_hash: str | None,
         proposed_content_hash: str,
-    ) -> None:
-        """Durably finish a prior rollback before closing as conflicted."""
+    ) -> str:
+        """Durably preserve a restart state before closing it as conflicted."""
         normalized, _ = self._normalize_source_path(relative_path)
         parent_fd, _ = self._open_parent_fd(workspace, PurePosixPath(normalized))
         swap_name = self._source_swap_name(proposal_id)
@@ -1583,16 +1690,53 @@ class ManuscriptSourceService(BaseService):
                 missing_ok=True,
                 validate_utf8=False,
             )
+            recovery_state = "missing"
             if swap is not None:
-                if _sha256(swap) != proposed_content_hash:
-                    raise ManuscriptSourceSecurityError(
-                        "unexpected source swap remains after rollback; refusing to "
-                        "close the proposal"
-                    )
-                os.unlink(swap_name, dir_fd=parent_fd)
+                swap_hash = _sha256(swap)
+                if swap_hash == proposed_content_hash:
+                    recovery_state = "retained_proposal"
+                elif expected_content_hash is not None and swap_hash == expected_content_hash:
+                    recovery_state = "retained_base"
+                else:
+                    # This can be a late write through a descriptor opened
+                    # before exchange. It is not safe to classify or delete,
+                    # but retaining and fsyncing it permits a terminal conflict
+                    # without losing either public or displaced bytes.
+                    recovery_state = "retained_unclassified"
             os.fsync(parent_fd)
+            return recovery_state
         finally:
             os.close(parent_fd)
+
+    def _source_swap_state(
+        self,
+        workspace: Path,
+        relative_path: str,
+        *,
+        proposal_id: str,
+        expected_content_hash: str | None,
+        proposed_content_hash: str,
+    ) -> str:
+        """Classify, but never mutate, one deterministic source-side recovery name."""
+        normalized, _ = self._normalize_source_path(relative_path)
+        parent_fd, _ = self._open_parent_fd(workspace, PurePosixPath(normalized))
+        try:
+            swap, _ = self._read_source_entry_at(
+                parent_fd,
+                self._source_swap_name(proposal_id),
+                missing_ok=True,
+                validate_utf8=False,
+            )
+        finally:
+            os.close(parent_fd)
+        if swap is None:
+            return "missing"
+        swap_hash = _sha256(swap)
+        if swap_hash == proposed_content_hash:
+            return "proposal"
+        if expected_content_hash is not None and swap_hash == expected_content_hash:
+            return "reviewed_base"
+        return "unclassified"
 
     @staticmethod
     def _source_swap_name(proposal_id: str) -> str:
@@ -1608,7 +1752,7 @@ class ManuscriptSourceService(BaseService):
         swap_name: str,
         value: bytes,
         mode: int,
-    ) -> None:
+    ) -> bool:
         try:
             temp_fd = os.open(
                 swap_name,
@@ -1628,19 +1772,32 @@ class ManuscriptSourceService(BaseService):
                 raise ManuscriptSourceSecurityError(
                     "existing source swap does not match this proposal"
                 )
+            created = False
         else:
+            created = True
             try:
-                view = memoryview(value)
-                while view:
-                    written = os.write(temp_fd, view)
-                    view = view[written:]
-                os.fchmod(temp_fd, mode)
-                os.fsync(temp_fd)
-            finally:
-                os.close(temp_fd)
+                try:
+                    view = memoryview(value)
+                    while view:
+                        written = os.write(temp_fd, view)
+                        view = view[written:]
+                    os.fchmod(temp_fd, mode)
+                    os.fsync(temp_fd)
+                finally:
+                    os.close(temp_fd)
+            except Exception:
+                try:
+                    os.unlink(swap_name, dir_fd=parent_fd)
+                    os.fsync(parent_fd)
+                except Exception as cleanup_error:
+                    raise ManuscriptSourceSecurityError(
+                        "incomplete source proposal swap could not be removed safely"
+                    ) from cleanup_error
+                raise
         # Make the proposed swap name durable before exchanging it. A crash can
         # then leave either the pre- or post-exchange naming state, both recoverable.
         os.fsync(parent_fd)
+        return created
 
     @staticmethod
     def _atomic_exchange_at(

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -1,0 +1,1312 @@
+"""Conflict-safe local Markdown/LaTeX synchronization for native manuscripts."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+from collections import Counter, defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+
+from rka.config import RKAConfig
+from rka.infra.ids import generate_id
+from rka.models.manuscript_source import (
+    ManuscriptSourceProposalCreate,
+    ManuscriptSourceProposalTransition,
+)
+from rka.services.base import BaseService, _now
+from rka.services.manuscript_native import ManuscriptNotFoundError, NativeManuscriptService
+
+
+SOURCE_SCHEMA_VERSION = "rka.manuscript-source/v1"
+SOURCE_PROPOSAL_SCHEMA_VERSION = "rka.manuscript-source-proposal/v1"
+_SOURCE_SUFFIXES = {".md": "markdown", ".markdown": "markdown", ".tex": "latex"}
+_SOURCE_STATUSES = {
+    "proposed", "applied", "rejected", "conflicted", "superseded", "expired"
+}
+_MARKDOWN_ANCHOR_RE = re.compile(
+    r"^\s*<!--\s*rka:unit\s+(mun_[0-9A-Z]+)\s+(begin|end)\s*-->\s*$"
+)
+_LATEX_ANCHOR_RE = re.compile(
+    r"^\s*%\s*rka:unit\s+(mun_[0-9A-Z]+)\s+(begin|end)\s*$"
+)
+_MARKDOWN_PROVENANCE_RE = re.compile(
+    r"<!--\s*rka:provenance\s+(.+?)\s*-->", re.IGNORECASE
+)
+_LATEX_PROVENANCE_RE = re.compile(r"%\s*rka:provenance\s+(.+?)\s*$", re.IGNORECASE)
+_PROVENANCE_FIELD_RE = re.compile(r"(?:^|\s)(claim|evidence|citation)=([^\s>]+)")
+_SAFE_STORAGE_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+
+
+class ManuscriptSourceNotFoundError(ValueError):
+    """The manuscript, source file, or source proposal is absent."""
+
+
+class ManuscriptSourceConflictError(ValueError):
+    """The proposal or file optimistic guard is stale."""
+
+
+class ManuscriptSourceSecurityError(ValueError):
+    """A workspace or relative path violates the local filesystem boundary."""
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _loads(value: Any, fallback: Any) -> Any:
+    if value is None:
+        return fallback
+    return json.loads(value) if isinstance(value, str) else value
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+class ManuscriptSourceService(BaseService):
+    """Project-scoped source proposal, inspection, and recovery service."""
+
+    def __init__(self, db, *, config: RKAConfig, project_id: str):
+        super().__init__(db=db, project_id=project_id)
+        self.config = config
+
+    async def list_files(self, manuscript_id: str) -> dict[str, Any]:
+        manuscript, workspace = await self._resolve_workspace(manuscript_id)
+        files: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        for root, dirs, names in os.walk(workspace, followlinks=False):
+            root_path = Path(root)
+            safe_dirs = []
+            for name in sorted(dirs):
+                candidate = root_path / name
+                if name.startswith(".") or candidate.is_symlink():
+                    continue
+                safe_dirs.append(name)
+            dirs[:] = safe_dirs
+            for name in sorted(names):
+                candidate = root_path / name
+                suffix = candidate.suffix.lower()
+                if name.startswith(".") or suffix not in _SOURCE_SUFFIXES:
+                    continue
+                relative = candidate.relative_to(workspace).as_posix()
+                try:
+                    snapshot = self._read_current(workspace, relative)
+                except (OSError, UnicodeError, ValueError) as exc:
+                    warnings.append(
+                        {"relative_path": relative, "code": "SOURCE_UNREADABLE", "message": str(exc)}
+                    )
+                    continue
+                if snapshot[0] is None:
+                    continue
+                files.append(
+                    {
+                        "relative_path": relative,
+                        "source_format": _SOURCE_SUFFIXES[suffix],
+                        "content_hash": _sha256(snapshot[0]),
+                        "size_bytes": len(snapshot[0]),
+                    }
+                )
+                if len(files) >= 500:
+                    warnings.append(
+                        {
+                            "code": "SOURCE_FILE_CAP_REACHED",
+                            "message": "Only the first 500 manuscript source files are listed.",
+                        }
+                    )
+                    break
+            if len(files) >= 500:
+                break
+        return {
+            "schema_version": SOURCE_SCHEMA_VERSION,
+            "project_id": self.project_id,
+            "manuscript_id": manuscript["id"],
+            "workspace_ref": manuscript["workspace_ref"],
+            "files": files,
+            "warnings": warnings,
+        }
+
+    async def read_file(self, manuscript_id: str, relative_path: str) -> dict[str, Any]:
+        manuscript, workspace = await self._resolve_workspace(manuscript_id)
+        normalized, source_format = self._normalize_source_path(relative_path)
+        raw, mode = self._read_current(workspace, normalized)
+        if raw is None:
+            raise ManuscriptSourceNotFoundError(f"source file {normalized!r} not found")
+        content = self._decode(raw)
+        inspection = await self.inspect_content(
+            manuscript["id"], normalized, source_format, content
+        )
+        return {
+            "schema_version": SOURCE_SCHEMA_VERSION,
+            "project_id": self.project_id,
+            "manuscript_id": manuscript["id"],
+            "relative_path": normalized,
+            "source_format": source_format,
+            "content": content,
+            "content_hash": _sha256(raw),
+            "size_bytes": len(raw),
+            "mode": mode,
+            **inspection,
+        }
+
+    async def get_overview(self, manuscript_id: str) -> dict[str, Any]:
+        manuscript, _ = await self._resolve_workspace(manuscript_id)
+        listing = await self.list_files(manuscript["id"])
+        anchor_locations: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        file_summaries: list[dict[str, Any]] = []
+        for item in listing["files"]:
+            snapshot = await self.read_file(manuscript["id"], item["relative_path"])
+            file_summaries.append(
+                {
+                    **item,
+                    "anchor_count": len(snapshot["anchors"]),
+                    "finding_count": len(snapshot["findings"]),
+                    "blocking": any(
+                        finding["severity"] == "error" for finding in snapshot["findings"]
+                    ),
+                }
+            )
+            for anchor in snapshot["anchors"]:
+                anchor_locations[anchor["unit_id"]].append(
+                    {
+                        "relative_path": item["relative_path"],
+                        "start_line": anchor["start_line"],
+                        "end_line": anchor["end_line"],
+                        "content_hash": anchor["content_hash"],
+                    }
+                )
+
+        context = await NativeManuscriptService(
+            self.db, project_id=self.project_id
+        ).get_context(manuscript["id"])
+        claims = {claim["id"]: claim for claim in context["claims"]}
+        quick_reader = []
+        private_risks: list[dict[str, Any]] = []
+        for unit in sorted(context["units"], key=lambda value: (value["sequence"], value["id"])):
+            if unit["status"] == "removed":
+                continue
+            unit_claims = [
+                claim
+                for claim in claims.values()
+                if any(link["unit_id"] == unit["id"] for link in claim.get("unit_links", []))
+            ]
+            quick_reader.append(
+                {
+                    "unit_id": unit["id"],
+                    "local_key": unit["local_key"],
+                    "title": unit.get("title"),
+                    "communicative_job": unit.get("communicative_job"),
+                    "intended_takeaway": unit.get("intended_takeaway"),
+                    "quick_reader_role": unit.get("quick_reader_role"),
+                    "anchors": anchor_locations.get(unit["id"], []),
+                    "anchor_state": "linked" if anchor_locations.get(unit["id"]) else "missing",
+                }
+            )
+            for claim in unit_claims:
+                if claim.get("prohibited_wording"):
+                    private_risks.append(
+                        {
+                            "kind": "claim_boundary",
+                            "unit_id": unit["id"],
+                            "claim_id": claim["id"],
+                            "items": claim["prohibited_wording"],
+                            "message": "Prohibited wording is private review context, not draft prose.",
+                        }
+                    )
+            for binding in unit.get("evidence", []):
+                if binding["role"] in {"qualifier", "counterevidence"}:
+                    private_risks.append(
+                        {
+                            "kind": binding["role"],
+                            "unit_id": unit["id"],
+                            "evidence_claim_id": binding["evidence_claim_id"],
+                            "content": binding.get("content"),
+                            "message": "Adverse evidence requires deliberate treatment.",
+                        }
+                    )
+            for citation in unit.get("citations", []):
+                if (
+                    citation.get("verification_state") != "verified"
+                    or not citation.get("verification_current", False)
+                ):
+                    private_risks.append(
+                        {
+                            "kind": "citation_verification",
+                            "unit_id": unit["id"],
+                            "citation_key": citation["citation_key"],
+                            "verification_state": citation.get("verification_state"),
+                            "verification_current": bool(
+                                citation.get("verification_current", False)
+                            ),
+                            "message": "Citation use is not currently verified.",
+                        }
+                    )
+        return {
+            "schema_version": SOURCE_SCHEMA_VERSION,
+            "project_id": self.project_id,
+            "manuscript_id": manuscript["id"],
+            "workspace_ref": manuscript["workspace_ref"],
+            "files": file_summaries,
+            "warnings": listing["warnings"],
+            "quick_reader": quick_reader,
+            "private_reviewer_risks": private_risks,
+            "public_private_boundary": {
+                "draft_source": "public authoring artifact",
+                "private_reviewer_risks": "private planning context; never copied automatically",
+            },
+        }
+
+    async def inspect_content(
+        self,
+        manuscript_id: str,
+        relative_path: str,
+        source_format: str,
+        content: str,
+    ) -> dict[str, Any]:
+        lines = content.splitlines(keepends=True)
+        anchor_re = _MARKDOWN_ANCHOR_RE if source_format == "markdown" else _LATEX_ANCHOR_RE
+        provenance_re = (
+            _MARKDOWN_PROVENANCE_RE if source_format == "markdown" else _LATEX_PROVENANCE_RE
+        )
+        findings: list[dict[str, Any]] = []
+        internal_anchors: list[dict[str, Any]] = []
+        opened: tuple[str, int] | None = None
+        for index, line in enumerate(lines):
+            match = anchor_re.match(line.rstrip("\r\n"))
+            if match is None:
+                continue
+            unit_id, action = match.groups()
+            if action == "begin":
+                if opened is not None:
+                    findings.append(
+                        {
+                            "severity": "error",
+                            "code": "NESTED_UNIT_ANCHOR",
+                            "message": f"unit anchor {unit_id} begins inside {opened[0]}",
+                            "line": index + 1,
+                        }
+                    )
+                else:
+                    opened = (unit_id, index)
+                continue
+            if opened is None:
+                findings.append(
+                    {
+                        "severity": "error",
+                        "code": "UNMATCHED_UNIT_ANCHOR_END",
+                        "message": f"unit anchor {unit_id} ends without a begin marker",
+                        "line": index + 1,
+                    }
+                )
+                continue
+            if opened[0] != unit_id:
+                findings.append(
+                    {
+                        "severity": "error",
+                        "code": "MISMATCHED_UNIT_ANCHOR",
+                        "message": f"unit anchor {opened[0]} closes as {unit_id}",
+                        "line": index + 1,
+                    }
+                )
+                opened = None
+                continue
+            body = "".join(lines[opened[1] + 1:index])
+            internal_anchors.append(
+                {
+                    "unit_id": unit_id,
+                    "start_line": opened[1] + 1,
+                    "content_start_line": opened[1] + 2,
+                    "content_end_line": index,
+                    "end_line": index + 1,
+                    "content_hash": _sha256(body.encode("utf-8")),
+                    "_body_start": opened[1] + 1,
+                    "_body_end": index,
+                }
+            )
+            opened = None
+        if opened is not None:
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "UNCLOSED_UNIT_ANCHOR",
+                    "message": f"unit anchor {opened[0]} has no end marker",
+                    "line": opened[1] + 1,
+                }
+            )
+        duplicates = [
+            unit_id
+            for unit_id, count in Counter(anchor["unit_id"] for anchor in internal_anchors).items()
+            if count > 1
+        ]
+        for unit_id in sorted(duplicates):
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "DUPLICATE_UNIT_ANCHOR",
+                    "message": f"unit {unit_id} appears in more than one range in this file",
+                    "unit_id": unit_id,
+                }
+            )
+
+        units = await self.db.fetchall(
+            """SELECT id, local_key, status FROM manuscript_units
+               WHERE manuscript_id = ? AND project_id = ?""",
+            [manuscript_id, self.project_id],
+        )
+        unit_map = {row["id"]: dict(row) for row in units}
+        claim_rows = await self.db.fetchall(
+            """SELECT cu.unit_id, cu.manuscript_claim_id
+               FROM manuscript_claim_units AS cu
+               WHERE cu.manuscript_id = ? AND cu.project_id = ?""",
+            [manuscript_id, self.project_id],
+        )
+        evidence_rows = await self.db.fetchall(
+            """SELECT unit_id, evidence_claim_id FROM manuscript_unit_evidence
+               WHERE manuscript_id = ? AND project_id = ?""",
+            [manuscript_id, self.project_id],
+        )
+        citation_rows = await self.db.fetchall(
+            """SELECT uc.unit_id, mr.citation_key
+               FROM manuscript_unit_citations AS uc
+               JOIN manuscript_reference_members AS mr
+                 ON mr.id = uc.reference_member_id AND mr.project_id = uc.project_id
+               WHERE uc.manuscript_id = ? AND uc.project_id = ?""",
+            [manuscript_id, self.project_id],
+        )
+        claims_by_unit: dict[str, set[str]] = defaultdict(set)
+        evidence_by_unit: dict[str, set[str]] = defaultdict(set)
+        citations_by_unit: dict[str, set[str]] = defaultdict(set)
+        for row in claim_rows:
+            claims_by_unit[row["unit_id"]].add(row["manuscript_claim_id"])
+        for row in evidence_rows:
+            evidence_by_unit[row["unit_id"]].add(row["evidence_claim_id"])
+        for row in citation_rows:
+            citations_by_unit[row["unit_id"]].add(row["citation_key"])
+
+        provenance: list[dict[str, Any]] = []
+        for anchor in internal_anchors:
+            unit_id = anchor["unit_id"]
+            unit = unit_map.get(unit_id)
+            if unit is None:
+                findings.append(
+                    {
+                        "severity": "error",
+                        "code": "FOREIGN_OR_UNKNOWN_UNIT_ANCHOR",
+                        "message": f"unit {unit_id} does not belong to this manuscript",
+                        "unit_id": unit_id,
+                    }
+                )
+            elif unit["status"] == "removed":
+                findings.append(
+                    {
+                        "severity": "error",
+                        "code": "REMOVED_UNIT_ANCHOR",
+                        "message": f"unit {unit_id} is removed from the active outline",
+                        "unit_id": unit_id,
+                    }
+                )
+            anchor_refs = 0
+            for line_number in range(anchor["_body_start"], anchor["_body_end"]):
+                line = lines[line_number].rstrip("\r\n")
+                for match in provenance_re.finditer(line):
+                    fields = _PROVENANCE_FIELD_RE.findall(match.group(1))
+                    if not fields:
+                        findings.append(
+                            {
+                                "severity": "error",
+                                "code": "EMPTY_PROVENANCE_COMMENT",
+                                "message": "provenance comment has no claim, evidence, or citation field",
+                                "unit_id": unit_id,
+                                "line": line_number + 1,
+                            }
+                        )
+                        continue
+                    anchor_refs += len(fields)
+                    for kind, value in fields:
+                        allowed = (
+                            claims_by_unit[unit_id]
+                            if kind == "claim"
+                            else evidence_by_unit[unit_id]
+                            if kind == "evidence"
+                            else citations_by_unit[unit_id]
+                        )
+                        verified = value in allowed
+                        item = {
+                            "unit_id": unit_id,
+                            "kind": kind,
+                            "value": value,
+                            "line": line_number + 1,
+                            "verified": verified,
+                        }
+                        provenance.append(item)
+                        if not verified:
+                            findings.append(
+                                {
+                                    "severity": "error",
+                                    "code": "UNBOUND_PROVENANCE_REFERENCE",
+                                    "message": f"{kind} {value!r} is not currently bound to unit {unit_id}",
+                                    **item,
+                                }
+                            )
+            if (
+                unit is not None
+                and unit["status"] != "removed"
+                and anchor_refs == 0
+                and (
+                    claims_by_unit[unit_id]
+                    or evidence_by_unit[unit_id]
+                    or citations_by_unit[unit_id]
+                )
+            ):
+                findings.append(
+                    {
+                        "severity": "warning",
+                        "code": "PROVENANCE_COMMENT_MISSING",
+                        "message": f"unit {unit_id} has semantic bindings but no provenance comment",
+                        "unit_id": unit_id,
+                    }
+                )
+
+        anchors = [
+            {key: value for key, value in anchor.items() if not key.startswith("_")}
+            for anchor in internal_anchors
+        ]
+        if not anchors:
+            findings.append(
+                {
+                    "severity": "warning",
+                    "code": "NO_UNIT_ANCHORS",
+                    "message": f"{relative_path} is not yet linked to a manuscript unit",
+                }
+            )
+        return {
+            "anchors": anchors,
+            "provenance": provenance,
+            "findings": findings,
+        }
+
+    async def create_proposal(
+        self,
+        manuscript_id: str,
+        data: ManuscriptSourceProposalCreate,
+    ) -> dict[str, Any]:
+        manuscript, workspace = await self._resolve_workspace(manuscript_id)
+        relative_path, source_format = self._normalize_source_path(data.relative_path)
+        proposed = data.content.encode("utf-8")
+        self._assert_size(proposed)
+        current, _ = self._read_current(workspace, relative_path)
+        current_hash = _sha256(current) if current is not None else None
+        if current_hash != data.expected_content_hash:
+            raise ManuscriptSourceConflictError(
+                f"source hash conflict: expected {data.expected_content_hash!r}, found {current_hash!r}"
+            )
+        proposed_hash = _sha256(proposed)
+        if proposed_hash == current_hash:
+            raise ValueError("source proposal has no content changes")
+        inspection = await self.inspect_content(
+            manuscript["id"], relative_path, source_format, data.content
+        )
+        if any(item["severity"] == "error" for item in inspection["findings"]):
+            raise ValueError("source proposal contains blocking anchor or provenance findings")
+
+        proposal_id = generate_id("manuscript_source_proposal")
+        async with self.db.transaction():
+            context_manifest_id = None
+            if data.origin != "human":
+                await self._validate_ai_context(
+                    manuscript,
+                    str(data.context_manifest_id),
+                    origin=data.origin,
+                    provider=str(data.provider),
+                    model=str(data.model),
+                    boundary=data.boundary,
+                )
+                context_manifest_id = data.context_manifest_id
+            if data.supersedes_proposal_id:
+                previous = await self._require_proposal_row(data.supersedes_proposal_id)
+                if previous["status"] not in {"proposed", "conflicted"}:
+                    raise ManuscriptSourceConflictError(
+                        "only proposed or conflicted source proposals may be superseded"
+                    )
+                if (
+                    previous["manuscript_id"] != manuscript["id"]
+                    or previous["relative_path"] != relative_path
+                ):
+                    raise ValueError("a source proposal may supersede only the same file")
+                await self._transition_row(
+                    previous,
+                    status="superseded",
+                    actor=data.created_by,
+                    reason=f"Superseded by {proposal_id}: {data.reason}",
+                    details={"superseded_by": proposal_id},
+                )
+            await self.db.execute(
+                """INSERT INTO manuscript_source_proposals
+                   (id, project_id, manuscript_id, origin, relative_path,
+                    source_format, base_content_hash, proposed_content,
+                    proposed_content_hash, created_by, reason,
+                    validation_findings, context_manifest_id, provider, model,
+                    boundary, supersedes_proposal_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    proposal_id,
+                    self.project_id,
+                    manuscript["id"],
+                    data.origin,
+                    relative_path,
+                    source_format,
+                    current_hash,
+                    data.content,
+                    proposed_hash,
+                    data.created_by,
+                    data.reason,
+                    _canonical_json(inspection["findings"]),
+                    context_manifest_id,
+                    data.provider,
+                    data.model,
+                    data.boundary,
+                    data.supersedes_proposal_id,
+                ],
+            )
+            await self._insert_event(
+                proposal_id,
+                revision=1,
+                action="proposed",
+                actor=data.created_by,
+                reason=data.reason,
+                details={
+                    "relative_path": relative_path,
+                    "base_content_hash": current_hash,
+                    "proposed_content_hash": proposed_hash,
+                    "finding_count": len(inspection["findings"]),
+                },
+            )
+        return await self.get_proposal(proposal_id)
+
+    async def get_proposal(self, proposal_id: str) -> dict[str, Any]:
+        row = await self._require_proposal_row(proposal_id)
+        result = dict(row)
+        result["validation_findings"] = _loads(result["validation_findings"], [])
+        events = await self.db.fetchall(
+            """SELECT * FROM manuscript_source_events
+               WHERE proposal_id = ? AND project_id = ?
+               ORDER BY proposal_revision""",
+            [proposal_id, self.project_id],
+        )
+        result["events"] = []
+        for event in events:
+            item = dict(event)
+            item["details"] = _loads(item["details"], {})
+            result["events"].append(item)
+        result["schema_version"] = SOURCE_PROPOSAL_SCHEMA_VERSION
+        return result
+
+    async def list_proposals(
+        self,
+        manuscript_id: str,
+        *,
+        status: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        canonical_id = await NativeManuscriptService(
+            self.db, project_id=self.project_id
+        ).resolve_id(manuscript_id)
+        if canonical_id is None:
+            raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
+        if status is not None and status not in _SOURCE_STATUSES:
+            raise ValueError("invalid manuscript source proposal status")
+        if not 1 <= limit <= 500:
+            raise ValueError("limit must be between 1 and 500")
+        sql = """SELECT id, project_id, manuscript_id, status, revision, origin,
+                        relative_path, source_format, base_content_hash,
+                        proposed_content_hash, created_by, reason,
+                        validation_findings, recovery_manifest_path,
+                        created_at, updated_at
+                 FROM manuscript_source_proposals
+                 WHERE project_id = ? AND manuscript_id = ?"""
+        params: list[Any] = [self.project_id, canonical_id]
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+        sql += " ORDER BY updated_at DESC, id DESC LIMIT ?"
+        params.append(limit)
+        rows = await self.db.fetchall(sql, params)
+        result = []
+        for raw in rows:
+            row = dict(raw)
+            row["validation_findings"] = _loads(row["validation_findings"], [])
+            row["schema_version"] = SOURCE_PROPOSAL_SCHEMA_VERSION
+            result.append(row)
+        return result
+
+    async def apply_proposal(
+        self,
+        proposal_id: str,
+        data: ManuscriptSourceProposalTransition,
+    ) -> dict[str, Any]:
+        row = await self._require_proposal_row(proposal_id)
+        self._assert_open(row, data.expected_revision)
+        manuscript, workspace = await self._resolve_workspace(row["manuscript_id"])
+        relative_path, _ = self._normalize_source_path(row["relative_path"])
+        lock_fd = self._open_lock_fd(manuscript["id"], relative_path)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            row = await self._require_proposal_row(proposal_id)
+            self._assert_open(row, data.expected_revision)
+            current, mode = self._read_current(workspace, relative_path)
+            current_hash = _sha256(current) if current is not None else None
+            proposed = row["proposed_content"].encode("utf-8")
+            proposed_hash = _sha256(proposed)
+            recovery_path = self._recovery_manifest_path(row)
+
+            if current_hash != row["base_content_hash"]:
+                if current_hash == proposed_hash and self._valid_recovery_manifest(
+                    recovery_path, row
+                ):
+                    await self._complete_applied_transition(
+                        row,
+                        data,
+                        recovery_path,
+                        recovered_after_restart=True,
+                    )
+                    return await self.get_proposal(proposal_id)
+                async with self.db.transaction():
+                    row = await self._require_proposal_row(proposal_id)
+                    self._assert_open(row, data.expected_revision)
+                    await self._transition_row(
+                        row,
+                        status="conflicted",
+                        actor=data.actor,
+                        reason=data.reason,
+                        details={
+                            "relative_path": relative_path,
+                            "expected_content_hash": row["base_content_hash"],
+                            "current_content_hash": current_hash,
+                            "proposed_content_hash": proposed_hash,
+                            "file_written": False,
+                        },
+                    )
+                raise ManuscriptSourceConflictError(
+                    "source changed after proposal creation; current and proposed versions were preserved"
+                )
+
+            inspection = await self.inspect_content(
+                manuscript["id"], relative_path, row["source_format"], row["proposed_content"]
+            )
+            if any(item["severity"] == "error" for item in inspection["findings"]):
+                raise ValueError("source proposal no longer passes anchor/provenance validation")
+            self._write_recovery(row, current, mode, recovery_path)
+            self._atomic_replace(workspace, relative_path, proposed, mode)
+            await self._complete_applied_transition(
+                row,
+                data,
+                recovery_path,
+                recovered_after_restart=False,
+            )
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(lock_fd)
+        return await self.get_proposal(proposal_id)
+
+    async def reject_proposal(
+        self,
+        proposal_id: str,
+        data: ManuscriptSourceProposalTransition,
+    ) -> dict[str, Any]:
+        async with self.db.transaction():
+            row = await self._require_proposal_row(proposal_id)
+            self._assert_open(row, data.expected_revision)
+            await self._transition_row(
+                row,
+                status="rejected",
+                actor=data.actor,
+                reason=data.reason,
+                details={},
+            )
+        return await self.get_proposal(proposal_id)
+
+    async def _complete_applied_transition(
+        self,
+        row: Mapping[str, Any],
+        data: ManuscriptSourceProposalTransition,
+        recovery_path: Path,
+        *,
+        recovered_after_restart: bool,
+    ) -> None:
+        recovery_relative = recovery_path.relative_to(
+            Path(self.db.db_path).resolve().parent
+        ).as_posix()
+        async with self.db.transaction():
+            current = await self._require_proposal_row(str(row["id"]))
+            self._assert_open(current, data.expected_revision)
+            await self._transition_row(
+                current,
+                status="applied",
+                actor=data.actor,
+                reason=data.reason,
+                details={
+                    "relative_path": row["relative_path"],
+                    "before_content_hash": row["base_content_hash"],
+                    "after_content_hash": row["proposed_content_hash"],
+                    "recovery_manifest_path": recovery_relative,
+                    "recovered_after_restart": recovered_after_restart,
+                    "git_operation": False,
+                },
+                recovery_manifest_path=recovery_relative,
+            )
+
+    async def _validate_ai_context(
+        self,
+        manuscript: Mapping[str, Any],
+        manifest_id: str,
+        *,
+        origin: str,
+        provider: str,
+        model: str,
+        boundary: str,
+    ) -> None:
+        row = await self.db.fetchone(
+            """SELECT * FROM semantic_patch_context_manifests
+               WHERE id = ? AND project_id = ?""",
+            [manifest_id, self.project_id],
+        )
+        if row is None:
+            raise ValueError("AI source proposal context manifest not found")
+        if (
+            row["origin"] != origin
+            or row["provider"] != provider
+            or row["model"] != model
+            or row["boundary"] != boundary
+        ):
+            raise ValueError("AI source proposal boundary does not match its context manifest")
+        targets = _loads(row["target_bases"], [])
+        target = next(
+            (
+                item
+                for item in targets
+                if item.get("target", {}).get("type") == "manuscript"
+                and item.get("target", {}).get("id") == manuscript["id"]
+            ),
+            None,
+        )
+        if target is None:
+            raise ValueError("AI context manifest does not disclose the target manuscript")
+        if int(target.get("revision", -1)) != int(manuscript["revision"]):
+            raise ManuscriptSourceConflictError("AI context manuscript revision is stale")
+
+    async def _resolve_workspace(self, manuscript_id: str) -> tuple[dict[str, Any], Path]:
+        manuscript = await NativeManuscriptService(
+            self.db, project_id=self.project_id
+        ).get(manuscript_id)
+        if manuscript is None:
+            raise ManuscriptNotFoundError(f"manuscript {manuscript_id!r} not found")
+        record = manuscript.model_dump()
+        workspace_ref = record.get("workspace_ref")
+        if not workspace_ref:
+            raise ManuscriptSourceSecurityError("manuscript has no workspace_ref")
+        roots = self._configured_roots()
+        if not roots:
+            raise ManuscriptSourceSecurityError(
+                "manuscript source access is disabled; configure RKA_MANUSCRIPT_WORKSPACE_ROOTS"
+            )
+        workspace = Path(os.path.abspath(os.path.expanduser(str(workspace_ref))))
+        matching_root = next(
+            (root for root in roots if workspace == root or root in workspace.parents),
+            None,
+        )
+        if matching_root is None:
+            raise ManuscriptSourceSecurityError("workspace_ref is outside configured roots")
+        if not workspace.exists() or not workspace.is_dir():
+            raise ManuscriptSourceSecurityError("workspace_ref is not an existing directory")
+        self._assert_no_symlink_components(matching_root, workspace)
+        return record, workspace
+
+    def _configured_roots(self) -> list[Path]:
+        result = []
+        for value in self.config.manuscript_workspace_roots.split(os.pathsep):
+            value = value.strip()
+            if not value:
+                continue
+            configured = Path(os.path.abspath(os.path.expanduser(value)))
+            if not configured.exists() or not configured.is_dir():
+                continue
+            # Canonicalize the explicitly trusted root once. A workspace_ref
+            # that reaches the same location through a symlink will not match
+            # this path and therefore cannot smuggle a symlink into later
+            # descriptor-relative traversal.
+            root = configured.resolve()
+            result.append(root)
+        return result
+
+    @staticmethod
+    def _assert_no_symlink_components(root: Path, candidate: Path) -> None:
+        relative = candidate.relative_to(root)
+        current = root
+        for part in relative.parts:
+            current = current / part
+            if current.is_symlink():
+                raise ManuscriptSourceSecurityError(
+                    f"workspace contains symlink component {part!r}"
+                )
+
+    @staticmethod
+    def _normalize_source_path(relative_path: str) -> tuple[str, str]:
+        value = relative_path.strip()
+        if "\\" in value:
+            raise ManuscriptSourceSecurityError("relative_path must use POSIX separators")
+        path = PurePosixPath(value)
+        if path.is_absolute() or not path.parts or any(
+            part in {"", ".", ".."} or part.startswith(".") for part in path.parts
+        ):
+            raise ManuscriptSourceSecurityError("relative_path is not a safe visible path")
+        source_format = _SOURCE_SUFFIXES.get(path.suffix.lower())
+        if source_format is None:
+            raise ManuscriptSourceSecurityError("only .md, .markdown, and .tex files are supported")
+        return path.as_posix(), source_format
+
+    def _read_current(self, workspace: Path, relative_path: str) -> tuple[bytes | None, int | None]:
+        normalized, _ = self._normalize_source_path(relative_path)
+        parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
+        try:
+            try:
+                file_fd = os.open(
+                    name,
+                    os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                    dir_fd=parent_fd,
+                )
+            except FileNotFoundError:
+                return None, None
+            try:
+                file_stat = os.fstat(file_fd)
+                if not stat.S_ISREG(file_stat.st_mode):
+                    raise ManuscriptSourceSecurityError("source target is not a regular file")
+                if file_stat.st_size > self.config.manuscript_source_max_bytes:
+                    raise ValueError("manuscript source file exceeds configured size limit")
+                chunks = []
+                remaining = self.config.manuscript_source_max_bytes + 1
+                while remaining > 0:
+                    chunk = os.read(file_fd, min(64 * 1024, remaining))
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                    remaining -= len(chunk)
+                value = b"".join(chunks)
+                self._assert_size(value)
+                self._decode(value)
+                return value, stat.S_IMODE(file_stat.st_mode)
+            finally:
+                os.close(file_fd)
+        finally:
+            os.close(parent_fd)
+
+    @staticmethod
+    def _open_parent_fd(workspace: Path, relative_path: PurePosixPath) -> tuple[int, str]:
+        directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        current_fd = ManuscriptSourceService._open_absolute_directory_fd(workspace)
+        try:
+            for part in relative_path.parts[:-1]:
+                next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+                os.close(current_fd)
+                current_fd = next_fd
+            return current_fd, relative_path.name
+        except Exception:
+            os.close(current_fd)
+            raise
+
+    @staticmethod
+    def _open_absolute_directory_fd(path: Path) -> int:
+        """Open every absolute path component without following symlinks."""
+        absolute = Path(os.path.abspath(path))
+        parts = absolute.parts
+        if not parts or not absolute.is_absolute():
+            raise ManuscriptSourceSecurityError("source directory is not absolute")
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        current_fd = os.open(parts[0], flags)
+        try:
+            for part in parts[1:]:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+                os.close(current_fd)
+                current_fd = next_fd
+            return current_fd
+        except Exception:
+            os.close(current_fd)
+            raise
+
+    def _assert_size(self, value: bytes) -> None:
+        if len(value) > self.config.manuscript_source_max_bytes:
+            raise ValueError("manuscript source content exceeds configured size limit")
+
+    @staticmethod
+    def _decode(value: bytes) -> str:
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("manuscript source must be valid UTF-8") from exc
+
+    def _recovery_root(self) -> Path:
+        return Path(self.db.db_path).resolve().parent / "manuscript-source-recovery"
+
+    def _open_lock_fd(self, manuscript_id: str, relative_path: str) -> int:
+        digest = _sha256(f"{self.project_id}\0{manuscript_id}\0{relative_path}".encode())
+        directory_fd, _ = self._open_recovery_directory(("locks",), create=True)
+        try:
+            return os.open(
+                f"{digest}.lock",
+                os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=directory_fd,
+            )
+        finally:
+            os.close(directory_fd)
+
+    def _recovery_components(self, row: Mapping[str, Any]) -> tuple[str, str, str]:
+        components = (
+            self.project_id,
+            str(row["manuscript_id"]),
+            str(row["id"]),
+        )
+        for value in components:
+            if value in {".", ".."} or not _SAFE_STORAGE_COMPONENT_RE.fullmatch(value):
+                raise ManuscriptSourceSecurityError(
+                    "source recovery identity is not safe for managed storage"
+                )
+        return components
+
+    def _open_recovery_directory(
+        self,
+        components: tuple[str, ...],
+        *,
+        create: bool,
+    ) -> tuple[int, Path]:
+        """Open a managed recovery directory without following any symlink."""
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        parent = Path(self.db.db_path).resolve().parent
+        current_fd = self._open_absolute_directory_fd(parent)
+        current_path = parent
+        try:
+            for component in ("manuscript-source-recovery", *components):
+                if component in {".", ".."} or not _SAFE_STORAGE_COMPONENT_RE.fullmatch(
+                    component
+                ):
+                    raise ManuscriptSourceSecurityError(
+                        "source recovery path contains an unsafe component"
+                    )
+                if create:
+                    try:
+                        os.mkdir(component, mode=0o700, dir_fd=current_fd)
+                    except FileExistsError:
+                        pass
+                try:
+                    next_fd = os.open(component, flags, dir_fd=current_fd)
+                except OSError as exc:
+                    raise ManuscriptSourceSecurityError(
+                        "source recovery path is missing, unsafe, or not a directory"
+                    ) from exc
+                if not stat.S_ISDIR(os.fstat(next_fd).st_mode):
+                    os.close(next_fd)
+                    raise ManuscriptSourceSecurityError(
+                        "source recovery component is not a directory"
+                    )
+                os.close(current_fd)
+                current_fd = next_fd
+                current_path = current_path / component
+            return current_fd, current_path
+        except Exception:
+            os.close(current_fd)
+            raise
+
+    def _recovery_manifest_path(self, row: Mapping[str, Any]) -> Path:
+        return self._recovery_root().joinpath(
+            *self._recovery_components(row), "manifest.json"
+        )
+
+    def _write_recovery(
+        self,
+        row: Mapping[str, Any],
+        before: bytes | None,
+        mode: int | None,
+        manifest_path: Path,
+    ) -> None:
+        components = self._recovery_components(row)
+        directory_fd, directory = self._open_recovery_directory(
+            components, create=True
+        )
+        if directory / "manifest.json" != manifest_path:
+            os.close(directory_fd)
+            raise ManuscriptSourceSecurityError("source recovery path changed")
+        manifest = {
+            "schema_version": "rka.manuscript-source-recovery/v1",
+            "proposal_id": row["id"],
+            "project_id": self.project_id,
+            "manuscript_id": row["manuscript_id"],
+            "relative_path": row["relative_path"],
+            "before_existed": before is not None,
+            "before_content_hash": _sha256(before) if before is not None else None,
+            "before_mode": mode,
+            "after_content_hash": row["proposed_content_hash"],
+            "created_at": _now(),
+        }
+        try:
+            if before is not None:
+                existing_before = self._read_managed_file(
+                    directory_fd, "before.bin", missing_ok=True
+                )
+                if existing_before is None:
+                    self._write_new_durable_at(
+                        directory_fd, "before.bin", before, mode=0o600
+                    )
+                elif _sha256(existing_before) != _sha256(before):
+                    raise ManuscriptSourceSecurityError(
+                        "existing source recovery copy does not match the current base"
+                    )
+            existing_manifest = self._read_managed_file(
+                directory_fd, "manifest.json", missing_ok=True
+            )
+            if existing_manifest is not None:
+                try:
+                    payload = json.loads(existing_manifest.decode("utf-8"))
+                except (ValueError, UnicodeError) as exc:
+                    raise ManuscriptSourceSecurityError(
+                        "existing source recovery manifest is invalid"
+                    ) from exc
+                if not self._recovery_manifest_matches(payload, row):
+                    raise ManuscriptSourceSecurityError(
+                        "existing source recovery manifest does not match this proposal"
+                    )
+            else:
+                self._write_new_durable_at(
+                    directory_fd,
+                    "manifest.json",
+                    (_canonical_json(manifest) + "\n").encode("utf-8"),
+                    mode=0o600,
+                )
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    @staticmethod
+    def _write_new_durable_at(
+        directory_fd: int,
+        name: str,
+        value: bytes,
+        *,
+        mode: int,
+    ) -> None:
+        fd = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            mode,
+            dir_fd=directory_fd,
+        )
+        try:
+            view = memoryview(value)
+            while view:
+                written = os.write(fd, view)
+                view = view[written:]
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _read_managed_file(
+        directory_fd: int,
+        name: str,
+        *,
+        missing_ok: bool,
+    ) -> bytes | None:
+        try:
+            fd = os.open(
+                name,
+                os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            if missing_ok:
+                return None
+            raise
+        try:
+            file_stat = os.fstat(fd)
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise ManuscriptSourceSecurityError(
+                    "source recovery entry is not a regular file"
+                )
+            if file_stat.st_size > 32 * 1024 * 1024:
+                raise ManuscriptSourceSecurityError("source recovery entry is oversized")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(fd, 64 * 1024)
+                if not chunk:
+                    return b"".join(chunks)
+                chunks.append(chunk)
+        finally:
+            os.close(fd)
+
+    def _valid_recovery_manifest(self, path: Path, row: Mapping[str, Any]) -> bool:
+        expected = self._recovery_manifest_path(row)
+        if path != expected:
+            return False
+        try:
+            directory_fd, directory = self._open_recovery_directory(
+                self._recovery_components(row), create=False
+            )
+            try:
+                if directory / "manifest.json" != path:
+                    return False
+                raw = self._read_managed_file(
+                    directory_fd, "manifest.json", missing_ok=False
+                )
+            finally:
+                os.close(directory_fd)
+            assert raw is not None
+            payload = json.loads(raw.decode("utf-8"))
+        except (OSError, ValueError, UnicodeError, ManuscriptSourceSecurityError):
+            return False
+        return self._recovery_manifest_matches(payload, row)
+
+    def _recovery_manifest_matches(
+        self,
+        payload: Mapping[str, Any],
+        row: Mapping[str, Any],
+    ) -> bool:
+        return bool(
+            payload.get("schema_version") == "rka.manuscript-source-recovery/v1"
+            and payload.get("proposal_id") == row["id"]
+            and payload.get("project_id") == self.project_id
+            and payload.get("manuscript_id") == row["manuscript_id"]
+            and payload.get("relative_path") == row["relative_path"]
+            and payload.get("before_content_hash") == row["base_content_hash"]
+            and payload.get("after_content_hash") == row["proposed_content_hash"]
+        )
+
+    def _atomic_replace(
+        self,
+        workspace: Path,
+        relative_path: str,
+        value: bytes,
+        previous_mode: int | None,
+    ) -> None:
+        normalized, _ = self._normalize_source_path(relative_path)
+        parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
+        temp_name = f".{name}.rka-{generate_id('manuscript_source_proposal')}"
+        temp_fd = None
+        try:
+            temp_fd = os.open(
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            view = memoryview(value)
+            while view:
+                written = os.write(temp_fd, view)
+                view = view[written:]
+            os.fchmod(temp_fd, previous_mode if previous_mode is not None else 0o644)
+            os.fsync(temp_fd)
+            os.close(temp_fd)
+            temp_fd = None
+            os.replace(temp_name, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            if temp_fd is not None:
+                os.close(temp_fd)
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+
+    async def _require_proposal_row(self, proposal_id: str) -> dict[str, Any]:
+        row = await self.db.fetchone(
+            "SELECT * FROM manuscript_source_proposals WHERE id = ? AND project_id = ?",
+            [proposal_id, self.project_id],
+        )
+        if row is None:
+            raise ManuscriptSourceNotFoundError(
+                f"manuscript source proposal {proposal_id!r} not found"
+            )
+        return dict(row)
+
+    @staticmethod
+    def _assert_open(row: Mapping[str, Any], expected_revision: int) -> None:
+        if row["status"] != "proposed":
+            raise ManuscriptSourceConflictError(f"proposal is already {row['status']!r}")
+        if int(row["revision"]) != expected_revision:
+            raise ManuscriptSourceConflictError(
+                f"proposal revision conflict: expected {expected_revision}, found {row['revision']}"
+            )
+
+    async def _transition_row(
+        self,
+        row: Mapping[str, Any],
+        *,
+        status: str,
+        actor: str,
+        reason: str,
+        details: dict[str, Any],
+        recovery_manifest_path: str | None = None,
+    ) -> None:
+        revision = int(row["revision"]) + 1
+        timestamp = _now()
+        cursor = await self.db.execute(
+            """UPDATE manuscript_source_proposals
+               SET status = ?, revision = revision + 1, updated_at = ?,
+                   applied_at = CASE WHEN ? = 'applied' THEN ? ELSE applied_at END,
+                   closed_at = ?,
+                   recovery_manifest_path = CASE WHEN ? = 'applied' THEN ? ELSE recovery_manifest_path END
+               WHERE id = ? AND project_id = ? AND status = ? AND revision = ?""",
+            [
+                status,
+                timestamp,
+                status,
+                timestamp,
+                timestamp,
+                status,
+                recovery_manifest_path,
+                row["id"],
+                self.project_id,
+                row["status"],
+                row["revision"],
+            ],
+        )
+        if cursor.rowcount != 1:
+            raise ManuscriptSourceConflictError("source proposal changed concurrently")
+        await self._insert_event(
+            str(row["id"]),
+            revision=revision,
+            action=status,
+            actor=actor,
+            reason=reason,
+            details=details,
+        )
+
+    async def _insert_event(
+        self,
+        proposal_id: str,
+        *,
+        revision: int,
+        action: str,
+        actor: str,
+        reason: str,
+        details: dict[str, Any],
+    ) -> None:
+        await self.db.execute(
+            """INSERT INTO manuscript_source_events
+               (id, proposal_id, project_id, proposal_revision, action, actor, reason, details)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                generate_id("manuscript_source_event"),
+                proposal_id,
+                self.project_id,
+                revision,
+                action,
+                actor,
+                reason,
+                _canonical_json(details),
+            ],
+        )

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -833,15 +833,20 @@ class ManuscriptSourceService(BaseService):
                     recovery_state=exc.recovery_state,
                 )
                 raise
+            swap_state = self._source_swap_state(
+                workspace,
+                relative_path,
+                proposal_id=str(row["id"]),
+                expected_content_hash=row["base_content_hash"],
+                proposed_content_hash=proposed_hash,
+            )
             await self._complete_applied_transition(
                 row,
                 data,
                 recovery_path,
                 recovered_after_restart=False,
-                source_recovery_state=(
-                    "retained_base"
-                    if row["base_content_hash"] is not None
-                    else "missing"
+                source_recovery_state=self._retention_state_from_swap_state(
+                    swap_state
                 ),
             )
         return await self.get_proposal(proposal_id)
@@ -905,13 +910,7 @@ class ManuscriptSourceService(BaseService):
                         else "not_observed"
                     ),
                     "final_target_preserved": True,
-                    "source_recovery_state": recovery_state,
-                    "retained_source_path": (
-                        self._retained_source_relative_path(row)
-                        if recovery_state
-                        in {"retained_base", "retained_proposal", "retained_unclassified"}
-                        else None
-                    ),
+                    **self._source_recovery_event_details(row, recovery_state),
                 },
             )
 
@@ -927,6 +926,9 @@ class ManuscriptSourceService(BaseService):
         recovery_relative = recovery_path.relative_to(
             Path(self.db.db_path).resolve().parent
         ).as_posix()
+        recovery_details = self._source_recovery_event_details(
+            row, source_recovery_state
+        )
         async with self.db.transaction():
             current = await self._require_proposal_row(str(row["id"]))
             self._assert_open(current, data.expected_revision)
@@ -941,11 +943,11 @@ class ManuscriptSourceService(BaseService):
                     "after_content_hash": row["proposed_content_hash"],
                     "recovery_manifest_path": recovery_relative,
                     "displaced_source_path": (
-                        self._retained_source_relative_path(row)
-                        if source_recovery_state.startswith("retained_")
+                        recovery_details["retained_source_path"]
+                        if row["base_content_hash"] is not None
                         else None
                     ),
-                    "source_recovery_state": source_recovery_state,
+                    **recovery_details,
                     "recovered_after_restart": recovered_after_restart,
                     "git_operation": False,
                 },
@@ -1212,15 +1214,7 @@ class ManuscriptSourceService(BaseService):
                 expected_content_hash=row["base_content_hash"],
                 proposed_content_hash=str(row["proposed_content_hash"]),
             )
-            return {
-                "source_recovery_state": recovery_state,
-                "retained_source_path": (
-                    self._retained_source_relative_path(row)
-                    if recovery_state
-                    in {"retained_base", "retained_proposal", "retained_unclassified"}
-                    else None
-                ),
-            }
+            return self._source_recovery_event_details(row, recovery_state)
         return {}
 
     def _recovery_components(self, row: Mapping[str, Any]) -> tuple[str, str, str]:
@@ -1590,12 +1584,15 @@ class ManuscriptSourceService(BaseService):
             # Remove only a name positively classified as this operation's
             # immutable proposal bytes. If preparation rejected a pre-existing
             # retained or unknown inode, ownership remains false.
-            if proposal_swap_owned:
-                try:
-                    os.unlink(swap_name, dir_fd=parent_fd)
-                except FileNotFoundError:
-                    pass
-            os.close(parent_fd)
+            try:
+                if proposal_swap_owned:
+                    try:
+                        os.unlink(swap_name, dir_fd=parent_fd)
+                    except FileNotFoundError:
+                        pass
+                    os.fsync(parent_fd)
+            finally:
+                os.close(parent_fd)
 
     def _reconcile_replaced_source(
         self,
@@ -1684,27 +1681,14 @@ class ManuscriptSourceService(BaseService):
         parent_fd, _ = self._open_parent_fd(workspace, PurePosixPath(normalized))
         swap_name = self._source_swap_name(proposal_id)
         try:
-            swap, _ = self._read_source_entry_at(
+            swap_state = self._classify_source_swap_at(
                 parent_fd,
                 swap_name,
-                missing_ok=True,
-                validate_utf8=False,
+                expected_content_hash=expected_content_hash,
+                proposed_content_hash=proposed_content_hash,
             )
-            recovery_state = "missing"
-            if swap is not None:
-                swap_hash = _sha256(swap)
-                if swap_hash == proposed_content_hash:
-                    recovery_state = "retained_proposal"
-                elif expected_content_hash is not None and swap_hash == expected_content_hash:
-                    recovery_state = "retained_base"
-                else:
-                    # This can be a late write through a descriptor opened
-                    # before exchange. It is not safe to classify or delete,
-                    # but retaining and fsyncing it permits a terminal conflict
-                    # without losing either public or displaced bytes.
-                    recovery_state = "retained_unclassified"
             os.fsync(parent_fd)
-            return recovery_state
+            return self._retention_state_from_swap_state(swap_state)
         finally:
             os.close(parent_fd)
 
@@ -1721,14 +1705,35 @@ class ManuscriptSourceService(BaseService):
         normalized, _ = self._normalize_source_path(relative_path)
         parent_fd, _ = self._open_parent_fd(workspace, PurePosixPath(normalized))
         try:
-            swap, _ = self._read_source_entry_at(
+            return self._classify_source_swap_at(
                 parent_fd,
                 self._source_swap_name(proposal_id),
-                missing_ok=True,
-                validate_utf8=False,
+                expected_content_hash=expected_content_hash,
+                proposed_content_hash=proposed_content_hash,
             )
         finally:
             os.close(parent_fd)
+
+    def _classify_source_swap_at(
+        self,
+        parent_fd: int,
+        swap_name: str,
+        *,
+        expected_content_hash: str | None,
+        proposed_content_hash: str,
+    ) -> str:
+        """Boundedly classify recovery bytes without rejecting an oversized inode."""
+        try:
+            swap, _ = self._read_source_entry_at(
+                parent_fd,
+                swap_name,
+                missing_ok=True,
+                validate_utf8=False,
+            )
+        except ValueError as exc:
+            if "exceeds configured size limit" not in str(exc):
+                raise
+            return "oversized"
         if swap is None:
             return "missing"
         swap_hash = _sha256(swap)
@@ -1737,6 +1742,40 @@ class ManuscriptSourceService(BaseService):
         if expected_content_hash is not None and swap_hash == expected_content_hash:
             return "reviewed_base"
         return "unclassified"
+
+    @staticmethod
+    def _retention_state_from_swap_state(swap_state: str) -> str:
+        return {
+            "missing": "missing",
+            "proposal": "retained_proposal",
+            "reviewed_base": "retained_base",
+            "unclassified": "retained_unclassified",
+            "oversized": "retained_oversized",
+        }[swap_state]
+
+    def _source_recovery_event_details(
+        self,
+        row: Mapping[str, Any],
+        recovery_state: str | None,
+    ) -> dict[str, Any]:
+        observed = {
+            None: None,
+            "missing": "missing",
+            "retained_proposal": "proposal",
+            "retained_base": "reviewed_base",
+            "retained_unclassified": "unclassified",
+            "retained_oversized": "oversized",
+        }[recovery_state]
+        retained = bool(recovery_state and recovery_state.startswith("retained_"))
+        return {
+            "source_recovery_state": (
+                "retained" if retained else "missing" if recovery_state else "not_checked"
+            ),
+            "source_recovery_last_observed": observed,
+            "retained_source_path": (
+                self._retained_source_relative_path(row) if retained else None
+            ),
+        }
 
     @staticmethod
     def _source_swap_name(proposal_id: str) -> str:

--- a/rka/services/manuscript_source.py
+++ b/rka/services/manuscript_source.py
@@ -54,6 +54,10 @@ class ManuscriptSourceNotFoundError(ValueError):
 class ManuscriptSourceConflictError(ValueError):
     """The proposal or file optimistic guard is stale."""
 
+    def __init__(self, message: str, *, transient_exchange: bool = False):
+        super().__init__(message)
+        self.transient_exchange = transient_exchange
+
 
 class ManuscriptSourceSecurityError(ValueError):
     """A workspace or relative path violates the local filesystem boundary."""
@@ -706,9 +710,8 @@ class ManuscriptSourceService(BaseService):
             recovery_path = self._recovery_manifest_path(row)
 
             if current_hash != row["base_content_hash"]:
-                if current_hash == proposed_hash and self._valid_recovery_manifest(
-                    recovery_path, row
-                ):
+                has_valid_recovery = self._valid_recovery_manifest(recovery_path, row)
+                if current_hash == proposed_hash and has_valid_recovery:
                     try:
                         self._reconcile_replaced_source(
                             workspace,
@@ -717,13 +720,14 @@ class ManuscriptSourceService(BaseService):
                             expected_content_hash=row["base_content_hash"],
                             proposed_content_hash=proposed_hash,
                         )
-                    except ManuscriptSourceConflictError:
+                    except ManuscriptSourceConflictError as exc:
                         latest, _ = self._read_current(workspace, relative_path)
                         latest_hash = _sha256(latest) if latest is not None else None
                         await self._mark_conflicted(
                             row,
                             data,
                             current_content_hash=latest_hash,
+                            transient_exchange=exc.transient_exchange,
                         )
                         raise
                     await self._complete_applied_transition(
@@ -733,10 +737,22 @@ class ManuscriptSourceService(BaseService):
                         recovered_after_restart=True,
                     )
                     return await self.get_proposal(proposal_id)
+                if has_valid_recovery:
+                    # A previous attempt may have restored an external object
+                    # but failed the rollback directory fsync. Do not close the
+                    # ledger until that naming state (and any proposal-only swap
+                    # cleanup) is durably committed.
+                    self._finalize_conflicted_source_state(
+                        workspace,
+                        relative_path,
+                        proposal_id=str(row["id"]),
+                        proposed_content_hash=proposed_hash,
+                    )
                 await self._mark_conflicted(
                     row,
                     data,
                     current_content_hash=current_hash,
+                    transient_exchange=None if has_valid_recovery else False,
                 )
                 raise ManuscriptSourceConflictError(
                     "source changed after proposal creation; current and proposed versions were preserved"
@@ -773,13 +789,14 @@ class ManuscriptSourceService(BaseService):
                     proposal_id=str(row["id"]),
                     expected_content_hash=row["base_content_hash"],
                 )
-            except ManuscriptSourceConflictError:
+            except ManuscriptSourceConflictError as exc:
                 latest, _ = self._read_current(workspace, relative_path)
                 latest_hash = _sha256(latest) if latest is not None else None
                 await self._mark_conflicted(
                     row,
                     data,
                     current_content_hash=latest_hash,
+                    transient_exchange=exc.transient_exchange,
                 )
                 raise
             await self._complete_applied_transition(
@@ -821,6 +838,7 @@ class ManuscriptSourceService(BaseService):
         data: ManuscriptSourceProposalTransition,
         *,
         current_content_hash: str | None,
+        transient_exchange: bool | None = False,
     ) -> None:
         async with self.db.transaction():
             current = await self._require_proposal_row(str(row["id"]))
@@ -835,7 +853,16 @@ class ManuscriptSourceService(BaseService):
                     "expected_content_hash": row["base_content_hash"],
                     "current_content_hash": current_content_hash,
                     "proposed_content_hash": row["proposed_content_hash"],
-                    "file_written": False,
+                    "file_written": transient_exchange,
+                    "transient_exchange": transient_exchange,
+                    "transient_exchange_state": (
+                        "possible"
+                        if transient_exchange is None
+                        else "observed"
+                        if transient_exchange
+                        else "not_observed"
+                    ),
+                    "final_target_preserved": True,
                 },
             )
 
@@ -863,6 +890,11 @@ class ManuscriptSourceService(BaseService):
                     "before_content_hash": row["base_content_hash"],
                     "after_content_hash": row["proposed_content_hash"],
                     "recovery_manifest_path": recovery_relative,
+                    "displaced_source_path": (
+                        self._retained_source_relative_path(row)
+                        if row["base_content_hash"] is not None
+                        else None
+                    ),
                     "recovered_after_restart": recovered_after_restart,
                     "git_operation": False,
                 },
@@ -1115,12 +1147,18 @@ class ManuscriptSourceService(BaseService):
         current, _ = self._read_current(workspace, str(row["relative_path"]))
         current_hash = _sha256(current) if current is not None else None
         recovery_path = self._recovery_manifest_path(row)
-        if current_hash == row["proposed_content_hash"] and self._valid_recovery_manifest(
-            recovery_path, row
-        ):
+        has_valid_recovery = self._valid_recovery_manifest(recovery_path, row)
+        if current_hash == row["proposed_content_hash"] and has_valid_recovery:
             raise ManuscriptSourceConflictError(
                 "proposal content is already on disk with valid recovery metadata; "
                 f"retry apply to reconcile the ledger before {action}"
+            )
+        if has_valid_recovery:
+            self._finalize_conflicted_source_state(
+                workspace,
+                str(row["relative_path"]),
+                proposal_id=str(row["id"]),
+                proposed_content_hash=str(row["proposed_content_hash"]),
             )
 
     def _recovery_components(self, row: Mapping[str, Any]) -> tuple[str, str, str]:
@@ -1213,6 +1251,11 @@ class ManuscriptSourceService(BaseService):
             "before_content_hash": _sha256(before) if before is not None else None,
             "before_mode": mode,
             "after_content_hash": row["proposed_content_hash"],
+            "displaced_source_path": (
+                self._retained_source_relative_path(row)
+                if before is not None
+                else None
+            ),
             "created_at": _now(),
         }
         try:
@@ -1361,6 +1404,7 @@ class ManuscriptSourceService(BaseService):
         parent_fd, name = self._open_parent_fd(workspace, PurePosixPath(normalized))
         swap_name = self._source_swap_name(proposal_id)
         exchanged = False
+        retain_swap = False
         try:
             self._prepare_source_swap(
                 parent_fd,
@@ -1407,16 +1451,22 @@ class ManuscriptSourceService(BaseService):
             except (OSError, ValueError, ManuscriptSourceSecurityError) as exc:
                 raise ManuscriptSourceConflictError(
                     "source became unsafe immediately before replacement; the exact "
-                    "displaced version will be restored"
+                    "displaced version will be restored",
+                    transient_exchange=True,
                 ) from exc
             assert displaced is not None
             if _sha256(displaced) != expected_content_hash:
                 raise ManuscriptSourceConflictError(
                     "source changed immediately before replacement; the exact "
-                    "displaced version will be restored"
+                    "displaced version will be restored",
+                    transient_exchange=True,
                 )
 
-            os.unlink(swap_name, dir_fd=parent_fd)
+            # Keep the exact displaced inode linked at its deterministic hidden
+            # name. An editor that opened the original target before exchange
+            # can still write through that descriptor; retaining the inode is
+            # the only way to ensure those later bytes remain recoverable.
+            retain_swap = True
             exchanged = False
             os.fsync(parent_fd)
         except Exception:
@@ -1435,7 +1485,7 @@ class ManuscriptSourceService(BaseService):
             # Before an exchange the swap contains only proposal bytes and is
             # safe to remove. If rollback itself failed, `exchanged` remains
             # true and both names are deliberately retained for recovery.
-            if not exchanged:
+            if not exchanged and not retain_swap:
                 try:
                     os.unlink(swap_name, dir_fd=parent_fd)
                 except FileNotFoundError:
@@ -1478,7 +1528,8 @@ class ManuscriptSourceService(BaseService):
                     ) from rollback_error
                 raise ManuscriptSourceConflictError(
                     "an unsafe external source version was restored after an "
-                    "interrupted replacement"
+                    "interrupted replacement",
+                    transient_exchange=True,
                 ) from exc
 
             if displaced is None:
@@ -1496,8 +1547,8 @@ class ManuscriptSourceService(BaseService):
                 return
             if displaced_hash == expected_content_hash:
                 # Exchange completed and the exact reviewed base is retained at
-                # the swap name. Recovery is already durable, so finish cleanup.
-                os.unlink(swap_name, dir_fd=parent_fd)
+                # the hidden recovery name. Keep that inode linked permanently:
+                # a pre-opened editor descriptor may still write through it.
                 os.fsync(parent_fd)
                 return
 
@@ -1507,14 +1558,49 @@ class ManuscriptSourceService(BaseService):
             os.unlink(swap_name, dir_fd=parent_fd)
             os.fsync(parent_fd)
             raise ManuscriptSourceConflictError(
-                "an external source version was restored after an interrupted replacement"
+                "an external source version was restored after an interrupted replacement",
+                transient_exchange=True,
             )
+        finally:
+            os.close(parent_fd)
+
+    def _finalize_conflicted_source_state(
+        self,
+        workspace: Path,
+        relative_path: str,
+        *,
+        proposal_id: str,
+        proposed_content_hash: str,
+    ) -> None:
+        """Durably finish a prior rollback before closing as conflicted."""
+        normalized, _ = self._normalize_source_path(relative_path)
+        parent_fd, _ = self._open_parent_fd(workspace, PurePosixPath(normalized))
+        swap_name = self._source_swap_name(proposal_id)
+        try:
+            swap, _ = self._read_source_entry_at(
+                parent_fd,
+                swap_name,
+                missing_ok=True,
+                validate_utf8=False,
+            )
+            if swap is not None:
+                if _sha256(swap) != proposed_content_hash:
+                    raise ManuscriptSourceSecurityError(
+                        "unexpected source swap remains after rollback; refusing to "
+                        "close the proposal"
+                    )
+                os.unlink(swap_name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
         finally:
             os.close(parent_fd)
 
     @staticmethod
     def _source_swap_name(proposal_id: str) -> str:
-        return f".rka-source-{_sha256(proposal_id.encode())[:32]}.swap"
+        return f".rka-source-{_sha256(proposal_id.encode())[:32]}.recovery"
+
+    def _retained_source_relative_path(self, row: Mapping[str, Any]) -> str:
+        source = PurePosixPath(str(row["relative_path"]))
+        return (source.parent / self._source_swap_name(str(row["id"]))).as_posix()
 
     def _prepare_source_swap(
         self,

--- a/rka/services/project.py
+++ b/rka/services/project.py
@@ -217,6 +217,8 @@ class ProjectService(BaseService):
     # Order: dependents first (reverse of insert order).
     _DELETE_TABLES = (
         # Native manuscript and immutable validation histories.
+        "manuscript_source_events",
+        "manuscript_source_proposals",
         "semantic_patch_provider_events",
         "manuscript_evaluation_events",
         "manuscript_planning_promotion_events",
@@ -340,12 +342,16 @@ class ProjectService(BaseService):
     async def delete_project(self, project_id: str, confirm: bool = False) -> dict:
         """Delete a project and all its scoped data. Requires confirm=True."""
         knowledge_pack_dir: Path | None = None
+        source_recovery_dir: Path | None = None
         async with self.db.transaction():
             if confirm:
                 # Preflight the only filesystem path this service owns before
                 # mutating the database. Filesystem removal itself happens
                 # after commit because it cannot be rolled back with SQLite.
                 knowledge_pack_dir = self._knowledge_pack_project_dir(project_id)
+                source_recovery_dir = self._manuscript_source_recovery_project_dir(
+                    project_id
+                )
             result = await self._delete_project(project_id, confirm)
 
         if knowledge_pack_dir is not None:
@@ -373,7 +379,63 @@ class ProjectService(BaseService):
                     "status": "deleted" if removed else "not_present",
                     "path": str(knowledge_pack_dir),
                 }
+        if source_recovery_dir is not None:
+            try:
+                removed = self._remove_manuscript_source_recovery_project_dir(
+                    project_id,
+                    expected_path=source_recovery_dir,
+                )
+            except (OSError, RuntimeError, ValueError) as exc:
+                result["manuscript_source_recovery_cleanup"] = {
+                    "status": "failed",
+                    "path": str(source_recovery_dir),
+                    "error": str(exc),
+                }
+                result["message"] = (
+                    f"Project '{result['project_name']}' was permanently deleted "
+                    "from RKA, but manuscript source recovery files require manual cleanup."
+                )
+            else:
+                result["manuscript_source_recovery_cleanup"] = {
+                    "status": "deleted" if removed else "not_present",
+                    "path": str(source_recovery_dir),
+                }
         return result
+
+    def _manuscript_source_recovery_project_dir(self, project_id: str) -> Path:
+        """Return one validated service-owned source-recovery directory."""
+        if project_id in {".", ".."} or not self._SAFE_STORAGE_PROJECT_ID.fullmatch(project_id):
+            raise ValueError("Project ID is not safe for source-recovery cleanup")
+        storage_root = Path(self.db.db_path).resolve().parent / "manuscript-source-recovery"
+        if storage_root.is_symlink():
+            raise ValueError("Manuscript source recovery root must not be a symbolic link")
+        resolved_root = storage_root.resolve()
+        project_dir = storage_root / project_id
+        if project_dir.is_symlink():
+            raise ValueError("Manuscript source recovery project directory must not be a symbolic link")
+        resolved_project_dir = project_dir.resolve()
+        if (
+            not resolved_project_dir.is_relative_to(resolved_root)
+            or resolved_project_dir.parent != resolved_root
+        ):
+            raise ValueError("Project ID escapes manuscript source recovery root")
+        if project_dir.exists() and not project_dir.is_dir():
+            raise ValueError("Manuscript source recovery path is not a directory")
+        return project_dir
+
+    def _remove_manuscript_source_recovery_project_dir(
+        self,
+        project_id: str,
+        *,
+        expected_path: Path,
+    ) -> bool:
+        project_dir = self._manuscript_source_recovery_project_dir(project_id)
+        if project_dir != expected_path:
+            raise RuntimeError("Manuscript source recovery path changed during deletion")
+        if project_dir.exists():
+            shutil.rmtree(project_dir)
+            return True
+        return False
 
     def _knowledge_pack_project_dir(self, project_id: str) -> Path:
         """Return the service-owned project directory after strict validation."""

--- a/rka/services/project.py
+++ b/rka/services/project.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import shutil
 import sqlite3
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from rka.constants import DEFAULT_PROJECT_ID, SENTINEL_PROJECT_ID
 from rka.infra.ids import generate_id
@@ -343,7 +344,11 @@ class ProjectService(BaseService):
         """Delete a project and all its scoped data. Requires confirm=True."""
         knowledge_pack_dir: Path | None = None
         source_recovery_dir: Path | None = None
+        retained_source_artifacts: list[dict[str, str]] = []
         async with self.db.transaction():
+            retained_source_artifacts = await self._retained_source_artifact_candidates(
+                project_id
+            )
             if confirm:
                 # Preflight the only filesystem path this service owns before
                 # mutating the database. Filesystem removal itself happens
@@ -353,6 +358,29 @@ class ProjectService(BaseService):
                     project_id
                 )
             result = await self._delete_project(project_id, confirm)
+
+        result["retained_workspace_artifacts"] = {
+            "status": (
+                "manual_review_required"
+                if retained_source_artifacts
+                else "none_recorded"
+            ),
+            "auto_deleted": False,
+            "items": retained_source_artifacts,
+            "message": (
+                "Source-adjacent hidden recovery artifacts are never auto-deleted; "
+                "the listed deterministic paths may exist and must be inspected "
+                "after all editor descriptors are closed."
+                if retained_source_artifacts
+                else "No source-adjacent recovery artifact candidates were recorded."
+            ),
+        }
+        if confirm and retained_source_artifacts:
+            result["message"] = (
+                f"Project '{result['project_name']}' was permanently deleted from "
+                "RKA-managed storage; source-adjacent recovery artifacts were "
+                "intentionally retained and are listed in retained_workspace_artifacts."
+            )
 
         if knowledge_pack_dir is not None:
             try:
@@ -400,6 +428,48 @@ class ProjectService(BaseService):
                     "status": "deleted" if removed else "not_present",
                     "path": str(source_recovery_dir),
                 }
+        return result
+
+    async def _retained_source_artifact_candidates(
+        self, project_id: str
+    ) -> list[dict[str, str]]:
+        """Enumerate deterministic source-side names before deleting their ledger."""
+        try:
+            rows = await self.db.fetchall(
+                """SELECT p.id AS proposal_id, p.manuscript_id, p.relative_path,
+                          p.status, m.workspace_ref
+                   FROM manuscript_source_proposals AS p
+                   JOIN manuscripts AS m
+                     ON m.id = p.manuscript_id AND m.project_id = p.project_id
+                   WHERE p.project_id = ?
+                   ORDER BY p.created_at, p.id""",
+                [project_id],
+            )
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower() or "no such column" in str(exc).lower():
+                return []
+            raise
+
+        result: list[dict[str, str]] = []
+        for raw in rows:
+            row = dict(raw)
+            source = PurePosixPath(str(row["relative_path"]))
+            swap_name = (
+                ".rka-source-"
+                f"{hashlib.sha256(str(row['proposal_id']).encode()).hexdigest()[:32]}"
+                ".recovery"
+            )
+            retained_relative = (source.parent / swap_name).as_posix()
+            result.append(
+                {
+                    "proposal_id": str(row["proposal_id"]),
+                    "manuscript_id": str(row["manuscript_id"]),
+                    "proposal_status": str(row["status"]),
+                    "workspace_ref": str(row["workspace_ref"] or ""),
+                    "source_relative_path": str(row["relative_path"]),
+                    "retained_relative_path": retained_relative,
+                }
+            )
         return result
 
     def _manuscript_source_recovery_project_dir(self, project_id: str) -> Path:
@@ -561,7 +631,11 @@ class ProjectService(BaseService):
                 "entity_counts": counts,
                 "total_rows": sum(counts.values()),
                 "confirmed": False,
-                "message": "Set confirm=true to permanently delete this project and all its data.",
+                "message": (
+                    "Set confirm=true to permanently delete this project and its "
+                    "RKA-managed data. Source-adjacent recovery candidates, when "
+                    "listed, are intentionally retained."
+                ),
             }
 
         await self.db.execute(
@@ -636,7 +710,10 @@ class ProjectService(BaseService):
             "entity_counts": counts,
             "total_rows": sum(counts.values()),
             "confirmed": True,
-            "message": f"Project '{project_name}' and all its data have been permanently deleted.",
+            "message": (
+                f"Project '{project_name}' and all RKA-managed database records "
+                "have been permanently deleted."
+            ),
         }
 
     def _row_to_model(self, row: dict) -> ProjectState:

--- a/tests/test_api/test_manuscript_sources.py
+++ b/tests/test_api/test_manuscript_sources.py
@@ -1,0 +1,179 @@
+"""REST authorization and explicit source-proposal workflow tests."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+
+
+HEADERS = {"X-RKA-Project": "proj_default"}
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+@pytest_asyncio.fixture
+async def source_client(tmp_path: Path):
+    workspace = tmp_path / "paper"
+    workspace.mkdir()
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path("source-api.db"),
+        data_dir=tmp_path / "data",
+        llm_enabled=False,
+        embeddings_enabled=False,
+        manuscript_workspace_roots=str(tmp_path),
+    )
+    app = create_app(config)
+    lifespan = app.router.lifespan_context(app)
+    await lifespan.__aenter__()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            created = await client.post(
+                "/api/manuscripts/native",
+                headers=HEADERS,
+                json={"title": "Source API", "workspace_ref": str(workspace)},
+            )
+            assert created.status_code == 201
+            manuscript_id = created.json()["id"]
+            spine = await client.put(
+                f"/api/manuscripts/{manuscript_id}/argument-spine",
+                headers=HEADERS,
+                json={
+                    "expected_revision": 1,
+                    "spine": {
+                        "claims": [],
+                        "units": [
+                            {
+                                "unit_id": "U1",
+                                "kind": "introduction",
+                                "location": "main.md#u1",
+                                "status": "planned",
+                                "outline_level": 3,
+                                "unit_role": "argument_block",
+                                "rhetorical_move": "frame_problem",
+                                "communicative_job": "Frame the problem.",
+                                "intended_takeaway": "The bounded problem matters.",
+                                "evidence_plan": ["One bounded source."],
+                            }
+                        ],
+                    },
+                },
+            )
+            assert spine.status_code == 200
+            unit_id = spine.json()["units"][0]["id"]
+            yield client, workspace, manuscript_id, unit_id
+    finally:
+        await lifespan.__aexit__(None, None, None)
+
+
+def _content(unit_id: str, sentence: str) -> str:
+    return (
+        f"<!-- rka:unit {unit_id} begin -->\n"
+        f"{sentence}\n"
+        f"<!-- rka:unit {unit_id} end -->\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rest_prepare_read_apply_and_overview(source_client) -> None:
+    client, workspace, manuscript_id, unit_id = source_client
+    before = _content(unit_id, "Before.")
+    after = _content(unit_id, "After.")
+    (workspace / "main.md").write_text(before)
+
+    read = await client.post(
+        f"/api/manuscripts/{manuscript_id}/source/read",
+        headers=HEADERS,
+        json={"relative_path": "main.md"},
+    )
+    assert read.status_code == 200
+    assert read.json()["content_hash"] == _hash(before)
+
+    prepared = await client.post(
+        f"/api/manuscripts/{manuscript_id}/source/proposals",
+        headers=HEADERS,
+        json={
+            "origin": "human",
+            "relative_path": "main.md",
+            "expected_content_hash": _hash(before),
+            "content": after,
+            "created_by": "web_ui",
+            "reason": "Prepare the reviewed source change.",
+        },
+    )
+    assert prepared.status_code == 201
+    assert (workspace / "main.md").read_text() == before
+
+    applied = await client.post(
+        f"/api/manuscript-source-proposals/{prepared.json()['id']}/apply",
+        headers=HEADERS,
+        json={
+            "expected_revision": 1,
+            "actor": "web_ui",
+            "reason": "Apply after reviewing the source diff.",
+        },
+    )
+    assert applied.status_code == 200
+    assert applied.json()["status"] == "applied"
+    assert (workspace / "main.md").read_text() == after
+
+    overview = await client.get(
+        f"/api/manuscripts/{manuscript_id}/source",
+        headers=HEADERS,
+    )
+    assert overview.status_code == 200
+    assert overview.json()["quick_reader"][0]["anchor_state"] == "linked"
+
+
+@pytest.mark.asyncio
+async def test_rest_conflict_and_mcp_transport_denial(source_client) -> None:
+    client, workspace, manuscript_id, unit_id = source_client
+    before = _content(unit_id, "Before.")
+    after = _content(unit_id, "After.")
+    external = _content(unit_id, "External.")
+    (workspace / "main.md").write_text(before)
+
+    denied = await client.post(
+        f"/api/manuscripts/{manuscript_id}/source/read",
+        headers={**HEADERS, "X-RKA-Actor": "executor"},
+        json={"relative_path": "main.md"},
+    )
+    assert denied.status_code == 403
+
+    prepared = await client.post(
+        f"/api/manuscripts/{manuscript_id}/source/proposals",
+        headers=HEADERS,
+        json={
+            "origin": "human",
+            "relative_path": "main.md",
+            "expected_content_hash": _hash(before),
+            "content": after,
+            "created_by": "web_ui",
+            "reason": "Prepare a source change.",
+        },
+    )
+    assert prepared.status_code == 201
+    (workspace / "main.md").write_text(external)
+    conflict = await client.post(
+        f"/api/manuscript-source-proposals/{prepared.json()['id']}/apply",
+        headers=HEADERS,
+        json={
+            "expected_revision": 1,
+            "actor": "web_ui",
+            "reason": "Attempt stale apply.",
+        },
+    )
+    assert conflict.status_code == 409
+    assert (workspace / "main.md").read_text() == external

--- a/tests/test_db/test_migration_050.py
+++ b/tests/test_db/test_migration_050.py
@@ -1,0 +1,133 @@
+"""Migration 050 source proposal immutability and restart contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rka.infra.ids import generate_id
+
+
+MIGRATION_050 = (
+    Path(__file__).parents[2]
+    / "rka"
+    / "db"
+    / "migrations"
+    / "050_add_manuscript_source_sync.sql"
+)
+
+
+def test_migration_050_applies_late_without_mutating_existing_manuscript(
+    tmp_path: Path,
+) -> None:
+    connection = sqlite3.connect(tmp_path / "late-050.db")
+    try:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.executescript(
+            """
+            CREATE TABLE projects (
+                id TEXT PRIMARY KEY
+            );
+            CREATE TABLE manuscripts (
+                id TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                title TEXT NOT NULL,
+                PRIMARY KEY (id),
+                UNIQUE (id, project_id),
+                FOREIGN KEY (project_id) REFERENCES projects(id)
+            );
+            CREATE TABLE semantic_patch_context_manifests (
+                id TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                PRIMARY KEY (id),
+                UNIQUE (id, project_id)
+            );
+            CREATE TABLE change_events (
+                cursor INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id TEXT NOT NULL,
+                source_table TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                manuscript_id TEXT,
+                details TEXT
+            );
+            CREATE TABLE project_deletion_authorizations (
+                project_id TEXT PRIMARY KEY
+            );
+            INSERT INTO projects VALUES ('prj_existing');
+            INSERT INTO manuscripts
+            VALUES ('man_existing', 'prj_existing', 'Existing manuscript');
+            """
+        )
+
+        connection.executescript(MIGRATION_050.read_text())
+
+        assert connection.execute(
+            "SELECT title FROM manuscripts WHERE id = 'man_existing'"
+        ).fetchone() == ("Existing manuscript",)
+        assert {
+            row[0]
+            for row in connection.execute(
+                """SELECT name FROM sqlite_master
+                   WHERE type = 'table' AND name LIKE 'manuscript_source_%'"""
+            )
+        } == {"manuscript_source_proposals", "manuscript_source_events"}
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        connection.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_050_tables_triggers_and_restart(db_with_project) -> None:
+    tables = {
+        row["name"]
+        for row in await db_with_project.fetchall(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+    assert {"manuscript_source_proposals", "manuscript_source_events"} <= tables
+    assert generate_id("manuscript_source_proposal").startswith("msp_")
+    assert generate_id("manuscript_source_event").startswith("mse_")
+    assert await db_with_project.run_migrations() == 0
+
+
+@pytest.mark.asyncio
+async def test_source_event_and_proposal_content_are_immutable(db_with_project) -> None:
+    manuscript_id = generate_id("manuscript")
+    proposal_id = generate_id("manuscript_source_proposal")
+    await db_with_project.execute(
+        """INSERT INTO manuscripts
+           (id, project_id, title, phase, state)
+           VALUES (?, 'proj_default', 'Source migration', 'planning', 'active')""",
+        [manuscript_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_source_proposals
+           (id, project_id, manuscript_id, origin, relative_path, source_format,
+            base_content_hash, proposed_content, proposed_content_hash,
+            created_by, reason, boundary)
+           VALUES (?, 'proj_default', ?, 'human', 'main.md', 'markdown',
+                   ?, 'after', ?, 'web_ui', 'Test proposal.', 'none')""",
+        [proposal_id, manuscript_id, "a" * 64, "b" * 64],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_source_events
+           (id, proposal_id, project_id, proposal_revision, action, actor, reason)
+           VALUES (?, ?, 'proj_default', 1, 'proposed', 'web_ui', 'Test event.')""",
+        [generate_id("manuscript_source_event"), proposal_id],
+    )
+    await db_with_project.commit()
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        await db_with_project.execute(
+            "UPDATE manuscript_source_events SET reason = 'changed' WHERE proposal_id = ?",
+            [proposal_id],
+        )
+    await db_with_project.conn.rollback()
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        await db_with_project.execute(
+            "UPDATE manuscript_source_proposals SET proposed_content = 'changed' WHERE id = ?",
+            [proposal_id],
+        )

--- a/tests/test_services/test_knowledge_pack_native.py
+++ b/tests/test_services/test_knowledge_pack_native.py
@@ -631,6 +631,15 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
                 "Diagnostics from the source installation's legacy migration, "
                 "not manuscript semantic state."
             ),
+            "manuscript_source_events": (
+                "Source-file apply and recovery events refer to installation-local "
+                "paths and are omitted with their source proposals."
+            ),
+            "manuscript_source_proposals": (
+                "Candidate source text, local workspace paths, and recovery state "
+                "are installation-local authoring data; export the manuscript files "
+                "separately."
+            ),
             "reference_validation_migration_issues": (
                 "Diagnostics from source-installation reference-validation "
                 "migration, not portable manuscript semantic state."
@@ -643,6 +652,8 @@ async def test_native_manuscript_round_trip_preserves_history_without_synthesis(
             "change_events",
             "jobs",
             "manuscript_migration_issues",
+            "manuscript_source_events",
+            "manuscript_source_proposals",
             "reference_validation_migration_issues",
         }
         & manifest["tables"].keys()

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -1288,6 +1288,98 @@ async def test_oversized_retained_inode_does_not_block_terminal_transition(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("unsafe_kind", ["symlink", "fifo", "directory"])
+async def test_unsafe_hidden_recovery_never_replaces_public_source(
+    db_with_project,
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before unsafe restart recovery.")
+    after = _markdown(unit_id, "Public proposal must remain a regular file.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Never promote an unsafe hidden recovery object.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    service._write_recovery(row, before.encode(), 0o644, service._recovery_manifest_path(row))
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        service._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    hidden = workspace / swap_name
+    hidden.unlink()
+    if unsafe_kind == "symlink":
+        hidden.symlink_to(workspace / "outside.md")
+    elif unsafe_kind == "fifo":
+        os.mkfifo(hidden)
+    else:
+        hidden.mkdir()
+
+    with pytest.raises(ManuscriptSourceConflictError, match="unclassifiable hidden recovery"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Retain unsafe recovery without moving it into public.",
+            ),
+        )
+    assert source.is_file()
+    assert not source.is_symlink()
+    assert source.read_text() == after
+    if unsafe_kind == "symlink":
+        assert hidden.is_symlink()
+    elif unsafe_kind == "fifo":
+        assert stat.S_ISFIFO(hidden.lstat().st_mode)
+    else:
+        assert hidden.is_dir()
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
+    details = conflicted["events"][-1]["details"]
+    assert details["source_recovery_state"] == "retained"
+    assert details["source_recovery_last_observed"] == "unsafe"
+    assert details["retained_source_path"] == swap_name
+    assert details["transient_exchange_state"] == "possible"
+
+    successor = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(after),
+            content=_markdown(unit_id, "Successor after unsafe recovery conflict."),
+            created_by="web_ui",
+            reason="Continue explicitly after inspecting the unsafe recovery path.",
+            supersedes_proposal_id=proposal["id"],
+        ),
+    )
+    assert successor["status"] == "proposed"
+    assert (await service.get_proposal(proposal["id"]))["status"] == "superseded"
+    if unsafe_kind == "symlink":
+        assert hidden.is_symlink()
+    elif unsafe_kind == "fifo":
+        assert stat.S_ISFIFO(hidden.lstat().st_mode)
+    else:
+        assert hidden.is_dir()
+
+
+@pytest.mark.asyncio
 async def test_atomic_replace_never_unlinks_an_unowned_source_swap(
     db_with_project,
     tmp_path: Path,

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -156,7 +156,10 @@ async def test_prepare_then_apply_is_atomic_mode_preserving_and_recoverable(
     assert applied["events"][-1]["details"]["git_operation"] is False
     displaced_relative = applied["events"][-1]["details"]["displaced_source_path"]
     assert displaced_relative == service._source_swap_name(proposal["id"])
-    assert applied["events"][-1]["details"]["source_recovery_state"] == "retained_base"
+    assert applied["events"][-1]["details"]["source_recovery_state"] == "retained"
+    assert applied["events"][-1]["details"]["source_recovery_last_observed"] == (
+        "reviewed_base"
+    )
     assert (workspace / displaced_relative).read_text() == before
 
 
@@ -220,6 +223,12 @@ async def test_preopened_external_descriptor_remains_linked_after_apply(
         assert os.fstat(editor_fd).st_ino == retained.stat().st_ino
         assert os.fstat(editor_fd).st_nlink >= 1
         assert retained.read_text() == external
+        assert applied["events"][-1]["details"]["source_recovery_state"] == (
+            "retained"
+        )
+        assert applied["events"][-1]["details"][
+            "source_recovery_last_observed"
+        ] == "unclassified"
         recovery = Path(db_with_project.db_path).resolve().parent / applied[
             "recovery_manifest_path"
         ]
@@ -268,6 +277,9 @@ async def test_apply_creates_a_missing_source_with_no_clobber_link(
     assert json.loads(recovery.read_text())["before_existed"] is False
     assert not (recovery.parent / "before.bin").exists()
     assert applied["events"][-1]["details"]["source_recovery_state"] == "missing"
+    assert applied["events"][-1]["details"]["source_recovery_last_observed"] == (
+        "missing"
+    )
 
 
 @pytest.mark.asyncio
@@ -321,10 +333,12 @@ async def test_missing_source_restart_retains_preexisting_proposal_inode(
     assert source.read_text() == after
     assert retained.read_text() == after
     assert source.stat().st_ino == retained.stat().st_ino
-    assert applied["events"][-1]["details"]["source_recovery_state"] == (
-        "retained_proposal"
+    assert applied["events"][-1]["details"]["source_recovery_state"] == "retained"
+    assert applied["events"][-1]["details"]["source_recovery_last_observed"] == (
+        "proposal"
     )
-    assert applied["events"][-1]["details"]["displaced_source_path"] == swap_name
+    assert applied["events"][-1]["details"]["displaced_source_path"] is None
+    assert applied["events"][-1]["details"]["retained_source_path"] == swap_name
 
 
 @pytest.mark.asyncio
@@ -351,6 +365,10 @@ async def test_external_file_appearing_at_missing_source_commit_is_preserved(
         ),
     )
     original_link = os.link
+    original_unlink = os.unlink
+    original_fsync = os.fsync
+    workspace_stat = workspace.stat()
+    source_directory_events: list[str] = []
     injected = False
 
     def inject_before_link(*args, **kwargs):
@@ -360,7 +378,31 @@ async def test_external_file_appearing_at_missing_source_commit_is_preserved(
             source.write_text(external)
         return original_link(*args, **kwargs)
 
+    def track_unlink(*args, **kwargs):
+        directory_fd = kwargs.get("dir_fd")
+        if directory_fd is not None:
+            target = os.fstat(directory_fd)
+            if (
+                stat.S_ISDIR(target.st_mode)
+                and target.st_dev == workspace_stat.st_dev
+                and target.st_ino == workspace_stat.st_ino
+            ):
+                source_directory_events.append("unlink")
+        return original_unlink(*args, **kwargs)
+
+    def track_fsync(fd: int) -> None:
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            source_directory_events.append("fsync")
+        original_fsync(fd)
+
     monkeypatch.setattr(os, "link", inject_before_link)
+    monkeypatch.setattr(os, "unlink", track_unlink)
+    monkeypatch.setattr(os, "fsync", track_fsync)
     with pytest.raises(ManuscriptSourceConflictError, match="appeared immediately"):
         await service.apply_proposal(
             proposal["id"],
@@ -373,6 +415,7 @@ async def test_external_file_appearing_at_missing_source_commit_is_preserved(
     assert source.read_text() == external
     assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
     assert not (workspace / service._source_swap_name(proposal["id"])).exists()
+    assert source_directory_events[-2:] == ["unlink", "fsync"]
 
 
 @pytest.mark.asyncio
@@ -901,14 +944,20 @@ async def test_terminal_conflict_retains_every_preexisting_recovery_inode(
     if swap_state == "proposed":
         assert swap.read_text() == after
         assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
-            "retained_proposal"
+            "retained"
         )
+        assert conflicted["events"][-1]["details"][
+            "source_recovery_last_observed"
+        ] == "proposal"
         assert conflicted["events"][-1]["details"]["retained_source_path"] == swap.name
     else:
         assert swap.read_text() == unexpected
         assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
-            "retained_unclassified"
+            "retained"
         )
+        assert conflicted["events"][-1]["details"][
+            "source_recovery_last_observed"
+        ] == "unclassified"
         assert conflicted["events"][-1]["details"]["retained_source_path"] == (
             swap.name
         )
@@ -976,8 +1025,9 @@ async def test_restart_base_equivalent_target_never_unlinks_retained_inode(
     assert (workspace / swap_name).read_text() == late
     conflicted = await service.get_proposal(proposal["id"])
     assert conflicted["status"] == "conflicted"
-    assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
-        "retained_base"
+    assert conflicted["events"][-1]["details"]["source_recovery_state"] == "retained"
+    assert conflicted["events"][-1]["details"]["source_recovery_last_observed"] == (
+        "reviewed_base"
     )
     assert conflicted["events"][-1]["details"]["transient_exchange_state"] == (
         "possible"
@@ -1144,8 +1194,97 @@ async def test_restart_external_target_with_retained_base_terminalizes(
     assert source_directory_fsyncs >= 1
     assert source.read_text() == external
     assert (workspace / swap_name).read_text() == before
-    assert prior["events"][-1]["details"]["source_recovery_state"] == "retained_base"
+    assert prior["events"][-1]["details"]["source_recovery_state"] == "retained"
+    assert prior["events"][-1]["details"]["source_recovery_last_observed"] == (
+        "reviewed_base"
+    )
     assert prior["events"][-1]["details"]["retained_source_path"] == swap_name
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closing_action", ["apply", "reject", "supersede"])
+async def test_oversized_retained_inode_does_not_block_terminal_transition(
+    db_with_project,
+    tmp_path: Path,
+    closing_action: str,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before an oversized late descriptor write.")
+    after = _markdown(unit_id, "Proposal associated with oversized recovery bytes.")
+    external = _markdown(unit_id, "External public target remains authoritative.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Retain an oversized displaced inode without reading it fully.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    service._write_recovery(row, before.encode(), 0o644, service._recovery_manifest_path(row))
+    source.write_text(external)
+    swap_name = service._source_swap_name(proposal["id"])
+    retained = workspace / swap_name
+    retained.write_bytes(before.encode())
+    retained_fd = os.open(retained, os.O_WRONLY)
+    try:
+        os.ftruncate(retained_fd, service.config.manuscript_source_max_bytes + 1)
+        os.fsync(retained_fd)
+    finally:
+        os.close(retained_fd)
+
+    if closing_action == "apply":
+        with pytest.raises(ManuscriptSourceConflictError, match="recoverable apply"):
+            await service.apply_proposal(
+                proposal["id"],
+                ManuscriptSourceProposalTransition(
+                    expected_revision=1,
+                    actor="web_ui",
+                    reason="Close oversized recovery as a durable conflict.",
+                ),
+            )
+        prior = await service.get_proposal(proposal["id"])
+        assert prior["status"] == "conflicted"
+    elif closing_action == "reject":
+        prior = await service.reject_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Reject while retaining oversized recovery.",
+            ),
+        )
+        assert prior["status"] == "rejected"
+    else:
+        successor = await service.create_proposal(
+            manuscript_id,
+            ManuscriptSourceProposalCreate(
+                origin="human",
+                relative_path="main.md",
+                expected_content_hash=_hash(external),
+                content=_markdown(unit_id, "Successor after oversized recovery."),
+                created_by="web_ui",
+                reason="Supersede while retaining oversized recovery.",
+                supersedes_proposal_id=proposal["id"],
+            ),
+        )
+        assert successor["status"] == "proposed"
+        prior = await service.get_proposal(proposal["id"])
+        assert prior["status"] == "superseded"
+
+    assert source.read_text() == external
+    assert retained.stat().st_size == service.config.manuscript_source_max_bytes + 1
+    details = prior["events"][-1]["details"]
+    assert details["source_recovery_state"] == "retained"
+    assert details["source_recovery_last_observed"] == "oversized"
+    assert details["retained_source_path"] == swap_name
 
 
 @pytest.mark.asyncio
@@ -1245,8 +1384,11 @@ async def test_proposal_swap_mutation_at_exchange_is_restored_and_retained(
     conflicted = await service.get_proposal(proposal["id"])
     assert conflicted["status"] == "conflicted"
     assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
-        "retained_unclassified"
+        "retained"
     )
+    assert conflicted["events"][-1]["details"][
+        "source_recovery_last_observed"
+    ] == "unclassified"
     assert conflicted["events"][-1]["details"]["retained_source_path"] == swap_name
 
 
@@ -1329,8 +1471,9 @@ async def test_reject_and_supersede_fsync_prior_rollback_state_before_closing(
     assert source.read_text() == external
     assert swap.read_text() == after
     prior = await service.get_proposal(proposal["id"])
-    assert prior["events"][-1]["details"]["source_recovery_state"] == (
-        "retained_proposal"
+    assert prior["events"][-1]["details"]["source_recovery_state"] == "retained"
+    assert prior["events"][-1]["details"]["source_recovery_last_observed"] == (
+        "proposal"
     )
     assert prior["events"][-1]["details"]["retained_source_path"] == swap.name
 
@@ -1493,8 +1636,11 @@ async def test_retry_restores_external_file_displaced_by_interrupted_exchange(
     assert conflicted["status"] == "conflicted"
     assert (workspace / swap_name).read_text() == after
     assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
-        "retained_proposal"
+        "retained"
     )
+    assert conflicted["events"][-1]["details"][
+        "source_recovery_last_observed"
+    ] == "proposal"
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -157,6 +157,93 @@ async def test_prepare_then_apply_is_atomic_mode_preserving_and_recoverable(
 
 
 @pytest.mark.asyncio
+async def test_apply_creates_a_missing_source_with_no_clobber_link(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    after = _markdown(unit_id, "Create a previously missing source.")
+    source = workspace / "main.md"
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=None,
+            content=after,
+            created_by="web_ui",
+            reason="Exercise atomic missing-file creation.",
+        ),
+    )
+
+    applied = await service.apply_proposal(
+        proposal["id"],
+        ManuscriptSourceProposalTransition(
+            expected_revision=1,
+            actor="web_ui",
+            reason="Create the reviewed source without clobbering.",
+        ),
+    )
+    assert applied["status"] == "applied"
+    assert source.read_text() == after
+    recovery = Path(db_with_project.db_path).resolve().parent / applied[
+        "recovery_manifest_path"
+    ]
+    assert json.loads(recovery.read_text())["before_existed"] is False
+    assert not (recovery.parent / "before.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_external_file_appearing_at_missing_source_commit_is_preserved(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    proposed = _markdown(unit_id, "Proposed missing source.")
+    external = _markdown(unit_id, "External source won the creation race.")
+    source = workspace / "main.md"
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=None,
+            content=proposed,
+            created_by="web_ui",
+            reason="Exercise a missing-file creation race.",
+        ),
+    )
+    original_link = os.link
+    injected = False
+
+    def inject_before_link(*args, **kwargs):
+        nonlocal injected
+        if not injected:
+            injected = True
+            source.write_text(external)
+        return original_link(*args, **kwargs)
+
+    monkeypatch.setattr(os, "link", inject_before_link)
+    with pytest.raises(ManuscriptSourceConflictError, match="appeared immediately"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Preserve the external creation winner.",
+            ),
+        )
+    assert source.read_text() == external
+    assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
+    assert not (workspace / service._source_swap_name(proposal["id"])).exists()
+
+
+@pytest.mark.asyncio
 async def test_external_edit_creates_durable_conflict_without_overwrite(
     db_with_project,
     tmp_path: Path,
@@ -429,13 +516,17 @@ async def test_external_edit_after_recovery_is_preserved_before_final_replace(
             reason="Exercise final pre-replace hash verification.",
         ),
     )
-    original_write_recovery = service._write_recovery
+    original_exchange = service._atomic_exchange_at
+    injected = False
 
     def inject_external_edit(*args, **kwargs):
-        original_write_recovery(*args, **kwargs)
-        source.write_text(external)
+        nonlocal injected
+        if not injected:
+            injected = True
+            source.write_text(external)
+        original_exchange(*args, **kwargs)
 
-    monkeypatch.setattr(service, "_write_recovery", inject_external_edit)
+    monkeypatch.setattr(service, "_atomic_exchange_at", inject_external_edit)
     with pytest.raises(ManuscriptSourceConflictError, match="immediately before"):
         await service.apply_proposal(
             proposal["id"],
@@ -481,13 +572,19 @@ async def test_retry_reconciles_failure_after_replace_before_directory_fsync(
         ),
     )
     original_fsync = os.fsync
-    directory_fsyncs = 0
+    workspace_stat = workspace.stat()
+    source_directory_fsyncs = 0
 
     def fail_second_directory_fsync(fd: int) -> None:
-        nonlocal directory_fsyncs
-        if stat.S_ISDIR(os.fstat(fd).st_mode):
-            directory_fsyncs += 1
-            if directory_fsyncs == 2:
+        nonlocal source_directory_fsyncs
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            source_directory_fsyncs += 1
+            if source_directory_fsyncs == 2:
                 raise OSError("simulated source-directory fsync failure")
         original_fsync(fd)
 
@@ -502,10 +599,182 @@ async def test_retry_reconciles_failure_after_replace_before_directory_fsync(
     assert source.read_text() == after
     assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
 
-    monkeypatch.setattr(os, "fsync", original_fsync)
+    retry_directory_fsyncs = 0
+
+    def count_retry_directory_fsync(fd: int) -> None:
+        nonlocal retry_directory_fsyncs
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            retry_directory_fsyncs += 1
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", count_retry_directory_fsync)
     recovered = await service.apply_proposal(proposal["id"], transition)
     assert recovered["status"] == "applied"
     assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
+    assert retry_directory_fsyncs >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_index", [1, 2, 3, 4])
+async def test_recovery_hierarchy_retries_every_parent_directory_fsync(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_index: int,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base for durable recovery hierarchy.")
+    after = _markdown(unit_id, "Proposed durable recovery hierarchy.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise every recovery hierarchy durability barrier.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    recovery = service._recovery_manifest_path(row)
+    original_fsync = os.fsync
+    directory_fsyncs = 0
+
+    def fail_selected_directory_fsync(fd: int) -> None:
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs == failure_index:
+                raise OSError(f"simulated recovery hierarchy fsync {failure_index}")
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fail_selected_directory_fsync)
+    with pytest.raises(OSError, match="recovery hierarchy fsync"):
+        service._write_recovery(
+            row,
+            before.encode(),
+            source.stat().st_mode & 0o777,
+            recovery,
+        )
+
+    monkeypatch.setattr(os, "fsync", original_fsync)
+    service._write_recovery(
+        row,
+        before.encode(),
+        source.stat().st_mode & 0o777,
+        recovery,
+    )
+    assert service._valid_recovery_manifest(recovery, row)
+    assert source.read_text() == before
+
+
+@pytest.mark.asyncio
+async def test_retry_finishes_interrupted_exchange_with_exact_base_in_swap(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base retained by interrupted exchange.")
+    after = _markdown(unit_id, "Proposed content visible after interrupted exchange.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Reconcile a crash after exchange and before cleanup.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    recovery = service._recovery_manifest_path(row)
+    service._write_recovery(row, before.encode(), 0o644, recovery)
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        service._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+    finally:
+        os.close(parent_fd)
+
+    assert source.read_text() == after
+    recovered = await service.apply_proposal(
+        proposal["id"],
+        ManuscriptSourceProposalTransition(
+            expected_revision=1,
+            actor="web_ui",
+            reason="Resume the interrupted exchange.",
+        ),
+    )
+    assert recovered["status"] == "applied"
+    assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
+    assert not (workspace / swap_name).exists()
+
+
+@pytest.mark.asyncio
+async def test_retry_restores_external_file_displaced_by_interrupted_exchange(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before interrupted external race.")
+    after = _markdown(unit_id, "Proposed content after interrupted external race.")
+    external = _markdown(unit_id, "External content displaced at the exchange point.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Restore an external inode captured by an interrupted exchange.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    recovery = service._recovery_manifest_path(row)
+    service._write_recovery(row, before.encode(), 0o644, recovery)
+    source.write_text(external)
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        service._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+    finally:
+        os.close(parent_fd)
+
+    assert source.read_text() == after
+    with pytest.raises(ManuscriptSourceConflictError, match="external source version"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Restore the displaced external source.",
+            ),
+        )
+    assert source.read_text() == external
+    assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
+    assert not (workspace / swap_name).exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -1,0 +1,590 @@
+"""Conflict, recovery, anchor, and path-safety tests for source synchronization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from rka.config import RKAConfig
+from rka.infra.ids import generate_id
+from rka.models.manuscript_native import ManuscriptCreate
+from rka.models.manuscript_native import ManuscriptUpdate
+from rka.models.manuscript_source import (
+    ManuscriptSourceProposalCreate,
+    ManuscriptSourceProposalTransition,
+)
+from rka.models.semantic_patch import ContextManifestCreate
+from rka.services.manuscript_native import NativeManuscriptService
+from rka.services.manuscript_source import (
+    ManuscriptSourceConflictError,
+    ManuscriptSourceSecurityError,
+    ManuscriptSourceService,
+)
+from rka.services.semantic_patch import SemanticPatchService
+from rka.services.knowledge_pack import KnowledgePackService
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+async def _source_fixture(db, tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=tmp_path / "source.db",
+        data_dir=tmp_path / "data",
+        llm_enabled=False,
+        embeddings_enabled=False,
+        manuscript_workspace_roots=str(tmp_path),
+    )
+    native = NativeManuscriptService(db, project_id="proj_default")
+    manuscript = await native.create(
+        ManuscriptCreate(title="Source paper", workspace_ref=str(workspace))
+    )
+    context = await native.upsert_argument_spine(
+        manuscript.id,
+        expected_revision=1,
+        spine={
+            "claims": [],
+            "units": [
+                {
+                    "unit_id": "U1",
+                    "kind": "introduction",
+                    "location": "main.md#u1",
+                    "status": "planned",
+                    "outline_level": 3,
+                    "unit_role": "argument_block",
+                    "rhetorical_move": "frame_problem",
+                    "communicative_job": "Frame the bounded problem.",
+                    "intended_takeaway": "The problem matters in the evaluated setting.",
+                    "evidence_plan": ["Link one bounded source."],
+                    "quick_reader_role": "Problem in one sentence.",
+                }
+            ],
+        },
+        actor="web_ui",
+    )
+    unit_id = context["units"][0]["id"]
+    service = ManuscriptSourceService(db, config=config, project_id="proj_default")
+    return service, config, manuscript.id, workspace, unit_id
+
+
+def _markdown(unit_id: str, sentence: str) -> str:
+    return (
+        "# Paper\n\n"
+        f"<!-- rka:unit {unit_id} begin -->\n"
+        f"{sentence}\n"
+        f"<!-- rka:unit {unit_id} end -->\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_then_apply_is_atomic_mode_preserving_and_recoverable(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Old bounded prose.")
+    after = _markdown(unit_id, "New bounded prose.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    source.chmod(0o640)
+
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Review and apply the revised introduction.",
+        ),
+    )
+    assert proposal["status"] == "proposed"
+    assert source.read_text() == before
+
+    applied = await service.apply_proposal(
+        proposal["id"],
+        ManuscriptSourceProposalTransition(
+            expected_revision=1,
+            actor="web_ui",
+            reason="PI accepted the source diff.",
+        ),
+    )
+    assert applied["status"] == "applied"
+    assert source.read_text() == after
+    assert source.stat().st_mode & 0o777 == 0o640
+    recovery = Path(db_with_project.db_path).resolve().parent / applied[
+        "recovery_manifest_path"
+    ]
+    payload = json.loads(recovery.read_text())
+    assert payload["before_content_hash"] == _hash(before)
+    assert payload["after_content_hash"] == _hash(after)
+    assert (recovery.parent / "before.bin").read_text() == before
+    assert applied["events"][-1]["details"]["git_operation"] is False
+
+
+@pytest.mark.asyncio
+async def test_external_edit_creates_durable_conflict_without_overwrite(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Initial prose.")
+    proposed = _markdown(unit_id, "Proposed prose.")
+    external = _markdown(unit_id, "Externally edited prose.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=proposed,
+            created_by="web_ui",
+            reason="Prepare a bounded revision.",
+        ),
+    )
+    source.write_text(external)
+
+    with pytest.raises(ManuscriptSourceConflictError, match="source changed"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Attempt apply after an external edit.",
+            ),
+        )
+    assert source.read_text() == external
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
+    assert conflicted["events"][-1]["details"]["file_written"] is False
+    assert conflicted["events"][-1]["details"]["current_content_hash"] == _hash(external)
+
+
+@pytest.mark.asyncio
+async def test_retry_completes_ledger_after_replace_before_transition_failure(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before interrupted apply.")
+    after = _markdown(unit_id, "After interrupted apply.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise recovery after the filesystem commit point.",
+        ),
+    )
+    complete = service._complete_applied_transition
+
+    async def fail_transition(*_args, **_kwargs) -> None:
+        raise RuntimeError("simulated database interruption")
+
+    monkeypatch.setattr(service, "_complete_applied_transition", fail_transition)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Apply with a simulated post-replace interruption.",
+    )
+    with pytest.raises(RuntimeError, match="simulated database interruption"):
+        await service.apply_proposal(proposal["id"], transition)
+    assert source.read_text() == after
+    assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
+
+    monkeypatch.setattr(service, "_complete_applied_transition", complete)
+    recovered = await service.apply_proposal(proposal["id"], transition)
+    assert recovered["status"] == "applied"
+    assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
+    assert source.read_text() == after
+
+
+@pytest.mark.asyncio
+async def test_markdown_and_latex_anchors_round_trip_and_invalid_links_block(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    markdown = _markdown(unit_id, "Bounded prose.")
+    (workspace / "main.md").write_text(markdown)
+    snapshot = await service.read_file(manuscript_id, "main.md")
+    assert snapshot["anchors"][0]["unit_id"] == unit_id
+    assert not [item for item in snapshot["findings"] if item["severity"] == "error"]
+
+    latex = (
+        f"% rka:unit {unit_id} begin\n"
+        "Bounded \\LaTeX{} prose.\n"
+        f"% rka:unit {unit_id} end\n"
+    )
+    (workspace / "main.tex").write_text(latex)
+    latex_snapshot = await service.read_file(manuscript_id, "main.tex")
+    assert latex_snapshot["source_format"] == "latex"
+    assert latex_snapshot["anchors"][0]["unit_id"] == unit_id
+
+    invalid = markdown.replace(unit_id, "mun_01ZZZZZZZZZZZZZZZZZZZZZZZZ")
+    with pytest.raises(ValueError, match="blocking anchor"):
+        await service.create_proposal(
+            manuscript_id,
+            ManuscriptSourceProposalCreate(
+                origin="human",
+                relative_path="main.md",
+                expected_content_hash=_hash(markdown),
+                content=invalid,
+                created_by="web_ui",
+                reason="This foreign anchor must be rejected.",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_symlink_and_unconfigured_root_fail_closed(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, config, manuscript_id, workspace, _ = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    with pytest.raises(ManuscriptSourceSecurityError):
+        await service.read_file(manuscript_id, "../secret.md")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("secret")
+    (workspace / "linked").symlink_to(outside, target_is_directory=True)
+    with pytest.raises((ManuscriptSourceSecurityError, OSError)):
+        await service.read_file(manuscript_id, "linked/secret.md")
+
+    fifo = workspace / "blocking.md"
+    os.mkfifo(fifo)
+    with pytest.raises(ManuscriptSourceSecurityError, match="regular file"):
+        await service.read_file(manuscript_id, "blocking.md")
+
+    disabled = ManuscriptSourceService(
+        db_with_project,
+        config=config.model_copy(update={"manuscript_workspace_roots": ""}),
+        project_id="proj_default",
+    )
+    with pytest.raises(ManuscriptSourceSecurityError, match="disabled"):
+        await disabled.list_files(manuscript_id)
+
+
+@pytest.mark.asyncio
+async def test_symlinked_workspace_ref_fails_closed(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    (workspace / "main.md").write_text(_markdown(unit_id, "Bounded prose."))
+    alias = tmp_path / "workspace-alias"
+    alias.symlink_to(workspace, target_is_directory=True)
+    await db_with_project.execute(
+        "UPDATE manuscripts SET workspace_ref = ? WHERE id = ? AND project_id = ?",
+        [str(alias), manuscript_id, "proj_default"],
+    )
+    await db_with_project.commit()
+
+    with pytest.raises(ManuscriptSourceSecurityError, match="symlink component"):
+        await service.read_file(manuscript_id, "main.md")
+
+
+@pytest.mark.asyncio
+async def test_symlinked_recovery_directory_fails_before_source_write(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before unsafe recovery path.")
+    after = _markdown(unit_id, "After unsafe recovery path.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="This must fail before writing through a recovery symlink.",
+        ),
+    )
+    external = tmp_path / "external-locks"
+    external.mkdir()
+    marker = external / "keep.bin"
+    marker.write_bytes(b"keep")
+    recovery_root = Path(db_with_project.db_path).resolve().parent / (
+        "manuscript-source-recovery"
+    )
+    recovery_root.mkdir(exist_ok=True)
+    (recovery_root / "locks").symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(ManuscriptSourceSecurityError, match="recovery path"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Reject the unsafe recovery path.",
+            ),
+        )
+    assert source.read_text() == before
+    assert marker.read_bytes() == b"keep"
+
+
+@pytest.mark.asyncio
+async def test_overview_separates_quick_reader_from_private_risk(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    (workspace / "main.md").write_text(_markdown(unit_id, "Bounded prose."))
+    overview = await service.get_overview(manuscript_id)
+    assert overview["quick_reader"][0]["anchor_state"] == "linked"
+    assert overview["quick_reader"][0]["quick_reader_role"] == "Problem in one sentence."
+    assert overview["public_private_boundary"]["draft_source"] == "public authoring artifact"
+    assert "never copied automatically" in overview["public_private_boundary"][
+        "private_reviewer_risks"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provenance_comments_must_match_current_unit_bindings(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    journal_id = generate_id("journal")
+    evidence_id = generate_id("claim")
+    manuscript_claim_id = generate_id("manuscript_claim")
+    literature_id = generate_id("literature")
+    reference_id = generate_id("manuscript_reference")
+    await db_with_project.execute(
+        """INSERT INTO journal
+           (id, type, content, source, confidence, importance, status, project_id)
+           VALUES (?, 'log', 'Observed bounded result.', 'executor',
+                   'tested', 'high', 'active', 'proj_default')""",
+        [journal_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO claims
+           (id, source_entry_id, claim_type, content, confidence, verified,
+            evidence_status, stale, project_id)
+           VALUES (?, ?, 'result', 'Observed bounded result.', 0.9, 1,
+                   'supported', 0, 'proj_default')""",
+        [evidence_id, journal_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_claims
+           (id, manuscript_id, project_id, local_key, kind, state)
+           VALUES (?, ?, 'proj_default', 'C1', 'empirical', 'active')""",
+        [manuscript_claim_id, manuscript_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_claim_versions
+           (claim_id, version, manuscript_id, project_id, exact_wording,
+            allowed_wording, prohibited_wording)
+           VALUES (?, 1, ?, 'proj_default', 'The bounded result held.',
+                   'The bounded result held in the evaluated setting.',
+                   '["The result always holds."]')""",
+        [manuscript_claim_id, manuscript_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_claim_units
+           (manuscript_id, project_id, manuscript_claim_id, claim_version,
+            unit_id, relationship)
+           VALUES (?, 'proj_default', ?, 1, ?, 'advances')""",
+        [manuscript_id, manuscript_claim_id, unit_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_unit_evidence
+           (manuscript_id, project_id, unit_id, evidence_claim_id, role, ordinal)
+           VALUES (?, 'proj_default', ?, ?, 'support', 0)""",
+        [manuscript_id, unit_id, evidence_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO literature
+           (id, title, authors, year, doi, status, added_by, project_id)
+           VALUES (?, 'Prior bounded study', '[]', 2025, '10.1000/source-sync',
+                   'cited', 'pi', 'proj_default')""",
+        [literature_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_reference_members
+           (id, manuscript_id, project_id, citation_key, literature_id)
+           VALUES (?, ?, 'proj_default', 'prior2025', ?)""",
+        [reference_id, manuscript_id, literature_id],
+    )
+    await db_with_project.execute(
+        """INSERT INTO manuscript_unit_citations
+           (id, manuscript_id, project_id, unit_id, reference_member_id,
+            citation_role, supported_proposition, verification_state)
+           VALUES (?, ?, 'proj_default', ?, ?, 'bounds',
+                   'Prior work bounds the comparison.', 'self_attested')""",
+        [
+            generate_id("manuscript_unit_citation"),
+            manuscript_id,
+            unit_id,
+            reference_id,
+        ],
+    )
+    await db_with_project.commit()
+
+    valid = (
+        f"<!-- rka:unit {unit_id} begin -->\n"
+        "Bounded prose.\n"
+        f"<!-- rka:provenance claim={manuscript_claim_id} "
+        f"evidence={evidence_id} citation=prior2025 -->\n"
+        f"<!-- rka:unit {unit_id} end -->\n"
+    )
+    (workspace / "main.md").write_text(valid)
+    snapshot = await service.read_file(manuscript_id, "main.md")
+    assert len(snapshot["provenance"]) == 3
+    assert all(item["verified"] for item in snapshot["provenance"])
+
+    invalid = valid.replace("citation=prior2025", "citation=unbound2025")
+    with pytest.raises(ValueError, match="blocking anchor or provenance"):
+        await service.create_proposal(
+            manuscript_id,
+            ManuscriptSourceProposalCreate(
+                origin="human",
+                relative_path="main.md",
+                expected_content_hash=_hash(valid),
+                content=invalid,
+                created_by="web_ui",
+                reason="Reject an unbound citation marker.",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_ai_source_proposal_requires_current_target_manifest(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before AI proposal.")
+    (workspace / "main.md").write_text(before)
+    patches = SemanticPatchService(db_with_project, project_id="proj_default")
+    manifest = await patches.create_context_manifest(
+        ContextManifestCreate(
+            origin="host_agent",
+            provider="openai",
+            model="host-model",
+            boundary="host_conversation",
+            targets=[{"target_type": "manuscript", "target_id": manuscript_id}],
+            constraints=["Preserve current evidence boundaries."],
+        )
+    )
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="host_agent",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=_markdown(unit_id, "AI-proposed bounded revision."),
+            created_by="web_ui",
+            reason="Prepare disclosed host-agent prose for PI review.",
+            provider="openai",
+            model="host-model",
+            boundary="host_conversation",
+            context_manifest_id=manifest["id"],
+        ),
+    )
+    assert proposal["context_manifest_id"] == manifest["id"]
+    assert proposal["status"] == "proposed"
+
+    native = NativeManuscriptService(db_with_project, project_id="proj_default")
+    current = await native.get(manuscript_id)
+    assert current is not None
+    await native.update(
+        manuscript_id,
+        ManuscriptUpdate(expected_revision=current.revision, title="Revised source paper"),
+        actor="pi",
+    )
+    with pytest.raises(ManuscriptSourceConflictError, match="revision is stale"):
+        await service.create_proposal(
+            manuscript_id,
+            ManuscriptSourceProposalCreate(
+                origin="host_agent",
+                relative_path="main.md",
+                expected_content_hash=_hash(before),
+                content=_markdown(unit_id, "Stale-context proposal."),
+                created_by="web_ui",
+                reason="This must not pass with a stale disclosure manifest.",
+                provider="openai",
+                model="host-model",
+                boundary="host_conversation",
+                context_manifest_id=manifest["id"],
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_knowledge_pack_omits_local_source_candidate_and_ledger(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Portable semantic context only.")
+    sentinel = "LOCAL-CANDIDATE-MUST-NOT-ENTER-KNOWLEDGE-PACK"
+    (workspace / "main.md").write_text(before)
+    await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=_markdown(unit_id, sentinel),
+            created_by="web_ui",
+            reason="Keep installation-local source out of the portable pack.",
+        ),
+    )
+
+    pack_path, _ = await KnowledgePackService(
+        db_with_project, project_id="proj_default"
+    ).export_pack()
+    with zipfile.ZipFile(pack_path) as archive:
+        manifest_bytes = archive.read("manifest.json")
+        manifest = json.loads(manifest_bytes)
+    assert "manuscript_source_proposals" not in manifest["tables"]
+    assert "manuscript_source_events" not in manifest["tables"]
+    assert "manuscript_source_proposals" in manifest["portability"]["excluded_tables"]
+    assert sentinel.encode() not in manifest_bytes

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
+import stat
 import zipfile
 from pathlib import Path
 
@@ -83,6 +85,26 @@ def _markdown(unit_id: str, sentence: str) -> str:
         f"{sentence}\n"
         f"<!-- rka:unit {unit_id} end -->\n"
     )
+
+
+async def _evidence_claim(db, content: str) -> str:
+    journal_id = generate_id("journal")
+    claim_id = generate_id("claim")
+    await db.execute(
+        """INSERT INTO journal
+           (id, type, content, source, confidence, importance, status, project_id)
+           VALUES (?, 'log', ?, 'executor', 'tested', 'high', 'active', 'proj_default')""",
+        [journal_id, content],
+    )
+    await db.execute(
+        """INSERT INTO claims
+           (id, source_entry_id, claim_type, content, confidence, verified,
+            evidence_status, stale, project_id)
+           VALUES (?, ?, 'result', ?, 0.9, 1, 'supported', 0, 'proj_default')""",
+        [claim_id, journal_id, content],
+    )
+    await db.commit()
+    return claim_id
 
 
 @pytest.mark.asyncio
@@ -216,11 +238,274 @@ async def test_retry_completes_ledger_after_replace_before_transition_failure(
     assert source.read_text() == after
     assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
 
+    with pytest.raises(ManuscriptSourceConflictError, match="already on disk"):
+        await service.reject_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Do not let reject falsify the crash-applied ledger.",
+            ),
+        )
+    assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
+
     monkeypatch.setattr(service, "_complete_applied_transition", complete)
     recovered = await service.apply_proposal(proposal["id"], transition)
     assert recovered["status"] == "applied"
     assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
     assert source.read_text() == after
+
+
+@pytest.mark.asyncio
+async def test_same_file_concurrent_applies_yield_without_event_loop_deadlock(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before concurrent applies.")
+    first_after = _markdown(unit_id, "First concurrent proposal.")
+    second_after = _markdown(unit_id, "Second concurrent proposal.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposals = []
+    for content in (first_after, second_after):
+        proposals.append(
+            await service.create_proposal(
+                manuscript_id,
+                ManuscriptSourceProposalCreate(
+                    origin="human",
+                    relative_path="main.md",
+                    expected_content_hash=_hash(before),
+                    content=content,
+                    created_by="web_ui",
+                    reason="Exercise serialized same-file apply.",
+                ),
+            )
+        )
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_inspect = service.inspect_content
+
+    async def pause_first(*args, **kwargs):
+        if args[3] == first_after:
+            entered.set()
+            await release.wait()
+        return await original_inspect(*args, **kwargs)
+
+    monkeypatch.setattr(service, "inspect_content", pause_first)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Apply one of two concurrent proposals.",
+    )
+    first_task = asyncio.create_task(
+        service.apply_proposal(proposals[0]["id"], transition)
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    second_task = asyncio.create_task(
+        service.apply_proposal(proposals[1]["id"], transition)
+    )
+    await asyncio.sleep(0.05)
+    assert not second_task.done()
+    release.set()
+    results = await asyncio.wait_for(
+        asyncio.gather(first_task, second_task, return_exceptions=True), timeout=2
+    )
+
+    assert results[0]["status"] == "applied"
+    assert isinstance(results[1], ManuscriptSourceConflictError)
+    assert source.read_text() == first_after
+    assert (await service.get_proposal(proposals[1]["id"]))["status"] == "conflicted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closing_action", ["reject", "supersede"])
+async def test_apply_serializes_reject_and_supersede_after_filesystem_commit(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    closing_action: str,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before terminal-state race.")
+    after = _markdown(unit_id, "Applied content wins the serialized race.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise terminal-state serialization.",
+        ),
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_complete = service._complete_applied_transition
+
+    async def pause_after_replace(*args, **kwargs):
+        entered.set()
+        await release.wait()
+        await original_complete(*args, **kwargs)
+
+    monkeypatch.setattr(service, "_complete_applied_transition", pause_after_replace)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Apply before a competing terminal transition.",
+    )
+    apply_task = asyncio.create_task(service.apply_proposal(proposal["id"], transition))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    if closing_action == "reject":
+        close_task = asyncio.create_task(
+            service.reject_proposal(
+                proposal["id"],
+                ManuscriptSourceProposalTransition(
+                    expected_revision=1,
+                    actor="web_ui",
+                    reason="Competing rejection must not falsify the ledger.",
+                ),
+            )
+        )
+    else:
+        close_task = asyncio.create_task(
+            service.create_proposal(
+                manuscript_id,
+                ManuscriptSourceProposalCreate(
+                    origin="human",
+                    relative_path="main.md",
+                    expected_content_hash=_hash(after),
+                    content=_markdown(unit_id, "Attempted superseding content."),
+                    created_by="web_ui",
+                    reason="Competing supersession must not falsify the ledger.",
+                    supersedes_proposal_id=proposal["id"],
+                ),
+            )
+        )
+    await asyncio.sleep(0.05)
+    assert not close_task.done()
+    release.set()
+    applied, close_result = await asyncio.wait_for(
+        asyncio.gather(apply_task, close_task, return_exceptions=True), timeout=2
+    )
+
+    assert applied["status"] == "applied"
+    assert isinstance(close_result, ManuscriptSourceConflictError)
+    assert (await service.get_proposal(proposal["id"]))["status"] == "applied"
+    assert source.read_text() == after
+
+
+@pytest.mark.asyncio
+async def test_external_edit_after_recovery_is_preserved_before_final_replace(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before late external edit.")
+    proposed = _markdown(unit_id, "Proposed content.")
+    external = _markdown(unit_id, "External edit after recovery.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=proposed,
+            created_by="web_ui",
+            reason="Exercise final pre-replace hash verification.",
+        ),
+    )
+    original_write_recovery = service._write_recovery
+
+    def inject_external_edit(*args, **kwargs):
+        original_write_recovery(*args, **kwargs)
+        source.write_text(external)
+
+    monkeypatch.setattr(service, "_write_recovery", inject_external_edit)
+    with pytest.raises(ManuscriptSourceConflictError, match="immediately before"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Do not overwrite the late external edit.",
+            ),
+        )
+
+    assert source.read_text() == external
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
+    assert conflicted["events"][-1]["details"]["current_content_hash"] == _hash(
+        external
+    )
+    recovery = service._recovery_manifest_path(conflicted)
+    assert (recovery.parent / "before.bin").read_text() == before
+
+
+@pytest.mark.asyncio
+async def test_retry_reconciles_failure_after_replace_before_directory_fsync(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Before directory fsync failure.")
+    after = _markdown(unit_id, "After directory fsync failure.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise the replace-to-directory-fsync crash window.",
+        ),
+    )
+    original_fsync = os.fsync
+    directory_fsyncs = 0
+
+    def fail_second_directory_fsync(fd: int) -> None:
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs == 2:
+                raise OSError("simulated source-directory fsync failure")
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fail_second_directory_fsync)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Apply across a simulated directory-fsync failure.",
+    )
+    with pytest.raises(OSError, match="source-directory fsync failure"):
+        await service.apply_proposal(proposal["id"], transition)
+    assert source.read_text() == after
+    assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
+
+    monkeypatch.setattr(os, "fsync", original_fsync)
+    recovered = await service.apply_proposal(proposal["id"], transition)
+    assert recovered["status"] == "applied"
+    assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
 
 
 @pytest.mark.asyncio
@@ -346,7 +631,7 @@ async def test_symlinked_recovery_directory_fails_before_source_write(
         "manuscript-source-recovery"
     )
     recovery_root.mkdir(exist_ok=True)
-    (recovery_root / "locks").symlink_to(external, target_is_directory=True)
+    (recovery_root / "proj_default").symlink_to(external, target_is_directory=True)
 
     with pytest.raises(ManuscriptSourceSecurityError, match="recovery path"):
         await service.apply_proposal(
@@ -377,6 +662,97 @@ async def test_overview_separates_quick_reader_from_private_risk(
     assert "never copied automatically" in overview["public_private_boundary"][
         "private_reviewer_risks"
     ]
+
+
+@pytest.mark.asyncio
+async def test_overview_projects_unallocated_claim_adverse_evidence_privately(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    support_id = await _evidence_claim(db_with_project, "Measured bounded support.")
+    qualifier_id = await _evidence_claim(db_with_project, "Observed boundary condition.")
+    counterevidence_id = await _evidence_claim(db_with_project, "Observed adverse case.")
+    native = NativeManuscriptService(db_with_project, project_id="proj_default")
+    manuscript = await native.get(manuscript_id)
+    assert manuscript is not None
+    context = await native.upsert_argument_spine(
+        manuscript_id,
+        expected_revision=manuscript.revision,
+        spine={
+            "claims": [
+                {
+                    "claim_id": "C1",
+                    "claim_type": "empirical",
+                    "status": "active",
+                    "text": "The bounded mechanism produced the measured effect.",
+                    "allowed_wording": "The effect held in the evaluated setting.",
+                    "prohibited_wording": ["The mechanism always works."],
+                    "evidence_ids": [support_id],
+                    "qualifier_ids": [qualifier_id],
+                    "counterevidence_ids": [counterevidence_id],
+                    "unit_links": [{"unit_key": "U1", "relationship": "advances"}],
+                }
+            ],
+            "units": [
+                {
+                    "unit_id": "U1",
+                    "kind": "introduction",
+                    "location": "main.md#u1",
+                    "status": "planned",
+                    "outline_level": 3,
+                    "unit_role": "argument_block",
+                    "rhetorical_move": "frame_problem",
+                    "communicative_job": "Frame the bounded problem.",
+                    "intended_takeaway": "The problem matters in the evaluated setting.",
+                    "evidence_plan": ["Link one bounded source."],
+                    "quick_reader_role": "Problem in one sentence.",
+                    "evidence_ids": [support_id],
+                }
+            ],
+        },
+        actor="web_ui",
+    )
+    assert context["units"][0]["id"] == unit_id
+    (workspace / "main.md").write_text(_markdown(unit_id, "Bounded prose."))
+
+    overview = await service.get_overview(manuscript_id)
+    assert {
+        (risk["kind"], risk.get("claim_id"), risk.get("evidence_claim_id"))
+        for risk in overview["private_reviewer_risks"]
+        if risk["kind"].startswith("unallocated_")
+    } == {
+        ("unallocated_qualifier", context["claims"][0]["id"], qualifier_id),
+        (
+            "unallocated_counterevidence",
+            context["claims"][0]["id"],
+            counterevidence_id,
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_direct_source_reads_reject_invalid_utf8_and_configured_oversize(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, config, manuscript_id, workspace, _ = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    (workspace / "invalid.md").write_bytes(b"\xff\xfe")
+    with pytest.raises(ValueError, match="valid UTF-8"):
+        await service.read_file(manuscript_id, "invalid.md")
+
+    bounded = ManuscriptSourceService(
+        db_with_project,
+        config=config.model_copy(update={"manuscript_source_max_bytes": 32}),
+        project_id="proj_default",
+    )
+    (workspace / "oversize.md").write_bytes(b"x" * 33)
+    with pytest.raises(ValueError, match="size limit"):
+        await bounded.read_file(manuscript_id, "oversize.md")
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -154,6 +154,79 @@ async def test_prepare_then_apply_is_atomic_mode_preserving_and_recoverable(
     assert payload["after_content_hash"] == _hash(after)
     assert (recovery.parent / "before.bin").read_text() == before
     assert applied["events"][-1]["details"]["git_operation"] is False
+    displaced_relative = applied["events"][-1]["details"]["displaced_source_path"]
+    assert displaced_relative == service._source_swap_name(proposal["id"])
+    assert (workspace / displaced_relative).read_text() == before
+
+
+@pytest.mark.asyncio
+async def test_preopened_external_descriptor_remains_linked_after_apply(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base inode opened by an external editor.")
+    after = _markdown(unit_id, "Reviewed proposal installed at the public target.")
+    external = _markdown(unit_id, "External bytes written through the pre-opened inode.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Retain the exact displaced inode across late descriptor writes.",
+        ),
+    )
+    swap_name = service._source_swap_name(proposal["id"])
+    editor_fd = os.open(source, os.O_RDWR)
+    original_read = service._read_source_entry_at
+    injected = False
+
+    def write_after_displaced_read(*args, **kwargs):
+        nonlocal injected
+        result = original_read(*args, **kwargs)
+        if args[1] == swap_name and result[0] is not None and not injected:
+            injected = True
+            os.lseek(editor_fd, 0, os.SEEK_SET)
+            view = memoryview(external.encode())
+            while view:
+                written = os.write(editor_fd, view)
+                view = view[written:]
+            os.ftruncate(editor_fd, len(external.encode()))
+            os.fsync(editor_fd)
+        return result
+
+    monkeypatch.setattr(service, "_read_source_entry_at", write_after_displaced_read)
+    try:
+        applied = await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Apply while preserving a late write to the displaced inode.",
+            ),
+        )
+        retained = workspace / swap_name
+        assert applied["status"] == "applied"
+        assert source.read_text() == after
+        assert os.fstat(editor_fd).st_ino == retained.stat().st_ino
+        assert os.fstat(editor_fd).st_nlink >= 1
+        assert retained.read_text() == external
+        recovery = Path(db_with_project.db_path).resolve().parent / applied[
+            "recovery_manifest_path"
+        ]
+        assert (recovery.parent / "before.bin").read_text() == before
+        assert json.loads(recovery.read_text())["displaced_source_path"] == swap_name
+    finally:
+        os.close(editor_fd)
+    assert (workspace / swap_name).read_text() == external
 
 
 @pytest.mark.asyncio
@@ -282,6 +355,12 @@ async def test_external_edit_creates_durable_conflict_without_overwrite(
     conflicted = await service.get_proposal(proposal["id"])
     assert conflicted["status"] == "conflicted"
     assert conflicted["events"][-1]["details"]["file_written"] is False
+    assert conflicted["events"][-1]["details"]["transient_exchange"] is False
+    assert (
+        conflicted["events"][-1]["details"]["transient_exchange_state"]
+        == "not_observed"
+    )
+    assert conflicted["events"][-1]["details"]["final_target_preserved"] is True
     assert conflicted["events"][-1]["details"]["current_content_hash"] == _hash(external)
 
 
@@ -543,6 +622,13 @@ async def test_external_edit_after_recovery_is_preserved_before_final_replace(
     assert conflicted["events"][-1]["details"]["current_content_hash"] == _hash(
         external
     )
+    assert conflicted["events"][-1]["details"]["file_written"] is True
+    assert conflicted["events"][-1]["details"]["transient_exchange"] is True
+    assert (
+        conflicted["events"][-1]["details"]["transient_exchange_state"]
+        == "observed"
+    )
+    assert conflicted["events"][-1]["details"]["final_target_preserved"] is True
     recovery = service._recovery_manifest_path(conflicted)
     assert (recovery.parent / "before.bin").read_text() == before
 
@@ -617,6 +703,230 @@ async def test_retry_reconciles_failure_after_replace_before_directory_fsync(
     assert recovered["status"] == "applied"
     assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
     assert retry_directory_fsyncs >= 1
+
+
+@pytest.mark.asyncio
+async def test_retry_fsyncs_restored_external_source_before_terminal_conflict(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before rollback durability failure.")
+    after = _markdown(unit_id, "Proposal involved in rollback durability failure.")
+    external = _markdown(unit_id, "External object restored before fsync failure.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Retry the rollback durability barrier before terminal conflict.",
+        ),
+    )
+    original_exchange = service._atomic_exchange_at
+    injected = False
+
+    def inject_external_before_exchange(*args, **kwargs):
+        nonlocal injected
+        if not injected:
+            injected = True
+            source.write_text(external)
+        original_exchange(*args, **kwargs)
+
+    monkeypatch.setattr(
+        service, "_atomic_exchange_at", inject_external_before_exchange
+    )
+    original_fsync = os.fsync
+    workspace_stat = workspace.stat()
+    source_directory_fsyncs = 0
+
+    def fail_rollback_directory_fsync(fd: int) -> None:
+        nonlocal source_directory_fsyncs
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            source_directory_fsyncs += 1
+            if source_directory_fsyncs == 2:
+                raise OSError("simulated rollback source-directory fsync failure")
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fail_rollback_directory_fsync)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Preserve and durably restore the external source.",
+    )
+    with pytest.raises(
+        ManuscriptSourceSecurityError, match="could not be rolled back safely"
+    ):
+        await service.apply_proposal(proposal["id"], transition)
+    assert source.read_text() == external
+    assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
+    assert not (workspace / service._source_swap_name(proposal["id"])).exists()
+
+    retry_directory_fsyncs = 0
+
+    def count_retry_directory_fsync(fd: int) -> None:
+        nonlocal retry_directory_fsyncs
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            retry_directory_fsyncs += 1
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", count_retry_directory_fsync)
+    with pytest.raises(ManuscriptSourceConflictError, match="source changed"):
+        await service.apply_proposal(proposal["id"], transition)
+    assert retry_directory_fsyncs >= 1
+    assert source.read_text() == external
+    assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("swap_state", ["proposed", "unexpected"])
+async def test_terminal_conflict_cleans_only_a_known_proposal_swap(
+    db_with_project,
+    tmp_path: Path,
+    swap_state: str,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before conflict-side swap cleanup.")
+    after = _markdown(unit_id, "Proposal retained at the deterministic swap name.")
+    external = _markdown(unit_id, "External source already restored at target.")
+    unexpected = _markdown(unit_id, "Unexpected object at deterministic swap name.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Reconcile a conflict-side deterministic swap.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    recovery = service._recovery_manifest_path(row)
+    service._write_recovery(row, before.encode(), 0o644, recovery)
+    source.write_text(external)
+    swap = workspace / service._source_swap_name(proposal["id"])
+    swap.write_text(after if swap_state == "proposed" else unexpected)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Finish conflict-side recovery safely.",
+    )
+
+    if swap_state == "proposed":
+        with pytest.raises(ManuscriptSourceConflictError, match="source changed"):
+            await service.apply_proposal(proposal["id"], transition)
+        assert not swap.exists()
+        assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
+    else:
+        with pytest.raises(
+            ManuscriptSourceSecurityError, match="unexpected source swap"
+        ):
+            await service.apply_proposal(proposal["id"], transition)
+        assert swap.read_text() == unexpected
+        assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
+    assert source.read_text() == external
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closing_action", ["reject", "supersede"])
+async def test_reject_and_supersede_fsync_prior_rollback_state_before_closing(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    closing_action: str,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before rollback-aware terminal close.")
+    after = _markdown(unit_id, "Proposal left at swap after rollback.")
+    external = _markdown(unit_id, "External target restored before terminal close.")
+    superseding = _markdown(unit_id, "Replacement proposal after durable cleanup.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise rollback-aware reject and supersede.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    recovery = service._recovery_manifest_path(row)
+    service._write_recovery(row, before.encode(), 0o644, recovery)
+    source.write_text(external)
+    swap = workspace / service._source_swap_name(proposal["id"])
+    swap.write_text(after)
+    original_fsync = os.fsync
+    workspace_stat = workspace.stat()
+    source_directory_fsyncs = 0
+
+    def count_source_directory_fsync(fd: int) -> None:
+        nonlocal source_directory_fsyncs
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            source_directory_fsyncs += 1
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", count_source_directory_fsync)
+    if closing_action == "reject":
+        result = await service.reject_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Reject only after durable rollback cleanup.",
+            ),
+        )
+        assert result["status"] == "rejected"
+    else:
+        result = await service.create_proposal(
+            manuscript_id,
+            ManuscriptSourceProposalCreate(
+                origin="human",
+                relative_path="main.md",
+                expected_content_hash=_hash(external),
+                content=superseding,
+                created_by="web_ui",
+                reason="Supersede only after durable rollback cleanup.",
+                supersedes_proposal_id=proposal["id"],
+            ),
+        )
+        assert result["status"] == "proposed"
+        assert (await service.get_proposal(proposal["id"]))["status"] == "superseded"
+    assert source_directory_fsyncs >= 1
+    assert source.read_text() == external
+    assert not swap.exists()
 
 
 @pytest.mark.asyncio
@@ -723,7 +1033,7 @@ async def test_retry_finishes_interrupted_exchange_with_exact_base_in_swap(
     )
     assert recovered["status"] == "applied"
     assert recovered["events"][-1]["details"]["recovered_after_restart"] is True
-    assert not (workspace / swap_name).exists()
+    assert (workspace / swap_name).read_text() == before
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_manuscript_source.py
+++ b/tests/test_services/test_manuscript_source.py
@@ -156,6 +156,7 @@ async def test_prepare_then_apply_is_atomic_mode_preserving_and_recoverable(
     assert applied["events"][-1]["details"]["git_operation"] is False
     displaced_relative = applied["events"][-1]["details"]["displaced_source_path"]
     assert displaced_relative == service._source_swap_name(proposal["id"])
+    assert applied["events"][-1]["details"]["source_recovery_state"] == "retained_base"
     assert (workspace / displaced_relative).read_text() == before
 
 
@@ -266,6 +267,64 @@ async def test_apply_creates_a_missing_source_with_no_clobber_link(
     ]
     assert json.loads(recovery.read_text())["before_existed"] is False
     assert not (recovery.parent / "before.bin").exists()
+    assert applied["events"][-1]["details"]["source_recovery_state"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_missing_source_restart_retains_preexisting_proposal_inode(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    after = _markdown(unit_id, "Crash-interrupted missing-file proposal.")
+    source = workspace / "main.md"
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=None,
+            content=after,
+            created_by="web_ui",
+            reason="Reconcile a no-clobber link after restart.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    service._write_recovery(row, None, None, service._recovery_manifest_path(row))
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        os.link(
+            swap_name,
+            name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+
+    applied = await service.apply_proposal(
+        proposal["id"],
+        ManuscriptSourceProposalTransition(
+            expected_revision=1,
+            actor="web_ui",
+            reason="Finish the interrupted missing-file ledger transition.",
+        ),
+    )
+    retained = workspace / swap_name
+    assert applied["status"] == "applied"
+    assert source.read_text() == after
+    assert retained.read_text() == after
+    assert source.stat().st_ino == retained.stat().st_ino
+    assert applied["events"][-1]["details"]["source_recovery_state"] == (
+        "retained_proposal"
+    )
+    assert applied["events"][-1]["details"]["displaced_source_path"] == swap_name
 
 
 @pytest.mark.asyncio
@@ -772,7 +831,8 @@ async def test_retry_fsyncs_restored_external_source_before_terminal_conflict(
         await service.apply_proposal(proposal["id"], transition)
     assert source.read_text() == external
     assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
-    assert not (workspace / service._source_swap_name(proposal["id"])).exists()
+    rollback_swap = workspace / service._source_swap_name(proposal["id"])
+    assert rollback_swap.read_text() == after
 
     retry_directory_fsyncs = 0
 
@@ -797,7 +857,7 @@ async def test_retry_fsyncs_restored_external_source_before_terminal_conflict(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("swap_state", ["proposed", "unexpected"])
-async def test_terminal_conflict_cleans_only_a_known_proposal_swap(
+async def test_terminal_conflict_retains_every_preexisting_recovery_inode(
     db_with_project,
     tmp_path: Path,
     swap_state: str,
@@ -834,19 +894,360 @@ async def test_terminal_conflict_cleans_only_a_known_proposal_swap(
         reason="Finish conflict-side recovery safely.",
     )
 
+    with pytest.raises(ManuscriptSourceConflictError, match="source changed"):
+        await service.apply_proposal(proposal["id"], transition)
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
     if swap_state == "proposed":
-        with pytest.raises(ManuscriptSourceConflictError, match="source changed"):
-            await service.apply_proposal(proposal["id"], transition)
-        assert not swap.exists()
-        assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
+        assert swap.read_text() == after
+        assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
+            "retained_proposal"
+        )
+        assert conflicted["events"][-1]["details"]["retained_source_path"] == swap.name
     else:
-        with pytest.raises(
-            ManuscriptSourceSecurityError, match="unexpected source swap"
-        ):
-            await service.apply_proposal(proposal["id"], transition)
         assert swap.read_text() == unexpected
-        assert (await service.get_proposal(proposal["id"]))["status"] == "proposed"
+        assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
+            "retained_unclassified"
+        )
+        assert conflicted["events"][-1]["details"]["retained_source_path"] == (
+            swap.name
+        )
     assert source.read_text() == external
+
+
+@pytest.mark.asyncio
+async def test_restart_base_equivalent_target_never_unlinks_retained_inode(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Reviewed base before an interrupted exchange.")
+    after = _markdown(unit_id, "Proposal visible at the interrupted commit point.")
+    late = _markdown(unit_id, "Late bytes written through the displaced descriptor.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise base-equivalent restart classification.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    service._write_recovery(row, before.encode(), 0o644, service._recovery_manifest_path(row))
+    editor_fd = os.open(source, os.O_RDWR)
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        service._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+
+    replacement = workspace / "replacement.md"
+    replacement.write_text(before)
+    os.replace(replacement, source)
+    transition = ManuscriptSourceProposalTransition(
+        expected_revision=1,
+        actor="web_ui",
+        reason="Preserve the retained inode instead of retrying replacement.",
+    )
+    try:
+        with pytest.raises(ManuscriptSourceConflictError, match="recoverable apply"):
+            await service.apply_proposal(proposal["id"], transition)
+        retained = workspace / swap_name
+        assert source.read_text() == before
+        assert retained.read_text() == before
+        assert retained.stat().st_ino == os.fstat(editor_fd).st_ino
+        assert os.fstat(editor_fd).st_nlink >= 1
+        os.lseek(editor_fd, 0, os.SEEK_SET)
+        os.write(editor_fd, late.encode())
+        os.ftruncate(editor_fd, len(late.encode()))
+        os.fsync(editor_fd)
+    finally:
+        os.close(editor_fd)
+    assert (workspace / swap_name).read_text() == late
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
+    assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
+        "retained_base"
+    )
+    assert conflicted["events"][-1]["details"]["transient_exchange_state"] == (
+        "possible"
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_proposal_equivalent_retained_inode_stays_linked(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base opened before a crash-interrupted apply.")
+    after = _markdown(unit_id, "Proposal bytes later mirrored through that descriptor.")
+    late = _markdown(unit_id, "Late distinct bytes remain reachable after reconciliation.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Retain a proposal-equivalent displaced inode on restart.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    service._write_recovery(row, before.encode(), 0o644, service._recovery_manifest_path(row))
+    editor_fd = os.open(source, os.O_RDWR)
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        service._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    os.lseek(editor_fd, 0, os.SEEK_SET)
+    os.write(editor_fd, after.encode())
+    os.ftruncate(editor_fd, len(after.encode()))
+    os.fsync(editor_fd)
+
+    try:
+        applied = await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Reconcile without unlinking an indistinguishable inode.",
+            ),
+        )
+        retained = workspace / swap_name
+        assert applied["status"] == "applied"
+        assert source.read_text() == after
+        assert retained.read_text() == after
+        assert retained.stat().st_ino == os.fstat(editor_fd).st_ino
+        os.lseek(editor_fd, 0, os.SEEK_SET)
+        os.write(editor_fd, late.encode())
+        os.ftruncate(editor_fd, len(late.encode()))
+        os.fsync(editor_fd)
+    finally:
+        os.close(editor_fd)
+    assert (workspace / swap_name).read_text() == late
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closing_action", ["apply", "reject", "supersede"])
+async def test_restart_external_target_with_retained_base_terminalizes(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    closing_action: str,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base retained beside an interrupted proposal.")
+    after = _markdown(unit_id, "Proposal visible before the process interruption.")
+    external = _markdown(unit_id, "External target installed after the interruption.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise terminal restart recovery.",
+        ),
+    )
+    row = await service._require_proposal_row(proposal["id"])
+    service._write_recovery(row, before.encode(), 0o644, service._recovery_manifest_path(row))
+    parent_fd, name = service._open_parent_fd(workspace, Path("main.md"))
+    swap_name = service._source_swap_name(proposal["id"])
+    try:
+        service._prepare_source_swap(parent_fd, swap_name, after.encode(), 0o644)
+        service._atomic_exchange_at(parent_fd, swap_name, parent_fd, name)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    source.write_text(external)
+
+    original_fsync = os.fsync
+    workspace_stat = workspace.stat()
+    source_directory_fsyncs = 0
+
+    def count_source_directory_fsync(fd: int) -> None:
+        nonlocal source_directory_fsyncs
+        target = os.fstat(fd)
+        if (
+            stat.S_ISDIR(target.st_mode)
+            and target.st_dev == workspace_stat.st_dev
+            and target.st_ino == workspace_stat.st_ino
+        ):
+            source_directory_fsyncs += 1
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", count_source_directory_fsync)
+    if closing_action == "apply":
+        with pytest.raises(ManuscriptSourceConflictError, match="recoverable apply"):
+            await service.apply_proposal(
+                proposal["id"],
+                ManuscriptSourceProposalTransition(
+                    expected_revision=1,
+                    actor="web_ui",
+                    reason="Close the restart state as conflicted.",
+                ),
+            )
+        prior = await service.get_proposal(proposal["id"])
+        assert prior["status"] == "conflicted"
+    elif closing_action == "reject":
+        prior = await service.reject_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Reject while retaining restart evidence.",
+            ),
+        )
+        assert prior["status"] == "rejected"
+    else:
+        successor = await service.create_proposal(
+            manuscript_id,
+            ManuscriptSourceProposalCreate(
+                origin="human",
+                relative_path="main.md",
+                expected_content_hash=_hash(external),
+                content=_markdown(unit_id, "Successor after retained restart evidence."),
+                created_by="web_ui",
+                reason="Supersede while retaining restart evidence.",
+                supersedes_proposal_id=proposal["id"],
+            ),
+        )
+        assert successor["status"] == "proposed"
+        prior = await service.get_proposal(proposal["id"])
+        assert prior["status"] == "superseded"
+
+    assert source_directory_fsyncs >= 1
+    assert source.read_text() == external
+    assert (workspace / swap_name).read_text() == before
+    assert prior["events"][-1]["details"]["source_recovery_state"] == "retained_base"
+    assert prior["events"][-1]["details"]["retained_source_path"] == swap_name
+
+
+@pytest.mark.asyncio
+async def test_atomic_replace_never_unlinks_an_unowned_source_swap(
+    db_with_project,
+    tmp_path: Path,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before an unowned recovery object.")
+    after = _markdown(unit_id, "Proposal must not delete the unowned object.")
+    unexpected = _markdown(unit_id, "Unowned recovery bytes remain inspectable.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Reject an unowned deterministic recovery object.",
+        ),
+    )
+    swap = workspace / service._source_swap_name(proposal["id"])
+    swap.write_text(unexpected)
+    with pytest.raises(ManuscriptSourceSecurityError, match="does not match"):
+        service._atomic_replace(
+            workspace,
+            "main.md",
+            after.encode(),
+            0o644,
+            proposal_id=proposal["id"],
+            expected_content_hash=_hash(before),
+        )
+    assert source.read_text() == before
+    assert swap.read_text() == unexpected
+
+
+@pytest.mark.asyncio
+async def test_proposal_swap_mutation_at_exchange_is_restored_and_retained(
+    db_with_project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, manuscript_id, workspace, unit_id = await _source_fixture(
+        db_with_project, tmp_path
+    )
+    before = _markdown(unit_id, "Base before proposal-swap mutation.")
+    after = _markdown(unit_id, "Proposal before boundary mutation.")
+    external = _markdown(unit_id, "External bytes injected into the proposal inode.")
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await service.create_proposal(
+        manuscript_id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=_hash(before),
+            content=after,
+            created_by="web_ui",
+            reason="Exercise mutation between proposal validation and exchange.",
+        ),
+    )
+    swap_name = service._source_swap_name(proposal["id"])
+    original_exchange = service._atomic_exchange_at
+    injected = False
+
+    def mutate_before_exchange(*args) -> None:
+        nonlocal injected
+        if not injected:
+            injected = True
+            swap_fd = os.open(swap_name, os.O_WRONLY, dir_fd=args[0])
+            try:
+                os.write(swap_fd, external.encode())
+                os.ftruncate(swap_fd, len(external.encode()))
+                os.fsync(swap_fd)
+            finally:
+                os.close(swap_fd)
+        original_exchange(*args)
+
+    monkeypatch.setattr(service, "_atomic_exchange_at", mutate_before_exchange)
+    with pytest.raises(ManuscriptSourceConflictError, match="proposal swap changed"):
+        await service.apply_proposal(
+            proposal["id"],
+            ManuscriptSourceProposalTransition(
+                expected_revision=1,
+                actor="web_ui",
+                reason="Restore the prior target and retain injected bytes.",
+            ),
+        )
+    retained = workspace / swap_name
+    assert source.read_text() == before
+    assert retained.read_text() == external
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
+    assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
+        "retained_unclassified"
+    )
+    assert conflicted["events"][-1]["details"]["retained_source_path"] == swap_name
 
 
 @pytest.mark.asyncio
@@ -926,7 +1327,12 @@ async def test_reject_and_supersede_fsync_prior_rollback_state_before_closing(
         assert (await service.get_proposal(proposal["id"]))["status"] == "superseded"
     assert source_directory_fsyncs >= 1
     assert source.read_text() == external
-    assert not swap.exists()
+    assert swap.read_text() == after
+    prior = await service.get_proposal(proposal["id"])
+    assert prior["events"][-1]["details"]["source_recovery_state"] == (
+        "retained_proposal"
+    )
+    assert prior["events"][-1]["details"]["retained_source_path"] == swap.name
 
 
 @pytest.mark.asyncio
@@ -1083,8 +1489,12 @@ async def test_retry_restores_external_file_displaced_by_interrupted_exchange(
             ),
         )
     assert source.read_text() == external
-    assert (await service.get_proposal(proposal["id"]))["status"] == "conflicted"
-    assert not (workspace / swap_name).exists()
+    conflicted = await service.get_proposal(proposal["id"])
+    assert conflicted["status"] == "conflicted"
+    assert (workspace / swap_name).read_text() == after
+    assert conflicted["events"][-1]["details"]["source_recovery_state"] == (
+        "retained_proposal"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_project.py
+++ b/tests/test_services/test_project.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from rka.infra.ids import generate_id
 from rka.models.project import ProjectCreate
 from rka.models.claim import ClaimCreate, ClaimScopeCondition, ClaimScopeWrite
 from rka.models.interpretation import InterpretationCandidateCreate
@@ -473,6 +474,87 @@ async def test_delete_project_removes_only_service_owned_knowledge_pack_dir(
     assert not project_pack_dir.exists()
     assert (sibling_dir / "keep.bin").read_bytes() == b"keep"
     assert external_artifact.read_text(encoding="utf-8") == "user-owned"
+
+
+@pytest.mark.asyncio
+async def test_delete_project_removes_source_proposals_and_owned_recovery(db) -> None:
+    svc = ProjectService(db)
+    project_id = "proj_delete_source_recovery"
+    await svc.create_project(
+        ProjectCreate(id=project_id, name="Delete Source Recovery"),
+        actor="system",
+    )
+    manuscript_id = generate_id("manuscript")
+    proposal_id = generate_id("manuscript_source_proposal")
+    await db.execute(
+        """INSERT INTO manuscripts
+           (id, project_id, title, phase, state)
+           VALUES (?, ?, 'Source cleanup', 'planning', 'active')""",
+        [manuscript_id, project_id],
+    )
+    await db.execute(
+        """INSERT INTO manuscript_source_proposals
+           (id, project_id, manuscript_id, origin, relative_path, source_format,
+            base_content_hash, proposed_content, proposed_content_hash,
+            created_by, reason, boundary)
+           VALUES (?, ?, ?, 'human', 'main.md', 'markdown', ?, 'after', ?,
+                   'web_ui', 'Cleanup fixture.', 'none')""",
+        [proposal_id, project_id, manuscript_id, "a" * 64, "b" * 64],
+    )
+    await db.execute(
+        """INSERT INTO manuscript_source_events
+           (id, proposal_id, project_id, proposal_revision, action, actor, reason)
+           VALUES (?, ?, ?, 1, 'proposed', 'web_ui', 'Cleanup fixture.')""",
+        [generate_id("manuscript_source_event"), proposal_id, project_id],
+    )
+    await db.commit()
+    recovery = (
+        Path(db.db_path).resolve().parent
+        / "manuscript-source-recovery"
+        / project_id
+        / manuscript_id
+        / proposal_id
+    )
+    recovery.mkdir(parents=True)
+    (recovery / "manifest.json").write_text("{}")
+
+    preview = await svc.delete_project(project_id, confirm=False)
+    assert preview["entity_counts"]["manuscript_source_proposals"] == 1
+    assert preview["entity_counts"]["manuscript_source_events"] == 1
+    assert recovery.exists()
+
+    result = await svc.delete_project(project_id, confirm=True)
+    assert result["manuscript_source_recovery_cleanup"]["status"] == "deleted"
+    assert not recovery.parents[1].exists()
+    assert await db.fetchone(
+        "SELECT id FROM manuscript_source_proposals WHERE id = ?", [proposal_id]
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_project_rejects_symlinked_source_recovery_dir(
+    db,
+    tmp_path: Path,
+) -> None:
+    svc = ProjectService(db)
+    project_id = "proj_symlink_source_recovery"
+    await svc.create_project(
+        ProjectCreate(id=project_id, name="Symlink Source Recovery"),
+        actor="system",
+    )
+    external = tmp_path / "external-recovery"
+    external.mkdir()
+    marker = external / "keep.bin"
+    marker.write_bytes(b"keep")
+    recovery_root = Path(db.db_path).resolve().parent / "manuscript-source-recovery"
+    recovery_root.mkdir()
+    (recovery_root / project_id).symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symbolic link"):
+        await svc.delete_project(project_id, confirm=True)
+
+    assert marker.read_bytes() == b"keep"
+    assert await db.fetchone("SELECT id FROM projects WHERE id = ?", [project_id])
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_project.py
+++ b/tests/test_services/test_project.py
@@ -12,7 +12,10 @@ import pytest
 from rka.config import RKAConfig
 from rka.infra.ids import generate_id
 from rka.models.manuscript_native import ManuscriptCreate
-from rka.models.manuscript_source import ManuscriptSourceProposalCreate
+from rka.models.manuscript_source import (
+    ManuscriptSourceProposalCreate,
+    ManuscriptSourceProposalTransition,
+)
 from rka.models.project import ProjectCreate
 from rka.models.claim import ClaimCreate, ClaimScopeCondition, ClaimScopeWrite
 from rka.models.interpretation import InterpretationCandidateCreate
@@ -535,6 +538,82 @@ async def test_delete_project_removes_source_proposals_and_owned_recovery(db) ->
     assert await db.fetchone(
         "SELECT id FROM manuscript_source_proposals WHERE id = ?", [proposal_id]
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_project_reports_retained_source_adjacent_artifact(
+    db,
+    tmp_path: Path,
+) -> None:
+    projects = ProjectService(db)
+    project_id = "proj_delete_retained_source"
+    await projects.create_project(
+        ProjectCreate(id=project_id, name="Delete Retained Source"),
+        actor="system",
+    )
+    workspace = tmp_path / "retained-source-workspace"
+    workspace.mkdir()
+    manuscript = await NativeManuscriptService(db, project_id=project_id).create(
+        ManuscriptCreate(title="Retained source", workspace_ref=str(workspace)),
+        actor="pi",
+    )
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path(db.db_path),
+        data_dir=tmp_path / "data",
+        llm_enabled=False,
+        embeddings_enabled=False,
+        manuscript_workspace_roots=str(tmp_path),
+    )
+    sources = ManuscriptSourceService(db, config=config, project_id=project_id)
+    before = "# Retained source base\n"
+    after = "# Retained source proposal\n"
+    source = workspace / "main.md"
+    source.write_text(before)
+    proposal = await sources.create_proposal(
+        manuscript.id,
+        ManuscriptSourceProposalCreate(
+            origin="human",
+            relative_path="main.md",
+            expected_content_hash=hashlib.sha256(before.encode()).hexdigest(),
+            content=after,
+            created_by="web_ui",
+            reason="Create a source-adjacent retained inode.",
+        ),
+    )
+    applied = await sources.apply_proposal(
+        proposal["id"],
+        ManuscriptSourceProposalTransition(
+            expected_revision=1,
+            actor="web_ui",
+            reason="Apply before project deletion.",
+        ),
+    )
+    retained = workspace / sources._source_swap_name(proposal["id"])
+    assert applied["status"] == "applied"
+    assert retained.read_text() == before
+
+    preview = await projects.delete_project(project_id, confirm=False)
+    report = preview["retained_workspace_artifacts"]
+    assert report["status"] == "manual_review_required"
+    assert report["auto_deleted"] is False
+    assert report["items"] == [
+        {
+            "proposal_id": proposal["id"],
+            "manuscript_id": manuscript.id,
+            "proposal_status": "applied",
+            "workspace_ref": str(workspace),
+            "source_relative_path": "main.md",
+            "retained_relative_path": retained.name,
+        }
+    ]
+
+    result = await projects.delete_project(project_id, confirm=True)
+    assert result["retained_workspace_artifacts"] == report
+    assert "intentionally retained" in result["message"]
+    assert retained.read_text() == before
+    managed = Path(db.db_path).resolve().parent / "manuscript-source-recovery" / project_id
+    assert not managed.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_project.py
+++ b/tests/test_services/test_project.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import sqlite3
 from pathlib import Path
 
 import pytest
 
+from rka.config import RKAConfig
 from rka.infra.ids import generate_id
+from rka.models.manuscript_native import ManuscriptCreate
+from rka.models.manuscript_source import ManuscriptSourceProposalCreate
 from rka.models.project import ProjectCreate
 from rka.models.claim import ClaimCreate, ClaimScopeCondition, ClaimScopeWrite
 from rka.models.interpretation import InterpretationCandidateCreate
@@ -17,6 +21,8 @@ from rka.models.planning import PlanningArtifactVersionAppend, PlanningBranchCre
 from rka.services.claims import ClaimService
 from rka.services.experiments import ExperimentService
 from rka.services.interpretation import InterpretationService
+from rka.services.manuscript_native import NativeManuscriptService
+from rka.services.manuscript_source import ManuscriptSourceService
 from rka.services.planning import ManuscriptPlanningService
 from rka.services.project import ProjectService
 
@@ -529,6 +535,67 @@ async def test_delete_project_removes_source_proposals_and_owned_recovery(db) ->
     assert await db.fetchone(
         "SELECT id FROM manuscript_source_proposals WHERE id = ?", [proposal_id]
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_project_removes_service_created_source_supersession_chain(
+    db,
+    tmp_path: Path,
+) -> None:
+    projects = ProjectService(db)
+    project_id = "proj_delete_source_chain"
+    await projects.create_project(
+        ProjectCreate(id=project_id, name="Delete Source Chain"),
+        actor="system",
+    )
+    workspace = tmp_path / "source-chain-workspace"
+    workspace.mkdir()
+    manuscript = await NativeManuscriptService(db, project_id=project_id).create(
+        ManuscriptCreate(title="Source chain", workspace_ref=str(workspace)),
+        actor="pi",
+    )
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path(db.db_path),
+        data_dir=tmp_path / "data",
+        llm_enabled=False,
+        embeddings_enabled=False,
+        manuscript_workspace_roots=str(tmp_path),
+    )
+    sources = ManuscriptSourceService(db, config=config, project_id=project_id)
+    before = "# Source chain\n"
+    source = workspace / "main.md"
+    source.write_text(before)
+    expected_hash = hashlib.sha256(before.encode()).hexdigest()
+
+    previous_id = None
+    proposal_ids = []
+    for index in range(3):
+        proposal = await sources.create_proposal(
+            manuscript.id,
+            ManuscriptSourceProposalCreate(
+                origin="human",
+                relative_path="main.md",
+                expected_content_hash=expected_hash,
+                content=f"# Source chain proposal {index}\n",
+                created_by="web_ui",
+                reason=f"Create supersession history {index}.",
+                supersedes_proposal_id=previous_id,
+            ),
+        )
+        previous_id = proposal["id"]
+        proposal_ids.append(proposal["id"])
+
+    preview = await projects.delete_project(project_id, confirm=False)
+    assert preview["entity_counts"]["manuscript_source_proposals"] == 3
+    assert preview["entity_counts"]["manuscript_source_events"] == 5
+
+    result = await projects.delete_project(project_id, confirm=True)
+    assert result["confirmed"] is True
+    for proposal_id in proposal_ids:
+        assert await db.fetchone(
+            "SELECT id FROM manuscript_source_proposals WHERE id = ?", [proposal_id]
+        ) is None
 
 
 @pytest.mark.asyncio

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -169,6 +169,10 @@ import type {
   ManuscriptReadiness,
   ManuscriptSpine,
   ManuscriptOutline,
+  ManuscriptSourceFile,
+  ManuscriptSourceOverview,
+  ManuscriptSourceProposal,
+  ManuscriptSourceProposalCreate,
   OutlineProposalRequest,
   OutlineProposalResult,
   ManuscriptWritingCandidates,
@@ -560,6 +564,39 @@ export const api = {
   getManuscriptImpact: (manuscriptId: string, sinceCursor = 0, limit = 100) =>
     get<ManuscriptImpact>(
       `/manuscripts/${encodeURIComponent(manuscriptId)}/impact?since_cursor=${sinceCursor}&limit=${limit}`,
+    ),
+  getManuscriptSourceOverview: (manuscriptId: string) =>
+    get<ManuscriptSourceOverview>(
+      `/manuscripts/${encodeURIComponent(manuscriptId)}/source`,
+    ),
+  readManuscriptSource: (manuscriptId: string, relativePath: string) =>
+    post<ManuscriptSourceFile>(
+      `/manuscripts/${encodeURIComponent(manuscriptId)}/source/read`,
+      { relative_path: relativePath },
+    ),
+  listManuscriptSourceProposals: (manuscriptId: string) =>
+    get<ManuscriptSourceProposal[]>(
+      `/manuscripts/${encodeURIComponent(manuscriptId)}/source/proposals`,
+    ),
+  getManuscriptSourceProposal: (proposalId: string) =>
+    get<ManuscriptSourceProposal>(
+      `/manuscript-source-proposals/${encodeURIComponent(proposalId)}`,
+    ),
+  createManuscriptSourceProposal: (
+    manuscriptId: string,
+    data: ManuscriptSourceProposalCreate,
+  ) => post<ManuscriptSourceProposal>(
+    `/manuscripts/${encodeURIComponent(manuscriptId)}/source/proposals`, data,
+  ),
+  applyManuscriptSourceProposal: (proposalId: string, expectedRevision: number, reason: string) =>
+    post<ManuscriptSourceProposal>(
+      `/manuscript-source-proposals/${encodeURIComponent(proposalId)}/apply`,
+      { expected_revision: expectedRevision, actor: "web_ui", reason },
+    ),
+  rejectManuscriptSourceProposal: (proposalId: string, expectedRevision: number, reason: string) =>
+    post<ManuscriptSourceProposal>(
+      `/manuscript-source-proposals/${encodeURIComponent(proposalId)}/reject`,
+      { expected_revision: expectedRevision, actor: "web_ui", reason },
     ),
 
   // Versioned, provisional workbench deliberation. These writes never mutate

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1084,6 +1084,138 @@ export interface ManuscriptOutline {
   }
 }
 
+// ---- Local manuscript Markdown/LaTeX source synchronization ----
+
+export interface ManuscriptSourceFinding {
+  severity: "error" | "warning"
+  code: string
+  message: string
+  unit_id?: string
+  line?: number
+  kind?: "claim" | "evidence" | "citation"
+  value?: string
+}
+
+export interface ManuscriptSourceAnchor {
+  unit_id: string
+  start_line: number
+  content_start_line: number
+  content_end_line: number
+  end_line: number
+  content_hash: string
+}
+
+export interface ManuscriptSourceProvenance {
+  unit_id: string
+  kind: "claim" | "evidence" | "citation"
+  value: string
+  line: number
+  verified: boolean
+}
+
+export interface ManuscriptSourceFile {
+  schema_version: "rka.manuscript-source/v1"
+  project_id: string
+  manuscript_id: string
+  relative_path: string
+  source_format: "markdown" | "latex"
+  content: string
+  content_hash: string
+  size_bytes: number
+  mode: number
+  anchors: ManuscriptSourceAnchor[]
+  provenance: ManuscriptSourceProvenance[]
+  findings: ManuscriptSourceFinding[]
+}
+
+export interface ManuscriptSourceOverview {
+  schema_version: "rka.manuscript-source/v1"
+  project_id: string
+  manuscript_id: string
+  workspace_ref: string
+  files: Array<{
+    relative_path: string
+    source_format: "markdown" | "latex"
+    content_hash: string
+    size_bytes: number
+    anchor_count: number
+    finding_count: number
+    blocking: boolean
+  }>
+  warnings: Array<{ relative_path?: string; code: string; message: string }>
+  quick_reader: Array<{
+    unit_id: string
+    local_key: string
+    title: string | null
+    communicative_job: string | null
+    intended_takeaway: string | null
+    quick_reader_role: string | null
+    anchors: Array<{
+      relative_path: string
+      start_line: number
+      end_line: number
+      content_hash: string
+    }>
+    anchor_state: "linked" | "missing"
+  }>
+  private_reviewer_risks: Array<{
+    kind: string
+    unit_id: string
+    message: string
+    claim_id?: string
+    evidence_claim_id?: string
+    citation_key?: string
+    content?: string | null
+    items?: string[]
+    verification_state?: string
+    verification_current?: boolean
+  }>
+  public_private_boundary: {
+    draft_source: string
+    private_reviewer_risks: string
+  }
+}
+
+export interface ManuscriptSourceProposal {
+  schema_version: "rka.manuscript-source-proposal/v1"
+  id: string
+  project_id: string
+  manuscript_id: string
+  status: "proposed" | "applied" | "rejected" | "conflicted" | "superseded" | "expired"
+  revision: number
+  origin: "human" | "host_agent" | "lm_studio"
+  relative_path: string
+  source_format: "markdown" | "latex"
+  base_content_hash: string | null
+  proposed_content?: string
+  proposed_content_hash: string
+  created_by: "pi" | "brain" | "executor" | "web_ui"
+  reason: string
+  validation_findings: ManuscriptSourceFinding[]
+  recovery_manifest_path: string | null
+  created_at: string
+  updated_at: string
+  events?: Array<{
+    id: string
+    proposal_revision: number
+    action: string
+    actor: string
+    reason: string
+    details: Record<string, unknown>
+    created_at: string
+  }>
+}
+
+export interface ManuscriptSourceProposalCreate {
+  origin: "human"
+  relative_path: string
+  expected_content_hash: string | null
+  content: string
+  created_by: "web_ui"
+  reason: string
+  supersedes_proposal_id?: string
+}
+
 export interface OutlineUnitPatch {
   title?: string | null
   location?: string

--- a/web/src/components/workbench/SourceSyncPanel.tsx
+++ b/web/src/components/workbench/SourceSyncPanel.tsx
@@ -170,11 +170,12 @@ function SourceFileWorkspace({
   sources: ReturnType<typeof useManuscriptSources>
 }) {
   const [draft, setDraft] = useState(snapshot.content)
+  const [loadedContent, setLoadedContent] = useState(snapshot.content)
   const [loadedHash, setLoadedHash] = useState(snapshot.content_hash)
   const [dirty, setDirty] = useState(false)
-  const [externalConflict, setExternalConflict] = useState(false)
   const [reason, setReason] = useState("Revise the public source while preserving the reviewed manuscript-unit boundary.")
   const [reviewedProposal, setReviewedProposal] = useState<ManuscriptSourceProposal | null>(null)
+  const externalConflict = dirty && snapshot.content_hash !== loadedHash
 
   const checkExternal = async () => {
     const result = await sources.file.refetch()
@@ -184,13 +185,12 @@ function SourceFileWorkspace({
       return
     }
     if (dirty) {
-      setExternalConflict(true)
       toast.warning("External edit detected; your unsent draft was preserved")
       return
     }
     setDraft(current.content)
+    setLoadedContent(current.content)
     setLoadedHash(current.content_hash)
-    setExternalConflict(false)
     toast.success("Reloaded the external source change")
   }
 
@@ -198,9 +198,9 @@ function SourceFileWorkspace({
     const current = sources.file.data
     if (!current) return
     setDraft(current.content)
+    setLoadedContent(current.content)
     setLoadedHash(current.content_hash)
     setDirty(false)
-    setExternalConflict(false)
   }
 
   const prepare = async () => {
@@ -228,10 +228,11 @@ function SourceFileWorkspace({
         revision: proposal.revision,
         reason: "PI applied the reviewed source diff in the manuscript workbench.",
       })
-      if (applied.proposed_content !== undefined) setDraft(applied.proposed_content)
+      const appliedContent = applied.proposed_content ?? draft
+      setDraft(appliedContent)
+      setLoadedContent(appliedContent)
       setLoadedHash(applied.proposed_content_hash)
       setDirty(false)
-      setExternalConflict(false)
       setReviewedProposal(null)
       toast.success("Source file replaced atomically; recovery metadata was retained")
     } catch (error) {
@@ -288,7 +289,7 @@ function SourceFileWorkspace({
             value={draft}
             onChange={(event) => {
               setDraft(event.target.value)
-              setDirty(event.target.value !== snapshot.content)
+              setDirty(event.target.value !== loadedContent)
             }}
           />
         </div>

--- a/web/src/components/workbench/SourceSyncPanel.tsx
+++ b/web/src/components/workbench/SourceSyncPanel.tsx
@@ -169,12 +169,20 @@ function SourceFileWorkspace({
   pending: ManuscriptSourceProposal[]
   sources: ReturnType<typeof useManuscriptSources>
 }) {
-  const [draft, setDraft] = useState(snapshot.content)
-  const [loadedContent, setLoadedContent] = useState(snapshot.content)
-  const [loadedHash, setLoadedHash] = useState(snapshot.content_hash)
+  const [editor, setEditor] = useState({
+    draft: snapshot.content,
+    loadedContent: snapshot.content,
+    loadedHash: snapshot.content_hash,
+  })
   const [dirty, setDirty] = useState(false)
   const [reason, setReason] = useState("Revise the public source while preserving the reviewed manuscript-unit boundary.")
   const [reviewedProposal, setReviewedProposal] = useState<ManuscriptSourceProposal | null>(null)
+  // A clean editor follows background snapshots directly. Once the researcher
+  // types, freeze the exact base content/hash alongside the draft so polling can
+  // reveal a conflict without replacing unsent work.
+  const draft = dirty ? editor.draft : snapshot.content
+  const loadedContent = dirty ? editor.loadedContent : snapshot.content
+  const loadedHash = dirty ? editor.loadedHash : snapshot.content_hash
   const externalConflict = dirty && snapshot.content_hash !== loadedHash
 
   const checkExternal = async () => {
@@ -188,18 +196,23 @@ function SourceFileWorkspace({
       toast.warning("External edit detected; your unsent draft was preserved")
       return
     }
-    setDraft(current.content)
-    setLoadedContent(current.content)
-    setLoadedHash(current.content_hash)
+    setEditor({
+      draft: current.content,
+      loadedContent: current.content,
+      loadedHash: current.content_hash,
+    })
+    setDirty(false)
     toast.success("Reloaded the external source change")
   }
 
   const reloadCurrent = () => {
     const current = sources.file.data
     if (!current) return
-    setDraft(current.content)
-    setLoadedContent(current.content)
-    setLoadedHash(current.content_hash)
+    setEditor({
+      draft: current.content,
+      loadedContent: current.content,
+      loadedHash: current.content_hash,
+    })
     setDirty(false)
   }
 
@@ -229,9 +242,11 @@ function SourceFileWorkspace({
         reason: "PI applied the reviewed source diff in the manuscript workbench.",
       })
       const appliedContent = applied.proposed_content ?? draft
-      setDraft(appliedContent)
-      setLoadedContent(appliedContent)
-      setLoadedHash(applied.proposed_content_hash)
+      setEditor({
+        draft: appliedContent,
+        loadedContent: appliedContent,
+        loadedHash: applied.proposed_content_hash,
+      })
       setDirty(false)
       setReviewedProposal(null)
       toast.success("Source file replaced atomically; recovery metadata was retained")
@@ -288,8 +303,13 @@ function SourceFileWorkspace({
             spellCheck={false}
             value={draft}
             onChange={(event) => {
-              setDraft(event.target.value)
-              setDirty(event.target.value !== loadedContent)
+              const nextDraft = event.target.value
+              setEditor({
+                draft: nextDraft,
+                loadedContent,
+                loadedHash,
+              })
+              setDirty(nextDraft !== loadedContent)
             }}
           />
         </div>

--- a/web/src/components/workbench/SourceSyncPanel.tsx
+++ b/web/src/components/workbench/SourceSyncPanel.tsx
@@ -1,0 +1,410 @@
+import { useMemo, useState } from "react"
+import { AlertTriangle, CheckCircle2, FileCode2, RefreshCw, Save, ShieldAlert, XCircle } from "lucide-react"
+import { toast } from "sonner"
+
+import { Markdown } from "@/components/shared/Markdown"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import { useManuscriptSources } from "@/hooks/useManuscriptSources"
+import type { ManuscriptSourceFile, ManuscriptSourceProposal } from "@/api/types"
+
+
+export function SourceSyncPanel({ manuscriptId }: { manuscriptId: string }) {
+  const [relativePath, setRelativePath] = useState<string | null>(null)
+  const sources = useManuscriptSources(manuscriptId, relativePath)
+
+  const pending = useMemo(
+    () => (sources.proposals.data ?? []).filter(
+      (proposal) => proposal.status === "proposed" && proposal.relative_path === sources.relativePath,
+    ),
+    [sources.proposals.data, sources.relativePath],
+  )
+
+  if (sources.overview.isLoading) {
+    return <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">Loading local manuscript sources…</div>
+  }
+  if (sources.overview.error) {
+    return (
+      <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+        <p className="font-medium">Local source synchronization is unavailable</p>
+        <p className="mt-1 text-xs opacity-80">{sources.overview.error.message}</p>
+        <p className="mt-2 text-xs opacity-80">
+          Set an existing manuscript workspace and explicitly allow its server-side root with <code>RKA_MANUSCRIPT_WORKSPACE_ROOTS</code>. Workspace metadata alone never grants file access.
+        </p>
+      </div>
+    )
+  }
+
+  const overview = sources.overview.data
+  if (!overview) return null
+
+  return (
+    <section className="min-w-0 space-y-3 rounded-lg border bg-card p-4" aria-labelledby="source-sync-heading">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <FileCode2 className="h-4 w-4" />
+            <h3 id="source-sync-heading" className="font-semibold">Draft source synchronization</h3>
+            <Badge variant="outline">local web only</Badge>
+          </div>
+          <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
+            Markdown/LaTeX owns public prose; RKA owns claims, evidence, citations, and unit semantics. Preparing a change never writes the file. Apply is explicit, expected-hash guarded, recoverable, and performs no Git operation.
+          </p>
+        </div>
+        <code className="max-w-full truncate rounded bg-muted px-2 py-1 text-[10px]" title={overview.workspace_ref}>
+          {overview.workspace_ref}
+        </code>
+      </div>
+
+      <Tabs defaultValue="source" className="min-w-0">
+        <TabsList className="h-auto w-full flex-wrap justify-start">
+          <TabsTrigger value="source">Draft source</TabsTrigger>
+          <TabsTrigger value="quick">Quick reader</TabsTrigger>
+          <TabsTrigger value="risk">Reviewer risk (private)</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="source" className="space-y-3 pt-3">
+          {overview.files.length === 0 ? (
+            <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+              No visible `.md`, `.markdown`, or `.tex` file exists in this workspace. Create one with your normal editor, then refresh this view.
+            </div>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <label htmlFor="manuscript-source-file" className="text-xs font-medium">Source file</label>
+                <select
+                  id="manuscript-source-file"
+                  className="w-full min-w-0 rounded-md border bg-background px-2 py-1.5 text-sm sm:w-auto sm:min-w-64"
+                  value={sources.relativePath ?? ""}
+                  onChange={(event) => {
+                    setRelativePath(event.target.value)
+                  }}
+                >
+                  {overview.files.map((file) => (
+                    <option key={file.relative_path} value={file.relative_path}>{file.relative_path}</option>
+                  ))}
+                </select>
+                {sources.file.data && (
+                  <>
+                    <Badge variant="outline">{sources.file.data.source_format}</Badge>
+                    <code className="text-[10px] text-muted-foreground">sha256:{sources.file.data.content_hash.slice(0, 12)}</code>
+                    <Badge variant={sources.file.data.findings.some((item) => item.severity === "error") ? "destructive" : "secondary"}>
+                      {sources.file.data.anchors.length} unit anchor{sources.file.data.anchors.length === 1 ? "" : "s"}
+                    </Badge>
+                  </>
+                )}
+              </div>
+
+              {sources.file.isLoading ? (
+                <p className="text-sm text-muted-foreground">Reading source…</p>
+              ) : sources.file.error ? (
+                <p className="rounded border border-red-300 bg-red-50 p-3 text-xs text-red-900">{sources.file.error.message}</p>
+              ) : sources.file.data ? (
+                <SourceFileWorkspace
+                  key={sources.file.data.relative_path}
+                  snapshot={sources.file.data}
+                  pending={pending}
+                  sources={sources}
+                />
+              ) : null}
+            </>
+          )}
+        </TabsContent>
+
+        <TabsContent value="quick" className="space-y-2 pt-3">
+          <p className="text-xs text-muted-foreground">This scan shows the fast-reader argument path and whether each stable `mun_` unit has a public source range.</p>
+          {overview.quick_reader.map((unit, index) => (
+            <div key={unit.unit_id} className="rounded-md border p-3 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">{index + 1}</Badge>
+                <strong>{unit.local_key}</strong>
+                <code className="break-all text-[10px] text-muted-foreground">{unit.unit_id}</code>
+                <Badge variant={unit.anchor_state === "linked" ? "secondary" : "destructive"}>{unit.anchor_state}</Badge>
+              </div>
+              <p className="mt-2"><strong>Job:</strong> {unit.communicative_job || "Not specified"}</p>
+              <p className="mt-1"><strong>Takeaway:</strong> {unit.intended_takeaway || "Not specified"}</p>
+              <p className="mt-1 text-xs text-muted-foreground"><strong>Quick-reader role:</strong> {unit.quick_reader_role || "Not specified"}</p>
+              {unit.anchors.map((anchor) => (
+                <p key={`${anchor.relative_path}:${anchor.start_line}`} className="mt-1 font-mono text-[10px] text-muted-foreground">
+                  {anchor.relative_path}:{anchor.start_line}-{anchor.end_line} · sha256:{anchor.content_hash.slice(0, 12)}
+                </p>
+              ))}
+            </div>
+          ))}
+        </TabsContent>
+
+        <TabsContent value="risk" className="space-y-3 pt-3">
+          <div className="rounded-md border border-purple-300 bg-purple-50 p-3 text-xs text-purple-950 dark:border-purple-900 dark:bg-purple-950 dark:text-purple-100">
+            <div className="flex items-center gap-2 font-medium"><ShieldAlert className="h-4 w-4" /> Private reviewer-risk workspace</div>
+            <p className="mt-1 opacity-80">These boundaries, qualifiers, counterevidence, and citation warnings inform strategy. This projection cannot insert them into public source automatically.</p>
+          </div>
+          {overview.private_reviewer_risks.length === 0 ? (
+            <p className="rounded border border-dashed p-4 text-sm text-muted-foreground">No typed private risks are currently projected. This is not proof that the manuscript has no weaknesses.</p>
+          ) : overview.private_reviewer_risks.map((risk, index) => (
+            <div key={`${risk.kind}:${risk.unit_id}:${risk.claim_id ?? risk.evidence_claim_id ?? risk.citation_key ?? index}`} className="rounded-md border p-3 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">{risk.kind.replaceAll("_", " ")}</Badge>
+                <code className="break-all text-[10px] text-muted-foreground">{risk.unit_id}</code>
+              </div>
+              <p className="mt-2">{risk.message}</p>
+              {risk.content && <p className="mt-1 text-xs text-muted-foreground">{risk.content}</p>}
+              {risk.items?.map((item) => <p key={item} className="mt-1 text-xs text-muted-foreground">• {item}</p>)}
+            </div>
+          ))}
+        </TabsContent>
+      </Tabs>
+    </section>
+  )
+}
+
+
+function SourceFileWorkspace({
+  snapshot,
+  pending,
+  sources,
+}: {
+  snapshot: ManuscriptSourceFile
+  pending: ManuscriptSourceProposal[]
+  sources: ReturnType<typeof useManuscriptSources>
+}) {
+  const [draft, setDraft] = useState(snapshot.content)
+  const [loadedHash, setLoadedHash] = useState(snapshot.content_hash)
+  const [dirty, setDirty] = useState(false)
+  const [externalConflict, setExternalConflict] = useState(false)
+  const [reason, setReason] = useState("Revise the public source while preserving the reviewed manuscript-unit boundary.")
+  const [reviewedProposal, setReviewedProposal] = useState<ManuscriptSourceProposal | null>(null)
+
+  const checkExternal = async () => {
+    const result = await sources.file.refetch()
+    const current = result.data
+    if (!current || current.content_hash === loadedHash) {
+      toast.success("No external source change detected")
+      return
+    }
+    if (dirty) {
+      setExternalConflict(true)
+      toast.warning("External edit detected; your unsent draft was preserved")
+      return
+    }
+    setDraft(current.content)
+    setLoadedHash(current.content_hash)
+    setExternalConflict(false)
+    toast.success("Reloaded the external source change")
+  }
+
+  const reloadCurrent = () => {
+    const current = sources.file.data
+    if (!current) return
+    setDraft(current.content)
+    setLoadedHash(current.content_hash)
+    setDirty(false)
+    setExternalConflict(false)
+  }
+
+  const prepare = async () => {
+    if (!dirty || externalConflict) return
+    try {
+      const proposal = await sources.create.mutateAsync({
+        origin: "human",
+        relative_path: snapshot.relative_path,
+        expected_content_hash: loadedHash,
+        content: draft,
+        created_by: "web_ui",
+        reason,
+      })
+      setReviewedProposal(proposal)
+      toast.success("Source proposal prepared; the file is still unchanged")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not prepare source proposal")
+    }
+  }
+
+  const apply = async (proposal: ManuscriptSourceProposal) => {
+    try {
+      const applied = await sources.apply.mutateAsync({
+        proposalId: proposal.id,
+        revision: proposal.revision,
+        reason: "PI applied the reviewed source diff in the manuscript workbench.",
+      })
+      if (applied.proposed_content !== undefined) setDraft(applied.proposed_content)
+      setLoadedHash(applied.proposed_content_hash)
+      setDirty(false)
+      setExternalConflict(false)
+      setReviewedProposal(null)
+      toast.success("Source file replaced atomically; recovery metadata was retained")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not apply source proposal")
+    }
+  }
+
+  const reject = async (proposal: ManuscriptSourceProposal) => {
+    try {
+      await sources.reject.mutateAsync({
+        proposalId: proposal.id,
+        revision: proposal.revision,
+        reason: "PI rejected the proposed source wording after review.",
+      })
+      setReviewedProposal(null)
+      toast.success("Source proposal rejected; the file was not changed")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not reject source proposal")
+    }
+  }
+
+  const review = async (proposal: ManuscriptSourceProposal) => {
+    try {
+      setReviewedProposal(await sources.review.mutateAsync(proposal.id))
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not load source proposal")
+    }
+  }
+
+  return (
+    <>
+      <div className="flex justify-end">
+        <Button size="sm" variant="outline" onClick={() => void checkExternal()} disabled={sources.file.isFetching}>
+          <RefreshCw className="mr-1 h-3.5 w-3.5" /> Check external edits
+        </Button>
+      </div>
+      {externalConflict && (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded border border-red-300 bg-red-50 p-3 text-xs text-red-950 dark:border-red-900 dark:bg-red-950 dark:text-red-100">
+          <div>
+            <p className="font-medium">The file changed outside this editor</p>
+            <p className="mt-1 opacity-80">Your unsent draft is preserved. Reload the current file, compare manually, then prepare a new proposal.</p>
+          </div>
+          <Button size="sm" variant="outline" onClick={reloadCurrent}>Reload current file</Button>
+        </div>
+      )}
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <div className="space-y-1">
+          <label htmlFor="manuscript-source-editor" className="text-xs font-medium">Editable public source</label>
+          <Textarea
+            id="manuscript-source-editor"
+            className="min-h-[28rem] font-mono text-xs"
+            spellCheck={false}
+            value={draft}
+            onChange={(event) => {
+              setDraft(event.target.value)
+              setDirty(event.target.value !== snapshot.content)
+            }}
+          />
+        </div>
+        <div className="space-y-1">
+          <p className="text-xs font-medium">Non-authoritative preview</p>
+          <div className="min-h-[28rem] overflow-auto rounded-md border bg-background p-3">
+            {snapshot.source_format === "markdown" ? (
+              <Markdown>{draft}</Markdown>
+            ) : (
+              <pre className="whitespace-pre-wrap font-mono text-xs">{draft}</pre>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+        <label className="space-y-1 text-xs font-medium">
+          Proposal reason
+          <Textarea value={reason} onChange={(event) => setReason(event.target.value)} rows={2} />
+        </label>
+        <Button
+          className="self-end"
+          disabled={!dirty || externalConflict || !reason.trim() || sources.create.isPending}
+          onClick={() => void prepare()}
+        >
+          <Save className="mr-1 h-4 w-4" /> Prepare change
+        </Button>
+      </div>
+
+      {snapshot.findings.length > 0 && (
+        <details className="rounded-md border p-3 text-xs" open={snapshot.findings.some((item) => item.severity === "error")}>
+          <summary className="cursor-pointer font-medium">Current anchor and provenance diagnostics ({snapshot.findings.length})</summary>
+          <ul className="mt-2 space-y-1">
+            {snapshot.findings.map((finding, index) => (
+              <li key={`${finding.code}:${finding.line ?? index}`} className="flex items-start gap-2">
+                {finding.severity === "error" ? <XCircle className="mt-0.5 h-3.5 w-3.5 text-red-600" /> : <AlertTriangle className="mt-0.5 h-3.5 w-3.5 text-amber-600" />}
+                <span><strong>{finding.code}</strong>: {finding.message}{finding.line ? ` · line ${finding.line}` : ""}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {pending.length > 0 && (
+        <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-950 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100">
+          <p className="font-medium">Pending reviewed source changes</p>
+          {pending.map((proposal) => (
+            <div key={proposal.id} className="rounded border border-blue-200/70 bg-background/60 p-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <code>{proposal.id}</code>
+                  <p className="mt-1 opacity-80">{proposal.reason}</p>
+                  <p className="mt-1 font-mono text-[10px] opacity-70">{proposal.base_content_hash?.slice(0, 12)} → {proposal.proposed_content_hash.slice(0, 12)}</p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void review(proposal)}
+                  disabled={sources.review.isPending}
+                >
+                  Review source diff
+                </Button>
+              </div>
+            </div>
+          ))}
+          {reviewedProposal?.status === "proposed" && reviewedProposal.proposed_content !== undefined && (
+            <div className="space-y-3 rounded border border-blue-300 bg-background p-3" aria-live="polite">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-medium">Review before apply</p>
+                  <p className="mt-1 opacity-80">
+                    {reviewedProposal.origin.replaceAll("_", " ")} proposal · revision {reviewedProposal.revision}
+                  </p>
+                </div>
+                <code className="text-[10px]">{reviewedProposal.id}</code>
+              </div>
+              <div className="grid gap-3 lg:grid-cols-2">
+                <div>
+                  <p className="mb-1 font-medium">Current file</p>
+                  <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded border bg-muted/40 p-2 font-mono text-[11px]">{snapshot.content}</pre>
+                </div>
+                <div>
+                  <p className="mb-1 font-medium">Proposed file</p>
+                  <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded border bg-muted/40 p-2 font-mono text-[11px]">{reviewedProposal.proposed_content}</pre>
+                </div>
+              </div>
+              {reviewedProposal.validation_findings.length > 0 && (
+                <ul className="space-y-1">
+                  {reviewedProposal.validation_findings.map((finding, index) => (
+                    <li key={`${finding.code}:${finding.line ?? index}`}>
+                      <strong>{finding.code}</strong>: {finding.message}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void reject(reviewedProposal)}
+                  disabled={sources.reject.isPending}
+                >
+                  Reject
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => void apply(reviewedProposal)}
+                  disabled={sources.apply.isPending}
+                >
+                  <CheckCircle2 className="mr-1 h-3.5 w-3.5" /> Apply reviewed change
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/src/hooks/useManuscriptSources.ts
+++ b/web/src/hooks/useManuscriptSources.ts
@@ -16,6 +16,11 @@ export function useManuscriptSources(manuscriptId: string, relativePath: string 
     queryKey: [...rootKey, "file", effectiveRelativePath],
     queryFn: () => api.readManuscriptSource(manuscriptId, effectiveRelativePath!),
     enabled: Boolean(effectiveRelativePath),
+    // A researcher may edit the same source in another local editor while the
+    // workbench remains open. Poll only while this query is mounted; the editor
+    // derives a conflict from the returned hash without replacing an unsent draft.
+    refetchInterval: 10_000,
+    refetchIntervalInBackground: false,
   })
   const proposals = useQuery({
     queryKey: [...rootKey, "proposals"],

--- a/web/src/hooks/useManuscriptSources.ts
+++ b/web/src/hooks/useManuscriptSources.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/api/client"
+import type { ManuscriptSourceProposalCreate } from "@/api/types"
+import { useActiveProjectId } from "@/hooks/useProjectSelection"
+
+export function useManuscriptSources(manuscriptId: string, relativePath: string | null) {
+  const projectId = useActiveProjectId()
+  const queryClient = useQueryClient()
+  const rootKey = ["manuscript-sources", projectId, manuscriptId] as const
+  const overview = useQuery({
+    queryKey: [...rootKey, "overview"],
+    queryFn: () => api.getManuscriptSourceOverview(manuscriptId),
+  })
+  const effectiveRelativePath = relativePath ?? overview.data?.files[0]?.relative_path ?? null
+  const file = useQuery({
+    queryKey: [...rootKey, "file", effectiveRelativePath],
+    queryFn: () => api.readManuscriptSource(manuscriptId, effectiveRelativePath!),
+    enabled: Boolean(effectiveRelativePath),
+  })
+  const proposals = useQuery({
+    queryKey: [...rootKey, "proposals"],
+    queryFn: () => api.listManuscriptSourceProposals(manuscriptId),
+  })
+  const refresh = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: rootKey }),
+      queryClient.invalidateQueries({ queryKey: ["manuscript-workbench", projectId] }),
+    ])
+  }
+  const create = useMutation({
+    mutationFn: (data: ManuscriptSourceProposalCreate) =>
+      api.createManuscriptSourceProposal(manuscriptId, data),
+    onSuccess: refresh,
+  })
+  const review = useMutation({
+    mutationFn: (proposalId: string) => api.getManuscriptSourceProposal(proposalId),
+  })
+  const apply = useMutation({
+    mutationFn: ({ proposalId, revision, reason }: {
+      proposalId: string
+      revision: number
+      reason: string
+    }) => api.applyManuscriptSourceProposal(proposalId, revision, reason),
+    onSuccess: refresh,
+  })
+  const reject = useMutation({
+    mutationFn: ({ proposalId, revision, reason }: {
+      proposalId: string
+      revision: number
+      reason: string
+    }) => api.rejectManuscriptSourceProposal(proposalId, revision, reason),
+    onSuccess: refresh,
+  })
+  return {
+    overview,
+    file,
+    proposals,
+    create,
+    review,
+    apply,
+    reject,
+    rootKey,
+    relativePath: effectiveRelativePath,
+  }
+}

--- a/web/src/pages/ManuscriptWorkbench.tsx
+++ b/web/src/pages/ManuscriptWorkbench.tsx
@@ -19,6 +19,7 @@ import { ArgumentWorkflowPanel } from "@/components/workbench/ArgumentWorkflowPa
 import { PlanningBranchPanel } from "@/components/workbench/PlanningBranchPanel"
 import { SemanticPatchPanel } from "@/components/workbench/SemanticPatchPanel"
 import { OutlineEditor } from "@/components/workbench/OutlineEditor"
+import { SourceSyncPanel } from "@/components/workbench/SourceSyncPanel"
 import {
   EvidenceInspector,
   type WorkbenchTraceItem,
@@ -438,7 +439,10 @@ function StageCanvas({
         )}
         {stage === "evaluation" && <EvaluationView units={units} onInspect={onInspect} />}
         {stage === "outline" && outline && outline.units.length > 0 && (
-          <OutlineEditor key={`${outline.manuscript_id}:${outline.manuscript_revision}`} outline={outline} onInspect={onInspect} />
+          <>
+            <OutlineEditor key={`${outline.manuscript_id}:${outline.manuscript_revision}`} outline={outline} onInspect={onInspect} />
+            <SourceSyncPanel manuscriptId={outline.manuscript_id} />
+          </>
         )}
         {stage === "outline" && outline && outline.units.length === 0 && (
           <EmptyState title="No native manuscript units" detail="Create claim-sized units through a reviewed argument-spine proposal before elaborating the outline." />

--- a/wiki/Deployment-Main.md
+++ b/wiki/Deployment-Main.md
@@ -250,7 +250,7 @@ Two rows, both running:
 
 ```
 NAME         IMAGE     STATUS                   PORTS
-rka-server   rka-rka   Up X minutes (healthy)   0.0.0.0:9712->9712/tcp
+rka-server   rka-rka   Up X minutes (healthy)   127.0.0.1:9712->9712/tcp
 rka-worker   rka-rka   Up X minutes
 ```
 


### PR DESCRIPTION
## Outcome

Adds the bounded M5 PR 10 manuscript drafting workbench source-sync layer on top of PR #84:

- allowlisted Markdown/LaTeX workspace reads with stable manuscript-unit anchors;
- proposal/review/apply/reject/supersede workflow;
- exact provenance validation and separate private reviewer-risk projection;
- conflict-safe external-edit detection and atomic, durable filesystem transitions;
- retained recovery artifacts for crash/interleaving cases, including unsafe hidden objects that are never promoted into the public manuscript path;
- local-web-only mutation boundary and loopback-only Docker publication;
- source-sync workbench UI with explicit full-source review before Apply.

No embedded LLM, automatic Git operation, automatic merge, arbitrary macro expansion, or Word round trip is introduced.

Closes #61.

## Validation

- Focused migration/source/API/project/pack suite: **75 passed**
- MCP schema/model-drift suite: **994 passed**
- Full Python suite: **3,208 passed**
- Ruff, compileall, diff-check, Docker Compose validation: **passed**
- Web production build and changed-file ESLint: **passed**
- Disposable browser prepare/review/apply/restart/conflict/private-risk pilot: **passed**

## Independent audit

Exact commit `8cd33645ce7d560cf19c935b6621f9cbfbdc6f7f` was independently audited against `116f76b7f36f1725d2215dbfd820451545be4d0b`.

- Verdict: **merge-ready**
- P0/P1 findings: **none**
- Independent full suite: **3,208 passed**
- Adversarial symlink/FIFO/directory recovery, forced fsync failure/retry, successor creation/apply, and prior retained-inode regressions: **passed**

The detailed contract is in ADR 0011 and exact evidence is recorded in `docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md`.