### PR TITLE
feat(writer): synthesize evidence into coherent discourse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ All notable changes to RKA are documented here. Format loosely follows
   separates RKA's evidence graph from the manuscript's reader-facing discourse
   graph. Section drafting compresses records into evidence bundles, builds a
   logic ladder and paragraph plan, drafts clean prose, and attaches provenance
-  post-hoc. A sample-calibration workflow captures an author's positive style
-  without copying source text, while the AI-tic linter is explicitly limited
-  to negative surface checks rather than treated as a coherence score.
+  post-hoc. Lightweight style-profile and per-section discourse artifacts make
+  sample calibration, disclosure coverage, native-unit mapping, and fresh-
+  context review inspectable without adding a second knowledge base. A
+  structural validator enforces those handoffs without pretending to score
+  coherence, while the AI-tic linter remains a negative surface check.
 - **Typed academic-writing semantic core.** Manuscript units now separate pure
   outline depth from structural role and rhetorical move. Unit-evidence uses
   can state the supported proposition and authorial warrant; immutable claim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to RKA are documented here. Format loosely follows
 
 ### Added
 
+- **Writer discourse synthesis and plain academic style.** The Writer now
+  separates RKA's evidence graph from the manuscript's reader-facing discourse
+  graph. Section drafting compresses records into evidence bundles, builds a
+  logic ladder and paragraph plan, drafts clean prose, and attaches provenance
+  post-hoc. A sample-calibration workflow captures an author's positive style
+  without copying source text, while the AI-tic linter is explicitly limited
+  to negative surface checks rather than treated as a coherence score.
 - **Typed academic-writing semantic core.** Manuscript units now separate pure
   outline depth from structural role and rhetorical move. Unit-evidence uses
   can state the supported proposition and authorial warrant; immutable claim

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: rka-writer
-description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, then produces persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
+description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, synthesizes the research graph into a coherent logic ladder, and produces plain, persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
 metadata:
-  version: "2.7.3"
+  version: "2.7.4"
 ---
 
 # Writer Skill
@@ -30,6 +30,14 @@ only for custom alternatives, missing evidence, disagreements not covered by
 the choices, or exact wording corrections. Follow
 [`references/framing_elicitation.md`](references/framing_elicitation.md).
 
+Discourse Law: **the evidence graph constrains prose but does not organize
+it.** Never translate journals, claims, clusters, or manuscript units into
+sentences one by one. First compress them into reader-facing propositions,
+arrange a section-level logic ladder, and form coherent paragraphs. Draft
+plain academic prose from that discourse plan; attach provenance and citations
+afterward. Follow
+[`references/discourse_synthesis.md`](references/discourse_synthesis.md).
+
 The native claim spine is part of RKA's manuscript aggregate, not a second
 knowledge base or orchestrator. RKA is authoritative for manuscript identity,
 claim wording and versions, evidence roles, PI ratifications, units,
@@ -52,6 +60,9 @@ commands.
   mandatory noise-smoothing path from journal records through grounded claims,
   Brain-reviewed clusters and research questions, PI-scoped contribution
   candidates, native units, and drafting.
+- [`references/discourse_synthesis.md`](references/discourse_synthesis.md):
+  separation of evidence and discourse graphs, plain academic style target,
+  section logic ladders, paragraph formation, and post-hoc provenance.
 - [`references/persuasive_framing.md`](references/persuasive_framing.md):
   two-channel author/manuscript discipline, limitation materiality triage,
   strength-first defense patterns, and the quick-reader path.
@@ -169,6 +180,12 @@ findings (`PASS`, `WARN`, `BLOCK`, `ERROR`), never a numeric quality score.
 
 When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(args={"operation": "collect_report_context", "project_id": "prj_...", "query": <the PI's description>, "filters": {"angle_queries": [3-5 short queries from different angles]}})` to assemble the candidate node set: it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80 to 1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill section "Retrieval Strategy" (drive RKA through several calls, never one-shot it).
 
+Treat that node set as an evidence packet, not a prose plan. Merge duplicate or
+closely related records into evidence bundles, distill the few propositions
+the reader needs, and order them by the section's rhetorical logic. Do not
+preserve retrieval rank, record chronology, entity type, or unit boundaries in
+the public prose unless one of them is itself relevant to the argument.
+
 ---
 
 ## Source Attribution
@@ -285,6 +302,11 @@ may inherit only disclosed claim/evidence bindings; condensation unions those
 bindings into the retained parent before removing named descendants; reorder
 must contain the complete active unit-key set. Never reconstruct the outline
 by free-form delete-and-recreate operations.
+
+Outline depth and bindings support audit and change impact. They do not impose
+a one-unit-to-one-paragraph mapping. During drafting, group active units into
+paragraphs according to rhetorical continuity and the section-level logic
+ladder in `references/discourse_synthesis.md`.
 
 Outline work is resumable while blockers remain. Re-query
 `manuscript_outline` after every applied proposal. Create an Outline checkpoint
@@ -610,6 +632,12 @@ When a revised draft is available, compare it against the prior review comments 
 26. **DON'T** record a framing micro-selection as evidence, claim ratification,
    or a formal PI decision. Persist it in `FRAMING_SESSION.yaml` until final
    confirmation.
+27. **DON'T** turn the RKA graph into prose by iterating records, assigning one
+    sentence per source, or assigning one paragraph per claim or manuscript
+    unit. Build and draft from a reader-facing discourse plan.
+28. **DON'T** treat provenance coverage or an AI-tic score as evidence of
+    coherence. Verify the logic ladder, paragraph bridges, and section
+    takeaway before surface polishing.
 
 ---
 
@@ -623,6 +651,8 @@ When a revised draft is available, compare it against the prior review comments 
   [`references/framing_elicitation.md`](references/framing_elicitation.md).
 - Persuasive framing, limitation triage, and quick-reader guidance:
   [`references/persuasive_framing.md`](references/persuasive_framing.md).
+- Discourse synthesis, plain academic style, and paragraph construction:
+  [`references/discourse_synthesis.md`](references/discourse_synthesis.md).
 - Implemented reference validation pipeline: [`references/reference_pipeline.md`](references/reference_pipeline.md).
 - Anti-AI-tic full tier table, replacements, structural detectors: [`references/ai_tics.md`](references/ai_tics.md).
 - Venue files: [`references/venue/CHI.md`](references/venue/CHI.md), [`references/venue/EMNLP.md`](references/venue/EMNLP.md).

--- a/plugin/skills/writer/SKILL.md
+++ b/plugin/skills/writer/SKILL.md
@@ -2,7 +2,7 @@
 name: rka-writer
 description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, synthesizes the research graph into a coherent logic ladder, and produces plain, persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
 metadata:
-  version: "2.7.4"
+  version: "2.7.5"
 ---
 
 # Writer Skill
@@ -45,7 +45,10 @@ checkpoints, readiness, and currency. `.planning/RKA_CLAIM_SPINE.yaml`,
 `.planning/CONTRIBUTION_CONTRACT.md`, `.planning/ARGUMENT_SPINE.md`, and
 `.planning/RESULTS_TRACE.md` are deterministic read-only projections. Refresh
 them with `rka writer sync`; change semantics only through revision-guarded RKA
-commands.
+commands. `.planning/STYLE_PROFILE.yaml` and per-section
+`.planning/DISCOURSE_<section-id>.yaml` are disposable private authoring state;
+they guide prose and validation but never become evidence or override native
+readiness.
 
 ## Supplementary references (load on demand)
 
@@ -62,7 +65,8 @@ commands.
   candidates, native units, and drafting.
 - [`references/discourse_synthesis.md`](references/discourse_synthesis.md):
   separation of evidence and discourse graphs, plain academic style target,
-  section logic ladders, paragraph formation, and post-hoc provenance.
+  section logic ladders, paragraph formation, private planning artifacts,
+  fresh-context review, and post-hoc provenance.
 - [`references/persuasive_framing.md`](references/persuasive_framing.md):
   two-channel author/manuscript discipline, limitation materiality triage,
   strength-first defense patterns, and the quick-reader path.
@@ -162,6 +166,11 @@ categorical report. Core manuscript validation queues the slow external work;
 the worker keeps retraction checking enabled and persists an immutable
 validation attestation. A pending job is not a verified reference.
 `overclaim_lint.py` scans drafts for calibration/overclaim wording (`verified`, `guaranteed`, `eliminates`, `model-agnostic`, ...) and emits `overclaim_report.json`. WARN-only, never BLOCK; ranks a hit higher when its backing `jrn_`/`clm_` is at `hypothesis`/`tested` confidence. Advisory input to the pre-submission review.
+`validate_discourse_artifacts.py` validates the private style profile and
+per-section discourse plan. It BLOCKs incomplete sample-profile approval,
+missing proposition/paragraph mappings, prior-work propositions without
+citation keys, non-exact mandatory-disclosure or native-unit coverage, and an
+incomplete fresh-context review. It does not score or certify prose coherence.
 `fetch_template.py` performs registry lookup, download, SHA-256 verification, cache reuse, and fail-closed PI pin handling.
 `claim_spine.py` safely loads both the legacy `rka-claim-spine/v1` migration
 format and the native `rka-claim-spine/v2` server projection. It validates
@@ -638,6 +647,10 @@ When a revised draft is available, compare it against the prior review comments 
 28. **DON'T** treat provenance coverage or an AI-tic score as evidence of
     coherence. Verify the logic ladder, paragraph bridges, and section
     takeaway before surface polishing.
+29. **DON'T** advance a section from an unrecorded discourse plan. Validate the
+    section artifact, exact required-unit and mandatory-disclosure coverage,
+    current provenance/citations, and fresh-context coherence review after the
+    final prose change.
 
 ---
 

--- a/plugin/skills/writer/docs/phase-1-mvp.md
+++ b/plugin/skills/writer/docs/phase-1-mvp.md
@@ -87,7 +87,8 @@ PATCH 2).
 
 - `.mcp.json`, `.latexmkrc`, `ai_tic_config.yaml`, `main.tex`, `refs.bib`.
 - `.planning/`: `ACTIVE_WORKFLOW.md`, `FRAMING_SESSION.yaml`, `PRECIS.md`,
-  `OUTLINE.md`, `REVIEW_STATE.md`.
+  `OUTLINE.md`, `REVIEW_STATE.md`, `STYLE_PROFILE.yaml`, and
+  `DISCOURSE_TEMPLATE.yaml`.
 - Directory placeholders: `sections/`, `figures/`, `tables/`, `charts/`,
   `styles/`.
 

--- a/plugin/skills/writer/references/ai_tics.md
+++ b/plugin/skills/writer/references/ai_tics.md
@@ -165,7 +165,7 @@ The linter loads the project's `ai_tic_config.yaml` if present, applies override
 
 The linter `scripts/ai_tic_lint.py` implements all Tier 1 + Tier 2 + Tier 3 lexical patterns, the four structural detectors (sentence-length variance, transition-word ratio, parallel-triplet density, bridge-repetition delegation to `bridge_repetition_check.py`), absolute bans, the style score formula, and the per-project override mechanism. Output is `ai_tic_report.json` with per-rule hit counts and per-hit line numbers, plus the computed style score.
 
-Further additions:
+Future additions (not implemented):
 
 - LLM-assisted rewrite suggestions for flagged passages.
 - Cross-manuscript trend tracking (is the project drifting toward AI-tic patterns over revisions).

--- a/plugin/skills/writer/references/ai_tics.md
+++ b/plugin/skills/writer/references/ai_tics.md
@@ -6,6 +6,13 @@ Load-bearing per `dec_01KS12H9KT1T03DHX2Q6FKTXHH` (PATCH 2 disposition; no third
 
 Pure lexical blacklists over-flag legitimate academic prose (Matsui 2025). The Writer's enforcement layer therefore combines a tiered lexical list with structural detectors and a per-project override mechanism. The lexical layer catches the obvious LLM tells; the structural layer catches the rhythmic and bridging patterns that survive lexical sanitization; the override layer respects venue-specific or PI-specific legitimate usage.
 
+This linter is a negative filter, not a prose generator or coherence judge. A
+high score shows only that the checked patterns are rare. It does not show that
+the section has a coherent argument, fluent paragraph transitions, appropriate
+information order, or the author's preferred academic voice. Build and revise
+the positive style target through `discourse_synthesis.md` before running this
+filter.
+
 Empirical floor for the rules: across six published studies covering 732 LLM-generated citations, cross-study average is 51 percent fabrication (Walters and Wilder 2023, Wagner and Ertl-Wagner 2023, Mugaanyi 2024, Spennemann 2025). Linter discipline is one half of the defense; the other half is the reference validation pipeline (`reference_pipeline.md`). Both must be active.
 
 ## Tier 1: CRITICAL (compile-blocking on any hit)
@@ -123,7 +130,7 @@ score = 1 - (critical_hits * 3 + high_hits + 0.3 * medium_hits) / total_sentence
 
 Threshold: sections with `score < 0.85` trigger auto-revise via the Revision Loop (Class R2). The auto-revise loop caps at three iterations before escalating to a PI Style checkpoint with three resolution options (continue revising, accept the section as is via PI override, or restructure the section).
 
-The score is one signal among several. PI editorial judgment overrides the score via `ai_tic_config.yaml`. The score is **not** the sole gate. Treating it as such is anti-pattern 10 in `SKILL.md`.
+The score is one signal among several. PI editorial judgment overrides the score via `ai_tic_config.yaml`. The score is **not** the sole gate. Treating it as such is anti-pattern 10 in `SKILL.md`. Never use the score to certify logic, coherence, fluency, or author-style fit.
 
 ## Per-project override mechanism
 
@@ -158,11 +165,13 @@ The linter loads the project's `ai_tic_config.yaml` if present, applies override
 
 The linter `scripts/ai_tic_lint.py` implements all Tier 1 + Tier 2 + Tier 3 lexical patterns, the four structural detectors (sentence-length variance, transition-word ratio, parallel-triplet density, bridge-repetition delegation to `bridge_repetition_check.py`), absolute bans, the style score formula, and the per-project override mechanism. Output is `ai_tic_report.json` with per-rule hit counts and per-hit line numbers, plus the computed style score.
 
-Phase 2 additions (not in scope for Phase 1):
+Further additions:
 
 - LLM-assisted rewrite suggestions for flagged passages.
 - Cross-manuscript trend tracking (is the project drifting toward AI-tic patterns over revisions).
-- Author-style fingerprinting baseline (calibrate the linter against the PI's pre-2023 publications).
+- Deterministic author-style diagnostics. Sample-driven qualitative calibration
+  is already available through `discourse_synthesis.md`; any future metric
+  must remain advisory and must not reduce author voice to a single score.
 
 ## References
 

--- a/plugin/skills/writer/references/architecture.md
+++ b/plugin/skills/writer/references/architecture.md
@@ -22,6 +22,8 @@ Writer session
         +-- .planning/ARGUMENT_SPINE.md          generated
         +-- .planning/RESULTS_TRACE.md            generated
         +-- .planning/FRAMING_SESSION.yaml        advisory interaction state
+        +-- .planning/STYLE_PROFILE.yaml          PI-approved style calibration
+        +-- .planning/DISCOURSE_<section>.yaml    private section discourse plan
         +-- .planning/ACTIVE_WORKFLOW.md          local session state
         +-- sections/, figures/, tables/, charts/
         +-- refs.bib, main.tex, styles/
@@ -41,7 +43,7 @@ the canonical `man_` id returned or resolved by `rka writer init`.
 | exact PI ratifications (`mra_`) | deterministic Markdown/YAML rendering |
 | manuscript units (`mun_`) and result boundaries | figures, tables, and chart source files |
 | checkpoints (`mck_`) and verification attestations (`mva_`) | compilation and layout audit |
-| readiness, change cursors, and impact | disposable local session notes |
+| readiness, change cursors, and impact | disposable style/discourse/session notes |
 
 Local files cannot create semantic truth. A local proposal changes the
 aggregate only through an explicit, revision-guarded command. A generated

--- a/plugin/skills/writer/references/discourse_synthesis.md
+++ b/plugin/skills/writer/references/discourse_synthesis.md
@@ -23,6 +23,28 @@ record order and turn each item into prose. Journal chronology is relevant
 only when the history of the research or design is itself part of the
 argument.
 
+## Planning artifacts
+
+Keep the discourse graph in disposable, private authoring state rather than
+adding a second research database:
+
+- `.planning/STYLE_PROFILE.yaml` stores sample-derived positive patterns,
+  operational prohibitions, the sample inventory, and PI approval. When
+  samples are registered, an approved profile is a drafting precondition.
+- Copy `.planning/DISCOURSE_TEMPLATE.yaml` to
+  `.planning/DISCOURSE_<section-id>.yaml` for each section. Record the section
+  takeaway, required native-unit set, propositions, paragraph cards,
+  mandatory-disclosure coverage, style-profile link, and fresh-context
+  coherence review.
+
+Run `scripts/validate_discourse_artifacts.py --style-profile
+.planning/STYLE_PROFILE.yaml --discourse-plan
+.planning/DISCOURSE_<section-id>.yaml` before advancing any mapped unit to
+`drafted`. The validator checks structure, exact disclosure and unit
+coverage, prior-work citation bindings, and review completion. It deliberately
+does not assign a coherence score. RKA remains authoritative for claims,
+evidence, units, status, and readiness.
+
 ## Plain academic target
 
 Write in direct academic language with visible reasoning and restrained
@@ -70,6 +92,25 @@ Avoid these negative patterns:
 - A paragraph that ends without changing what the reader knows or expects
   next.
 
+### Synthetic contrastive example
+
+This example demonstrates information packaging only; it is not research
+evidence and must not be reused as manuscript content.
+
+**Record-shaped:** “The monitor records prompts, tool calls, timestamps,
+policy decisions, retries, and token counts. It applies validation, filtering,
+rate limits, rollback, and sandboxing. We measure attack success, false
+positives, runtime, and token overhead.” The paragraph catalogs available
+records and controls before establishing the problem they solve.
+
+**Synthesized:** “An agent can satisfy every local policy check and still
+produce an unsafe action when individually benign steps interact. Our key
+observation is that the monitor must preserve the causal path from a request
+to its external effect. We therefore connect policy decisions across tool
+boundaries and evaluate whether this history exposes attacks that isolated
+checks miss.” The rewrite moves from failure to observation to response and
+payoff; implementation fields can follow after their purpose is clear.
+
 ## Drafting workflow
 
 ### 1. Build an evidence packet
@@ -82,9 +123,11 @@ Do not start prose from this packet.
 
 ### 2. Distill discourse propositions
 
-Compress the packet into three to seven reader-facing propositions for a
-normal section. A proposition is a statement the reader must understand for
-the next move to follow. It may combine many records.
+Compress the packet into roughly three to seven reader-facing propositions
+for a normal section. This is a planning heuristic, not a cap: one proposition
+may combine several ladder moves, and a complex section may need more. A
+proposition is a statement the reader must understand for the next move to
+follow. It may combine many records.
 
 For each proposition, record privately:
 
@@ -92,16 +135,21 @@ For each proposition, record privately:
 - its role in the section;
 - the evidence bundle that supports it;
 - the condition or qualifier that changes its meaning;
+- citation keys when it attributes a claim to specific prior work;
 - the inference that connects it to the next proposition.
 
 Merge duplicate and closely related records. Omit records that do not serve
 the section's communicative job. Omission from prose does not remove them from
-RKA.
+RKA. Never omit an active M1/M2 item or required counterevidence from the
+section plan: list each one in `mandatory_disclosure_ids` and map it to a
+public location before the plan may pass validation.
 
 ### 3. Arrange the logic ladder
 
-Choose the ladder that fits the section. Do not force every move into every
-section.
+Choose, reorder, combine, or omit moves to fit the section. The ladders below
+are diagnostic patterns, not fill-in templates. Do not force every move into
+every section, reuse a visibly identical skeleton across the manuscript, or
+preserve these labels as headings.
 
 **Introduction or motivation**
 
@@ -150,6 +198,35 @@ need and consequence
 -> evaluation and expected knowledge gain
 ```
 
+**Related work**
+
+```text
+reader's comparison frame
+-> organizing dimension such as problem, technique, or threat class
+-> synthesis of what a family of approaches achieves
+-> boundary that matters for the present problem
+-> explicit delta and positioning takeaway
+```
+
+Organize around the reader's comparison question, never around RKA cluster
+identity. Attribute statements about a specific work with the citation key
+kept on the corresponding private proposition during drafting.
+
+**Threat model or security assumptions**
+
+```text
+protected assets and security goal
+-> adversary capabilities and control
+-> trust boundaries and assumptions
+-> explicit out-of-scope conditions that affect interpretation
+-> attacks the model admits
+-> connection from each material challenge to a design response or evaluation
+```
+
+State assumptions before relying on them, but do not turn the section into a
+field inventory. The order should follow what a reader needs to judge whether
+the claimed defense applies.
+
 The logic ladder is a reasoning path, not a set of headings. A reader should be
 able to explain why each move makes the next move necessary.
 
@@ -163,16 +240,26 @@ paragraph, decide:
 - **development:** explanation, example, contrast, or evidence bundle;
 - **bridge:** the inference that makes the next paragraph natural;
 - **takeaway:** the claim the reader should retain.
+- **unit keys:** the exact native units whose obligations the paragraph helps
+  discharge.
 
 A paragraph may realize several manuscript units, and a complex unit may span
 several paragraphs. Choose boundaries from rhetorical continuity, not from RKA
 IDs or unit keys.
 
+The union of paragraph-card `unit_keys` must exactly equal the section's
+`required_unit_keys`. Every proposition must appear in at least one paragraph
+card. A unit advances to `drafted` only after all paragraph cards mapped to it
+are committed and the final discourse, provenance, citation, and mandatory-
+disclosure checks pass.
+
 ### 5. Draft clean prose
 
-Draft from the logic ladder and paragraph cards with RKA IDs, citations, and
-private risk labels hidden. Keep the evidence packet available as a boundary,
-not as a sentence template.
+Draft from the logic ladder and paragraph cards with RKA IDs, provenance
+comments, and private risk labels hidden. Keep citation keys attached to
+private propositions that make claims about specific prior work, even when
+the public citation markup is inserted later. Keep the evidence packet
+available as a boundary, not as a sentence template.
 
 Explain the idea before the machinery. Delay exhaustive implementation lists
 until the reader understands their purpose. Use the strongest concrete
@@ -186,6 +273,12 @@ back to its evidence bundle. Add hidden provenance comments and validated
 citations without changing the reader-facing organization. If a sentence
 cannot be grounded, narrow or remove it. Do not split a coherent paragraph
 into record-shaped fragments merely to make provenance attachment easier.
+
+Any narrowing, citation correction, mandatory-disclosure relocation, or later
+surface edit changes the artifact under review. Re-run the coherence review,
+provenance and citation validation, disclosure coverage, and discourse-
+artifact validation after the last prose change. Advance only after one pass
+makes no further prose change; escalate after three unsuccessful passes.
 
 ### 7. Revise in the right order
 
@@ -223,10 +316,17 @@ prose alone:
 If any answer is unclear, revise the discourse plan before polishing
 sentences.
 
+Persist the takeaway, paragraph jobs, answers, and reviewer identity in the
+section's `DISCOURSE_<section-id>.yaml`. A fresh-context reviewer—not the
+section drafter—records the final answers. Surface the takeaway and paragraph
+jobs at the Draft section checkpoint so the PI can inspect the argument
+without reading internal RKA records.
+
 ## Calibrating to author samples
 
 When the author supplies several good examples and one or more disliked
-examples, derive a project-local style profile before drafting:
+examples, register them in `.planning/STYLE_PROFILE.yaml` and derive the
+project-local profile before drafting:
 
 1. Compare matched rhetorical locations such as abstracts, introduction
    openings, gap paragraphs, approach overviews, result summaries, and task
@@ -237,9 +337,15 @@ examples, derive a project-local style profile before drafting:
    as `bad style`.
 4. Paraphrase short examples; do not copy sentences from the calibration
    corpus into a new manuscript.
-5. Treat the profile as a positive drafting target. Venue requirements and
-   current PI instructions override it.
+5. Record the sample inventory without copying the sample texts into the
+   repository or profile.
+6. Ask the PI to approve or edit the profile, then set `status: approved` with
+   the approval record.
+7. Treat the approved profile as a positive drafting target. Venue
+   requirements and current PI instructions override it.
 
 Do not imitate grammar errors, stale terminology, unsupported claims, or
 venue-specific formatting from a sample. Learn the author's reasoning and
-information-packaging habits rather than copying surface text.
+information-packaging habits rather than copying surface text. When registered
+samples exist, do not draft until the profile is approved and linked from the
+section discourse artifact.

--- a/plugin/skills/writer/references/discourse_synthesis.md
+++ b/plugin/skills/writer/references/discourse_synthesis.md
@@ -1,0 +1,245 @@
+# Discourse Synthesis and Plain Academic Style
+
+Use this workflow after the claim spine and outline are current and before
+drafting public prose. RKA constrains what the paper may say. It must not
+determine the order, sentence boundaries, or surface vocabulary of the paper.
+
+## Evidence graph and discourse graph
+
+Keep two representations separate:
+
+1. **Evidence graph.** RKA records claims, scope, support, qualifiers,
+   counterevidence, decisions, and provenance. Preserve this graph completely.
+2. **Discourse graph.** The manuscript guides a reader through a small number
+   of propositions in a deliberate order. Build this graph for comprehension
+   and persuasion, then attach its propositions back to the evidence graph.
+
+The mapping is many-to-many. Several RKA records may support one sentence or
+paragraph. One RKA claim may inform several rhetorical moves. A manuscript
+unit is an argument-planning object, not a required paragraph boundary.
+
+Never traverse journal entries, claims, clusters, or manuscript units in
+record order and turn each item into prose. Journal chronology is relevant
+only when the history of the research or design is itself part of the
+argument.
+
+## Plain academic target
+
+Write in direct academic language with visible reasoning and restrained
+technical detail. Use these positive features:
+
+- Begin from a concrete problem, consequence, or observation before moving to
+  an abstraction.
+- Use an explicit logic ladder: context, problem, prior approach, gap, insight,
+  challenge, response, evidence, and implication. Include only the moves the
+  section needs.
+- Give each paragraph one communicative job, but allow several claims and
+  evidence records to serve that job.
+- State the main point early. Explain why it follows and why it matters before
+  adding implementation detail.
+- Use examples to make a threat, failure, or design need tangible.
+- Prefer common verbs such as `use`, `show`, `compare`, `measure`, `detect`,
+  `build`, and `reduce`. Use a technical term when it is more precise, not
+  merely more formal.
+- Keep one name for one concept. Repetition of the exact technical term is
+  clearer than elegant variation.
+- Use first-person active constructions when the venue permits them: `we
+  observe`, `we design`, `we evaluate`, and `the results show`.
+- Let a sentence carry a real logical relation. Plain language does not require
+  uniformly short sentences or a sequence of clipped statements.
+- Present a challenge and its corresponding design response close together.
+- State bounded contributions confidently. Put a material boundary where the
+  reader interprets the affected claim, not as an unrelated confession in the
+  opening narrative.
+
+Avoid these negative patterns:
+
+- RKA vocabulary, record IDs, evidence-status labels, or audit language in
+  public prose unless the system's provenance mechanism is itself a research
+  contribution.
+- One sentence per source, one paragraph per claim, or one subsection per
+  manuscript unit.
+- Catalogs of controls, checks, fields, or components before the reader
+  understands the problem they solve.
+- Early defensive qualifications that interrupt the problem-to-insight path.
+- Repeated labels such as `bounded`, `typed`, `current`, `immutable`, or
+  `auditable` when a concrete explanation would be clearer.
+- Dense noun stacks, unnecessary nominalizations, and abstract topic
+  sentences that merely classify the literature.
+- Mechanical transitions added to connect otherwise unrelated facts.
+- A paragraph that ends without changing what the reader knows or expects
+  next.
+
+## Drafting workflow
+
+### 1. Build an evidence packet
+
+For the section, resolve current support, qualifiers, counterevidence,
+conditions, allowed interpretation, prohibited wording, and publication
+boundary. Keep exact IDs and source details in private notes.
+
+Do not start prose from this packet.
+
+### 2. Distill discourse propositions
+
+Compress the packet into three to seven reader-facing propositions for a
+normal section. A proposition is a statement the reader must understand for
+the next move to follow. It may combine many records.
+
+For each proposition, record privately:
+
+- its reader-facing statement;
+- its role in the section;
+- the evidence bundle that supports it;
+- the condition or qualifier that changes its meaning;
+- the inference that connects it to the next proposition.
+
+Merge duplicate and closely related records. Omit records that do not serve
+the section's communicative job. Omission from prose does not remove them from
+RKA.
+
+### 3. Arrange the logic ladder
+
+Choose the ladder that fits the section. Do not force every move into every
+section.
+
+**Introduction or motivation**
+
+```text
+concrete setting and stakes
+-> current practice or prior approach
+-> precise limitation
+-> central observation or insight
+-> technical challenges
+-> corresponding design responses
+-> strongest evidence and payoff
+-> contribution summary
+```
+
+**System or method**
+
+```text
+goal and input-output contract
+-> why the direct approach fails
+-> design insight
+-> mechanism
+-> how the mechanism resolves the challenge
+-> interface with the next component
+```
+
+**Evaluation or results**
+
+```text
+research question
+-> setup needed to interpret the result
+-> principal result
+-> explanation or mechanism
+-> comparison or sensitivity evidence
+-> supported implication and material boundary
+```
+
+**NSF project or thrust**
+
+```text
+need and consequence
+-> knowledge or capability gap
+-> preliminary insight or evidence
+-> objective
+-> challenges
+-> tasks matched to those challenges
+-> evaluation and expected knowledge gain
+```
+
+The logic ladder is a reasoning path, not a set of headings. A reader should be
+able to explain why each move makes the next move necessary.
+
+### 4. Form paragraph cards
+
+Group propositions into paragraphs before writing sentences. For each
+paragraph, decide:
+
+- **job:** what changes in the reader's understanding;
+- **opening:** the main point or concrete setup;
+- **development:** explanation, example, contrast, or evidence bundle;
+- **bridge:** the inference that makes the next paragraph natural;
+- **takeaway:** the claim the reader should retain.
+
+A paragraph may realize several manuscript units, and a complex unit may span
+several paragraphs. Choose boundaries from rhetorical continuity, not from RKA
+IDs or unit keys.
+
+### 5. Draft clean prose
+
+Draft from the logic ladder and paragraph cards with RKA IDs, citations, and
+private risk labels hidden. Keep the evidence packet available as a boundary,
+not as a sentence template.
+
+Explain the idea before the machinery. Delay exhaustive implementation lists
+until the reader understands their purpose. Use the strongest concrete
+example or result once; do not restate it in slightly different words merely
+because several records support it.
+
+### 6. Attach provenance post-hoc
+
+After the prose is coherent, map each checkable assertion or substantive block
+back to its evidence bundle. Add hidden provenance comments and validated
+citations without changing the reader-facing organization. If a sentence
+cannot be grounded, narrow or remove it. Do not split a coherent paragraph
+into record-shaped fragments merely to make provenance attachment easier.
+
+### 7. Revise in the right order
+
+Run separate passes in this order:
+
+1. **Section argument:** verify that the central takeaway and logic ladder are
+   complete.
+2. **Paragraph coherence:** verify topic continuity, known-to-new information,
+   causal bridges, and non-redundant paragraph jobs.
+3. **Plain language:** replace avoidable jargon, noun stacks, and abstract
+   bookkeeping terms; define necessary terminology once.
+4. **Evidence and boundaries:** verify every factual assertion, citation,
+   qualifier, and M1/M2 treatment.
+5. **Surface style:** run AI-tic, repetition, and venue checks last.
+
+A linter pass does not establish coherence. Absence of banned terms, varied
+sentence length, and valid provenance are necessary checks, not a writing
+strategy.
+
+## Coherence review
+
+Before presenting a section to the PI, answer these questions from the public
+prose alone:
+
+1. What single takeaway does the section establish?
+2. Why does each paragraph follow the previous one?
+3. Does each paragraph develop one job rather than list several records?
+4. Are challenges paired with the design choices that answer them?
+5. Can a reader understand the idea before encountering detailed mechanisms?
+6. Do examples and results advance the argument rather than decorate it?
+7. Does the final paragraph deliver the promise made by the opening?
+8. Would removing all provenance comments leave a fluent, self-contained
+   manuscript?
+
+If any answer is unclear, revise the discourse plan before polishing
+sentences.
+
+## Calibrating to author samples
+
+When the author supplies several good examples and one or more disliked
+examples, derive a project-local style profile before drafting:
+
+1. Compare matched rhetorical locations such as abstracts, introduction
+   openings, gap paragraphs, approach overviews, result summaries, and task
+   descriptions.
+2. Record positive patterns in logic order, paragraph construction,
+   terminology, voice, example use, and technical-detail timing.
+3. Record negative patterns as operational prohibitions, not vague labels such
+   as `bad style`.
+4. Paraphrase short examples; do not copy sentences from the calibration
+   corpus into a new manuscript.
+5. Treat the profile as a positive drafting target. Venue requirements and
+   current PI instructions override it.
+
+Do not imitate grammar errors, stale terminology, unsupported claims, or
+venue-specific formatting from a sample. Learn the author's reasoning and
+information-packaging habits rather than copying surface text.

--- a/plugin/skills/writer/references/evidence_to_spine_pipeline.md
+++ b/plugin/skills/writer/references/evidence_to_spine_pipeline.md
@@ -44,7 +44,11 @@ mcl_ manuscript claims + PI ratification
         v
 mun_ units, argument spine, and results trace
         |
-        | evidence-grounded, claim-centered drafting and citation validation
+        | synthesize units into reader-facing propositions and a logic ladder
+        v
+section discourse plan and paragraph cards
+        |
+        | draft clean prose, then attach provenance and validate citations
         v
 manuscript prose
 ```
@@ -191,7 +195,7 @@ suppression of a claim-relevant mixed result, or deletion of provenance.
 
 ## 5. Argument spine and unit plan
 
-Build the argument at claim-sized granularity:
+Build the argument at argument-beat granularity:
 
 ```text
 problem -> gap -> response -> evidence -> interpretation -> boundary
@@ -216,6 +220,12 @@ merely a list of section headings. The deterministic
 - which discussion statement resolves each research question;
 - where material or venue-required boundaries constrain interpretation.
 
+Argument beats preserve semantics and change impact. They are not prose
+containers. Do not assign one sentence to each evidence record, one paragraph
+to each claim, or one subsection to each unit. During drafting, group several
+beats into a paragraph when they perform one communicative job, or expand one
+complex beat across paragraphs when the reader needs a staged explanation.
+
 ## 6. Results-to-claim trace
 
 Every active empirical contribution must have an active result unit, and every
@@ -236,21 +246,30 @@ authoritative.
 
 ## 7. Writing strategy
 
-Draft one unit at a time:
+Draft from a section-level discourse plan, not from individual records or
+units:
 
-1. Resolve the unit, ratified claim version, positive support, qualifiers,
-   counterevidence, prohibited wording, and publication-boundary
+1. Resolve all relevant units, ratified claim versions, positive support,
+   qualifiers, counterevidence, prohibited wording, and publication-boundary
    classifications from RKA and the private planning record.
-2. Extract the evidence facts, conditions, and material boundaries before
-   drafting.
-3. Draft the smallest claim-centered, strength-first prose block that performs
-   the unit's communicative job and makes the strongest evidence easy to find.
-4. Stay within the allowed interpretation and apply M1-M4/S public placement.
-5. Run the quick-reader checks in `persuasive_framing.md`; revise the framing
+2. Build one private evidence packet. Merge duplicate and closely related
+   records into evidence bundles; do not preserve record order.
+3. Distill the packet into a small set of reader-facing propositions and
+   arrange them into the section's logic ladder.
+4. Group those propositions into paragraphs with an opening, development,
+   takeaway, and bridge to the next paragraph. Paragraph boundaries follow
+   rhetorical continuity rather than RKA entity or unit boundaries.
+5. Draft clean, plain academic prose from the logic ladder and paragraph
+   plan. Keep IDs and private risk labels out of the public text.
+6. Stay within the allowed interpretation and apply M1-M4/S public placement.
+7. Revise section argument and paragraph coherence before sentence-level style
+   polishing. Use `discourse_synthesis.md` for this pass.
+8. Attach hidden provenance and citations in a separate pass, then validate
+   them. Do not fragment coherent prose merely to simplify provenance mapping.
+9. Run the quick-reader checks in `persuasive_framing.md`; revise the framing
    or escalate an unresolved materiality decision.
-6. Attach citations in a separate pass and validate them.
-7. Update unit status through a revision-guarded aggregate change.
-8. Synchronize projections and re-run readiness.
+10. Update affected unit statuses through a revision-guarded aggregate change,
+    synchronize projections, and re-run readiness.
 
 Generated projections aid review but never supply evidence. A local prose edit
 does not change RKA semantics.

--- a/plugin/skills/writer/references/evidence_to_spine_pipeline.md
+++ b/plugin/skills/writer/references/evidence_to_spine_pipeline.md
@@ -255,21 +255,35 @@ units:
 2. Build one private evidence packet. Merge duplicate and closely related
    records into evidence bundles; do not preserve record order.
 3. Distill the packet into a small set of reader-facing propositions and
-   arrange them into the section's logic ladder.
+   arrange them into the section's logic ladder. Keep citation keys on
+   propositions that attribute specific prior work. Populate
+   `mandatory_disclosure_ids` with every M1/M2 item and required active
+   counterevidence.
 4. Group those propositions into paragraphs with an opening, development,
-   takeaway, and bridge to the next paragraph. Paragraph boundaries follow
-   rhetorical continuity rather than RKA entity or unit boundaries.
+   takeaway, bridge to the next paragraph, proposition IDs, and native-unit
+   keys. Record them in `.planning/DISCOURSE_<section-id>.yaml`. Paragraph
+   boundaries follow rhetorical continuity rather than RKA entity or unit
+   boundaries.
 5. Draft clean, plain academic prose from the logic ladder and paragraph
    plan. Keep IDs and private risk labels out of the public text.
 6. Stay within the allowed interpretation and apply M1-M4/S public placement.
-7. Revise section argument and paragraph coherence before sentence-level style
-   polishing. Use `discourse_synthesis.md` for this pass.
+   Map every mandatory disclosure to a public location before advancing.
+7. Have a different fresh-context reviewer revise section argument and
+   paragraph coherence before provenance attachment or sentence-level style
+   polishing. Persist the review in the discourse artifact.
 8. Attach hidden provenance and citations in a separate pass, then validate
-   them. Do not fragment coherent prose merely to simplify provenance mapping.
+   them. Do not fragment coherent prose merely to simplify provenance mapping;
+   retain proposition-level citation bindings for prior-work attribution.
 9. Run the quick-reader checks in `persuasive_framing.md`; revise the framing
    or escalate an unresolved materiality decision.
-10. Update affected unit statuses through a revision-guarded aggregate change,
-    synchronize projections, and re-run readiness.
+10. After the last prose change, re-run coherence, provenance, citation,
+    mandatory-disclosure, and discourse-artifact validation until one pass
+    makes no further prose change. Escalate after three unsuccessful passes.
+11. Require the union of paragraph-card `unit_keys` to equal the section's
+    `required_unit_keys`. Advance a unit to `drafted` only when all cards mapped
+    to it are committed and all final checks pass. Apply the revision-guarded
+    aggregate change, synchronize projections, re-run readiness, and read back
+    the affected units.
 
 Generated projections aid review but never supply evidence. A local prose edit
 does not change RKA semantics.

--- a/plugin/skills/writer/references/persuasive_framing.md
+++ b/plugin/skills/writer/references/persuasive_framing.md
@@ -136,6 +136,11 @@ switching, give each paragraph one communicative job, and lead with its
 takeaway. If a scan fails, revise or escalate to the PI. Never make a scan pass
 by deleting a material limitation or unsupported result.
 
+Run these scans on the public prose with provenance comments hidden. A reader
+should encounter a research argument, not the shape or vocabulary of the RKA
+record. Use `discourse_synthesis.md` to repair a section whose claims are
+grounded but whose logic still reads as a list.
+
 Accessibility does not mean removing technical precision. Use a plain-language
 sentence first, then add the formal or implementation detail.
 

--- a/plugin/skills/writer/references/server_authoritative_workflow.md
+++ b/plugin/skills/writer/references/server_authoritative_workflow.md
@@ -26,6 +26,8 @@ Writer owns:
 - LaTeX, Word, Markdown, figures, tables, and other manuscript files;
 - venue structure, citation formatting, rendering, and layout checks;
 - `.planning/ACTIVE_WORKFLOW.md` as disposable authoring-session state;
+- `.planning/STYLE_PROFILE.yaml` and per-section `DISCOURSE_*.yaml` as
+  disposable, validated authoring plans that never supply research evidence;
 - deterministic projections such as `RKA_CLAIM_SPINE.yaml`,
   `CONTRIBUTION_CONTRACT.md`, `ARGUMENT_SPINE.md`, and `RESULTS_TRACE.md`.
 
@@ -71,6 +73,10 @@ resolved `man_...` identifier.
 6. Continue only when the server returns a non-blocking categorical verdict.
    Local renderers may add stricter file-level findings, but cannot override a
    server `BLOCK` or `ERROR`.
+7. Before a section advances to `drafted`, validate its style/discourse
+   artifacts, exact unit and mandatory-disclosure coverage, current
+   provenance/citations, and fresh-context coherence review. These local gates
+   may block advancement but cannot authorize it when server readiness blocks.
 
 The synchronized cursor is captured before the aggregate projection is read.
 This is intentionally conservative: a concurrent change may be reported again,

--- a/plugin/skills/writer/references/workflows.md
+++ b/plugin/skills/writer/references/workflows.md
@@ -344,9 +344,10 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    units, freshly resolved positive evidence, qualifiers, counterevidence,
    publication-boundary classifications, references in scope, and the claim's
    prohibited wording. It also reads
-   [`discourse_synthesis.md`](discourse_synthesis.md) and any PI-approved
-   project-local author-style profile. Generated views are explanatory;
-   resolution is against RKA.
+   [`discourse_synthesis.md`](discourse_synthesis.md) and
+   `.planning/STYLE_PROFILE.yaml`. If samples are registered, a missing or
+   unapproved profile is a BLOCK. Generated views are explanatory; resolution
+   is against RKA.
 3. Subagent builds one private evidence packet for the section. It extracts
    facts, conditions, and boundaries, groups duplicate or closely related
    records into evidence bundles, and removes out-of-scope material. It does
@@ -355,10 +356,14 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
 4. Subagent distills the packet into a small set of reader-facing propositions,
    arranges the section-level logic ladder, and groups the propositions into
    paragraph cards. Each paragraph card records one communicative job, its
-   opening, development, takeaway, and bridge. Several RKA records or native
-   units may serve one paragraph; one complex unit may span paragraphs.
+   opening, development, takeaway, bridge, proposition IDs, and native-unit
+   keys. Prior-work propositions retain their citation keys. Copy
+   `.planning/DISCOURSE_TEMPLATE.yaml` to
+   `.planning/DISCOURSE_<section-id>.yaml` and record the exact required-unit
+   set. Several RKA records or native units may serve one paragraph; one
+   complex unit may span paragraphs.
 5. Subagent drafts plain academic prose from the discourse plan with RKA IDs,
-   citations, and private risk labels hidden. It explains the idea before
+   provenance comments and private risk labels hidden. It explains the idea before
    exhaustive machinery and pairs each challenge with the design response
    that addresses it. Quote a source only when its exact wording matters; do
    not build prose by patching quotations or evidence snippets together.
@@ -368,15 +373,20 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    or reproducibility material; M4 and S items remain in the private risk
    record unless venue policy requires them. Never omit an issue whose absence
    would materially mislead a reasonable reader. Map every M1/M2 item to its
-   public paragraph, figure, table, caption, or claim. If a mapping is missing,
-   escalate and do not advance the affected unit to `drafted`.
-7. Subagent attaches hidden provenance comments and citations post-hoc to the
-   coherent draft, then validates them. It narrows unsupported wording instead
-   of splitting the prose into one-source fragments.
-8. Run the discourse-synthesis coherence review: verify the section takeaway,
+   public paragraph, figure, table, caption, or claim in
+   `mandatory_disclosure_map`; include required active counterevidence. If a
+   mapping is missing, escalate and do not advance the affected unit to
+   `drafted`; when several units are affected, block all of them.
+7. Run the discourse-synthesis coherence review with a different fresh-context
+   reviewer before provenance attachment. Verify the section takeaway,
    proposition order, paragraph jobs, known-to-new flow, causal bridges,
-   challenge-response pairing, and delivery of the opening promise. Revise the
-   discourse plan before polishing sentences when any check fails.
+   challenge-response pairing, and delivery of the opening promise. Persist
+   the answers and reviewer identity in the section discourse artifact. Revise
+   the plan and prose when any answer fails.
+8. Subagent attaches hidden provenance comments and citations post-hoc to the
+   coherent draft, then validates them. It keeps citation keys bound to
+   propositions that attribute prior work and narrows unsupported wording
+   instead of splitting the prose into one-source fragments.
 9. Run the four quick-reader checks in `persuasive_framing.md`. If a scan
    fails, revise the framing or escalate the unresolved evidence/wording
    decision; never delete a material limitation merely to make the scan pass.
@@ -387,12 +397,24 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    `scripts/ai_tic_lint.py` on the section and resolves genuine surface-style
    findings. The score cannot establish logic or fluency. Iterate until the
    score reaches 0.85 or three iterations elapse.
-12. If three iterations fail, ESCALATE via the Revision Loop Class R2.
-13. Otherwise commit the section to `sections/<section-id>.tex`, update the
-   corresponding native unit status through a revision-guarded spine update,
-   synchronize, and surface it to the PI for the Draft section checkpoint.
+12. After the last prose change, run a fixed-point pass: repeat the fresh-
+    context coherence review, provenance and citation validation, exact M1/M2
+    and counterevidence coverage, and
+    `scripts/validate_discourse_artifacts.py`. Any prose change from narrowing,
+    citation repair, quick-reader revision, or surface lint restarts this pass.
+    Invoke it with both `--style-profile .planning/STYLE_PROFILE.yaml` and
+    `--discourse-plan .planning/DISCOURSE_<section-id>.yaml` so registered
+    samples cannot be bypassed. Stop only when one pass makes no prose change.
+13. If three validation/revision passes fail, ESCALATE via the Revision Loop
+    Class R2.
+14. Otherwise commit the section to `sections/<section-id>.tex`. Advance only
+    native units in the artifact's `required_unit_keys` whose mapped paragraph
+    cards are all committed and current. Apply the revision-guarded spine
+    update, synchronize, re-run readiness, and read back the affected units.
 
-PI ratifies via the Draft section checkpoint (one of the six PI checkpoints). Three options: accept, revise (with PI comments), escalate.
+PI ratifies via the Draft section checkpoint (one of the six PI checkpoints).
+Surface the section takeaway, paragraph jobs, mapped unit keys, and coherence
+review with three options: accept, revise (with PI comments), escalate.
 
 ### 6. Local renderer plus layout auditor
 

--- a/plugin/skills/writer/references/workflows.md
+++ b/plugin/skills/writer/references/workflows.md
@@ -343,14 +343,26 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
 2. Subagent reads: section sketch, ratified outline, the relevant claim-spine
    units, freshly resolved positive evidence, qualifiers, counterevidence,
    publication-boundary classifications, references in scope, and the claim's
-   prohibited wording. Generated views are explanatory; resolution is against
-   RKA.
-3. Subagent first extracts evidence facts, conditions, and boundaries into its
-   private working notes. It then drafts claim-centered, strength-first prose
-   around the section's communicative job. Quote a source only when its exact
-   wording matters; do not build the prose by patching quotations together.
-   Place hidden provenance comments before each evidence-citation prose unit.
-4. Apply the publication boundary from
+   prohibited wording. It also reads
+   [`discourse_synthesis.md`](discourse_synthesis.md) and any PI-approved
+   project-local author-style profile. Generated views are explanatory;
+   resolution is against RKA.
+3. Subagent builds one private evidence packet for the section. It extracts
+   facts, conditions, and boundaries, groups duplicate or closely related
+   records into evidence bundles, and removes out-of-scope material. It does
+   not preserve retrieval order, journal chronology, or entity boundaries as
+   a prose sequence.
+4. Subagent distills the packet into a small set of reader-facing propositions,
+   arranges the section-level logic ladder, and groups the propositions into
+   paragraph cards. Each paragraph card records one communicative job, its
+   opening, development, takeaway, and bridge. Several RKA records or native
+   units may serve one paragraph; one complex unit may span paragraphs.
+5. Subagent drafts plain academic prose from the discourse plan with RKA IDs,
+   citations, and private risk labels hidden. It explains the idea before
+   exhaustive machinery and pairs each challenge with the design response
+   that addresses it. Quote a source only when its exact wording matters; do
+   not build prose by patching quotations or evidence snippets together.
+6. Apply the publication boundary from
    [`persuasive_framing.md`](persuasive_framing.md): M1 and M2 issues receive
    visible public treatment; M3 details go to the method, appendix, artifact,
    or reproducibility material; M4 and S items remain in the private risk
@@ -358,16 +370,25 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    would materially mislead a reasonable reader. Map every M1/M2 item to its
    public paragraph, figure, table, caption, or claim. If a mapping is missing,
    escalate and do not advance the affected unit to `drafted`.
-5. Run the four quick-reader checks in `persuasive_framing.md`. If a scan
+7. Subagent attaches hidden provenance comments and citations post-hoc to the
+   coherent draft, then validates them. It narrows unsupported wording instead
+   of splitting the prose into one-source fragments.
+8. Run the discourse-synthesis coherence review: verify the section takeaway,
+   proposition order, paragraph jobs, known-to-new flow, causal bridges,
+   challenge-response pairing, and delivery of the opening promise. Revise the
+   discourse plan before polishing sentences when any check fails.
+9. Run the four quick-reader checks in `persuasive_framing.md`. If a scan
    fails, revise the framing or escalate the unresolved evidence/wording
    decision; never delete a material limitation merely to make the scan pass.
-6. Subagent checks that no new contribution appeared in prose and that each
+10. Subagent checks that no new contribution appeared in prose and that each
    empirical statement has role-appropriate terminal support. A decision or
    evidence cluster alone is not support.
-7. Subagent self-audits before commit: runs `scripts/ai_tic_lint.py` on the
-   section; iterates until style score reaches 0.85 or three iterations elapse.
-8. If three iterations fail, ESCALATE via the Revision Loop Class R2.
-9. Otherwise commit the section to `sections/<section-id>.tex`, update the
+11. Only after coherence and provenance checks pass, subagent runs
+   `scripts/ai_tic_lint.py` on the section and resolves genuine surface-style
+   findings. The score cannot establish logic or fluency. Iterate until the
+   score reaches 0.85 or three iterations elapse.
+12. If three iterations fail, ESCALATE via the Revision Loop Class R2.
+13. Otherwise commit the section to `sections/<section-id>.tex`, update the
    corresponding native unit status through a revision-guarded spine update,
    synchronize, and surface it to the PI for the Draft section checkpoint.
 

--- a/plugin/skills/writer/scripts/validate_discourse_artifacts.py
+++ b/plugin/skills/writer/scripts/validate_discourse_artifacts.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Validate Writer style-profile and section discourse-plan artifacts.
+
+This validator enforces structural, coverage, and handoff invariants. It does
+not score prose quality or claim that a section is coherent; that judgment
+remains a fresh-context review surfaced to the PI.
+
+Exit codes: 0 PASS, 2 BLOCK, 3 invalid input or usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+STYLE_SCHEMA = "rka.writer-style-profile/v1"
+DISCOURSE_SCHEMA = "rka.writer-discourse-plan/v1"
+COHERENCE_QUESTIONS = {
+    "single_takeaway",
+    "paragraph_sequence",
+    "one_job_per_paragraph",
+    "challenge_response",
+    "idea_before_mechanism",
+    "evidence_advances_argument",
+    "opening_promise_delivered",
+    "prose_self_contained",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    message: str
+    field: str | None = None
+    severity: str = "BLOCK"
+
+
+@dataclass
+class ValidationReport:
+    findings: list[Finding]
+
+    @property
+    def verdict(self) -> str:
+        return "BLOCK" if self.findings else "PASS"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "findings": [asdict(finding) for finding in self.findings],
+            "note": "Structural validation does not establish prose coherence.",
+        }
+
+
+def load_document(path: str | Path) -> dict[str, Any]:
+    source = Path(path)
+    try:
+        text = source.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"cannot read {source}: {exc}") from exc
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+
+        loaded = yaml.safe_load(text)
+    except ImportError:
+        try:
+            loaded = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("PyYAML is unavailable; supply JSON-compatible YAML") from exc
+    except Exception as exc:
+        raise ValueError(f"invalid or unsafe YAML/JSON document: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise TypeError("artifact must be a mapping/object")
+    return loaded
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _duplicate(values: list[str]) -> str | None:
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            return value
+        seen.add(value)
+    return None
+
+
+def validate_style_profile(data: Mapping[str, Any]) -> ValidationReport:
+    findings: list[Finding] = []
+    if data.get("schema_version") != STYLE_SCHEMA:
+        findings.append(Finding("STYLE_SCHEMA", f"schema_version must be {STYLE_SCHEMA}"))
+
+    status = _text(data.get("status"))
+    if status not in {"not_started", "draft", "approved"}:
+        findings.append(Finding("STYLE_STATUS", "status must be not_started, draft, or approved"))
+
+    samples_registered = data.get("samples_registered") is True
+    inventory = _string_list(data.get("sample_inventory"))
+    patterns = _mapping(data.get("positive_patterns"))
+    prohibitions = _string_list(data.get("prohibitions"))
+    approval = _mapping(data.get("approval"))
+
+    if samples_registered:
+        if not inventory:
+            findings.append(
+                Finding("STYLE_SAMPLES", "registered samples require sample_inventory entries")
+            )
+        if not patterns:
+            findings.append(
+                Finding("STYLE_PATTERNS", "registered samples require positive_patterns")
+            )
+        if not prohibitions:
+            findings.append(
+                Finding("STYLE_PROHIBITIONS", "registered samples require prohibitions")
+            )
+        if status != "approved":
+            findings.append(
+                Finding("STYLE_APPROVAL", "a sample-derived profile must be PI-approved")
+            )
+
+    if status == "approved" and (
+        not _text(approval.get("approved_by"))
+        or not _text(approval.get("approved_at"))
+    ):
+        findings.append(
+            Finding(
+                "STYLE_APPROVAL_RECORD",
+                "approved profiles require approved_by and approved_at",
+                "approval",
+            )
+        )
+
+    return ValidationReport(findings)
+
+
+def validate_discourse_plan(data: Mapping[str, Any]) -> ValidationReport:
+    findings: list[Finding] = []
+    if data.get("schema_version") != DISCOURSE_SCHEMA:
+        findings.append(
+            Finding("DISCOURSE_SCHEMA", f"schema_version must be {DISCOURSE_SCHEMA}")
+        )
+    if data.get("status") != "reviewed":
+        findings.append(
+            Finding("DISCOURSE_STATUS", "status must be reviewed before drafting advances")
+        )
+    if not _text(data.get("section_id")):
+        findings.append(Finding("SECTION_ID", "section_id is required"))
+    if not _text(data.get("takeaway")):
+        findings.append(Finding("TAKEAWAY", "a reader-facing section takeaway is required"))
+
+    required_units = _string_list(data.get("required_unit_keys"))
+    if not required_units:
+        findings.append(Finding("REQUIRED_UNITS", "required_unit_keys cannot be empty"))
+    if duplicate := _duplicate(required_units):
+        findings.append(Finding("DUPLICATE_UNIT", f"duplicate required unit key: {duplicate}"))
+
+    propositions_raw = data.get("propositions")
+    propositions = propositions_raw if isinstance(propositions_raw, list) else []
+    proposition_ids = [
+        _text(item.get("id")) for item in propositions if isinstance(item, Mapping)
+    ]
+    if not propositions or any(not item for item in proposition_ids):
+        findings.append(Finding("PROPOSITIONS", "each proposition requires a non-empty id"))
+    if duplicate := _duplicate([item for item in proposition_ids if item]):
+        findings.append(Finding("DUPLICATE_PROPOSITION", f"duplicate proposition id: {duplicate}"))
+
+    for index, proposition in enumerate(propositions):
+        if not isinstance(proposition, Mapping):
+            findings.append(Finding("PROPOSITION_SHAPE", "propositions must be mappings"))
+            continue
+        if not _text(proposition.get("statement")) or not _text(proposition.get("role")):
+            findings.append(
+                Finding(
+                    "PROPOSITION_CONTENT",
+                    "each proposition requires statement and role",
+                    f"propositions[{index}]",
+                )
+            )
+        if proposition.get("role") == "prior_work" and not _string_list(
+            proposition.get("citation_keys")
+        ):
+            findings.append(
+                Finding(
+                    "PRIOR_WORK_CITATION",
+                    "prior_work propositions must retain citation_keys during drafting",
+                    f"propositions[{index}].citation_keys",
+                )
+            )
+
+    paragraphs_raw = data.get("paragraphs")
+    paragraphs = paragraphs_raw if isinstance(paragraphs_raw, list) else []
+    paragraph_ids = [
+        _text(item.get("id")) for item in paragraphs if isinstance(item, Mapping)
+    ]
+    if not paragraphs or any(not item for item in paragraph_ids):
+        findings.append(Finding("PARAGRAPHS", "each paragraph card requires a non-empty id"))
+    if duplicate := _duplicate([item for item in paragraph_ids if item]):
+        findings.append(Finding("DUPLICATE_PARAGRAPH", f"duplicate paragraph id: {duplicate}"))
+
+    known_propositions = set(proposition_ids)
+    known_units = set(required_units)
+    used_propositions: set[str] = set()
+    mapped_units: set[str] = set()
+    for index, paragraph in enumerate(paragraphs):
+        if not isinstance(paragraph, Mapping):
+            findings.append(Finding("PARAGRAPH_SHAPE", "paragraph cards must be mappings"))
+            continue
+        field = f"paragraphs[{index}]"
+        if not all(
+            _text(paragraph.get(name)) for name in ("job", "opening", "bridge", "takeaway")
+        ):
+            findings.append(
+                Finding(
+                    "PARAGRAPH_CONTENT",
+                    "each paragraph card requires job, opening, bridge, and takeaway",
+                    field,
+                )
+            )
+        card_propositions = set(_string_list(paragraph.get("proposition_ids")))
+        card_units = set(_string_list(paragraph.get("unit_keys")))
+        if not card_propositions:
+            findings.append(
+                Finding("PARAGRAPH_PROPOSITIONS", "paragraph card has no propositions", field)
+            )
+        if not card_units:
+            findings.append(Finding("PARAGRAPH_UNITS", "paragraph card has no unit_keys", field))
+        unknown_propositions = card_propositions - known_propositions
+        unknown_units = card_units - known_units
+        if unknown_propositions:
+            findings.append(
+                Finding(
+                    "UNKNOWN_PROPOSITION",
+                    f"unknown proposition ids: {sorted(unknown_propositions)}",
+                    field,
+                )
+            )
+        if unknown_units:
+            findings.append(
+                Finding("UNKNOWN_UNIT", f"unknown unit keys: {sorted(unknown_units)}", field)
+            )
+        used_propositions.update(card_propositions)
+        mapped_units.update(card_units)
+
+    missing_propositions = known_propositions - used_propositions
+    if missing_propositions:
+        findings.append(
+            Finding(
+                "UNMAPPED_PROPOSITIONS",
+                f"propositions absent from paragraph cards: {sorted(missing_propositions)}",
+            )
+        )
+    if mapped_units != known_units:
+        findings.append(
+            Finding(
+                "UNIT_COVERAGE",
+                "the union of paragraph-card unit_keys must equal required_unit_keys",
+            )
+        )
+
+    required_disclosures = set(_string_list(data.get("mandatory_disclosure_ids")))
+    disclosure_map = _mapping(data.get("mandatory_disclosure_map"))
+    mapped_disclosures = {str(key) for key in disclosure_map}
+    if mapped_disclosures != required_disclosures:
+        findings.append(
+            Finding(
+                "DISCLOSURE_COVERAGE",
+                "mandatory_disclosure_map keys must exactly equal mandatory_disclosure_ids",
+            )
+        )
+    for disclosure_id, locations in disclosure_map.items():
+        if not _string_list(locations):
+            findings.append(
+                Finding(
+                    "DISCLOSURE_LOCATION",
+                    f"mandatory disclosure {disclosure_id} requires a public location",
+                    "mandatory_disclosure_map",
+                )
+            )
+
+    style_profile = _mapping(data.get("style_profile"))
+    if style_profile.get("required") is True and (
+        style_profile.get("status") != "approved"
+        or not _text(style_profile.get("path"))
+    ):
+        findings.append(
+            Finding(
+                "STYLE_PROFILE_LINK",
+                "a required style profile must have an approved status and path",
+                "style_profile",
+            )
+        )
+
+    review = _mapping(data.get("coherence_review"))
+    if review.get("status") != "pass" or not _text(review.get("reviewer")):
+        findings.append(
+            Finding(
+                "COHERENCE_REVIEW",
+                "a fresh-context reviewer must record a pass and reviewer identifier",
+                "coherence_review",
+            )
+        )
+    answers = _mapping(review.get("answers"))
+    missing_answers = COHERENCE_QUESTIONS - set(answers)
+    failed_answers = {key for key in COHERENCE_QUESTIONS if answers.get(key) is not True}
+    if missing_answers or failed_answers:
+        findings.append(
+            Finding(
+                "COHERENCE_ANSWERS",
+                "all eight coherence answers must be present and true",
+                "coherence_review.answers",
+            )
+        )
+
+    return ValidationReport(findings)
+
+
+def validate_profile_linkage(
+    style_profile: Mapping[str, Any], discourse_plan: Mapping[str, Any]
+) -> ValidationReport:
+    """Require a section to load an approved profile when samples exist."""
+
+    findings: list[Finding] = []
+    plan_profile = _mapping(discourse_plan.get("style_profile"))
+    if style_profile.get("samples_registered") is True and (
+        plan_profile.get("required") is not True
+        or plan_profile.get("status") != "approved"
+        or not _text(plan_profile.get("path"))
+    ):
+        findings.append(
+            Finding(
+                "STYLE_PROFILE_REQUIRED",
+                "registered samples require the section to link the approved style profile",
+                "style_profile",
+            )
+        )
+    return ValidationReport(findings)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--style-profile", type=Path)
+    parser.add_argument("--discourse-plan", type=Path)
+    args = parser.parse_args(argv)
+    if args.style_profile is None and args.discourse_plan is None:
+        parser.error("provide --style-profile and/or --discourse-plan")
+
+    reports: dict[str, Any] = {}
+    try:
+        style_data: dict[str, Any] | None = None
+        discourse_data: dict[str, Any] | None = None
+        if args.style_profile is not None:
+            style_data = load_document(args.style_profile)
+            reports["style_profile"] = validate_style_profile(style_data).as_dict()
+        if args.discourse_plan is not None:
+            discourse_data = load_document(args.discourse_plan)
+            reports["discourse_plan"] = validate_discourse_plan(discourse_data).as_dict()
+        if style_data is not None and discourse_data is not None:
+            reports["profile_linkage"] = validate_profile_linkage(
+                style_data, discourse_data
+            ).as_dict()
+    except (TypeError, ValueError) as exc:
+        print(json.dumps({"verdict": "ERROR", "error": str(exc)}, indent=2))
+        return 3
+
+    verdict = "BLOCK" if any(item["verdict"] == "BLOCK" for item in reports.values()) else "PASS"
+    print(json.dumps({"verdict": verdict, "artifacts": reports}, indent=2, sort_keys=True))
+    return 2 if verdict == "BLOCK" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/skills/writer/workspace-template/.planning/DISCOURSE_TEMPLATE.yaml
+++ b/plugin/skills/writer/workspace-template/.planning/DISCOURSE_TEMPLATE.yaml
@@ -1,0 +1,52 @@
+schema_version: rka.writer-discourse-plan/v1
+status: not_started
+section_id: null
+takeaway: null
+
+style_profile:
+  required: false
+  path: .planning/STYLE_PROFILE.yaml
+  status: not_required
+
+# Copy this file to .planning/DISCOURSE_<section-id>.yaml. Populate the exact
+# active native-unit set assigned to the section.
+required_unit_keys: []
+mandatory_disclosure_ids: []
+
+propositions: []
+# - id: p1
+#   statement: null
+#   role: context | gap | insight | challenge | response | evidence | prior_work
+#   evidence_ids: []
+#   qualifier_ids: []
+#   citation_keys: []
+#   next_inference: null
+
+paragraphs: []
+# - id: para1
+#   job: null
+#   proposition_ids: []
+#   unit_keys: []
+#   opening: null
+#   bridge: null
+#   takeaway: null
+
+# Keys must exactly equal mandatory_disclosure_ids. Values are public locations
+# such as paragraph:para2, figure:fig3, table:tab2, caption:fig3, or claim:mcl_...
+mandatory_disclosure_map: {}
+
+coherence_review:
+  status: pending
+  reviewer: null
+  answers:
+    single_takeaway: false
+    paragraph_sequence: false
+    one_job_per_paragraph: false
+    challenge_response: false
+    idea_before_mechanism: false
+    evidence_advances_argument: false
+    opening_promise_delivered: false
+    prose_self_contained: false
+
+# Private authoring state only. RKA remains authoritative for claims, evidence,
+# units, status, and readiness.

--- a/plugin/skills/writer/workspace-template/.planning/STYLE_PROFILE.yaml
+++ b/plugin/skills/writer/workspace-template/.planning/STYLE_PROFILE.yaml
@@ -1,0 +1,16 @@
+schema_version: rka.writer-style-profile/v1
+status: not_started
+samples_registered: false
+sample_inventory: []
+
+# Populate by rhetorical slot, for example introduction_opening, gap,
+# approach_overview, results_summary, or nsf_thrust.
+positive_patterns: {}
+prohibitions: []
+
+approval:
+  approved_by: null
+  approved_at: null
+
+# Advisory drafting calibration only. This file is not research evidence and
+# must not copy prose from the sample corpus.

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: rka-writer
-description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, then produces persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
+description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, synthesizes the research graph into a coherent logic ladder, and produces plain, persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
 metadata:
-  version: "2.7.3"
+  version: "2.7.4"
 ---
 
 # Writer Skill
@@ -30,6 +30,14 @@ only for custom alternatives, missing evidence, disagreements not covered by
 the choices, or exact wording corrections. Follow
 [`references/framing_elicitation.md`](references/framing_elicitation.md).
 
+Discourse Law: **the evidence graph constrains prose but does not organize
+it.** Never translate journals, claims, clusters, or manuscript units into
+sentences one by one. First compress them into reader-facing propositions,
+arrange a section-level logic ladder, and form coherent paragraphs. Draft
+plain academic prose from that discourse plan; attach provenance and citations
+afterward. Follow
+[`references/discourse_synthesis.md`](references/discourse_synthesis.md).
+
 The native claim spine is part of RKA's manuscript aggregate, not a second
 knowledge base or orchestrator. RKA is authoritative for manuscript identity,
 claim wording and versions, evidence roles, PI ratifications, units,
@@ -52,6 +60,9 @@ commands.
   mandatory noise-smoothing path from journal records through grounded claims,
   Brain-reviewed clusters and research questions, PI-scoped contribution
   candidates, native units, and drafting.
+- [`references/discourse_synthesis.md`](references/discourse_synthesis.md):
+  separation of evidence and discourse graphs, plain academic style target,
+  section logic ladders, paragraph formation, and post-hoc provenance.
 - [`references/persuasive_framing.md`](references/persuasive_framing.md):
   two-channel author/manuscript discipline, limitation materiality triage,
   strength-first defense patterns, and the quick-reader path.
@@ -169,6 +180,12 @@ findings (`PASS`, `WARN`, `BLOCK`, `ERROR`), never a numeric quality score.
 
 When the PI describes a section or report scope in prose, do NOT rely on a single search. Call `rka_query(args={"operation": "collect_report_context", "project_id": "prj_...", "query": <the PI's description>, "filters": {"angle_queries": [3-5 short queries from different angles]}})` to assemble the candidate node set: it unions multi-angle search seeds with provenance-weighted graph expansion and returns per-node `included_via` so every inclusion is auditable. Then verify borderline nodes by fetching their content, and re-search any report dimension that came back thin. Iterative retrieval measured 0.80 to 1.00 recall vs 0.32 for one-shot paragraph search (eval-v3). The full strategy lives in the Brain skill section "Retrieval Strategy" (drive RKA through several calls, never one-shot it).
 
+Treat that node set as an evidence packet, not a prose plan. Merge duplicate or
+closely related records into evidence bundles, distill the few propositions
+the reader needs, and order them by the section's rhetorical logic. Do not
+preserve retrieval rank, record chronology, entity type, or unit boundaries in
+the public prose unless one of them is itself relevant to the argument.
+
 ---
 
 ## Source Attribution
@@ -285,6 +302,11 @@ may inherit only disclosed claim/evidence bindings; condensation unions those
 bindings into the retained parent before removing named descendants; reorder
 must contain the complete active unit-key set. Never reconstruct the outline
 by free-form delete-and-recreate operations.
+
+Outline depth and bindings support audit and change impact. They do not impose
+a one-unit-to-one-paragraph mapping. During drafting, group active units into
+paragraphs according to rhetorical continuity and the section-level logic
+ladder in `references/discourse_synthesis.md`.
 
 Outline work is resumable while blockers remain. Re-query
 `manuscript_outline` after every applied proposal. Create an Outline checkpoint
@@ -610,6 +632,12 @@ When a revised draft is available, compare it against the prior review comments 
 26. **DON'T** record a framing micro-selection as evidence, claim ratification,
    or a formal PI decision. Persist it in `FRAMING_SESSION.yaml` until final
    confirmation.
+27. **DON'T** turn the RKA graph into prose by iterating records, assigning one
+    sentence per source, or assigning one paragraph per claim or manuscript
+    unit. Build and draft from a reader-facing discourse plan.
+28. **DON'T** treat provenance coverage or an AI-tic score as evidence of
+    coherence. Verify the logic ladder, paragraph bridges, and section
+    takeaway before surface polishing.
 
 ---
 
@@ -623,6 +651,8 @@ When a revised draft is available, compare it against the prior review comments 
   [`references/framing_elicitation.md`](references/framing_elicitation.md).
 - Persuasive framing, limitation triage, and quick-reader guidance:
   [`references/persuasive_framing.md`](references/persuasive_framing.md).
+- Discourse synthesis, plain academic style, and paragraph construction:
+  [`references/discourse_synthesis.md`](references/discourse_synthesis.md).
 - Implemented reference validation pipeline: [`references/reference_pipeline.md`](references/reference_pipeline.md).
 - Anti-AI-tic full tier table, replacements, structural detectors: [`references/ai_tics.md`](references/ai_tics.md).
 - Venue files: [`references/venue/CHI.md`](references/venue/CHI.md), [`references/venue/EMNLP.md`](references/venue/EMNLP.md).

--- a/rka/skills/writer/SKILL.md
+++ b/rka/skills/writer/SKILL.md
@@ -2,7 +2,7 @@
 name: rka-writer
 description: "Manuscript-drafting AI for RKA-managed research projects. Interactively elicits paper framing through AI-proposed choices, synthesizes the research graph into a coherent logic ladder, and produces plain, persuasive, reviewer-resilient prose while keeping every substantive block grounded in current RKA evidence and decisions. Load when initializing or resuming a manuscript, checking Writer readiness, handling a revision mission, reviewing a submission, framing contributions or limitations, or building and validating a claim spine, argument spine, results trace, references, figures, or layout."
 metadata:
-  version: "2.7.4"
+  version: "2.7.5"
 ---
 
 # Writer Skill
@@ -45,7 +45,10 @@ checkpoints, readiness, and currency. `.planning/RKA_CLAIM_SPINE.yaml`,
 `.planning/CONTRIBUTION_CONTRACT.md`, `.planning/ARGUMENT_SPINE.md`, and
 `.planning/RESULTS_TRACE.md` are deterministic read-only projections. Refresh
 them with `rka writer sync`; change semantics only through revision-guarded RKA
-commands.
+commands. `.planning/STYLE_PROFILE.yaml` and per-section
+`.planning/DISCOURSE_<section-id>.yaml` are disposable private authoring state;
+they guide prose and validation but never become evidence or override native
+readiness.
 
 ## Supplementary references (load on demand)
 
@@ -62,7 +65,8 @@ commands.
   candidates, native units, and drafting.
 - [`references/discourse_synthesis.md`](references/discourse_synthesis.md):
   separation of evidence and discourse graphs, plain academic style target,
-  section logic ladders, paragraph formation, and post-hoc provenance.
+  section logic ladders, paragraph formation, private planning artifacts,
+  fresh-context review, and post-hoc provenance.
 - [`references/persuasive_framing.md`](references/persuasive_framing.md):
   two-channel author/manuscript discipline, limitation materiality triage,
   strength-first defense patterns, and the quick-reader path.
@@ -162,6 +166,11 @@ categorical report. Core manuscript validation queues the slow external work;
 the worker keeps retraction checking enabled and persists an immutable
 validation attestation. A pending job is not a verified reference.
 `overclaim_lint.py` scans drafts for calibration/overclaim wording (`verified`, `guaranteed`, `eliminates`, `model-agnostic`, ...) and emits `overclaim_report.json`. WARN-only, never BLOCK; ranks a hit higher when its backing `jrn_`/`clm_` is at `hypothesis`/`tested` confidence. Advisory input to the pre-submission review.
+`validate_discourse_artifacts.py` validates the private style profile and
+per-section discourse plan. It BLOCKs incomplete sample-profile approval,
+missing proposition/paragraph mappings, prior-work propositions without
+citation keys, non-exact mandatory-disclosure or native-unit coverage, and an
+incomplete fresh-context review. It does not score or certify prose coherence.
 `fetch_template.py` performs registry lookup, download, SHA-256 verification, cache reuse, and fail-closed PI pin handling.
 `claim_spine.py` safely loads both the legacy `rka-claim-spine/v1` migration
 format and the native `rka-claim-spine/v2` server projection. It validates
@@ -638,6 +647,10 @@ When a revised draft is available, compare it against the prior review comments 
 28. **DON'T** treat provenance coverage or an AI-tic score as evidence of
     coherence. Verify the logic ladder, paragraph bridges, and section
     takeaway before surface polishing.
+29. **DON'T** advance a section from an unrecorded discourse plan. Validate the
+    section artifact, exact required-unit and mandatory-disclosure coverage,
+    current provenance/citations, and fresh-context coherence review after the
+    final prose change.
 
 ---
 

--- a/rka/skills/writer/docs/phase-1-mvp.md
+++ b/rka/skills/writer/docs/phase-1-mvp.md
@@ -87,7 +87,8 @@ PATCH 2).
 
 - `.mcp.json`, `.latexmkrc`, `ai_tic_config.yaml`, `main.tex`, `refs.bib`.
 - `.planning/`: `ACTIVE_WORKFLOW.md`, `FRAMING_SESSION.yaml`, `PRECIS.md`,
-  `OUTLINE.md`, `REVIEW_STATE.md`.
+  `OUTLINE.md`, `REVIEW_STATE.md`, `STYLE_PROFILE.yaml`, and
+  `DISCOURSE_TEMPLATE.yaml`.
 - Directory placeholders: `sections/`, `figures/`, `tables/`, `charts/`,
   `styles/`.
 

--- a/rka/skills/writer/references/ai_tics.md
+++ b/rka/skills/writer/references/ai_tics.md
@@ -165,7 +165,7 @@ The linter loads the project's `ai_tic_config.yaml` if present, applies override
 
 The linter `scripts/ai_tic_lint.py` implements all Tier 1 + Tier 2 + Tier 3 lexical patterns, the four structural detectors (sentence-length variance, transition-word ratio, parallel-triplet density, bridge-repetition delegation to `bridge_repetition_check.py`), absolute bans, the style score formula, and the per-project override mechanism. Output is `ai_tic_report.json` with per-rule hit counts and per-hit line numbers, plus the computed style score.
 
-Further additions:
+Future additions (not implemented):
 
 - LLM-assisted rewrite suggestions for flagged passages.
 - Cross-manuscript trend tracking (is the project drifting toward AI-tic patterns over revisions).

--- a/rka/skills/writer/references/ai_tics.md
+++ b/rka/skills/writer/references/ai_tics.md
@@ -6,6 +6,13 @@ Load-bearing per `dec_01KS12H9KT1T03DHX2Q6FKTXHH` (PATCH 2 disposition; no third
 
 Pure lexical blacklists over-flag legitimate academic prose (Matsui 2025). The Writer's enforcement layer therefore combines a tiered lexical list with structural detectors and a per-project override mechanism. The lexical layer catches the obvious LLM tells; the structural layer catches the rhythmic and bridging patterns that survive lexical sanitization; the override layer respects venue-specific or PI-specific legitimate usage.
 
+This linter is a negative filter, not a prose generator or coherence judge. A
+high score shows only that the checked patterns are rare. It does not show that
+the section has a coherent argument, fluent paragraph transitions, appropriate
+information order, or the author's preferred academic voice. Build and revise
+the positive style target through `discourse_synthesis.md` before running this
+filter.
+
 Empirical floor for the rules: across six published studies covering 732 LLM-generated citations, cross-study average is 51 percent fabrication (Walters and Wilder 2023, Wagner and Ertl-Wagner 2023, Mugaanyi 2024, Spennemann 2025). Linter discipline is one half of the defense; the other half is the reference validation pipeline (`reference_pipeline.md`). Both must be active.
 
 ## Tier 1: CRITICAL (compile-blocking on any hit)
@@ -123,7 +130,7 @@ score = 1 - (critical_hits * 3 + high_hits + 0.3 * medium_hits) / total_sentence
 
 Threshold: sections with `score < 0.85` trigger auto-revise via the Revision Loop (Class R2). The auto-revise loop caps at three iterations before escalating to a PI Style checkpoint with three resolution options (continue revising, accept the section as is via PI override, or restructure the section).
 
-The score is one signal among several. PI editorial judgment overrides the score via `ai_tic_config.yaml`. The score is **not** the sole gate. Treating it as such is anti-pattern 10 in `SKILL.md`.
+The score is one signal among several. PI editorial judgment overrides the score via `ai_tic_config.yaml`. The score is **not** the sole gate. Treating it as such is anti-pattern 10 in `SKILL.md`. Never use the score to certify logic, coherence, fluency, or author-style fit.
 
 ## Per-project override mechanism
 
@@ -158,11 +165,13 @@ The linter loads the project's `ai_tic_config.yaml` if present, applies override
 
 The linter `scripts/ai_tic_lint.py` implements all Tier 1 + Tier 2 + Tier 3 lexical patterns, the four structural detectors (sentence-length variance, transition-word ratio, parallel-triplet density, bridge-repetition delegation to `bridge_repetition_check.py`), absolute bans, the style score formula, and the per-project override mechanism. Output is `ai_tic_report.json` with per-rule hit counts and per-hit line numbers, plus the computed style score.
 
-Phase 2 additions (not in scope for Phase 1):
+Further additions:
 
 - LLM-assisted rewrite suggestions for flagged passages.
 - Cross-manuscript trend tracking (is the project drifting toward AI-tic patterns over revisions).
-- Author-style fingerprinting baseline (calibrate the linter against the PI's pre-2023 publications).
+- Deterministic author-style diagnostics. Sample-driven qualitative calibration
+  is already available through `discourse_synthesis.md`; any future metric
+  must remain advisory and must not reduce author voice to a single score.
 
 ## References
 

--- a/rka/skills/writer/references/architecture.md
+++ b/rka/skills/writer/references/architecture.md
@@ -22,6 +22,8 @@ Writer session
         +-- .planning/ARGUMENT_SPINE.md          generated
         +-- .planning/RESULTS_TRACE.md            generated
         +-- .planning/FRAMING_SESSION.yaml        advisory interaction state
+        +-- .planning/STYLE_PROFILE.yaml          PI-approved style calibration
+        +-- .planning/DISCOURSE_<section>.yaml    private section discourse plan
         +-- .planning/ACTIVE_WORKFLOW.md          local session state
         +-- sections/, figures/, tables/, charts/
         +-- refs.bib, main.tex, styles/
@@ -41,7 +43,7 @@ the canonical `man_` id returned or resolved by `rka writer init`.
 | exact PI ratifications (`mra_`) | deterministic Markdown/YAML rendering |
 | manuscript units (`mun_`) and result boundaries | figures, tables, and chart source files |
 | checkpoints (`mck_`) and verification attestations (`mva_`) | compilation and layout audit |
-| readiness, change cursors, and impact | disposable local session notes |
+| readiness, change cursors, and impact | disposable style/discourse/session notes |
 
 Local files cannot create semantic truth. A local proposal changes the
 aggregate only through an explicit, revision-guarded command. A generated

--- a/rka/skills/writer/references/discourse_synthesis.md
+++ b/rka/skills/writer/references/discourse_synthesis.md
@@ -23,6 +23,28 @@ record order and turn each item into prose. Journal chronology is relevant
 only when the history of the research or design is itself part of the
 argument.
 
+## Planning artifacts
+
+Keep the discourse graph in disposable, private authoring state rather than
+adding a second research database:
+
+- `.planning/STYLE_PROFILE.yaml` stores sample-derived positive patterns,
+  operational prohibitions, the sample inventory, and PI approval. When
+  samples are registered, an approved profile is a drafting precondition.
+- Copy `.planning/DISCOURSE_TEMPLATE.yaml` to
+  `.planning/DISCOURSE_<section-id>.yaml` for each section. Record the section
+  takeaway, required native-unit set, propositions, paragraph cards,
+  mandatory-disclosure coverage, style-profile link, and fresh-context
+  coherence review.
+
+Run `scripts/validate_discourse_artifacts.py --style-profile
+.planning/STYLE_PROFILE.yaml --discourse-plan
+.planning/DISCOURSE_<section-id>.yaml` before advancing any mapped unit to
+`drafted`. The validator checks structure, exact disclosure and unit
+coverage, prior-work citation bindings, and review completion. It deliberately
+does not assign a coherence score. RKA remains authoritative for claims,
+evidence, units, status, and readiness.
+
 ## Plain academic target
 
 Write in direct academic language with visible reasoning and restrained
@@ -70,6 +92,25 @@ Avoid these negative patterns:
 - A paragraph that ends without changing what the reader knows or expects
   next.
 
+### Synthetic contrastive example
+
+This example demonstrates information packaging only; it is not research
+evidence and must not be reused as manuscript content.
+
+**Record-shaped:** “The monitor records prompts, tool calls, timestamps,
+policy decisions, retries, and token counts. It applies validation, filtering,
+rate limits, rollback, and sandboxing. We measure attack success, false
+positives, runtime, and token overhead.” The paragraph catalogs available
+records and controls before establishing the problem they solve.
+
+**Synthesized:** “An agent can satisfy every local policy check and still
+produce an unsafe action when individually benign steps interact. Our key
+observation is that the monitor must preserve the causal path from a request
+to its external effect. We therefore connect policy decisions across tool
+boundaries and evaluate whether this history exposes attacks that isolated
+checks miss.” The rewrite moves from failure to observation to response and
+payoff; implementation fields can follow after their purpose is clear.
+
 ## Drafting workflow
 
 ### 1. Build an evidence packet
@@ -82,9 +123,11 @@ Do not start prose from this packet.
 
 ### 2. Distill discourse propositions
 
-Compress the packet into three to seven reader-facing propositions for a
-normal section. A proposition is a statement the reader must understand for
-the next move to follow. It may combine many records.
+Compress the packet into roughly three to seven reader-facing propositions
+for a normal section. This is a planning heuristic, not a cap: one proposition
+may combine several ladder moves, and a complex section may need more. A
+proposition is a statement the reader must understand for the next move to
+follow. It may combine many records.
 
 For each proposition, record privately:
 
@@ -92,16 +135,21 @@ For each proposition, record privately:
 - its role in the section;
 - the evidence bundle that supports it;
 - the condition or qualifier that changes its meaning;
+- citation keys when it attributes a claim to specific prior work;
 - the inference that connects it to the next proposition.
 
 Merge duplicate and closely related records. Omit records that do not serve
 the section's communicative job. Omission from prose does not remove them from
-RKA.
+RKA. Never omit an active M1/M2 item or required counterevidence from the
+section plan: list each one in `mandatory_disclosure_ids` and map it to a
+public location before the plan may pass validation.
 
 ### 3. Arrange the logic ladder
 
-Choose the ladder that fits the section. Do not force every move into every
-section.
+Choose, reorder, combine, or omit moves to fit the section. The ladders below
+are diagnostic patterns, not fill-in templates. Do not force every move into
+every section, reuse a visibly identical skeleton across the manuscript, or
+preserve these labels as headings.
 
 **Introduction or motivation**
 
@@ -150,6 +198,35 @@ need and consequence
 -> evaluation and expected knowledge gain
 ```
 
+**Related work**
+
+```text
+reader's comparison frame
+-> organizing dimension such as problem, technique, or threat class
+-> synthesis of what a family of approaches achieves
+-> boundary that matters for the present problem
+-> explicit delta and positioning takeaway
+```
+
+Organize around the reader's comparison question, never around RKA cluster
+identity. Attribute statements about a specific work with the citation key
+kept on the corresponding private proposition during drafting.
+
+**Threat model or security assumptions**
+
+```text
+protected assets and security goal
+-> adversary capabilities and control
+-> trust boundaries and assumptions
+-> explicit out-of-scope conditions that affect interpretation
+-> attacks the model admits
+-> connection from each material challenge to a design response or evaluation
+```
+
+State assumptions before relying on them, but do not turn the section into a
+field inventory. The order should follow what a reader needs to judge whether
+the claimed defense applies.
+
 The logic ladder is a reasoning path, not a set of headings. A reader should be
 able to explain why each move makes the next move necessary.
 
@@ -163,16 +240,26 @@ paragraph, decide:
 - **development:** explanation, example, contrast, or evidence bundle;
 - **bridge:** the inference that makes the next paragraph natural;
 - **takeaway:** the claim the reader should retain.
+- **unit keys:** the exact native units whose obligations the paragraph helps
+  discharge.
 
 A paragraph may realize several manuscript units, and a complex unit may span
 several paragraphs. Choose boundaries from rhetorical continuity, not from RKA
 IDs or unit keys.
 
+The union of paragraph-card `unit_keys` must exactly equal the section's
+`required_unit_keys`. Every proposition must appear in at least one paragraph
+card. A unit advances to `drafted` only after all paragraph cards mapped to it
+are committed and the final discourse, provenance, citation, and mandatory-
+disclosure checks pass.
+
 ### 5. Draft clean prose
 
-Draft from the logic ladder and paragraph cards with RKA IDs, citations, and
-private risk labels hidden. Keep the evidence packet available as a boundary,
-not as a sentence template.
+Draft from the logic ladder and paragraph cards with RKA IDs, provenance
+comments, and private risk labels hidden. Keep citation keys attached to
+private propositions that make claims about specific prior work, even when
+the public citation markup is inserted later. Keep the evidence packet
+available as a boundary, not as a sentence template.
 
 Explain the idea before the machinery. Delay exhaustive implementation lists
 until the reader understands their purpose. Use the strongest concrete
@@ -186,6 +273,12 @@ back to its evidence bundle. Add hidden provenance comments and validated
 citations without changing the reader-facing organization. If a sentence
 cannot be grounded, narrow or remove it. Do not split a coherent paragraph
 into record-shaped fragments merely to make provenance attachment easier.
+
+Any narrowing, citation correction, mandatory-disclosure relocation, or later
+surface edit changes the artifact under review. Re-run the coherence review,
+provenance and citation validation, disclosure coverage, and discourse-
+artifact validation after the last prose change. Advance only after one pass
+makes no further prose change; escalate after three unsuccessful passes.
 
 ### 7. Revise in the right order
 
@@ -223,10 +316,17 @@ prose alone:
 If any answer is unclear, revise the discourse plan before polishing
 sentences.
 
+Persist the takeaway, paragraph jobs, answers, and reviewer identity in the
+section's `DISCOURSE_<section-id>.yaml`. A fresh-context reviewer—not the
+section drafter—records the final answers. Surface the takeaway and paragraph
+jobs at the Draft section checkpoint so the PI can inspect the argument
+without reading internal RKA records.
+
 ## Calibrating to author samples
 
 When the author supplies several good examples and one or more disliked
-examples, derive a project-local style profile before drafting:
+examples, register them in `.planning/STYLE_PROFILE.yaml` and derive the
+project-local profile before drafting:
 
 1. Compare matched rhetorical locations such as abstracts, introduction
    openings, gap paragraphs, approach overviews, result summaries, and task
@@ -237,9 +337,15 @@ examples, derive a project-local style profile before drafting:
    as `bad style`.
 4. Paraphrase short examples; do not copy sentences from the calibration
    corpus into a new manuscript.
-5. Treat the profile as a positive drafting target. Venue requirements and
-   current PI instructions override it.
+5. Record the sample inventory without copying the sample texts into the
+   repository or profile.
+6. Ask the PI to approve or edit the profile, then set `status: approved` with
+   the approval record.
+7. Treat the approved profile as a positive drafting target. Venue
+   requirements and current PI instructions override it.
 
 Do not imitate grammar errors, stale terminology, unsupported claims, or
 venue-specific formatting from a sample. Learn the author's reasoning and
-information-packaging habits rather than copying surface text.
+information-packaging habits rather than copying surface text. When registered
+samples exist, do not draft until the profile is approved and linked from the
+section discourse artifact.

--- a/rka/skills/writer/references/discourse_synthesis.md
+++ b/rka/skills/writer/references/discourse_synthesis.md
@@ -1,0 +1,245 @@
+# Discourse Synthesis and Plain Academic Style
+
+Use this workflow after the claim spine and outline are current and before
+drafting public prose. RKA constrains what the paper may say. It must not
+determine the order, sentence boundaries, or surface vocabulary of the paper.
+
+## Evidence graph and discourse graph
+
+Keep two representations separate:
+
+1. **Evidence graph.** RKA records claims, scope, support, qualifiers,
+   counterevidence, decisions, and provenance. Preserve this graph completely.
+2. **Discourse graph.** The manuscript guides a reader through a small number
+   of propositions in a deliberate order. Build this graph for comprehension
+   and persuasion, then attach its propositions back to the evidence graph.
+
+The mapping is many-to-many. Several RKA records may support one sentence or
+paragraph. One RKA claim may inform several rhetorical moves. A manuscript
+unit is an argument-planning object, not a required paragraph boundary.
+
+Never traverse journal entries, claims, clusters, or manuscript units in
+record order and turn each item into prose. Journal chronology is relevant
+only when the history of the research or design is itself part of the
+argument.
+
+## Plain academic target
+
+Write in direct academic language with visible reasoning and restrained
+technical detail. Use these positive features:
+
+- Begin from a concrete problem, consequence, or observation before moving to
+  an abstraction.
+- Use an explicit logic ladder: context, problem, prior approach, gap, insight,
+  challenge, response, evidence, and implication. Include only the moves the
+  section needs.
+- Give each paragraph one communicative job, but allow several claims and
+  evidence records to serve that job.
+- State the main point early. Explain why it follows and why it matters before
+  adding implementation detail.
+- Use examples to make a threat, failure, or design need tangible.
+- Prefer common verbs such as `use`, `show`, `compare`, `measure`, `detect`,
+  `build`, and `reduce`. Use a technical term when it is more precise, not
+  merely more formal.
+- Keep one name for one concept. Repetition of the exact technical term is
+  clearer than elegant variation.
+- Use first-person active constructions when the venue permits them: `we
+  observe`, `we design`, `we evaluate`, and `the results show`.
+- Let a sentence carry a real logical relation. Plain language does not require
+  uniformly short sentences or a sequence of clipped statements.
+- Present a challenge and its corresponding design response close together.
+- State bounded contributions confidently. Put a material boundary where the
+  reader interprets the affected claim, not as an unrelated confession in the
+  opening narrative.
+
+Avoid these negative patterns:
+
+- RKA vocabulary, record IDs, evidence-status labels, or audit language in
+  public prose unless the system's provenance mechanism is itself a research
+  contribution.
+- One sentence per source, one paragraph per claim, or one subsection per
+  manuscript unit.
+- Catalogs of controls, checks, fields, or components before the reader
+  understands the problem they solve.
+- Early defensive qualifications that interrupt the problem-to-insight path.
+- Repeated labels such as `bounded`, `typed`, `current`, `immutable`, or
+  `auditable` when a concrete explanation would be clearer.
+- Dense noun stacks, unnecessary nominalizations, and abstract topic
+  sentences that merely classify the literature.
+- Mechanical transitions added to connect otherwise unrelated facts.
+- A paragraph that ends without changing what the reader knows or expects
+  next.
+
+## Drafting workflow
+
+### 1. Build an evidence packet
+
+For the section, resolve current support, qualifiers, counterevidence,
+conditions, allowed interpretation, prohibited wording, and publication
+boundary. Keep exact IDs and source details in private notes.
+
+Do not start prose from this packet.
+
+### 2. Distill discourse propositions
+
+Compress the packet into three to seven reader-facing propositions for a
+normal section. A proposition is a statement the reader must understand for
+the next move to follow. It may combine many records.
+
+For each proposition, record privately:
+
+- its reader-facing statement;
+- its role in the section;
+- the evidence bundle that supports it;
+- the condition or qualifier that changes its meaning;
+- the inference that connects it to the next proposition.
+
+Merge duplicate and closely related records. Omit records that do not serve
+the section's communicative job. Omission from prose does not remove them from
+RKA.
+
+### 3. Arrange the logic ladder
+
+Choose the ladder that fits the section. Do not force every move into every
+section.
+
+**Introduction or motivation**
+
+```text
+concrete setting and stakes
+-> current practice or prior approach
+-> precise limitation
+-> central observation or insight
+-> technical challenges
+-> corresponding design responses
+-> strongest evidence and payoff
+-> contribution summary
+```
+
+**System or method**
+
+```text
+goal and input-output contract
+-> why the direct approach fails
+-> design insight
+-> mechanism
+-> how the mechanism resolves the challenge
+-> interface with the next component
+```
+
+**Evaluation or results**
+
+```text
+research question
+-> setup needed to interpret the result
+-> principal result
+-> explanation or mechanism
+-> comparison or sensitivity evidence
+-> supported implication and material boundary
+```
+
+**NSF project or thrust**
+
+```text
+need and consequence
+-> knowledge or capability gap
+-> preliminary insight or evidence
+-> objective
+-> challenges
+-> tasks matched to those challenges
+-> evaluation and expected knowledge gain
+```
+
+The logic ladder is a reasoning path, not a set of headings. A reader should be
+able to explain why each move makes the next move necessary.
+
+### 4. Form paragraph cards
+
+Group propositions into paragraphs before writing sentences. For each
+paragraph, decide:
+
+- **job:** what changes in the reader's understanding;
+- **opening:** the main point or concrete setup;
+- **development:** explanation, example, contrast, or evidence bundle;
+- **bridge:** the inference that makes the next paragraph natural;
+- **takeaway:** the claim the reader should retain.
+
+A paragraph may realize several manuscript units, and a complex unit may span
+several paragraphs. Choose boundaries from rhetorical continuity, not from RKA
+IDs or unit keys.
+
+### 5. Draft clean prose
+
+Draft from the logic ladder and paragraph cards with RKA IDs, citations, and
+private risk labels hidden. Keep the evidence packet available as a boundary,
+not as a sentence template.
+
+Explain the idea before the machinery. Delay exhaustive implementation lists
+until the reader understands their purpose. Use the strongest concrete
+example or result once; do not restate it in slightly different words merely
+because several records support it.
+
+### 6. Attach provenance post-hoc
+
+After the prose is coherent, map each checkable assertion or substantive block
+back to its evidence bundle. Add hidden provenance comments and validated
+citations without changing the reader-facing organization. If a sentence
+cannot be grounded, narrow or remove it. Do not split a coherent paragraph
+into record-shaped fragments merely to make provenance attachment easier.
+
+### 7. Revise in the right order
+
+Run separate passes in this order:
+
+1. **Section argument:** verify that the central takeaway and logic ladder are
+   complete.
+2. **Paragraph coherence:** verify topic continuity, known-to-new information,
+   causal bridges, and non-redundant paragraph jobs.
+3. **Plain language:** replace avoidable jargon, noun stacks, and abstract
+   bookkeeping terms; define necessary terminology once.
+4. **Evidence and boundaries:** verify every factual assertion, citation,
+   qualifier, and M1/M2 treatment.
+5. **Surface style:** run AI-tic, repetition, and venue checks last.
+
+A linter pass does not establish coherence. Absence of banned terms, varied
+sentence length, and valid provenance are necessary checks, not a writing
+strategy.
+
+## Coherence review
+
+Before presenting a section to the PI, answer these questions from the public
+prose alone:
+
+1. What single takeaway does the section establish?
+2. Why does each paragraph follow the previous one?
+3. Does each paragraph develop one job rather than list several records?
+4. Are challenges paired with the design choices that answer them?
+5. Can a reader understand the idea before encountering detailed mechanisms?
+6. Do examples and results advance the argument rather than decorate it?
+7. Does the final paragraph deliver the promise made by the opening?
+8. Would removing all provenance comments leave a fluent, self-contained
+   manuscript?
+
+If any answer is unclear, revise the discourse plan before polishing
+sentences.
+
+## Calibrating to author samples
+
+When the author supplies several good examples and one or more disliked
+examples, derive a project-local style profile before drafting:
+
+1. Compare matched rhetorical locations such as abstracts, introduction
+   openings, gap paragraphs, approach overviews, result summaries, and task
+   descriptions.
+2. Record positive patterns in logic order, paragraph construction,
+   terminology, voice, example use, and technical-detail timing.
+3. Record negative patterns as operational prohibitions, not vague labels such
+   as `bad style`.
+4. Paraphrase short examples; do not copy sentences from the calibration
+   corpus into a new manuscript.
+5. Treat the profile as a positive drafting target. Venue requirements and
+   current PI instructions override it.
+
+Do not imitate grammar errors, stale terminology, unsupported claims, or
+venue-specific formatting from a sample. Learn the author's reasoning and
+information-packaging habits rather than copying surface text.

--- a/rka/skills/writer/references/evidence_to_spine_pipeline.md
+++ b/rka/skills/writer/references/evidence_to_spine_pipeline.md
@@ -44,7 +44,11 @@ mcl_ manuscript claims + PI ratification
         v
 mun_ units, argument spine, and results trace
         |
-        | evidence-grounded, claim-centered drafting and citation validation
+        | synthesize units into reader-facing propositions and a logic ladder
+        v
+section discourse plan and paragraph cards
+        |
+        | draft clean prose, then attach provenance and validate citations
         v
 manuscript prose
 ```
@@ -191,7 +195,7 @@ suppression of a claim-relevant mixed result, or deletion of provenance.
 
 ## 5. Argument spine and unit plan
 
-Build the argument at claim-sized granularity:
+Build the argument at argument-beat granularity:
 
 ```text
 problem -> gap -> response -> evidence -> interpretation -> boundary
@@ -216,6 +220,12 @@ merely a list of section headings. The deterministic
 - which discussion statement resolves each research question;
 - where material or venue-required boundaries constrain interpretation.
 
+Argument beats preserve semantics and change impact. They are not prose
+containers. Do not assign one sentence to each evidence record, one paragraph
+to each claim, or one subsection to each unit. During drafting, group several
+beats into a paragraph when they perform one communicative job, or expand one
+complex beat across paragraphs when the reader needs a staged explanation.
+
 ## 6. Results-to-claim trace
 
 Every active empirical contribution must have an active result unit, and every
@@ -236,21 +246,30 @@ authoritative.
 
 ## 7. Writing strategy
 
-Draft one unit at a time:
+Draft from a section-level discourse plan, not from individual records or
+units:
 
-1. Resolve the unit, ratified claim version, positive support, qualifiers,
-   counterevidence, prohibited wording, and publication-boundary
+1. Resolve all relevant units, ratified claim versions, positive support,
+   qualifiers, counterevidence, prohibited wording, and publication-boundary
    classifications from RKA and the private planning record.
-2. Extract the evidence facts, conditions, and material boundaries before
-   drafting.
-3. Draft the smallest claim-centered, strength-first prose block that performs
-   the unit's communicative job and makes the strongest evidence easy to find.
-4. Stay within the allowed interpretation and apply M1-M4/S public placement.
-5. Run the quick-reader checks in `persuasive_framing.md`; revise the framing
+2. Build one private evidence packet. Merge duplicate and closely related
+   records into evidence bundles; do not preserve record order.
+3. Distill the packet into a small set of reader-facing propositions and
+   arrange them into the section's logic ladder.
+4. Group those propositions into paragraphs with an opening, development,
+   takeaway, and bridge to the next paragraph. Paragraph boundaries follow
+   rhetorical continuity rather than RKA entity or unit boundaries.
+5. Draft clean, plain academic prose from the logic ladder and paragraph
+   plan. Keep IDs and private risk labels out of the public text.
+6. Stay within the allowed interpretation and apply M1-M4/S public placement.
+7. Revise section argument and paragraph coherence before sentence-level style
+   polishing. Use `discourse_synthesis.md` for this pass.
+8. Attach hidden provenance and citations in a separate pass, then validate
+   them. Do not fragment coherent prose merely to simplify provenance mapping.
+9. Run the quick-reader checks in `persuasive_framing.md`; revise the framing
    or escalate an unresolved materiality decision.
-6. Attach citations in a separate pass and validate them.
-7. Update unit status through a revision-guarded aggregate change.
-8. Synchronize projections and re-run readiness.
+10. Update affected unit statuses through a revision-guarded aggregate change,
+    synchronize projections, and re-run readiness.
 
 Generated projections aid review but never supply evidence. A local prose edit
 does not change RKA semantics.

--- a/rka/skills/writer/references/evidence_to_spine_pipeline.md
+++ b/rka/skills/writer/references/evidence_to_spine_pipeline.md
@@ -255,21 +255,35 @@ units:
 2. Build one private evidence packet. Merge duplicate and closely related
    records into evidence bundles; do not preserve record order.
 3. Distill the packet into a small set of reader-facing propositions and
-   arrange them into the section's logic ladder.
+   arrange them into the section's logic ladder. Keep citation keys on
+   propositions that attribute specific prior work. Populate
+   `mandatory_disclosure_ids` with every M1/M2 item and required active
+   counterevidence.
 4. Group those propositions into paragraphs with an opening, development,
-   takeaway, and bridge to the next paragraph. Paragraph boundaries follow
-   rhetorical continuity rather than RKA entity or unit boundaries.
+   takeaway, bridge to the next paragraph, proposition IDs, and native-unit
+   keys. Record them in `.planning/DISCOURSE_<section-id>.yaml`. Paragraph
+   boundaries follow rhetorical continuity rather than RKA entity or unit
+   boundaries.
 5. Draft clean, plain academic prose from the logic ladder and paragraph
    plan. Keep IDs and private risk labels out of the public text.
 6. Stay within the allowed interpretation and apply M1-M4/S public placement.
-7. Revise section argument and paragraph coherence before sentence-level style
-   polishing. Use `discourse_synthesis.md` for this pass.
+   Map every mandatory disclosure to a public location before advancing.
+7. Have a different fresh-context reviewer revise section argument and
+   paragraph coherence before provenance attachment or sentence-level style
+   polishing. Persist the review in the discourse artifact.
 8. Attach hidden provenance and citations in a separate pass, then validate
-   them. Do not fragment coherent prose merely to simplify provenance mapping.
+   them. Do not fragment coherent prose merely to simplify provenance mapping;
+   retain proposition-level citation bindings for prior-work attribution.
 9. Run the quick-reader checks in `persuasive_framing.md`; revise the framing
    or escalate an unresolved materiality decision.
-10. Update affected unit statuses through a revision-guarded aggregate change,
-    synchronize projections, and re-run readiness.
+10. After the last prose change, re-run coherence, provenance, citation,
+    mandatory-disclosure, and discourse-artifact validation until one pass
+    makes no further prose change. Escalate after three unsuccessful passes.
+11. Require the union of paragraph-card `unit_keys` to equal the section's
+    `required_unit_keys`. Advance a unit to `drafted` only when all cards mapped
+    to it are committed and all final checks pass. Apply the revision-guarded
+    aggregate change, synchronize projections, re-run readiness, and read back
+    the affected units.
 
 Generated projections aid review but never supply evidence. A local prose edit
 does not change RKA semantics.

--- a/rka/skills/writer/references/persuasive_framing.md
+++ b/rka/skills/writer/references/persuasive_framing.md
@@ -136,6 +136,11 @@ switching, give each paragraph one communicative job, and lead with its
 takeaway. If a scan fails, revise or escalate to the PI. Never make a scan pass
 by deleting a material limitation or unsupported result.
 
+Run these scans on the public prose with provenance comments hidden. A reader
+should encounter a research argument, not the shape or vocabulary of the RKA
+record. Use `discourse_synthesis.md` to repair a section whose claims are
+grounded but whose logic still reads as a list.
+
 Accessibility does not mean removing technical precision. Use a plain-language
 sentence first, then add the formal or implementation detail.
 

--- a/rka/skills/writer/references/server_authoritative_workflow.md
+++ b/rka/skills/writer/references/server_authoritative_workflow.md
@@ -26,6 +26,8 @@ Writer owns:
 - LaTeX, Word, Markdown, figures, tables, and other manuscript files;
 - venue structure, citation formatting, rendering, and layout checks;
 - `.planning/ACTIVE_WORKFLOW.md` as disposable authoring-session state;
+- `.planning/STYLE_PROFILE.yaml` and per-section `DISCOURSE_*.yaml` as
+  disposable, validated authoring plans that never supply research evidence;
 - deterministic projections such as `RKA_CLAIM_SPINE.yaml`,
   `CONTRIBUTION_CONTRACT.md`, `ARGUMENT_SPINE.md`, and `RESULTS_TRACE.md`.
 
@@ -71,6 +73,10 @@ resolved `man_...` identifier.
 6. Continue only when the server returns a non-blocking categorical verdict.
    Local renderers may add stricter file-level findings, but cannot override a
    server `BLOCK` or `ERROR`.
+7. Before a section advances to `drafted`, validate its style/discourse
+   artifacts, exact unit and mandatory-disclosure coverage, current
+   provenance/citations, and fresh-context coherence review. These local gates
+   may block advancement but cannot authorize it when server readiness blocks.
 
 The synchronized cursor is captured before the aggregate projection is read.
 This is intentionally conservative: a concurrent change may be reported again,

--- a/rka/skills/writer/references/workflows.md
+++ b/rka/skills/writer/references/workflows.md
@@ -344,9 +344,10 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    units, freshly resolved positive evidence, qualifiers, counterevidence,
    publication-boundary classifications, references in scope, and the claim's
    prohibited wording. It also reads
-   [`discourse_synthesis.md`](discourse_synthesis.md) and any PI-approved
-   project-local author-style profile. Generated views are explanatory;
-   resolution is against RKA.
+   [`discourse_synthesis.md`](discourse_synthesis.md) and
+   `.planning/STYLE_PROFILE.yaml`. If samples are registered, a missing or
+   unapproved profile is a BLOCK. Generated views are explanatory; resolution
+   is against RKA.
 3. Subagent builds one private evidence packet for the section. It extracts
    facts, conditions, and boundaries, groups duplicate or closely related
    records into evidence bundles, and removes out-of-scope material. It does
@@ -355,10 +356,14 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
 4. Subagent distills the packet into a small set of reader-facing propositions,
    arranges the section-level logic ladder, and groups the propositions into
    paragraph cards. Each paragraph card records one communicative job, its
-   opening, development, takeaway, and bridge. Several RKA records or native
-   units may serve one paragraph; one complex unit may span paragraphs.
+   opening, development, takeaway, bridge, proposition IDs, and native-unit
+   keys. Prior-work propositions retain their citation keys. Copy
+   `.planning/DISCOURSE_TEMPLATE.yaml` to
+   `.planning/DISCOURSE_<section-id>.yaml` and record the exact required-unit
+   set. Several RKA records or native units may serve one paragraph; one
+   complex unit may span paragraphs.
 5. Subagent drafts plain academic prose from the discourse plan with RKA IDs,
-   citations, and private risk labels hidden. It explains the idea before
+   provenance comments and private risk labels hidden. It explains the idea before
    exhaustive machinery and pairs each challenge with the design response
    that addresses it. Quote a source only when its exact wording matters; do
    not build prose by patching quotations or evidence snippets together.
@@ -368,15 +373,20 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    or reproducibility material; M4 and S items remain in the private risk
    record unless venue policy requires them. Never omit an issue whose absence
    would materially mislead a reasonable reader. Map every M1/M2 item to its
-   public paragraph, figure, table, caption, or claim. If a mapping is missing,
-   escalate and do not advance the affected unit to `drafted`.
-7. Subagent attaches hidden provenance comments and citations post-hoc to the
-   coherent draft, then validates them. It narrows unsupported wording instead
-   of splitting the prose into one-source fragments.
-8. Run the discourse-synthesis coherence review: verify the section takeaway,
+   public paragraph, figure, table, caption, or claim in
+   `mandatory_disclosure_map`; include required active counterevidence. If a
+   mapping is missing, escalate and do not advance the affected unit to
+   `drafted`; when several units are affected, block all of them.
+7. Run the discourse-synthesis coherence review with a different fresh-context
+   reviewer before provenance attachment. Verify the section takeaway,
    proposition order, paragraph jobs, known-to-new flow, causal bridges,
-   challenge-response pairing, and delivery of the opening promise. Revise the
-   discourse plan before polishing sentences when any check fails.
+   challenge-response pairing, and delivery of the opening promise. Persist
+   the answers and reviewer identity in the section discourse artifact. Revise
+   the plan and prose when any answer fails.
+8. Subagent attaches hidden provenance comments and citations post-hoc to the
+   coherent draft, then validates them. It keeps citation keys bound to
+   propositions that attribute prior work and narrows unsupported wording
+   instead of splitting the prose into one-source fragments.
 9. Run the four quick-reader checks in `persuasive_framing.md`. If a scan
    fails, revise the framing or escalate the unresolved evidence/wording
    decision; never delete a material limitation merely to make the scan pass.
@@ -387,12 +397,24 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    `scripts/ai_tic_lint.py` on the section and resolves genuine surface-style
    findings. The score cannot establish logic or fluency. Iterate until the
    score reaches 0.85 or three iterations elapse.
-12. If three iterations fail, ESCALATE via the Revision Loop Class R2.
-13. Otherwise commit the section to `sections/<section-id>.tex`, update the
-   corresponding native unit status through a revision-guarded spine update,
-   synchronize, and surface it to the PI for the Draft section checkpoint.
+12. After the last prose change, run a fixed-point pass: repeat the fresh-
+    context coherence review, provenance and citation validation, exact M1/M2
+    and counterevidence coverage, and
+    `scripts/validate_discourse_artifacts.py`. Any prose change from narrowing,
+    citation repair, quick-reader revision, or surface lint restarts this pass.
+    Invoke it with both `--style-profile .planning/STYLE_PROFILE.yaml` and
+    `--discourse-plan .planning/DISCOURSE_<section-id>.yaml` so registered
+    samples cannot be bypassed. Stop only when one pass makes no prose change.
+13. If three validation/revision passes fail, ESCALATE via the Revision Loop
+    Class R2.
+14. Otherwise commit the section to `sections/<section-id>.tex`. Advance only
+    native units in the artifact's `required_unit_keys` whose mapped paragraph
+    cards are all committed and current. Apply the revision-guarded spine
+    update, synchronize, re-run readiness, and read back the affected units.
 
-PI ratifies via the Draft section checkpoint (one of the six PI checkpoints). Three options: accept, revise (with PI comments), escalate.
+PI ratifies via the Draft section checkpoint (one of the six PI checkpoints).
+Surface the section takeaway, paragraph jobs, mapped unit keys, and coherence
+review with three options: accept, revise (with PI comments), escalate.
 
 ### 6. Local renderer plus layout auditor
 

--- a/rka/skills/writer/references/workflows.md
+++ b/rka/skills/writer/references/workflows.md
@@ -343,14 +343,26 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
 2. Subagent reads: section sketch, ratified outline, the relevant claim-spine
    units, freshly resolved positive evidence, qualifiers, counterevidence,
    publication-boundary classifications, references in scope, and the claim's
-   prohibited wording. Generated views are explanatory; resolution is against
-   RKA.
-3. Subagent first extracts evidence facts, conditions, and boundaries into its
-   private working notes. It then drafts claim-centered, strength-first prose
-   around the section's communicative job. Quote a source only when its exact
-   wording matters; do not build the prose by patching quotations together.
-   Place hidden provenance comments before each evidence-citation prose unit.
-4. Apply the publication boundary from
+   prohibited wording. It also reads
+   [`discourse_synthesis.md`](discourse_synthesis.md) and any PI-approved
+   project-local author-style profile. Generated views are explanatory;
+   resolution is against RKA.
+3. Subagent builds one private evidence packet for the section. It extracts
+   facts, conditions, and boundaries, groups duplicate or closely related
+   records into evidence bundles, and removes out-of-scope material. It does
+   not preserve retrieval order, journal chronology, or entity boundaries as
+   a prose sequence.
+4. Subagent distills the packet into a small set of reader-facing propositions,
+   arranges the section-level logic ladder, and groups the propositions into
+   paragraph cards. Each paragraph card records one communicative job, its
+   opening, development, takeaway, and bridge. Several RKA records or native
+   units may serve one paragraph; one complex unit may span paragraphs.
+5. Subagent drafts plain academic prose from the discourse plan with RKA IDs,
+   citations, and private risk labels hidden. It explains the idea before
+   exhaustive machinery and pairs each challenge with the design response
+   that addresses it. Quote a source only when its exact wording matters; do
+   not build prose by patching quotations or evidence snippets together.
+6. Apply the publication boundary from
    [`persuasive_framing.md`](persuasive_framing.md): M1 and M2 issues receive
    visible public treatment; M3 details go to the method, appendix, artifact,
    or reproducibility material; M4 and S items remain in the private risk
@@ -358,16 +370,25 @@ Procedure (OpenScholar evidence-grounded per `jrn_01KS0AVZRDA0KPXK61MN9PV5DE`):
    would materially mislead a reasonable reader. Map every M1/M2 item to its
    public paragraph, figure, table, caption, or claim. If a mapping is missing,
    escalate and do not advance the affected unit to `drafted`.
-5. Run the four quick-reader checks in `persuasive_framing.md`. If a scan
+7. Subagent attaches hidden provenance comments and citations post-hoc to the
+   coherent draft, then validates them. It narrows unsupported wording instead
+   of splitting the prose into one-source fragments.
+8. Run the discourse-synthesis coherence review: verify the section takeaway,
+   proposition order, paragraph jobs, known-to-new flow, causal bridges,
+   challenge-response pairing, and delivery of the opening promise. Revise the
+   discourse plan before polishing sentences when any check fails.
+9. Run the four quick-reader checks in `persuasive_framing.md`. If a scan
    fails, revise the framing or escalate the unresolved evidence/wording
    decision; never delete a material limitation merely to make the scan pass.
-6. Subagent checks that no new contribution appeared in prose and that each
+10. Subagent checks that no new contribution appeared in prose and that each
    empirical statement has role-appropriate terminal support. A decision or
    evidence cluster alone is not support.
-7. Subagent self-audits before commit: runs `scripts/ai_tic_lint.py` on the
-   section; iterates until style score reaches 0.85 or three iterations elapse.
-8. If three iterations fail, ESCALATE via the Revision Loop Class R2.
-9. Otherwise commit the section to `sections/<section-id>.tex`, update the
+11. Only after coherence and provenance checks pass, subagent runs
+   `scripts/ai_tic_lint.py` on the section and resolves genuine surface-style
+   findings. The score cannot establish logic or fluency. Iterate until the
+   score reaches 0.85 or three iterations elapse.
+12. If three iterations fail, ESCALATE via the Revision Loop Class R2.
+13. Otherwise commit the section to `sections/<section-id>.tex`, update the
    corresponding native unit status through a revision-guarded spine update,
    synchronize, and surface it to the PI for the Draft section checkpoint.
 

--- a/rka/skills/writer/scripts/validate_discourse_artifacts.py
+++ b/rka/skills/writer/scripts/validate_discourse_artifacts.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Validate Writer style-profile and section discourse-plan artifacts.
+
+This validator enforces structural, coverage, and handoff invariants. It does
+not score prose quality or claim that a section is coherent; that judgment
+remains a fresh-context review surfaced to the PI.
+
+Exit codes: 0 PASS, 2 BLOCK, 3 invalid input or usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+STYLE_SCHEMA = "rka.writer-style-profile/v1"
+DISCOURSE_SCHEMA = "rka.writer-discourse-plan/v1"
+COHERENCE_QUESTIONS = {
+    "single_takeaway",
+    "paragraph_sequence",
+    "one_job_per_paragraph",
+    "challenge_response",
+    "idea_before_mechanism",
+    "evidence_advances_argument",
+    "opening_promise_delivered",
+    "prose_self_contained",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    message: str
+    field: str | None = None
+    severity: str = "BLOCK"
+
+
+@dataclass
+class ValidationReport:
+    findings: list[Finding]
+
+    @property
+    def verdict(self) -> str:
+        return "BLOCK" if self.findings else "PASS"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "findings": [asdict(finding) for finding in self.findings],
+            "note": "Structural validation does not establish prose coherence.",
+        }
+
+
+def load_document(path: str | Path) -> dict[str, Any]:
+    source = Path(path)
+    try:
+        text = source.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"cannot read {source}: {exc}") from exc
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+
+        loaded = yaml.safe_load(text)
+    except ImportError:
+        try:
+            loaded = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("PyYAML is unavailable; supply JSON-compatible YAML") from exc
+    except Exception as exc:
+        raise ValueError(f"invalid or unsafe YAML/JSON document: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise TypeError("artifact must be a mapping/object")
+    return loaded
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _duplicate(values: list[str]) -> str | None:
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            return value
+        seen.add(value)
+    return None
+
+
+def validate_style_profile(data: Mapping[str, Any]) -> ValidationReport:
+    findings: list[Finding] = []
+    if data.get("schema_version") != STYLE_SCHEMA:
+        findings.append(Finding("STYLE_SCHEMA", f"schema_version must be {STYLE_SCHEMA}"))
+
+    status = _text(data.get("status"))
+    if status not in {"not_started", "draft", "approved"}:
+        findings.append(Finding("STYLE_STATUS", "status must be not_started, draft, or approved"))
+
+    samples_registered = data.get("samples_registered") is True
+    inventory = _string_list(data.get("sample_inventory"))
+    patterns = _mapping(data.get("positive_patterns"))
+    prohibitions = _string_list(data.get("prohibitions"))
+    approval = _mapping(data.get("approval"))
+
+    if samples_registered:
+        if not inventory:
+            findings.append(
+                Finding("STYLE_SAMPLES", "registered samples require sample_inventory entries")
+            )
+        if not patterns:
+            findings.append(
+                Finding("STYLE_PATTERNS", "registered samples require positive_patterns")
+            )
+        if not prohibitions:
+            findings.append(
+                Finding("STYLE_PROHIBITIONS", "registered samples require prohibitions")
+            )
+        if status != "approved":
+            findings.append(
+                Finding("STYLE_APPROVAL", "a sample-derived profile must be PI-approved")
+            )
+
+    if status == "approved" and (
+        not _text(approval.get("approved_by"))
+        or not _text(approval.get("approved_at"))
+    ):
+        findings.append(
+            Finding(
+                "STYLE_APPROVAL_RECORD",
+                "approved profiles require approved_by and approved_at",
+                "approval",
+            )
+        )
+
+    return ValidationReport(findings)
+
+
+def validate_discourse_plan(data: Mapping[str, Any]) -> ValidationReport:
+    findings: list[Finding] = []
+    if data.get("schema_version") != DISCOURSE_SCHEMA:
+        findings.append(
+            Finding("DISCOURSE_SCHEMA", f"schema_version must be {DISCOURSE_SCHEMA}")
+        )
+    if data.get("status") != "reviewed":
+        findings.append(
+            Finding("DISCOURSE_STATUS", "status must be reviewed before drafting advances")
+        )
+    if not _text(data.get("section_id")):
+        findings.append(Finding("SECTION_ID", "section_id is required"))
+    if not _text(data.get("takeaway")):
+        findings.append(Finding("TAKEAWAY", "a reader-facing section takeaway is required"))
+
+    required_units = _string_list(data.get("required_unit_keys"))
+    if not required_units:
+        findings.append(Finding("REQUIRED_UNITS", "required_unit_keys cannot be empty"))
+    if duplicate := _duplicate(required_units):
+        findings.append(Finding("DUPLICATE_UNIT", f"duplicate required unit key: {duplicate}"))
+
+    propositions_raw = data.get("propositions")
+    propositions = propositions_raw if isinstance(propositions_raw, list) else []
+    proposition_ids = [
+        _text(item.get("id")) for item in propositions if isinstance(item, Mapping)
+    ]
+    if not propositions or any(not item for item in proposition_ids):
+        findings.append(Finding("PROPOSITIONS", "each proposition requires a non-empty id"))
+    if duplicate := _duplicate([item for item in proposition_ids if item]):
+        findings.append(Finding("DUPLICATE_PROPOSITION", f"duplicate proposition id: {duplicate}"))
+
+    for index, proposition in enumerate(propositions):
+        if not isinstance(proposition, Mapping):
+            findings.append(Finding("PROPOSITION_SHAPE", "propositions must be mappings"))
+            continue
+        if not _text(proposition.get("statement")) or not _text(proposition.get("role")):
+            findings.append(
+                Finding(
+                    "PROPOSITION_CONTENT",
+                    "each proposition requires statement and role",
+                    f"propositions[{index}]",
+                )
+            )
+        if proposition.get("role") == "prior_work" and not _string_list(
+            proposition.get("citation_keys")
+        ):
+            findings.append(
+                Finding(
+                    "PRIOR_WORK_CITATION",
+                    "prior_work propositions must retain citation_keys during drafting",
+                    f"propositions[{index}].citation_keys",
+                )
+            )
+
+    paragraphs_raw = data.get("paragraphs")
+    paragraphs = paragraphs_raw if isinstance(paragraphs_raw, list) else []
+    paragraph_ids = [
+        _text(item.get("id")) for item in paragraphs if isinstance(item, Mapping)
+    ]
+    if not paragraphs or any(not item for item in paragraph_ids):
+        findings.append(Finding("PARAGRAPHS", "each paragraph card requires a non-empty id"))
+    if duplicate := _duplicate([item for item in paragraph_ids if item]):
+        findings.append(Finding("DUPLICATE_PARAGRAPH", f"duplicate paragraph id: {duplicate}"))
+
+    known_propositions = set(proposition_ids)
+    known_units = set(required_units)
+    used_propositions: set[str] = set()
+    mapped_units: set[str] = set()
+    for index, paragraph in enumerate(paragraphs):
+        if not isinstance(paragraph, Mapping):
+            findings.append(Finding("PARAGRAPH_SHAPE", "paragraph cards must be mappings"))
+            continue
+        field = f"paragraphs[{index}]"
+        if not all(
+            _text(paragraph.get(name)) for name in ("job", "opening", "bridge", "takeaway")
+        ):
+            findings.append(
+                Finding(
+                    "PARAGRAPH_CONTENT",
+                    "each paragraph card requires job, opening, bridge, and takeaway",
+                    field,
+                )
+            )
+        card_propositions = set(_string_list(paragraph.get("proposition_ids")))
+        card_units = set(_string_list(paragraph.get("unit_keys")))
+        if not card_propositions:
+            findings.append(
+                Finding("PARAGRAPH_PROPOSITIONS", "paragraph card has no propositions", field)
+            )
+        if not card_units:
+            findings.append(Finding("PARAGRAPH_UNITS", "paragraph card has no unit_keys", field))
+        unknown_propositions = card_propositions - known_propositions
+        unknown_units = card_units - known_units
+        if unknown_propositions:
+            findings.append(
+                Finding(
+                    "UNKNOWN_PROPOSITION",
+                    f"unknown proposition ids: {sorted(unknown_propositions)}",
+                    field,
+                )
+            )
+        if unknown_units:
+            findings.append(
+                Finding("UNKNOWN_UNIT", f"unknown unit keys: {sorted(unknown_units)}", field)
+            )
+        used_propositions.update(card_propositions)
+        mapped_units.update(card_units)
+
+    missing_propositions = known_propositions - used_propositions
+    if missing_propositions:
+        findings.append(
+            Finding(
+                "UNMAPPED_PROPOSITIONS",
+                f"propositions absent from paragraph cards: {sorted(missing_propositions)}",
+            )
+        )
+    if mapped_units != known_units:
+        findings.append(
+            Finding(
+                "UNIT_COVERAGE",
+                "the union of paragraph-card unit_keys must equal required_unit_keys",
+            )
+        )
+
+    required_disclosures = set(_string_list(data.get("mandatory_disclosure_ids")))
+    disclosure_map = _mapping(data.get("mandatory_disclosure_map"))
+    mapped_disclosures = {str(key) for key in disclosure_map}
+    if mapped_disclosures != required_disclosures:
+        findings.append(
+            Finding(
+                "DISCLOSURE_COVERAGE",
+                "mandatory_disclosure_map keys must exactly equal mandatory_disclosure_ids",
+            )
+        )
+    for disclosure_id, locations in disclosure_map.items():
+        if not _string_list(locations):
+            findings.append(
+                Finding(
+                    "DISCLOSURE_LOCATION",
+                    f"mandatory disclosure {disclosure_id} requires a public location",
+                    "mandatory_disclosure_map",
+                )
+            )
+
+    style_profile = _mapping(data.get("style_profile"))
+    if style_profile.get("required") is True and (
+        style_profile.get("status") != "approved"
+        or not _text(style_profile.get("path"))
+    ):
+        findings.append(
+            Finding(
+                "STYLE_PROFILE_LINK",
+                "a required style profile must have an approved status and path",
+                "style_profile",
+            )
+        )
+
+    review = _mapping(data.get("coherence_review"))
+    if review.get("status") != "pass" or not _text(review.get("reviewer")):
+        findings.append(
+            Finding(
+                "COHERENCE_REVIEW",
+                "a fresh-context reviewer must record a pass and reviewer identifier",
+                "coherence_review",
+            )
+        )
+    answers = _mapping(review.get("answers"))
+    missing_answers = COHERENCE_QUESTIONS - set(answers)
+    failed_answers = {key for key in COHERENCE_QUESTIONS if answers.get(key) is not True}
+    if missing_answers or failed_answers:
+        findings.append(
+            Finding(
+                "COHERENCE_ANSWERS",
+                "all eight coherence answers must be present and true",
+                "coherence_review.answers",
+            )
+        )
+
+    return ValidationReport(findings)
+
+
+def validate_profile_linkage(
+    style_profile: Mapping[str, Any], discourse_plan: Mapping[str, Any]
+) -> ValidationReport:
+    """Require a section to load an approved profile when samples exist."""
+
+    findings: list[Finding] = []
+    plan_profile = _mapping(discourse_plan.get("style_profile"))
+    if style_profile.get("samples_registered") is True and (
+        plan_profile.get("required") is not True
+        or plan_profile.get("status") != "approved"
+        or not _text(plan_profile.get("path"))
+    ):
+        findings.append(
+            Finding(
+                "STYLE_PROFILE_REQUIRED",
+                "registered samples require the section to link the approved style profile",
+                "style_profile",
+            )
+        )
+    return ValidationReport(findings)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--style-profile", type=Path)
+    parser.add_argument("--discourse-plan", type=Path)
+    args = parser.parse_args(argv)
+    if args.style_profile is None and args.discourse_plan is None:
+        parser.error("provide --style-profile and/or --discourse-plan")
+
+    reports: dict[str, Any] = {}
+    try:
+        style_data: dict[str, Any] | None = None
+        discourse_data: dict[str, Any] | None = None
+        if args.style_profile is not None:
+            style_data = load_document(args.style_profile)
+            reports["style_profile"] = validate_style_profile(style_data).as_dict()
+        if args.discourse_plan is not None:
+            discourse_data = load_document(args.discourse_plan)
+            reports["discourse_plan"] = validate_discourse_plan(discourse_data).as_dict()
+        if style_data is not None and discourse_data is not None:
+            reports["profile_linkage"] = validate_profile_linkage(
+                style_data, discourse_data
+            ).as_dict()
+    except (TypeError, ValueError) as exc:
+        print(json.dumps({"verdict": "ERROR", "error": str(exc)}, indent=2))
+        return 3
+
+    verdict = "BLOCK" if any(item["verdict"] == "BLOCK" for item in reports.values()) else "PASS"
+    print(json.dumps({"verdict": verdict, "artifacts": reports}, indent=2, sort_keys=True))
+    return 2 if verdict == "BLOCK" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rka/skills/writer/workspace-template/.planning/DISCOURSE_TEMPLATE.yaml
+++ b/rka/skills/writer/workspace-template/.planning/DISCOURSE_TEMPLATE.yaml
@@ -1,0 +1,52 @@
+schema_version: rka.writer-discourse-plan/v1
+status: not_started
+section_id: null
+takeaway: null
+
+style_profile:
+  required: false
+  path: .planning/STYLE_PROFILE.yaml
+  status: not_required
+
+# Copy this file to .planning/DISCOURSE_<section-id>.yaml. Populate the exact
+# active native-unit set assigned to the section.
+required_unit_keys: []
+mandatory_disclosure_ids: []
+
+propositions: []
+# - id: p1
+#   statement: null
+#   role: context | gap | insight | challenge | response | evidence | prior_work
+#   evidence_ids: []
+#   qualifier_ids: []
+#   citation_keys: []
+#   next_inference: null
+
+paragraphs: []
+# - id: para1
+#   job: null
+#   proposition_ids: []
+#   unit_keys: []
+#   opening: null
+#   bridge: null
+#   takeaway: null
+
+# Keys must exactly equal mandatory_disclosure_ids. Values are public locations
+# such as paragraph:para2, figure:fig3, table:tab2, caption:fig3, or claim:mcl_...
+mandatory_disclosure_map: {}
+
+coherence_review:
+  status: pending
+  reviewer: null
+  answers:
+    single_takeaway: false
+    paragraph_sequence: false
+    one_job_per_paragraph: false
+    challenge_response: false
+    idea_before_mechanism: false
+    evidence_advances_argument: false
+    opening_promise_delivered: false
+    prose_self_contained: false
+
+# Private authoring state only. RKA remains authoritative for claims, evidence,
+# units, status, and readiness.

--- a/rka/skills/writer/workspace-template/.planning/STYLE_PROFILE.yaml
+++ b/rka/skills/writer/workspace-template/.planning/STYLE_PROFILE.yaml
@@ -1,0 +1,16 @@
+schema_version: rka.writer-style-profile/v1
+status: not_started
+samples_registered: false
+sample_inventory: []
+
+# Populate by rhetorical slot, for example introduction_opening, gap,
+# approach_overview, results_summary, or nsf_thrust.
+positive_patterns: {}
+prohibitions: []
+
+approval:
+  approved_by: null
+  approved_at: null
+
+# Advisory drafting calibration only. This file is not research evidence and
+# must not copy prose from the sample corpus.

--- a/tests/skills/writer/conftest.py
+++ b/tests/skills/writer/conftest.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 SCRIPTS_DIR = (
     Path(__file__).resolve().parents[3] / "rka" / "skills" / "writer" / "scripts"
 )
@@ -75,6 +74,11 @@ def verify_citations():
 @pytest.fixture
 def overclaim_lint():
     return _load_module("overclaim_lint")
+
+
+@pytest.fixture
+def validate_discourse_artifacts():
+    return _load_module("validate_discourse_artifacts")
 
 
 @pytest.fixture

--- a/tests/skills/writer/test_discourse_artifacts.py
+++ b/tests/skills/writer/test_discourse_artifacts.py
@@ -1,0 +1,196 @@
+"""Objective contracts for private Writer discourse-planning artifacts."""
+
+from __future__ import annotations
+
+import json
+
+
+def _style_profile(*, approved: bool = True) -> dict:
+    return {
+        "schema_version": "rka.writer-style-profile/v1",
+        "status": "approved" if approved else "draft",
+        "samples_registered": True,
+        "sample_inventory": ["good/paper-a.pdf", "bad/draft-a.pdf"],
+        "positive_patterns": {
+            "introduction_opening": ["concrete consequence before abstraction"]
+        },
+        "prohibitions": ["catalog controls before explaining their purpose"],
+        "approval": {
+            "approved_by": "pi" if approved else None,
+            "approved_at": "2026-08-19T12:00:00-04:00" if approved else None,
+        },
+    }
+
+
+def _discourse_plan() -> dict:
+    return {
+        "schema_version": "rka.writer-discourse-plan/v1",
+        "status": "reviewed",
+        "section_id": "intro",
+        "takeaway": "Cross-step context reveals attacks hidden from local checks.",
+        "style_profile": {
+            "required": True,
+            "path": ".planning/STYLE_PROFILE.yaml",
+            "status": "approved",
+        },
+        "required_unit_keys": ["problem", "insight", "evidence"],
+        "mandatory_disclosure_ids": ["risk_feedback_bundle"],
+        "propositions": [
+            {
+                "id": "p1",
+                "statement": "Local checks miss unsafe cross-step effects.",
+                "role": "gap",
+                "evidence_ids": ["clm_01ABCDEFGHIJKLMNOPQRSTUVWX"],
+                "qualifier_ids": [],
+                "citation_keys": [],
+                "next_inference": "The monitor needs cross-step context.",
+            },
+            {
+                "id": "p2",
+                "statement": "Prior monitors inspect steps independently.",
+                "role": "prior_work",
+                "evidence_ids": ["lit_01ABCDEFGHIJKLMNOPQRSTUVWX"],
+                "qualifier_ids": [],
+                "citation_keys": ["author2025monitor"],
+                "next_inference": "This leaves a causal-history gap.",
+            },
+        ],
+        "paragraphs": [
+            {
+                "id": "para1",
+                "job": "establish the gap and motivating consequence",
+                "proposition_ids": ["p1", "p2"],
+                "unit_keys": ["problem", "insight", "evidence"],
+                "opening": "A concrete unsafe cross-step effect",
+                "bridge": "The failure identifies the missing context",
+                "takeaway": "Independent checks cannot reconstruct causality",
+            }
+        ],
+        "mandatory_disclosure_map": {
+            "risk_feedback_bundle": ["paragraph:para1"]
+        },
+        "coherence_review": {
+            "status": "pass",
+            "reviewer": "fresh-reviewer-1",
+            "answers": {
+                "single_takeaway": True,
+                "paragraph_sequence": True,
+                "one_job_per_paragraph": True,
+                "challenge_response": True,
+                "idea_before_mechanism": True,
+                "evidence_advances_argument": True,
+                "opening_promise_delivered": True,
+                "prose_self_contained": True,
+            },
+        },
+    }
+
+
+def _codes(report) -> set[str]:
+    return {finding.code for finding in report.findings}
+
+
+def test_valid_artifacts_pass_without_claiming_coherence(
+    validate_discourse_artifacts,
+) -> None:
+    style_report = validate_discourse_artifacts.validate_style_profile(_style_profile())
+    discourse_report = validate_discourse_artifacts.validate_discourse_plan(
+        _discourse_plan()
+    )
+
+    assert style_report.verdict == "PASS"
+    assert discourse_report.verdict == "PASS"
+    assert "does not establish prose coherence" in discourse_report.as_dict()["note"]
+
+
+def test_registered_samples_require_pi_approval(validate_discourse_artifacts) -> None:
+    report = validate_discourse_artifacts.validate_style_profile(
+        _style_profile(approved=False)
+    )
+
+    assert report.verdict == "BLOCK"
+    assert "STYLE_APPROVAL" in _codes(report)
+
+
+def test_registered_samples_must_be_linked_from_section(
+    validate_discourse_artifacts,
+) -> None:
+    plan = _discourse_plan()
+    plan["style_profile"]["required"] = False
+    plan["style_profile"]["status"] = "not_required"
+
+    report = validate_discourse_artifacts.validate_profile_linkage(
+        _style_profile(), plan
+    )
+
+    assert "STYLE_PROFILE_REQUIRED" in _codes(report)
+
+
+def test_cli_blocks_unlinked_registered_samples(
+    validate_discourse_artifacts, tmp_path, capsys
+) -> None:
+    style_path = tmp_path / "STYLE_PROFILE.json"
+    plan_path = tmp_path / "DISCOURSE_intro.json"
+    plan = _discourse_plan()
+    plan["style_profile"]["required"] = False
+    plan["style_profile"]["status"] = "not_required"
+    style_path.write_text(json.dumps(_style_profile()), encoding="utf-8")
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+
+    exit_code = validate_discourse_artifacts.main(
+        [
+            "--style-profile",
+            str(style_path),
+            "--discourse-plan",
+            str(plan_path),
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert output["verdict"] == "BLOCK"
+    assert output["artifacts"]["profile_linkage"]["findings"][0]["code"] == (
+        "STYLE_PROFILE_REQUIRED"
+    )
+
+
+def test_mandatory_disclosures_require_exact_public_mapping(
+    validate_discourse_artifacts,
+) -> None:
+    plan = _discourse_plan()
+    plan["mandatory_disclosure_map"] = {}
+
+    report = validate_discourse_artifacts.validate_discourse_plan(plan)
+
+    assert "DISCLOSURE_COVERAGE" in _codes(report)
+
+
+def test_paragraph_cards_must_cover_exact_required_unit_set(
+    validate_discourse_artifacts,
+) -> None:
+    plan = _discourse_plan()
+    plan["paragraphs"][0]["unit_keys"] = ["problem", "insight"]
+
+    report = validate_discourse_artifacts.validate_discourse_plan(plan)
+
+    assert "UNIT_COVERAGE" in _codes(report)
+
+
+def test_prior_work_propositions_retain_citation_keys(
+    validate_discourse_artifacts,
+) -> None:
+    plan = _discourse_plan()
+    plan["propositions"][1]["citation_keys"] = []
+
+    report = validate_discourse_artifacts.validate_discourse_plan(plan)
+
+    assert "PRIOR_WORK_CITATION" in _codes(report)
+
+
+def test_fresh_context_review_must_be_complete(validate_discourse_artifacts) -> None:
+    plan = _discourse_plan()
+    plan["coherence_review"]["answers"]["paragraph_sequence"] = False
+
+    report = validate_discourse_artifacts.validate_discourse_plan(plan)
+
+    assert "COHERENCE_ANSWERS" in _codes(report)

--- a/tests/skills/writer/test_discourse_synthesis.py
+++ b/tests/skills/writer/test_discourse_synthesis.py
@@ -42,9 +42,12 @@ def test_section_drafter_runs_coherence_before_surface_lint(skill_dir: Path) -> 
     )
     section = workflows[workflows.index("### 5. Section drafter") :]
     coherence = section.index("Run the discourse-synthesis coherence review")
+    provenance = section.index(
+        "attaches hidden provenance comments and citations post-hoc"
+    )
     lint = section.index("scripts/ai_tic_lint.py")
 
-    assert coherence < lint
+    assert coherence < provenance < lint
     assert "groups duplicate or closely related records into evidence bundles" in (
         _squash(section)
     )
@@ -55,6 +58,8 @@ def test_section_drafter_runs_coherence_before_surface_lint(skill_dir: Path) -> 
         _squash(section)
     )
     assert "The score cannot establish logic or fluency" in section
+    assert "Any prose change" in section
+    assert "validate_discourse_artifacts.py" in section
 
 
 def test_plain_academic_profile_is_positive_and_sample_calibratable(
@@ -70,3 +75,20 @@ def test_plain_academic_profile_is_positive_and_sample_calibratable(
     assert "concrete problem, consequence, or observation" in discourse
     assert "do not copy sentences" in discourse.lower()
     assert "Do not imitate grammar errors" in discourse
+    assert ".planning/STYLE_PROFILE.yaml" in discourse
+    assert "status: approved" in discourse
+
+
+def test_security_sections_and_contrastive_example_are_actionable(
+    skill_dir: Path,
+) -> None:
+    discourse = (
+        skill_dir / "references" / "discourse_synthesis.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Related work**" in discourse
+    assert "**Threat model or security assumptions**" in discourse
+    assert "diagnostic patterns, not fill-in templates" in discourse
+    assert "Synthetic contrastive example" in discourse
+    assert "Record-shaped:" in discourse
+    assert "Synthesized:" in discourse

--- a/tests/skills/writer/test_discourse_synthesis.py
+++ b/tests/skills/writer/test_discourse_synthesis.py
@@ -1,0 +1,72 @@
+"""Contracts that keep RKA provenance from becoming record-shaped prose."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_skill_exposes_evidence_to_discourse_separation(
+    skill_dir: Path, skill_md_path: Path
+) -> None:
+    skill_text = skill_md_path.read_text(encoding="utf-8")
+    discourse_path = skill_dir / "references" / "discourse_synthesis.md"
+    discourse = discourse_path.read_text(encoding="utf-8")
+
+    assert "Discourse Law" in skill_text
+    assert "references/discourse_synthesis.md" in skill_text
+    assert "Evidence graph and discourse graph" in discourse
+    assert "The mapping is many-to-many" in discourse
+    assert "Never traverse journal entries" in discourse
+    assert "one paragraph per claim" in discourse
+
+
+def test_pipeline_does_not_map_units_directly_to_paragraphs(skill_dir: Path) -> None:
+    pipeline = (
+        skill_dir / "references" / "evidence_to_spine_pipeline.md"
+    ).read_text(encoding="utf-8")
+    pipeline_flat = _squash(pipeline)
+
+    assert "section-level discourse plan" in pipeline
+    assert "do not preserve record order" in pipeline_flat.lower()
+    assert "Paragraph boundaries follow rhetorical continuity" in pipeline_flat
+    assert "Do not fragment coherent prose" in pipeline_flat
+
+
+def test_section_drafter_runs_coherence_before_surface_lint(skill_dir: Path) -> None:
+    workflows = (skill_dir / "references" / "workflows.md").read_text(
+        encoding="utf-8"
+    )
+    section = workflows[workflows.index("### 5. Section drafter") :]
+    coherence = section.index("Run the discourse-synthesis coherence review")
+    lint = section.index("scripts/ai_tic_lint.py")
+
+    assert coherence < lint
+    assert "groups duplicate or closely related records into evidence bundles" in (
+        _squash(section)
+    )
+    assert "Several RKA records or native units may serve one paragraph" in (
+        _squash(section)
+    )
+    assert "attaches hidden provenance comments and citations post-hoc" in (
+        _squash(section)
+    )
+    assert "The score cannot establish logic or fluency" in section
+
+
+def test_plain_academic_profile_is_positive_and_sample_calibratable(
+    skill_dir: Path,
+) -> None:
+    discourse = (
+        skill_dir / "references" / "discourse_synthesis.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Plain academic target" in discourse
+    assert "Calibrating to author samples" in discourse
+    assert "logic ladder" in discourse
+    assert "concrete problem, consequence, or observation" in discourse
+    assert "do not copy sentences" in discourse.lower()
+    assert "Do not imitate grammar errors" in discourse

--- a/tests/skills/writer/test_package_data.py
+++ b/tests/skills/writer/test_package_data.py
@@ -35,10 +35,12 @@ def test_package_data_includes_hidden_writer_planning_templates() -> None:
 
     expected = {
         "skills/writer/workspace-template/.planning/ACTIVE_WORKFLOW.md",
+        "skills/writer/workspace-template/.planning/DISCOURSE_TEMPLATE.yaml",
         "skills/writer/workspace-template/.planning/FRAMING_SESSION.yaml",
         "skills/writer/workspace-template/.planning/OUTLINE.md",
         "skills/writer/workspace-template/.planning/PRECIS.md",
         "skills/writer/workspace-template/.planning/REVIEW_STATE.md",
         "skills/writer/workspace-template/.planning/RKA_CLAIM_SPINE.yaml",
+        "skills/writer/workspace-template/.planning/STYLE_PROFILE.yaml",
     }
     assert expected <= packaged

--- a/tests/skills/writer/test_skill_loads.py
+++ b/tests/skills/writer/test_skill_loads.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-
 EXPECTED_SECTIONS = [
     "# Writer Skill",
     "## Supplementary references",
@@ -43,7 +42,7 @@ def test_frontmatter_has_name_description_version(skill_md_path: Path) -> None:
     fm = text[4:end]
     assert re.search(r"^name:\s*rka-writer\s*$", fm, re.MULTILINE)
     assert re.search(r"^metadata:\s*$", fm, re.MULTILINE)
-    assert re.search(r'^\s+version:\s*"2\.7\.3"\s*$', fm, re.MULTILINE)
+    assert re.search(r'^\s+version:\s*"2\.7\.4"\s*$', fm, re.MULTILINE)
     assert re.search(r"^description:\s*\S", fm, re.MULTILINE)
 
 

--- a/tests/skills/writer/test_skill_loads.py
+++ b/tests/skills/writer/test_skill_loads.py
@@ -42,7 +42,7 @@ def test_frontmatter_has_name_description_version(skill_md_path: Path) -> None:
     fm = text[4:end]
     assert re.search(r"^name:\s*rka-writer\s*$", fm, re.MULTILINE)
     assert re.search(r"^metadata:\s*$", fm, re.MULTILINE)
-    assert re.search(r'^\s+version:\s*"2\.7\.4"\s*$', fm, re.MULTILINE)
+    assert re.search(r'^\s+version:\s*"2\.7\.5"\s*$', fm, re.MULTILINE)
     assert re.search(r"^description:\s*\S", fm, re.MULTILINE)
 
 

--- a/tests/skills/writer/test_skill_mirror.py
+++ b/tests/skills/writer/test_skill_mirror.py
@@ -1,0 +1,30 @@
+"""The distributable plugin and installed-package Writer trees must not drift."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _files(root: Path) -> dict[Path, Path]:
+    ignored_names = {".DS_Store"}
+    return {
+        path.relative_to(root): path
+        for path in root.rglob("*")
+        if path.is_file()
+        and "__pycache__" not in path.parts
+        and path.suffix != ".pyc"
+        and path.name not in ignored_names
+        and not path.name.startswith("._")
+    }
+
+
+def test_writer_package_and_plugin_trees_are_byte_identical() -> None:
+    repo = Path(__file__).resolve().parents[3]
+    package_files = _files(repo / "rka" / "skills" / "writer")
+    plugin_files = _files(repo / "plugin" / "skills" / "writer")
+
+    assert package_files.keys() == plugin_files.keys()
+    for relative_path in sorted(package_files):
+        assert package_files[relative_path].read_bytes() == plugin_files[
+            relative_path
+        ].read_bytes(), relative_path


### PR DESCRIPTION
## Summary

Surfaces the existing `codex/writer-discourse-synthesis` branch (pushed 2026-08-19, no PR until now) so it enters the normal review path. Two commits:

- `6b45a70` feat(writer): synthesize evidence into coherent discourse
- `318ba64` fix(writer): operationalize discourse planning

## Changes

- New `discourse_synthesis.md` reference (351 lines) for the Writer skill, mirrored in `plugin/skills/writer/` and `rka/skills/writer/`
- Extends `evidence_to_spine_pipeline.md`, `workflows.md`, `persuasive_framing.md`, `server_authoritative_workflow.md`, and `SKILL.md` to wire discourse planning into the evidence-to-spine workflow
- New `validate_discourse_artifacts.py` script (389 lines) and workspace-template planning artifacts (`DISCOURSE_TEMPLATE.yaml`, `STYLE_PROFILE.yaml`)
- Tests: `test_discourse_artifacts.py`, `test_discourse_synthesis.py`, plus package-data/skill-load/skill-mirror coverage updates

31 files changed, +2321 / −87. Based on the current `main` tip (`db2e78d`), so it merges cleanly.

## Notes

Opened as draft during branch triage: this was the only branch with real unmerged content (`feature/rka-workbench-scope-navigation` and `codex/writer-framing-elicitation` were verified fully re-landed on main). Review and promote when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01483iQNzezhTkueKNcCxWbz

---
_Generated by [Claude Code](https://claude.ai/code/session_01483iQNzezhTkueKNcCxWbz)_