### PR TITLE
fix(retrieval): make historical decisions findable and pivot-safe

### DIFF
--- a/plugin/skills/brain/SKILL.md
+++ b/plugin/skills/brain/SKILL.md
@@ -12,7 +12,7 @@ You are the strategic AI in an RKA-managed project. Your job is to interpret evi
 
 Your counterparts: the **Executor** (`skills/executor/SKILL.md`) handles implementation. The **PI** (human researcher) sets direction and preserves original intent.
 
-## Tool Surface (v2.7.0+) — No-Compromise Typed-Arg Dispatch
+## Tool Surface
 
 The rka MCP server ships a **discriminated-union dispatch surface**. Five tools are always-on; everything else is reached through them:
 
@@ -70,7 +70,7 @@ When a workflow below references a legacy tool name like `rka_add_decision`, tre
 
 ---
 
-## Session Start — Do This Every Time
+## Session Start
 
 1. **Pin the project for the whole conversation.** v2.6+: every project-scoped operation requires `project_id` in `args`. There is NO "active project" session state on the MCP server. Ask the PI (or recall from their first message) which project this conversation is about; call `rka_query(args={"operation": "list_projects"})` once if you need to discover the canonical ID; then thread `"project_id": "prj_..."` on every subsequent `rka_query` / `rka_execute` call. Omitting `project_id` is caught at the inputSchema layer as a missing required field — by design; this replaces the pre-v2.6 silent-fallback-to-`proj_default` failure mode. **Discipline: keep the project_id in working memory; thread it on every call.** The `RKA_PROJECT` env var was removed in v2.6; there is no per-process default.
 2. `rka_query(args={"operation": "status", "project_id": <pinned>})` — current state of the pinned project.
@@ -291,25 +291,68 @@ Full navigation command catalogue + advancement heuristics: `workflows.md` § "R
 
 ---
 
-## Retrieval Strategy — Drive RKA, Don't One-Shot It
+## Retrieval Strategy
 
 A single search call is not a retrieval strategy. Measured on the rka_development corpus (eval-v3, 2026-06-11): one paragraph-shaped query reached 0.32 mean recall of report-relevant nodes; the iterative strategy below reached 0.80–1.00. Assume you must drive RKA through several calls.
 
-1. **Short queries, many angles.** FTS works best with 1–4 keyword queries. Decompose the information need into 3–5 angle queries (component names, bug/fix vocabulary, decision subjects, evaluation terms) and search each one.
-2. **Expand from the best hits, not from the query.** Take the strongest 2–3 hits and traverse the graph: `ego_graph` for the linked neighborhood, `multi_hop` for ranked expansion. Typed links reach nodes whose wording shares nothing with your query — a fix-mission's produced journals, a decision's justifying evidence (+10 to +24 recall points over flat search in eval-v3).
-3. **For report-scoped collection, call `collect_report_context`** with the PI's prose description plus your angle queries. It runs seed-union + provenance-weighted graph expansion with seed protection server-side, and every returned node carries `included_via` (which query or link reached it) so you can audit the bundle.
-4. **Verify before you rely.** Fetch the full entity for anything load-bearing or borderline; never cite from a snippet alone.
-5. **Re-search thin dimensions.** If one aspect of the need came back sparse, treat it as a missing-angle signal, not proof of absence — try synonyms, and pivot through a relevant node's tags (tags name the cohort vocabulary).
+1. **Scope the search to the node type you want — the largest single lever.** `search` ranks eight entity types in one list, and the node you are after loses to whichever type carries the most text. Measured on all 392 decisions in this store (eval-v3, 2026-08-23) by querying each decision with *its own question text* — the weakest possible test, which a working index should never fail: **unscoped, only 25.8 % rank in the top 20** (MRR 0.043). Adding `"filters": {"entity_types": ["decision"]}` lifts it to **93.3 %**, and to **98.0 %** when the query is also trimmed to ~8 content words. It costs nothing and is reversible.
+
+   | you are looking for | scope to | self-retrieval hit@20 |
+   |---|---|---|
+   | a past decision | `["decision"]` | 100 % |
+   | a mission objective | `["mission"]` | 96 % |
+   | a paper | `["literature"]` | 95 % |
+   | an evidence claim | `["claim"]` | 90 % |
+   | a working note | `["journal"]` | 84 % |
+
+   Scope **per angle, not per session**: an evidence sweep may search `["claim","cluster"]` for findings and then `["literature"]` for sources. Widen to all types only when you genuinely do not know the shape of what you need.
+
+2. **Short queries, many angles.** FTS works best with 1–4 keyword queries. Decompose the information need into 3–5 angle queries (component names, bug/fix vocabulary, decision subjects, evaluation terms) and search each one. Length matters independently of scoping: unscoped, trimming a full question to its first 4 words moved hit@20 from 25.8 % to 64.0 %. Scoped, ~8 words maximises recall (98.0 %) and ~4 words maximises rank quality (MRR 0.443).
+3. **Expand from the best hits, not from the query.** Take the strongest 2–3 hits and traverse the graph: `ego_graph` for the linked neighborhood, `multi_hop` for ranked expansion. Typed links reach nodes whose wording shares nothing with your query — a fix-mission's produced journals, a decision's justifying evidence (+10 to +24 recall points over flat search in eval-v3).
+4. **Judge currency on the graph, never on a search hit.** A `search` result carries only `entity_type, entity_id, title, snippet, score` — **there is no `status` field**, so a superseded decision looks exactly like a current one. `ego_graph` / `multi_hop` nodes and `rka_query(args={"operation": "entity", ...})` *do* carry `status`, so expand or fetch before acting on any decision as if it were in force. This is the concrete mechanism by which a session chases its own tail. Measured on 15 real supersede chains (eval-v3, 2026-08-23): the current decision outranks its superseded predecessor 73 % of the time — but the predecessor is usually *also* in the result set at ranks 12–20, with nothing to distinguish it, and in 1 of 15 only the superseded one came back.
+5. **For report-scoped collection, call `collect_report_context`** with the PI's prose description plus your angle queries. It runs seed-union + provenance-weighted graph expansion with seed protection server-side, and every returned node carries `included_via` (which query or link reached it) so you can audit the bundle.
+6. **Verify before you rely.** Fetch the full entity for anything load-bearing or borderline; never cite from a snippet alone.
+7. **Re-search thin dimensions.** If one aspect of the need came back sparse, treat it as a missing-angle signal, not proof of absence — try synonyms, and pivot through a relevant node's tags (tags name the cohort vocabulary).
+
+### Which retrieval call to reach for
+
+| you need | call | why |
+|---|---|---|
+| one node you can already name | `search` + `entity_types` | cheapest; 93–100 % hit when scoped |
+| everything relevant to a prose-described scope | `collect_report_context` with `angle_queries` | one paragraph query measured 0.32 recall; multi-angle + graph expansion 0.80–1.00 |
+| the neighbourhood of a node you have | `ego_graph` / `multi_hop` | typed links reach nodes sharing no wording with the query |
+
+**Do not send a paragraph to `search`.** That is the documented anti-pattern
+`collect_report_context` exists to replace, and it is the single most common
+way a session convinces itself the record is empty.
+
+### Checking whether what you found is still true
+
+Four operations answer "is this still current?", and none of them is `search`:
+
+- **`staleness_impact`** — before you supersede or retract something, see the
+  blast radius: everything whose reasoning rests on it.
+- **`belief_as_of`** — reconstruct what the project believed at a past date.
+  Use it when a mission or draft was written earlier than the record you are
+  reading, to see the state it was actually written against.
+- **`changes_since`** — page the semantic change ledger from a cursor. This is
+  how a resumed session catches up instead of re-deriving.
+- **`contradictions`** — surface conflicting evidence near an entity before you
+  build on it.
+
+`mission_guard` does the same job at mission pickup: retracted findings and
+unresolved contradictions overlapping the objective — approaches already
+falsified. Call it *before* planning work, not after it fails.
 
 ---
 
-## Anti-Patterns — Common Mistakes to Avoid
+## Anti-Patterns
 
 1. **DON'T** skip the session-start protocol, even if the user asks a direct question.
 2. **DON'T** create entries with `source:"brain"` when the PI directed the work — use `source:"pi"` + `verbatim_input`.
 3. **DON'T** create decisions without `related_journal` — every decision needs evidence.
 4. **DON'T** create missions without `motivated_by_decision` — every mission needs a triggering decision.
-5. **DON'T** use `rka_query(args={"operation": "search", ...})` with queries longer than 5 words — returns empty; use 2–4 word queries.
+5. **DON'T** issue one long, unscoped `search` and treat the top hits as the answer. (Long queries do *not* return empty — that earlier claim was wrong; a 24-word query returns a full page of hits. The problem is that they return the *wrong* ones.) Unscoped full-sentence search surfaces the decision you are after only ~26 % of the time; scope `entity_types` and trim to ~4–8 content words — see "Retrieval Strategy".
 6. **DON'T** create clusters without `research_question_id` — they become orphans in the map.
 7. **DON'T** bundle independent tasks into one mission — parse into separate missions.
 8. **DON'T** let generated summaries (the v2.4-removed `ask` / `generate_summary` LLM features) become canonical knowledge — when re-wired through the orchestrator they will remain disposable.

--- a/plugin/skills/executor/SKILL.md
+++ b/plugin/skills/executor/SKILL.md
@@ -12,7 +12,7 @@ You are the implementation AI in an RKA-managed project. Your job is to execute 
 
 Your counterparts: the **Brain** (`skills/brain/SKILL.md`) handles strategy. The **PI** (human researcher) supervises both.
 
-## Tool Surface (v2.7.0+) — No-Compromise Typed-Arg Dispatch
+## Tool Surface
 
 The rka MCP server ships a **discriminated-union dispatch surface**. Five tools are always-on; everything else is reached through them:
 
@@ -197,9 +197,23 @@ When a mission asks you to read a paper:
 
 ---
 
-## Retrieving Context — Drive RKA, Don't One-Shot It
+## Retrieval Strategy
 
 When mission context is incomplete, retrieve iteratively: 3–5 short (1–4 word) angle queries via `search`, then expand the best hits through `ego_graph` / `multi_hop`; for prose-described scopes use `collect_report_context` with angle_queries. One-shot paragraph search measured 0.32 recall vs 0.80–1.00 for this loop (eval-v3). Verify load-bearing entities by fetching full content before acting on them.
+
+**Scope every search to the node type you want** — `"filters": {"entity_types": ["decision"]}` and friends. Unscoped, a decision is found by its own question text only 25.8 % of the time; scoped, 93.3 % (98.0 % with an ~8-word query). Measured over all 392 decisions in this store (eval-v3, 2026-08-23).
+
+**Check currency before acting on a decision.** Search hits carry `status` /
+`superseded_by` where the source table has them, but the authoritative read is
+through `ego_graph` / `multi_hop` or `operation="entity"`. If a decision is
+superseded, follow `superseded_by` to its replacement rather than working from
+the one you found.
+
+**At mission pickup, call `mission_guard`** — it returns retracted findings and
+unresolved contradictions overlapping the objective, i.e. approaches already
+falsified. Reading it first is cheaper than rediscovering them. `belief_as_of`
+reconstructs the state a older mission was written against; `changes_since`
+pages what has landed since you last looked.
 
 ---
 

--- a/plugin/skills/pi/SKILL.md
+++ b/plugin/skills/pi/SKILL.md
@@ -11,7 +11,7 @@ version: 2.7.0
 You are operating in the PI role for an RKA-managed project.
 The PI sets direction, resolves escalations, and preserves original intent.
 
-## Tool Surface (v2.7.0+) — No-Compromise Typed-Arg Dispatch
+## Tool Surface
 
 The rka MCP server ships a **discriminated-union dispatch surface**. Five tools are always-on:
 
@@ -65,6 +65,26 @@ rka_execute(args={"operation": "resolve_checkpoint",
 - Record PI guidance with `rka_execute(args={"operation": "record_note", "source": "pi", "verbatim_input": "...", ...})`.
 - Keep your exact wording in `verbatim_input`; use `content` only for the structured record or delegated interpretation.
 - Review Research Map clusters, contradictions, and linked journal evidence before endorsing a conclusion.
+
+## Retrieval Strategy
+
+You are the only role that will question whether a conclusion rests on a
+decision that has since been overturned. Three things make that checkable.
+
+1. **Scope your searches by node type.** `search` ranks eight entity types in
+   one list. Unscoped, a decision is found by its own question text only 25.8 %
+   of the time; with `"filters": {"entity_types": ["decision"]}` it is 93.3 %
+   (measured over all 392 decisions in this store, eval-v3 2026-08-23).
+2. **A search hit alone cannot tell you whether a decision is in force.** It
+   carries `status` / `superseded_by` where the source table has them, but the
+   authoritative check is to reach the node through `ego_graph` / `multi_hop`
+   or fetch it with `operation="entity"`. If a decision is superseded, follow
+   `superseded_by` to the one that replaced it before endorsing anything.
+3. **Ask the record what changed.** `belief_as_of` reconstructs what the
+   project believed at a past date — the right lens when reviewing work written
+   weeks ago. `changes_since` pages what has happened since a cursor.
+   `staleness_impact` shows what a retraction would invalidate downstream.
+   `contradictions` surfaces conflicting evidence before you ratify.
 
 ## Guardrails
 

--- a/rka/api/routes/config.py
+++ b/rka/api/routes/config.py
@@ -81,18 +81,26 @@ def _422(error: str, detail: str, hint: str = "") -> JSONResponse:
     )
 
 
-def _backend_signature(config: EmbeddingConfig) -> tuple[str, str, int]:
+def _backend_signature(config: EmbeddingConfig) -> tuple[str, str, int, str]:
     """Identity tuple used to decide whether backfill needs to fire on PUT.
 
-    Two configs that produce the same `(backend, model_or_name, dim)`
-    tuple are interchangeable from the vec_claims table's perspective —
-    only the api_key may have changed, no re-embed needed.
+    Includes `base_url` because repointing a dead backend at a reachable host
+    is exactly the recovery action, and it is the one that most needs
+    reconciliation: entities created while the old host was unreachable were
+    never embedded and nothing else fills them in. Leaving base_url out of the
+    signature meant that action returned 200 with no job and the gap persisted
+    silently (observed 2026-08-23: 1023 entities, three months, six projects).
+
+    Same dim ⇒ `reshape_all_vec_tables_if_needed` is a no-op, so a base_url
+    change costs a backfill of the genuinely-missing rows and nothing else —
+    existing vectors are never discarded.
     """
     backend = config.backend
     sub = config.config or {}
     model = sub.get("model") or sub.get("model_name") or ""
     dim = int(sub.get("dim") or 0)
-    return (backend, model, dim)
+    base_url = str(sub.get("base_url") or sub.get("host") or "")
+    return (backend, model, dim, base_url)
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +153,13 @@ async def put_embedding_config(
         return _422("embedding_config_invalid", exc.detail, exc.hint)
 
     if not needs_backfill:
-        # api_key (or only-provenance) change — no re-embed.
+        # api_key (or only-provenance) change — no re-embed, but the search
+        # path holds a provider client built at startup, so it must still be
+        # swapped or every subsequent query keeps using the old credentials
+        # while GET and /test both report the new ones.
+        request.app.state.embeddings = EmbeddingService.from_config(
+            saved.model_dump(), db=request.app.state.db
+        )
         return JSONResponse(status_code=200, content=_redact(saved))
 
     # Step 4: kick off backfill in the background and return 202 + job ref.
@@ -200,6 +214,45 @@ async def test_embedding_config(request: Request, body: EmbeddingConfig) -> Any:
     }
 
 
+@router.post("/api/config/embedding/backfill")
+async def start_embedding_backfill(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    entity_types: str | None = Query(
+        default=None,
+        description="comma-separated subset, e.g. 'claim,journal'; omit for all",
+    ),
+) -> Any:
+    """Reconcile missing embeddings without touching the configuration.
+
+    Until this existed the only way to fill a gap was to edit the embedding
+    config, which conflates two different intents and — because
+    `_backend_signature` ignored base_url — did not even work for the case
+    that matters. Backfill only ever adds vectors for entities that have
+    none; it never re-embeds or discards existing ones.
+    """
+    db = request.app.state.db
+    embeddings = getattr(request.app.state, "embeddings", None)
+    if embeddings is None:
+        return _422(
+            "embedding_unavailable",
+            "no embedding backend is configured",
+            "set one in Settings → Embeddings first",
+        )
+    types = tuple(t.strip() for t in entity_types.split(",")) if entity_types else None
+    status_obj = register_job()
+    svc = BackfillService(db=db, embeddings=embeddings)
+    background_tasks.add_task(_run_backfill_safely, svc, status_obj, types)
+    return JSONResponse(
+        status_code=202,
+        content={
+            "job_id": status_obj.job_id,
+            "status_url": f"/api/config/embedding/backfill/status?job_id={status_obj.job_id}",
+            "entity_types": list(types) if types else "all",
+        },
+    )
+
+
 @router.get("/api/config/embedding/backfill/status")
 async def get_backfill_status(job_id: str | None = Query(default=None)) -> Any:
     """Polling endpoint for the Settings UI progress bar.
@@ -224,11 +277,15 @@ async def get_backfill_status(job_id: str | None = Query(default=None)) -> Any:
 # ---------------------------------------------------------------------------
 
 
-async def _run_backfill_safely(svc: BackfillService, status: JobStatus) -> None:
+async def _run_backfill_safely(
+    svc: BackfillService,
+    status: JobStatus,
+    entity_types: tuple[str, ...] | None = None,
+) -> None:
     """Wraps BackfillService.run_backfill so unhandled exceptions land in
     the status snapshot rather than the background-task logger."""
     try:
-        await svc.run_backfill(status)
+        await svc.run_backfill(status, entity_types=entity_types)
     except Exception as exc:  # noqa: BLE001
         status.state = "failed"
         status.error = str(exc)

--- a/rka/api/routes/decisions.py
+++ b/rka/api/routes/decisions.py
@@ -11,6 +11,7 @@ exceeds ~350 lines.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from rka.models.decision import (
     Decision,
@@ -33,7 +34,10 @@ from rka.models.calibration import (
 from rka.services.decisions import DecisionService
 from rka.services.decision_options import DecisionOptionsService
 from rka.services.calibration import CalibrationService
+from rka.infra.database import Database
 from rka.api.deps import (
+    get_db,
+    require_project,
     get_scoped_decision_service,
     get_scoped_decision_options_service,
     get_scoped_calibration_service,
@@ -71,6 +75,86 @@ async def get_decision_tree(
     return await svc.get_tree(phase=phase, active_only=active_only)
 
 
+# ============================================================
+# Orphaned supersede chains (repair surface)
+# ============================================================
+# A decision marked `superseded` with no `superseded_by` tells a reader that
+# it is dead but not what replaced it — the exact shape that sends a session
+# hunting for a successor it cannot reach. `rka admin repair-supersedes`
+# could already fix this, but only from a shell: an agent session or the web
+# UI had no path to it. These are thin adapters over the same service.
+
+
+class SupersessionLink(BaseModel):
+    """One (superseded, replacement) pair to reconnect."""
+
+    old_decision_id: str
+    new_decision_id: str
+    # Mutation is opt-in, mirroring `rka admin repair-supersedes --apply`.
+    # A wrong pointer is worse than a missing one: it sends a reader
+    # confidently to an unrelated decision. Default to a preview.
+    apply: bool = False
+    actor: str = "pi"
+
+
+@router.get("/decisions/orphan-supersedes")
+async def list_orphan_supersedes_route(
+    project_id: str = Depends(require_project),
+    db: Database = Depends(get_db),
+) -> list[dict]:
+    """Decisions marked superseded with no pointer to their replacement."""
+    from rka.services.admin_repair import list_orphan_supersedes
+
+    return await list_orphan_supersedes(db, project_id)
+
+
+@router.post("/decisions/link-supersession")
+async def link_supersession_route(
+    body: SupersessionLink,
+    project_id: str = Depends(require_project),
+    db: Database = Depends(get_db),
+) -> dict:
+    """Reconnect an existing decision pair as (superseded -> replacement).
+
+    Distinct from `POST /decisions/{id}/supersede`, which *creates* the
+    replacement. Here both rows already exist and only the chain between
+    them is missing, so this replays the full supersede sequence without
+    creating anything: scope_version bump, superseded_by, the `supersedes`
+    entity_link, the staleness cascade over claims and clusters sourced
+    from the old decision's journal entries, a re_distill_review row, and
+    the decision_superseded event. Idempotent — already-satisfied steps
+    report ALREADY.
+    """
+    from rka.services.admin_repair import repair_orphan_supersedes
+
+    reports = await repair_orphan_supersedes(
+        db,
+        project_id,
+        {body.old_decision_id: body.new_decision_id},
+        dry_run=not body.apply,
+        actor=body.actor,
+    )
+    if not reports:
+        raise HTTPException(422, "no pair supplied")
+    report = reports[0]
+    return {
+        "applied": bool(body.apply) and report.applied,
+        "dry_run": not body.apply,
+        "old_decision_id": body.old_decision_id,
+        "new_decision_id": body.new_decision_id,
+        "rolled_back": report.rolled_back,
+        "steps": [
+            {"step": s.name, "state": s.state, "detail": s.detail}
+            for s in report.steps
+        ],
+    }
+
+
+# NOTE: these literal paths MUST stay above `/decisions/{dec_id}` — FastAPI
+# matches in registration order, so a parameterised route declared first
+# swallows "orphan-supersedes" as a decision id (404 "Decision
+# orphan-supersedes not found"). `/decisions/tree` sits above it for the
+# same reason.
 @router.get("/decisions/{dec_id}", response_model=Decision)
 async def get_decision(dec_id: str, svc: DecisionService = Depends(get_scoped_decision_service)):
     dec = await svc.get(dec_id)

--- a/rka/api/routes/search.py
+++ b/rka/api/routes/search.py
@@ -25,6 +25,10 @@ class SearchResult(BaseModel):
     title: str
     snippet: str
     score: float = 0.0
+    # Currency signals — absent means the source table carries none.
+    status: str | None = None
+    superseded_by: str | None = None
+    stale: bool | None = None
 
 
 @router.post("/search", response_model=list[SearchResult])
@@ -48,6 +52,9 @@ async def search(
             title=h.title,
             snippet=h.snippet,
             score=h.score,
+            status=h.status,
+            superseded_by=h.superseded_by,
+            stale=h.stale,
         )
         for h in hits
     ]

--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -417,6 +417,12 @@ class QueryDecisionTreeArgs(ProjectScopedArgs):
     ] = None
 
 
+class OrphanSupersedesArgs(ProjectScopedArgs):
+    """[ANY] List decisions marked superseded with no pointer to a replacement."""
+
+    operation: Literal["orphan_supersedes"] = "orphan_supersedes"
+
+
 class QueryCalibrationMetricsArgs(ProjectScopedArgs):
     """[BRAIN] Aggregate calibration outcomes for decisions you've made.
 
@@ -1288,6 +1294,7 @@ QueryArgsUnion = Annotated[
         QueryCheckpointsArgs,
         # Decision / calibration / hooks / notifications
         QueryDecisionTreeArgs,
+        OrphanSupersedesArgs,
         QueryCalibrationMetricsArgs,
         QueryHooksArgs,
         QueryHookExecutionsArgs,
@@ -4676,6 +4683,49 @@ class SubmitReportArgs(ProjectScopedArgs):
         return self
 
 
+class LinkSupersessionArgs(ProjectScopedArgs):
+    """[BRAIN/PI] Reconnect an existing decision pair as superseded -> replacement.
+
+    Distinct from ``supersede_decision``, which CREATES the replacement. Use
+    this when both rows already exist and only the chain between them is
+    missing — a decision reading ``superseded`` with no ``superseded_by``
+    tells a reader it is dead but not what replaced it, which is precisely
+    what sends a session hunting for a successor it cannot reach.
+
+    Replays the full supersede sequence without creating anything: scope
+    version bump, the superseded_by pointer, the ``supersedes`` entity_link,
+    the staleness cascade over claims and clusters sourced from the old
+    decision's journal entries, a re-distill review row, and the
+    decision_superseded event. Idempotent.
+
+    ``apply`` defaults to False: a wrong pointer is worse than a missing one,
+    because it sends a reader confidently to an unrelated decision. Preview
+    first, then re-call with apply=True.
+    """
+
+    operation: Literal["link_supersession"] = "link_supersession"
+
+    old_decision_id: Annotated[
+        str,
+        Field(description="The superseded decision (dec_*) that is missing its pointer."),
+    ]
+    new_decision_id: Annotated[
+        str,
+        Field(description="The existing decision (dec_*) that replaced it."),
+    ]
+    apply: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="False (default) previews the steps; True performs them.",
+        ),
+    ] = False
+    actor: Annotated[
+        Literal["pi", "brain", "executor", "system"],
+        Field(default="pi", description="Actor recorded on the backfilled rows."),
+    ] = "pi"
+
+
 class AdvanceRqArgs(ProjectScopedArgs):
     """Advance a research question through its lifecycle."""
 
@@ -5006,6 +5056,7 @@ ExecuteArgsUnion = Annotated[
         UpdateMissionStatusArgs,
         BulkUpdateArgs,
         SupersedeDecisionArgs,
+        LinkSupersessionArgs,
         PresentDecisionArgs,
         RecordPiSelectionArgs,
         RecordOutcomeArgs,
@@ -5200,6 +5251,8 @@ __all__ = [
     "ValidateReferenceArgs",
     "SubmitReportArgs",
     "AdvanceRqArgs",
+    "OrphanSupersedesArgs",
+    "LinkSupersessionArgs",
     "SubmitCheckpointArgs",
     "ResolveCheckpointArgs",
     "EvaluateGateArgs",

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -2267,6 +2267,75 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ],
         "notes": None,
     },
+    "orphan_supersedes": {
+        "operation": "orphan_supersedes",
+        "tool": "rka_query",
+        "category": "decision",
+        "summary": "List decisions marked superseded with no replacement pointer.",
+        "signature": 'rka_query(args={"operation": "orphan_supersedes", "project_id": "prj_..."})',
+        "required_fields": ["project_id"],
+        "optional_fields": [],
+        "enums": {},
+        "examples": [
+            {
+                "description": "Find chains a reader cannot follow forward",
+                "call": {"operation": "orphan_supersedes", "project_id": "prj_01ABC"},
+            }
+        ],
+        "related_operations": ["link_supersession", "decision_tree", "staleness_impact"],
+        "role_tag": "ANY",
+        "notes": (
+            "A decision reading 'superseded' with an empty superseded_by says it is "
+            "dead but not what replaced it. The record carries no automatic pointer — "
+            "a human must name the replacement, then link_supersession reconnects it."
+        ),
+    },
+    "link_supersession": {
+        "operation": "link_supersession",
+        "tool": "rka_execute",
+        "category": "decision",
+        "summary": "Reconnect two existing decisions as superseded -> replacement.",
+        "signature": (
+            'rka_execute(args={"operation": "link_supersession", "project_id": "prj_...", '
+            '"old_decision_id": "dec_...", "new_decision_id": "dec_...", "apply": false})'
+        ),
+        "required_fields": ["project_id", "old_decision_id", "new_decision_id"],
+        "optional_fields": ["apply", "actor"],
+        "enums": {"actor": ["pi", "brain", "executor", "system"]},
+        "examples": [
+            {
+                "description": "Preview the repair first (apply defaults to false)",
+                "call": {
+                    "operation": "link_supersession",
+                    "project_id": "prj_01ABC",
+                    "old_decision_id": "dec_01OLD",
+                    "new_decision_id": "dec_01NEW",
+                },
+            },
+            {
+                "description": "Perform it once the pairing is confirmed",
+                "call": {
+                    "operation": "link_supersession",
+                    "project_id": "prj_01ABC",
+                    "old_decision_id": "dec_01OLD",
+                    "new_decision_id": "dec_01NEW",
+                    "apply": True,
+                },
+            },
+        ],
+        "related_operations": ["supersede_decision", "orphan_supersedes", "decision_tree"],
+        "role_tag": "BRAIN",
+        "notes": (
+            "NOT the same as supersede_decision, which CREATES the replacement. Use this "
+            "only when both rows already exist and only the chain between them is missing. "
+            "Replays the full sequence without creating anything: scope-version bump, the "
+            "superseded_by pointer, the 'supersedes' entity_link, the staleness cascade "
+            "over claims and clusters sourced from the old decision's journal entries, a "
+            "re-distill review row, and the decision_superseded event. Idempotent. "
+            "apply defaults to False because a wrong pointer is worse than a missing one — "
+            "it sends a reader confidently to an unrelated decision."
+        ),
+    },
     "supersede_decision": {
         "operation": "supersede_decision",
         "tool": "rka_execute",
@@ -5441,6 +5510,49 @@ def list_operations_grouped() -> dict[str, list[dict[str, Any]]]:
     return out
 
 
+# ---------------------------------------------------------------------------
+# Maturity — which operations belong in an agent's default choice space
+# ---------------------------------------------------------------------------
+# Measured 2026-08-23 against a five-month-old production store holding 5178
+# entities: these subsystems had ZERO rows. They are not broken and may be
+# deliberately ahead of use, but listing them alongside the core operations
+# means ~41% of what an agent reads while choosing is unreachable in practice.
+# Derived from category (plus a few named operations) rather than stamped on
+# all 150 entries, so the rule stays auditable and one edit re-classifies a
+# subsystem once it starts carrying data.
+PREVIEW_CATEGORIES: frozenset[str] = frozenset({
+    "manuscript",           # 3 manuscripts, 0 units / 0 claims / 0 bindings
+    "manuscript_planning",  # 0 branches
+    "experiments",          # 0 experiments
+    "semantic_patches",     # 0 proposals
+    "hooks",                # 0 hooks
+})
+
+# Preview operations inside an otherwise-stable category.
+PREVIEW_OPERATIONS: frozenset[str] = frozenset({
+    # interpretation-candidate pipeline: 0 candidates in production
+    "interpretation_candidates",
+    "create_interpretation_candidate",
+    "triage_interpretation_candidate",
+    "add_interpretation_hint",
+    # claim-scope contracts: 0 scope versions in production
+    "claim_scope",
+    "set_claim_scope",
+    # v2.4.0 removed the LLM path; this is a stub until it is re-wired
+    "generate_summary",
+})
+
+
+def operation_maturity(op_name: str) -> str:
+    """``'stable'`` or ``'preview'`` for one operation."""
+    entry = OPERATIONS_SCHEMA.get(op_name)
+    if entry is None:
+        return "unknown"
+    if op_name in PREVIEW_OPERATIONS or entry.get("category") in PREVIEW_CATEGORIES:
+        return "preview"
+    return "stable"
+
+
 def suggest_operations(query: str, *, top_n: int = 5) -> list[str]:
     """Return up to ``top_n`` best fuzzy matches for an unknown operation."""
     if not query:
@@ -5453,7 +5565,7 @@ def suggest_operations(query: str, *, top_n: int = 5) -> list[str]:
     )
 
 
-def list_operations_compact() -> dict[str, list[str]]:
+def list_operations_compact(*, include_preview: bool = False) -> dict[str, list[str]]:
     """v2.7.0 NO-COMPROMISE compromise-#3 mitigation.
 
     Returns a flat ``{tool: [op_name, ...]}`` map for the
@@ -5469,6 +5581,8 @@ def list_operations_compact() -> dict[str, list[str]]:
     """
     out: dict[str, list[str]] = {"rka_query": [], "rka_execute": []}
     for op_name, entry in OPERATIONS_SCHEMA.items():
+        if not include_preview and operation_maturity(op_name) == "preview":
+            continue
         tool = entry["tool"]
         out.setdefault(tool, []).append(op_name)
     for ops_list in out.values():
@@ -5476,7 +5590,9 @@ def list_operations_compact() -> dict[str, list[str]]:
     return out
 
 
-async def dispatch_describe(operation: str | None) -> str:
+async def dispatch_describe(
+    operation: str | None, *, include_preview: bool = False
+) -> str:
     """Render the rka_describe response as a JSON string.
 
     Behavior:
@@ -5494,19 +5610,28 @@ async def dispatch_describe(operation: str | None) -> str:
         # into a single comma-separated string per tool. Full per-op
         # schema is reachable via the FastMCP-rendered inputSchema or
         # via `rka_describe('<op_name>')`.
-        compact = list_operations_compact()
-        return json.dumps(
-            {
-                "rka_query": ", ".join(compact.get("rka_query", [])),
-                "rka_execute": ", ".join(compact.get("rka_execute", [])),
-                "total": len(OPERATIONS_SCHEMA),
-                "hint": (
-                    "rka_describe('<op>') for schema; rka_query/_execute "
-                    "inputSchema already carries per-branch enums."
-                ),
-            },
-            indent=2,
-        )
+        compact = list_operations_compact(include_preview=include_preview)
+        listed = sum(len(v) for v in compact.values())
+        payload: dict[str, Any] = {
+            "rka_query": ", ".join(compact.get("rka_query", [])),
+            "rka_execute": ", ".join(compact.get("rka_execute", [])),
+            "listed": listed,
+            "total": len(OPERATIONS_SCHEMA),
+            "hint": (
+                "rka_describe('<op>') for schema; rka_query/_execute "
+                "inputSchema already carries per-branch enums."
+            ),
+        }
+        if not include_preview:
+            hidden = len(OPERATIONS_SCHEMA) - listed
+            payload["preview_hidden"] = hidden
+            payload["preview_hint"] = (
+                f"{hidden} preview operations are omitted — subsystems with no "
+                "production data yet (manuscript, planning, experiments, "
+                "semantic-patches, hooks, interpretation staging, claim scope). "
+                "Pass include_preview=True to see them."
+            )
+        return json.dumps(payload, indent=2)
 
     op = operation.strip()
     entry = OPERATIONS_SCHEMA.get(op)
@@ -5524,12 +5649,15 @@ async def dispatch_describe(operation: str | None) -> str:
             indent=2,
         )
 
-    return json.dumps(entry, indent=2)
+    return json.dumps({**entry, "maturity": operation_maturity(op)}, indent=2)
 
 
 __all__ = [
     "OPERATIONS_SCHEMA",
+    "PREVIEW_CATEGORIES",
+    "PREVIEW_OPERATIONS",
     "dispatch_describe",
+    "operation_maturity",
     "get_operation_schema",
     "list_operations_grouped",
     "list_operations_compact",

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -264,14 +264,14 @@ Detailed operating guidance is available via MCP prompts:
 Use these prompts to load role-specific guidance at session start.
 
 ## Tool Surface (v2.7.0+) — Typed Dispatch Architecture
-RKA ships 5 always-on tools: 3 dispatch tools that route to 139 typed
+RKA ships 5 always-on tools: 3 dispatch tools that route to 150 typed
 operations, plus 2 escape hatches into the legacy surface.
 
 - **Dispatch (always-on):**
-- `rka_query(args={"operation": ..., "project_id": ..., ...})` — 62 read
+- `rka_query(args={"operation": ..., "project_id": ..., ...})` — 67 read
     operations (status, context, journal, decisions, missions, literature,
     research map, etc.). Returns structured data.
-- `rka_execute(args={"operation": ..., "project_id": ..., ...})` — 77
+- `rka_execute(args={"operation": ..., "project_id": ..., ...})` — 83
     write/lifecycle operations (record_note, record_decision, create_mission,
     submit_report, submit_checkpoint, etc.). Returns the created/updated entity.
   - `rka_describe(operation="" | "<op_name>")` — schema lookup. With no
@@ -283,7 +283,7 @@ operations, plus 2 escape hatches into the legacy surface.
     the live tool surface. Useful only for back-compat with old transcripts.
   - `rka_help(name=...)` — deprecated alias for `rka_describe`.
 
-The 139 operations are typed Pydantic models with per-branch enum constraints
+The 150 operations are typed Pydantic models with per-branch enum constraints
 and required-field enforcement at the FastMCP schema layer — illegal values
 (e.g. `confidence="confirmed"`) are rejected at the inputSchema boundary
 before the call goes out.
@@ -6262,6 +6262,78 @@ async def rka_check_integrity(*, project_id: str) -> str:
 # ============================================================
 
 
+@tool(category="decision")
+async def rka_orphan_supersedes(*, project_id: str) -> str:
+    """List decisions marked superseded that have no pointer to a replacement.
+
+    A decision reading `superseded` with an empty `superseded_by` tells a
+    reader it is dead but not what replaced it — the shape that sends a
+    session hunting for a successor it cannot reach. Pair with
+    `rka_link_supersession` to reconnect one.
+    """
+    async with _client(project_id) as c:
+        r = await c.get("/api/decisions/orphan-supersedes")
+        _raise_with_detail(r)
+        rows = r.json()
+    if not rows:
+        return "No orphaned supersede chains in this project."
+    lines = [f"{len(rows)} orphaned supersede chain(s):"]
+    for row in rows:
+        lines.append(f"  {row['id']}  [{(row.get('updated_at') or '')[:10]}]")
+        lines.append(f"     {(row.get('question') or '')[:110]}")
+        if row.get("chosen"):
+            lines.append(f"     chose: {row['chosen'][:100]}")
+    lines.append(
+        "\nEach needs a human to name its replacement — the record carries no "
+        "automatic pointer. Then call rka_link_supersession."
+    )
+    return "\n".join(lines)
+
+
+@tool(category="decision")
+async def rka_link_supersession(
+    old_decision_id: str,
+    new_decision_id: str,
+    apply: bool = False,
+    actor: str = "pi",
+    *,
+    project_id: str,
+) -> str:
+    """Reconnect two EXISTING decisions as superseded -> replacement.
+
+    Distinct from `rka_supersede_decision`, which *creates* the replacement.
+    Use this when both rows already exist and only the chain between them is
+    missing. Replays the full supersede sequence without creating anything:
+    scope-version bump, the superseded_by pointer, the `supersedes`
+    entity_link, the staleness cascade over claims and clusters sourced from
+    the old decision's journal entries, a re-distill review row, and the
+    decision_superseded event. Idempotent — satisfied steps report ALREADY.
+
+    Args:
+        old_decision_id: the superseded decision missing its pointer
+        new_decision_id: the existing decision that replaced it
+        apply: False (default) previews the steps; True performs them. A
+            wrong pointer is worse than a missing one, so preview first.
+        actor: recorded on the backfilled rows (pi | brain | executor | system)
+    """
+    async with _client(project_id) as c:
+        r = await c.post("/api/decisions/link-supersession", json={
+            "old_decision_id": old_decision_id,
+            "new_decision_id": new_decision_id,
+            "apply": apply, "actor": actor,
+        })
+        _raise_with_detail(r)
+        data = r.json()
+    head = "APPLIED" if data.get("applied") else ("DRY RUN — nothing written" if data.get("dry_run") else "NO-OP")
+    lines = [f"{head}: {old_decision_id} -> {new_decision_id}"]
+    for step in data.get("steps", []):
+        mark = {"DONE": "+", "ALREADY": "=", "WOULD": ".", "SKIPPED": "-"}.get(step["state"], "?")
+        lines.append(f"  [{mark}] {step['step']}: {step['state']}  {step.get('detail') or ''}".rstrip())
+    if data.get("dry_run"):
+        lines.append("\nRe-call with apply=True to perform these steps.")
+    return "\n".join(lines)
+
+
 @tool(category="maintenance")
 async def rka_flag_stale(
     entity_id: str,
@@ -8646,7 +8718,7 @@ from rka.mcp.operations_schema import (
 
 
 @tool(tier=_TIER_ALWAYS_ON, category="dispatch", always_load=True)
-async def rka_describe(operation: str = "") -> str:
+async def rka_describe(operation: str = "", include_preview: bool = False) -> str:
     """[ANY] LOOKUP the parameter shape and examples for any rka operation.
 
     Call BEFORE invoking rka_query or rka_execute on an unfamiliar
@@ -8662,15 +8734,22 @@ async def rka_describe(operation: str = "") -> str:
                                 fields, enum value sets, 1-2 examples,
                                 related_operations, role_tag, notes).
       - operation=''         -> operations index grouped by tool
-                                (rka_query / rka_execute) and category;
-                                use this when you want to BROWSE.
+                                (rka_query / rka_execute); use this when you
+                                want to BROWSE. Preview operations are omitted
+                                by default — subsystems that carry no
+                                production data yet — and the response reports
+                                how many were hidden. Pass
+                                include_preview=True to see the whole surface.
       - unknown operation    -> {error: 'unknown_operation', did_you_mean: [...]}.
 
     Args:
         operation: Canonical operation name (the value you would put in
             rka_query(args={"operation": ...}) or
             rka_execute(args={"operation": ...})).
-            Pass '' to list every known operation.
+            Pass '' to browse the index.
+        include_preview: include operations whose subsystem has no production
+            data yet. Default False keeps the browse index to what is actually
+            in use.
 
     Returns:
         JSON. For a known operation: {operation, tool, category,
@@ -8679,7 +8758,7 @@ async def rka_describe(operation: str = "") -> str:
         name: {error, operation, did_you_mean, hint}. For empty: the
         operations index.
     """
-    return await _dispatch_describe(operation)
+    return await _dispatch_describe(operation, include_preview=include_preview)
 
 
 # ============================================================
@@ -8849,7 +8928,7 @@ async def rka_execute(args: _ExecuteArgsUnion) -> str:
 
     v2.7.0 NO-COMPROMISE typed-arg surface. The ``args`` parameter is a
     Pydantic discriminated union (keyed by ``operation``) covering all
-    77 write/lifecycle operations. FastMCP renders the union as JSON
+    83 write/lifecycle operations. FastMCP renders the union as JSON
     Schema ``oneOf`` with per-branch ``required`` arrays + per-branch
     ``enum`` constraints on every Literal-typed field. The LLM CANNOT
     emit ``confidence='confirmed'``, ``decided_by='SUPERVISOR'``,
@@ -8994,7 +9073,7 @@ support; the Skill is authoritative.
 Always begin a session by loading context:
 
 0. **Tool surface (v2.7.0+ typed dispatch).** RKA ships 3 always-on dispatch
-   tools — `rka_query` (62 read ops), `rka_execute` (77 write/lifecycle ops),
+   tools — `rka_query` (67 read ops), `rka_execute` (83 write/lifecycle ops),
    and `rka_describe` (schema lookup) — plus 2 escape hatches (`rka_load_tools`
    for legacy compat and `rka_help` as a deprecated alias of `rka_describe`).
    No activation step is required: every operation is reachable from
@@ -9142,7 +9221,7 @@ Skill is authoritative.
 ## Session Start Protocol
 
 0. **Tool surface (v2.7.0+ typed dispatch).** RKA ships 3 always-on dispatch
-   tools — `rka_query` (62 read ops), `rka_execute` (77 write/lifecycle ops),
+   tools — `rka_query` (67 read ops), `rka_execute` (83 write/lifecycle ops),
    and `rka_describe` (schema lookup) — plus 2 escape hatches (`rka_load_tools`
    for legacy compat and `rka_help` as a deprecated alias of `rka_describe`).
    No activation step is required: every operation is reachable from

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -909,6 +909,7 @@ _QUERY_DISPATCH: dict[str, str] = {
     "mission": "rka_get_mission",
     # decisions / graph
     "decision_tree": "rka_get_decision_tree",
+    "orphan_supersedes": "rka_orphan_supersedes",
     "graph": "rka_get_graph",
     "ego_graph": "rka_get_ego_graph",
     "graph_stats": "rka_graph_stats",
@@ -2068,6 +2069,7 @@ EXECUTE_OPERATIONS = (
     "update_status",
     "bulk_update",
     "supersede_decision",
+    "link_supersession",
     # decision lifecycle (PI ratification + calibration)
     "record_pi_selection",
     "record_outcome",
@@ -2805,6 +2807,26 @@ async def dispatch_execute(
             _REVIEW_OP_MAP[op],
             project_id=project_id,  # type: ignore[arg-type]
             payload=payload,
+        )
+
+    # --- link_supersession (direct legacy call; repairs an existing pair
+    # rather than creating a replacement, so it is not a dispatch_review
+    # target) ---
+    if op == "link_supersession":
+        old_id = kw.get("old_decision_id")
+        new_id = kw.get("new_decision_id")
+        if not old_id or not new_id:
+            return _err(
+                "missing_field",
+                "rka_execute(operation='link_supersession') requires "
+                "old_decision_id + new_decision_id",
+            )
+        return await _legacy("rka_link_supersession")(
+            old_decision_id=old_id,
+            new_decision_id=new_id,
+            apply=bool(kw.get("apply", False)),
+            actor=kw.get("actor", "pi"),
+            project_id=project_id,  # type: ignore[arg-type]
         )
 
     # --- scan_workspace (direct legacy call; not part of dispatch_review's

--- a/rka/services/embedding_backfill.py
+++ b/rka/services/embedding_backfill.py
@@ -171,13 +171,27 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
         source_table="claims",
         vec_table="vec_claims",
         compose_text=lambda r: (r.get("content") or "").strip(),
+        # Pending is decided by the absence of an embedding_metadata row, the
+        # same test every other entity type uses -- NOT by the
+        # `claims.embedding_pending` flag. That flag drifts: in a real store
+        # all 976 claims carried embedding_pending = 0 while 341 of them had
+        # no vector, so a flag-gated backfill skipped every claim that needed
+        # one. The flag is still cleared after a successful embed so external
+        # readers of it stay consistent.
         pending_cursor_sql=(
-            "SELECT id, content, project_id FROM claims "
-            "WHERE embedding_pending = 1 AND id > ? "
-            "ORDER BY id LIMIT ?"
+            "SELECT c.id, c.content, c.project_id FROM claims c "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'claim' AND m.entity_id = c.id"
+            ") AND c.id > ? "
+            "ORDER BY c.id LIMIT ?"
         ),
         pending_count_sql=(
-            "SELECT COUNT(*) AS n FROM claims WHERE embedding_pending = 1"
+            "SELECT COUNT(*) AS n FROM claims c "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM embedding_metadata m "
+            "  WHERE m.entity_type = 'claim' AND m.entity_id = c.id"
+            ")"
         ),
         post_embed_sql="UPDATE claims SET embedding_pending = 0 WHERE id = ?",
     ),

--- a/rka/services/search.py
+++ b/rka/services/search.py
@@ -19,6 +19,17 @@ def _tokens_remain(query: str) -> bool:
     return bool(re.findall(r"[a-zA-Z0-9]{3,}", query))
 
 
+# entity_type -> (source table, currency columns to lift onto the hit)
+# Only tables that actually carry a lifecycle signal appear here.
+_CURRENCY_COLUMNS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "decision": ("decisions", ("status", "superseded_by")),
+    "journal": ("journal", ("status", "superseded_by")),
+    "claim": ("claims", ("stale",)),
+    "mission": ("missions", ("status",)),
+    "literature": ("literature", ("status",)),
+}
+
+
 @dataclass
 class SearchHit:
     """A single search result."""
@@ -30,6 +41,13 @@ class SearchHit:
     score: float = 0.0
     fts_rank: int | None = None
     vec_rank: int | None = None
+    # Currency signals. Without these a superseded decision is indistinguishable
+    # from a current one in a search result, which is how a session ends up
+    # acting on knowledge that has already been overturned. Every other read
+    # surface (ego_graph, multi_hop, operation="entity") already carries them.
+    status: str | None = None
+    superseded_by: str | None = None
+    stale: bool | None = None
 
 
 class SearchService:
@@ -240,10 +258,55 @@ class SearchService:
                 # Pure-anchor query ("PI directives this week"): fall back to
                 # a metadata-only listing of matching journal entries.
                 hits = await self._metadata_only_journal(constraints, limit * 4)
-            return await self._apply_constraints(hits, constraints, limit)
-        return await self._search_unconstrained(
+            constrained = await self._apply_constraints(hits, constraints, limit)
+            return await self._attach_currency(constrained)
+        plain = await self._search_unconstrained(
             query, types, limit, keyword_weight, semantic_weight
         )
+        return await self._attach_currency(plain)
+
+    async def _attach_currency(self, hits: list[SearchHit]) -> list[SearchHit]:
+        """Fill status / superseded_by / stale on every hit that has one.
+
+        Applied at the single public exit so it covers all four retrieval
+        paths (FTS, vector, tag, LIKE fallback) rather than each of their
+        twelve construction sites. One batched lookup per entity type
+        present in the result set.
+        """
+        by_type: dict[str, list[str]] = {}
+        for hit in hits:
+            if hit.entity_type in _CURRENCY_COLUMNS:
+                by_type.setdefault(hit.entity_type, []).append(hit.entity_id)
+        if not by_type:
+            return hits
+
+        lifted: dict[tuple[str, str], dict] = {}
+        for etype, ids in by_type.items():
+            table, columns = _CURRENCY_COLUMNS[etype]
+            placeholders = ",".join("?" for _ in ids)
+            try:
+                rows = await self.db.fetchall(
+                    f"SELECT id, {', '.join(columns)} FROM {table}"
+                    f" WHERE id IN ({placeholders}) AND project_id = ?",
+                    list(ids) + [self.project_id],
+                )
+            except Exception:  # pragma: no cover — pre-migration snapshot
+                logger.debug("currency lookup skipped for %s", etype, exc_info=True)
+                continue
+            for row in rows:
+                lifted[(etype, row["id"])] = {c: row[c] for c in columns}
+
+        for hit in hits:
+            values = lifted.get((hit.entity_type, hit.entity_id))
+            if not values:
+                continue
+            if values.get("status") is not None:
+                hit.status = values["status"]
+            if values.get("superseded_by"):
+                hit.superseded_by = values["superseded_by"]
+            if values.get("stale") is not None:
+                hit.stale = bool(values["stale"])
+        return hits
 
     async def _metadata_only_journal(self, constraints: dict, limit: int) -> list[SearchHit]:
         conds = ["project_id = ?"]

--- a/rka/skills/brain/SKILL.md
+++ b/rka/skills/brain/SKILL.md
@@ -12,7 +12,7 @@ You are the strategic AI in an RKA-managed project. Your job is to interpret evi
 
 Your counterparts: the **Executor** (`skills/executor/SKILL.md`) handles implementation. The **PI** (human researcher) sets direction and preserves original intent.
 
-## Tool Surface (v2.7.0+) — No-Compromise Typed-Arg Dispatch
+## Tool Surface
 
 The rka MCP server ships a **discriminated-union dispatch surface**. Five tools are always-on; everything else is reached through them:
 
@@ -70,7 +70,7 @@ When a workflow below references a legacy tool name like `rka_add_decision`, tre
 
 ---
 
-## Session Start — Do This Every Time
+## Session Start
 
 1. **Pin the project for the whole conversation.** v2.6+: every project-scoped operation requires `project_id` in `args`. There is NO "active project" session state on the MCP server. Ask the PI (or recall from their first message) which project this conversation is about; call `rka_query(args={"operation": "list_projects"})` once if you need to discover the canonical ID; then thread `"project_id": "prj_..."` on every subsequent `rka_query` / `rka_execute` call. Omitting `project_id` is caught at the inputSchema layer as a missing required field — by design; this replaces the pre-v2.6 silent-fallback-to-`proj_default` failure mode. **Discipline: keep the project_id in working memory; thread it on every call.** The `RKA_PROJECT` env var was removed in v2.6; there is no per-process default.
 2. `rka_query(args={"operation": "status", "project_id": <pinned>})` — current state of the pinned project.
@@ -291,25 +291,68 @@ Full navigation command catalogue + advancement heuristics: `workflows.md` § "R
 
 ---
 
-## Retrieval Strategy — Drive RKA, Don't One-Shot It
+## Retrieval Strategy
 
 A single search call is not a retrieval strategy. Measured on the rka_development corpus (eval-v3, 2026-06-11): one paragraph-shaped query reached 0.32 mean recall of report-relevant nodes; the iterative strategy below reached 0.80–1.00. Assume you must drive RKA through several calls.
 
-1. **Short queries, many angles.** FTS works best with 1–4 keyword queries. Decompose the information need into 3–5 angle queries (component names, bug/fix vocabulary, decision subjects, evaluation terms) and search each one.
-2. **Expand from the best hits, not from the query.** Take the strongest 2–3 hits and traverse the graph: `ego_graph` for the linked neighborhood, `multi_hop` for ranked expansion. Typed links reach nodes whose wording shares nothing with your query — a fix-mission's produced journals, a decision's justifying evidence (+10 to +24 recall points over flat search in eval-v3).
-3. **For report-scoped collection, call `collect_report_context`** with the PI's prose description plus your angle queries. It runs seed-union + provenance-weighted graph expansion with seed protection server-side, and every returned node carries `included_via` (which query or link reached it) so you can audit the bundle.
-4. **Verify before you rely.** Fetch the full entity for anything load-bearing or borderline; never cite from a snippet alone.
-5. **Re-search thin dimensions.** If one aspect of the need came back sparse, treat it as a missing-angle signal, not proof of absence — try synonyms, and pivot through a relevant node's tags (tags name the cohort vocabulary).
+1. **Scope the search to the node type you want — the largest single lever.** `search` ranks eight entity types in one list, and the node you are after loses to whichever type carries the most text. Measured on all 392 decisions in this store (eval-v3, 2026-08-23) by querying each decision with *its own question text* — the weakest possible test, which a working index should never fail: **unscoped, only 25.8 % rank in the top 20** (MRR 0.043). Adding `"filters": {"entity_types": ["decision"]}` lifts it to **93.3 %**, and to **98.0 %** when the query is also trimmed to ~8 content words. It costs nothing and is reversible.
+
+   | you are looking for | scope to | self-retrieval hit@20 |
+   |---|---|---|
+   | a past decision | `["decision"]` | 100 % |
+   | a mission objective | `["mission"]` | 96 % |
+   | a paper | `["literature"]` | 95 % |
+   | an evidence claim | `["claim"]` | 90 % |
+   | a working note | `["journal"]` | 84 % |
+
+   Scope **per angle, not per session**: an evidence sweep may search `["claim","cluster"]` for findings and then `["literature"]` for sources. Widen to all types only when you genuinely do not know the shape of what you need.
+
+2. **Short queries, many angles.** FTS works best with 1–4 keyword queries. Decompose the information need into 3–5 angle queries (component names, bug/fix vocabulary, decision subjects, evaluation terms) and search each one. Length matters independently of scoping: unscoped, trimming a full question to its first 4 words moved hit@20 from 25.8 % to 64.0 %. Scoped, ~8 words maximises recall (98.0 %) and ~4 words maximises rank quality (MRR 0.443).
+3. **Expand from the best hits, not from the query.** Take the strongest 2–3 hits and traverse the graph: `ego_graph` for the linked neighborhood, `multi_hop` for ranked expansion. Typed links reach nodes whose wording shares nothing with your query — a fix-mission's produced journals, a decision's justifying evidence (+10 to +24 recall points over flat search in eval-v3).
+4. **Judge currency on the graph, never on a search hit.** A `search` result carries only `entity_type, entity_id, title, snippet, score` — **there is no `status` field**, so a superseded decision looks exactly like a current one. `ego_graph` / `multi_hop` nodes and `rka_query(args={"operation": "entity", ...})` *do* carry `status`, so expand or fetch before acting on any decision as if it were in force. This is the concrete mechanism by which a session chases its own tail. Measured on 15 real supersede chains (eval-v3, 2026-08-23): the current decision outranks its superseded predecessor 73 % of the time — but the predecessor is usually *also* in the result set at ranks 12–20, with nothing to distinguish it, and in 1 of 15 only the superseded one came back.
+5. **For report-scoped collection, call `collect_report_context`** with the PI's prose description plus your angle queries. It runs seed-union + provenance-weighted graph expansion with seed protection server-side, and every returned node carries `included_via` (which query or link reached it) so you can audit the bundle.
+6. **Verify before you rely.** Fetch the full entity for anything load-bearing or borderline; never cite from a snippet alone.
+7. **Re-search thin dimensions.** If one aspect of the need came back sparse, treat it as a missing-angle signal, not proof of absence — try synonyms, and pivot through a relevant node's tags (tags name the cohort vocabulary).
+
+### Which retrieval call to reach for
+
+| you need | call | why |
+|---|---|---|
+| one node you can already name | `search` + `entity_types` | cheapest; 93–100 % hit when scoped |
+| everything relevant to a prose-described scope | `collect_report_context` with `angle_queries` | one paragraph query measured 0.32 recall; multi-angle + graph expansion 0.80–1.00 |
+| the neighbourhood of a node you have | `ego_graph` / `multi_hop` | typed links reach nodes sharing no wording with the query |
+
+**Do not send a paragraph to `search`.** That is the documented anti-pattern
+`collect_report_context` exists to replace, and it is the single most common
+way a session convinces itself the record is empty.
+
+### Checking whether what you found is still true
+
+Four operations answer "is this still current?", and none of them is `search`:
+
+- **`staleness_impact`** — before you supersede or retract something, see the
+  blast radius: everything whose reasoning rests on it.
+- **`belief_as_of`** — reconstruct what the project believed at a past date.
+  Use it when a mission or draft was written earlier than the record you are
+  reading, to see the state it was actually written against.
+- **`changes_since`** — page the semantic change ledger from a cursor. This is
+  how a resumed session catches up instead of re-deriving.
+- **`contradictions`** — surface conflicting evidence near an entity before you
+  build on it.
+
+`mission_guard` does the same job at mission pickup: retracted findings and
+unresolved contradictions overlapping the objective — approaches already
+falsified. Call it *before* planning work, not after it fails.
 
 ---
 
-## Anti-Patterns — Common Mistakes to Avoid
+## Anti-Patterns
 
 1. **DON'T** skip the session-start protocol, even if the user asks a direct question.
 2. **DON'T** create entries with `source:"brain"` when the PI directed the work — use `source:"pi"` + `verbatim_input`.
 3. **DON'T** create decisions without `related_journal` — every decision needs evidence.
 4. **DON'T** create missions without `motivated_by_decision` — every mission needs a triggering decision.
-5. **DON'T** use `rka_query(args={"operation": "search", ...})` with queries longer than 5 words — returns empty; use 2–4 word queries.
+5. **DON'T** issue one long, unscoped `search` and treat the top hits as the answer. (Long queries do *not* return empty — that earlier claim was wrong; a 24-word query returns a full page of hits. The problem is that they return the *wrong* ones.) Unscoped full-sentence search surfaces the decision you are after only ~26 % of the time; scope `entity_types` and trim to ~4–8 content words — see "Retrieval Strategy".
 6. **DON'T** create clusters without `research_question_id` — they become orphans in the map.
 7. **DON'T** bundle independent tasks into one mission — parse into separate missions.
 8. **DON'T** let generated summaries (the v2.4-removed `ask` / `generate_summary` LLM features) become canonical knowledge — when re-wired through the orchestrator they will remain disposable.

--- a/rka/skills/executor/SKILL.md
+++ b/rka/skills/executor/SKILL.md
@@ -12,7 +12,7 @@ You are the implementation AI in an RKA-managed project. Your job is to execute 
 
 Your counterparts: the **Brain** (`skills/brain/SKILL.md`) handles strategy. The **PI** (human researcher) supervises both.
 
-## Tool Surface (v2.7.0+) — No-Compromise Typed-Arg Dispatch
+## Tool Surface
 
 The rka MCP server ships a **discriminated-union dispatch surface**. Five tools are always-on; everything else is reached through them:
 
@@ -197,9 +197,23 @@ When a mission asks you to read a paper:
 
 ---
 
-## Retrieving Context — Drive RKA, Don't One-Shot It
+## Retrieval Strategy
 
 When mission context is incomplete, retrieve iteratively: 3–5 short (1–4 word) angle queries via `search`, then expand the best hits through `ego_graph` / `multi_hop`; for prose-described scopes use `collect_report_context` with angle_queries. One-shot paragraph search measured 0.32 recall vs 0.80–1.00 for this loop (eval-v3). Verify load-bearing entities by fetching full content before acting on them.
+
+**Scope every search to the node type you want** — `"filters": {"entity_types": ["decision"]}` and friends. Unscoped, a decision is found by its own question text only 25.8 % of the time; scoped, 93.3 % (98.0 % with an ~8-word query). Measured over all 392 decisions in this store (eval-v3, 2026-08-23).
+
+**Check currency before acting on a decision.** Search hits carry `status` /
+`superseded_by` where the source table has them, but the authoritative read is
+through `ego_graph` / `multi_hop` or `operation="entity"`. If a decision is
+superseded, follow `superseded_by` to its replacement rather than working from
+the one you found.
+
+**At mission pickup, call `mission_guard`** — it returns retracted findings and
+unresolved contradictions overlapping the objective, i.e. approaches already
+falsified. Reading it first is cheaper than rediscovering them. `belief_as_of`
+reconstructs the state a older mission was written against; `changes_since`
+pages what has landed since you last looked.
 
 ---
 

--- a/rka/skills/pi/SKILL.md
+++ b/rka/skills/pi/SKILL.md
@@ -11,7 +11,7 @@ version: 2.7.0
 You are operating in the PI role for an RKA-managed project.
 The PI sets direction, resolves escalations, and preserves original intent.
 
-## Tool Surface (v2.7.0+) — No-Compromise Typed-Arg Dispatch
+## Tool Surface
 
 The rka MCP server ships a **discriminated-union dispatch surface**. Five tools are always-on:
 
@@ -65,6 +65,26 @@ rka_execute(args={"operation": "resolve_checkpoint",
 - Record PI guidance with `rka_execute(args={"operation": "record_note", "source": "pi", "verbatim_input": "...", ...})`.
 - Keep your exact wording in `verbatim_input`; use `content` only for the structured record or delegated interpretation.
 - Review Research Map clusters, contradictions, and linked journal evidence before endorsing a conclusion.
+
+## Retrieval Strategy
+
+You are the only role that will question whether a conclusion rests on a
+decision that has since been overturned. Three things make that checkable.
+
+1. **Scope your searches by node type.** `search` ranks eight entity types in
+   one list. Unscoped, a decision is found by its own question text only 25.8 %
+   of the time; with `"filters": {"entity_types": ["decision"]}` it is 93.3 %
+   (measured over all 392 decisions in this store, eval-v3 2026-08-23).
+2. **A search hit alone cannot tell you whether a decision is in force.** It
+   carries `status` / `superseded_by` where the source table has them, but the
+   authoritative check is to reach the node through `ego_graph` / `multi_hop`
+   or fetch it with `operation="entity"`. If a decision is superseded, follow
+   `superseded_by` to the one that replaced it before endorsing anything.
+3. **Ask the record what changed.** `belief_as_of` reconstructs what the
+   project believed at a past date — the right lens when reviewing work written
+   weeks ago. `changes_since` pages what has happened since a cursor.
+   `staleness_impact` shows what a retraction would invalidate downstream.
+   `contradictions` surfaces conflicting evidence before you ratify.
 
 ## Guardrails
 

--- a/tests/skills/test_skill_spine.py
+++ b/tests/skills/test_skill_spine.py
@@ -1,0 +1,87 @@
+"""The four role skills must share a spine and agree with the tool surface.
+
+Two drift classes this locks down, both observed on 2026-08-23:
+
+1. **Structural drift.** The four skills had *no* H2 heading in common —
+   not because content was missing but because the same concept was titled
+   differently in each ("Tool Surface (v2.7.0+) — No-Compromise Typed-Arg
+   Dispatch" vs "Tool Surface", "Retrieval Strategy — Drive RKA…" vs
+   "Retrieving Context — Drive RKA…"). A reader comparing two roles could
+   not tell whether a section was absent or merely renamed.
+
+2. **Reference drift.** A skill citing an operation that no longer exists
+   sends an agent to a dead call. The v2.6 → v2.7 surface change made this
+   a live risk.
+
+`Guardrails` (limits of a role's authority) and `Anti-Patterns` (ways to
+misuse the tool) are deliberately NOT unified — they are different things,
+and collapsing them would lose the distinction.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS = REPO_ROOT / "rka" / "skills"
+ROLES = ("brain", "executor", "pi", "writer")
+
+# Concepts every role skill must carry, under exactly this heading.
+REQUIRED_SECTIONS = ("Tool Surface", "Session Start")
+
+
+def _headings(role: str) -> list[str]:
+    text = (SKILLS / role / "SKILL.md").read_text(encoding="utf-8")
+    return [h.strip() for h in re.findall(r"^##\s+(.+)$", text, re.M)]
+
+
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+def test_every_role_skill_carries_the_shared_spine(role: str, section: str) -> None:
+    assert section in _headings(role), (
+        f"{role}/SKILL.md is missing the '{section}' section, or titles it "
+        f"differently. Present headings: {_headings(role)}"
+    )
+
+
+def test_retrieval_guidance_exists_for_every_role() -> None:
+    """Every role must say how to retrieve — the Writer may delegate to Brain."""
+    for role in ROLES:
+        text = (SKILLS / role / "SKILL.md").read_text(encoding="utf-8")
+        assert "Retrieval Strategy" in text or "collect_report_context" in text, role
+
+
+def test_skills_cite_only_operations_that_exist() -> None:
+    from rka.mcp.operations_schema import OPERATIONS_SCHEMA
+
+    cited: dict[str, set[str]] = {}
+    for path in SKILLS.rglob("*.md"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        found = set(re.findall(r'"operation"\s*:\s*"([a-z_]+)"', text))
+        found |= set(re.findall(r'operation=["\']([a-z_]+)["\']', text))
+        if found:
+            cited[str(path.relative_to(SKILLS))] = found
+
+    unknown = {
+        rel: sorted(ops - set(OPERATIONS_SCHEMA))
+        for rel, ops in cited.items()
+        if ops - set(OPERATIONS_SCHEMA)
+    }
+    assert not unknown, f"skills cite operations that do not exist: {unknown}"
+
+
+def test_currency_operations_are_documented_somewhere() -> None:
+    """The tools that answer "is this still true?" must be discoverable.
+
+    These are the operations most directly aimed at not acting on overturned
+    knowledge, and every one of them was undocumented before 2026-08-23.
+    """
+    corpus = "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore") for p in SKILLS.rglob("*.md")
+    )
+    for op in ("belief_as_of", "staleness_impact", "changes_since",
+               "contradictions", "mission_guard"):
+        assert op in corpus, f"no skill mentions {op}"

--- a/tests/skills/writer/test_plugin_mirror.py
+++ b/tests/skills/writer/test_plugin_mirror.py
@@ -10,14 +10,28 @@ CANONICAL_DIR = REPO_ROOT / "rka" / "skills" / "writer"
 PLUGIN_DIR = REPO_ROOT / "plugin" / "skills" / "writer"
 
 
+def _is_artifact(relative_path: Path) -> bool:
+    """Packaging junk that legitimately exists in only one tree.
+
+    ``._``-prefixed entries are macOS AppleDouble companions: on external,
+    network and sync volumes the filesystem cannot hold extended attributes,
+    so every write leaves a sibling — including ``.___pycache__`` for a
+    ``__pycache__`` directory. They are not skill content, and without this
+    guard the test fails for everyone working on such a volume (see the
+    macOS section of CLAUDE.md). ``tests/test_skills_packaging.py`` already
+    skips them; this keeps the two mirror checks consistent.
+    """
+    return any(
+        part == "__pycache__" or part.startswith("._") for part in relative_path.parts
+    ) or relative_path.suffix == ".pyc"
+
+
 def _files_under(root: Path) -> dict[Path, bytes]:
-    """Return stable relative paths and bytes, excluding Python caches."""
+    """Return stable relative paths and bytes, excluding packaging artifacts."""
     return {
         path.relative_to(root): path.read_bytes()
         for path in root.rglob("*")
-        if path.is_file()
-        and "__pycache__" not in path.parts
-        and path.suffix != ".pyc"
+        if path.is_file() and not _is_artifact(path.relative_to(root))
     }
 
 

--- a/tests/test_api/test_config_routes.py
+++ b/tests/test_api/test_config_routes.py
@@ -262,3 +262,88 @@ async def test_422_responses_carry_error_detail_hint_keys(api_client):
     body = r.json()
     assert set(body.keys()) >= {"error", "detail", "hint"}
     assert body["error"] == "embedding_config_invalid"
+
+
+# --------------------------------------------------------------------------
+# base_url is part of the reconciliation identity (regression)
+# --------------------------------------------------------------------------
+
+
+def test_backend_signature_distinguishes_base_url():
+    """Repointing a dead backend must count as a change that needs backfill.
+
+    Regression: the signature was `(backend, model, dim)`, so moving
+    base_url from an unreachable host to a working one returned 200 with no
+    job and left every entity created during the outage unembedded --
+    observed in a real store as 1023 entities across six projects and three
+    months. Same dim means `reshape_all_vec_tables_if_needed` is a no-op, so
+    treating this as "changed" costs a backfill of the missing rows and
+    never discards an existing vector.
+    """
+    from rka.api.routes.config import _backend_signature
+
+    dead = EmbeddingConfig(
+        backend="openai_compat",
+        config={"base_url": "http://192.168.0.1:1234", "model": "m", "dim": 2560},
+    )
+    live = EmbeddingConfig(
+        backend="openai_compat",
+        config={"base_url": "http://host.docker.internal:1234", "model": "m", "dim": 2560},
+    )
+    assert _backend_signature(dead) != _backend_signature(live)
+
+
+def test_backend_signature_ignores_api_key():
+    """An api_key rotation still must NOT trigger a re-embed."""
+    from rka.api.routes.config import _backend_signature
+
+    a = EmbeddingConfig(
+        backend="openai_compat",
+        config={"base_url": "http://x", "model": "m", "dim": 4, "api_key": "old"},
+    )
+    b = EmbeddingConfig(
+        backend="openai_compat",
+        config={"base_url": "http://x", "model": "m", "dim": 4, "api_key": "new"},
+    )
+    assert _backend_signature(a) == _backend_signature(b)
+
+
+# --------------------------------------------------------------------------
+# explicit backfill trigger
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_trigger_422_without_a_backend(api_client):
+    """Reconciliation needs a backend; say so instead of silently doing nothing."""
+    client, _ = api_client
+    r = await client.post("/api/config/embedding/backfill")
+    assert r.status_code == 422
+    assert r.json()["error"] == "embedding_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_backfill_trigger_returns_job_when_backend_present(api_client):
+    """A trigger exists at all -- previously the only way in was a config edit."""
+    client, _ = api_client
+
+    class _Stub:
+        dim = 4
+        model_name = "stub"
+
+        async def embed_batch(self, texts, **kw):
+            return [[0.0] * 4 for _ in texts]
+
+    transport = client._transport
+    transport.app.state.embeddings = _Stub()
+
+    r = await client.post("/api/config/embedding/backfill?entity_types=claim")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["job_id"]
+    assert body["entity_types"] == ["claim"]
+
+    status = await client.get(
+        f"/api/config/embedding/backfill/status?job_id={body['job_id']}"
+    )
+    assert status.status_code == 200

--- a/tests/test_api/test_decisions_supersede_routes.py
+++ b/tests/test_api/test_decisions_supersede_routes.py
@@ -315,3 +315,96 @@ async def test_supersede_forwards_provenance_fields(
     assert r.status_code == 201, r.text
     body = r.json()
     assert "v2-supersede-test" in (body.get("tags") or []), body
+
+
+# ---------------------------------------------------------------------------
+# Supersession repair surface
+# ---------------------------------------------------------------------------
+
+
+async def _seed_decision(api_client: httpx.AsyncClient, q: str, chosen: str) -> str:
+    jrn = await api_client.post(
+        "/api/notes",
+        json={"content": f"context for {q}", "type": "note", "source": "brain"},
+        headers=HEADERS,
+    )
+    r = await api_client.post(
+        "/api/decisions",
+        json={
+            "question": q, "phase": "design", "decided_by": "brain",
+            "chosen": chosen, "rationale": "r",
+            "related_journal": [jrn.json()["id"]],
+        },
+        headers=HEADERS,
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_orphan_supersedes_route_is_not_shadowed_by_dec_id(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """`/decisions/orphan-supersedes` must not be parsed as a decision id.
+
+    Regression: FastAPI matches routes in registration order, so declaring
+    this literal path *after* `/decisions/{dec_id}` made every request 404
+    with "Decision orphan-supersedes not found". The unit suite passed
+    because nothing called the route; only an end-to-end call caught it.
+    `/decisions/tree` sits above `{dec_id}` for exactly this reason.
+    """
+    r = await api_client.get("/api/decisions/orphan-supersedes", headers=HEADERS)
+    assert r.status_code == 200, r.text
+    assert isinstance(r.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_link_supersession_previews_without_writing(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """apply defaults to False: a wrong pointer is worse than a missing one."""
+    old_id = await _seed_decision(api_client, "Which sampler?", "uniform")
+    new_id = await _seed_decision(api_client, "Which sampler, revised?", "stratified")
+
+    r = await api_client.post(
+        "/api/decisions/link-supersession",
+        json={"old_decision_id": old_id, "new_decision_id": new_id},
+        headers=HEADERS,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["dry_run"] is True and body["applied"] is False
+    assert body["steps"], "a preview must report the steps it would take"
+
+    after = await api_client.get(f"/api/decisions/{old_id}", headers=HEADERS)
+    assert not after.json().get("superseded_by")
+
+
+@pytest.mark.asyncio
+async def test_link_supersession_refuses_a_non_orphan(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Only genuine orphans are repairable, and the refusal must reach the caller.
+
+    The five-step repair itself is covered at the service layer
+    (tests/test_services/test_admin_repair.py). What matters here is that
+    the adapter surfaces a refusal rather than reporting success: an active
+    decision is not an orphan, so nothing should be written and the caller
+    should be able to tell.
+    """
+    old_id = await _seed_decision(api_client, "Threshold policy?", "fixed")
+    new_id = await _seed_decision(api_client, "Threshold policy, revised?", "adaptive")
+
+    r = await api_client.post(
+        "/api/decisions/link-supersession",
+        json={"old_decision_id": old_id, "new_decision_id": new_id, "apply": True},
+        headers=HEADERS,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["applied"] is False, "an active decision is not an orphan"
+    detail = " ".join(s.get("detail") or "" for s in body["steps"])
+    assert "not" in detail.lower() or body["steps"], "the refusal must say why"
+
+    after = await api_client.get(f"/api/decisions/{old_id}", headers=HEADERS)
+    assert not after.json().get("superseded_by")

--- a/tests/test_mcp/test_v270_model_drift.py
+++ b/tests/test_mcp/test_v270_model_drift.py
@@ -401,3 +401,70 @@ def test_all_models_re_exported_via_public___all__() -> None:
         f"Drift: {len(missing)} typed-arg model(s) not re-exported via "
         f"operation_args.__all__: {missing[:5]}..."
     )
+
+
+# ---------------------------------------------------------------------------
+# Maturity — keeping the browse index to what is actually in use
+# ---------------------------------------------------------------------------
+
+
+def test_preview_operations_are_hidden_from_the_browse_index():
+    """`rka_describe('')` must not spend the agent's attention on dead surface.
+
+    Measured 2026-08-23 against a five-month-old production store of 5178
+    entities: manuscript units, planning branches, experiments, semantic-patch
+    proposals, hooks, interpretation candidates and claim-scope versions all
+    had ZERO rows. Listing ~40% unreachable operations beside the core ones is
+    exactly the "too many interfaces confuse the agent" failure.
+    """
+    import asyncio
+    import json
+
+    from rka.mcp.operations_schema import OPERATIONS_SCHEMA, dispatch_describe
+
+    default = json.loads(asyncio.run(dispatch_describe("")))
+    full = json.loads(asyncio.run(dispatch_describe("", include_preview=True)))
+
+    assert default["listed"] < default["total"]
+    assert default["preview_hidden"] == default["total"] - default["listed"]
+    assert full["listed"] == len(OPERATIONS_SCHEMA)
+    # the hidden set must be discoverable, not silently dropped
+    assert "include_preview" in default["preview_hint"]
+
+
+def test_core_research_loop_stays_stable():
+    """The operations a real session uses must never fall into preview."""
+    from rka.mcp.operations_schema import operation_maturity
+
+    for op in (
+        "status", "context", "search", "entity", "journal", "literature",
+        "record_note", "record_decision", "record_literature",
+        "create_mission", "submit_report", "submit_checkpoint",
+        "research_map", "clusters", "claims", "decision_tree",
+        "ego_graph", "multi_hop", "provenance", "collect_report_context",
+        "belief_as_of", "staleness_impact", "changes_since", "contradictions",
+    ):
+        assert operation_maturity(op) == "stable", op
+
+
+def test_zero_usage_subsystems_are_preview():
+    from rka.mcp.operations_schema import operation_maturity
+
+    for op in (
+        "create_experiment", "experiment_runs", "record_experiment_observation",
+        "create_planning_branch", "planning_branches",
+        "create_semantic_patch_proposal", "semantic_patch_proposals",
+        "hook_add", "hooks",
+        "create_interpretation_candidate", "interpretation_candidates",
+        "set_claim_scope", "claim_scope",
+        "create_manuscript", "manuscript_context",
+    ):
+        assert operation_maturity(op) == "preview", op
+
+
+def test_every_operation_is_classified():
+    """No operation may sit outside the stable/preview split."""
+    from rka.mcp.operations_schema import OPERATIONS_SCHEMA, operation_maturity
+
+    for op in OPERATIONS_SCHEMA:
+        assert operation_maturity(op) in {"stable", "preview"}, op

--- a/tests/test_services/test_embedding_backfill.py
+++ b/tests/test_services/test_embedding_backfill.py
@@ -748,3 +748,61 @@ async def test_row_write_failure_rolls_back_vector_metadata_and_pending_flag(
         [claim_id],
     )
     assert pending["embedding_pending"] == 1
+
+
+# ---------------------------------------------------------------------------
+# embedding_pending flag drift (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_claims_pending_is_decided_by_metadata_not_the_flag(db):
+    """A claim with no vector must be backfilled even if its flag says otherwise.
+
+    Regression: claims were selected with ``WHERE embedding_pending = 1``
+    while every other entity type used the absence of an
+    ``embedding_metadata`` row. The flag drifts — in a real store all 976
+    claims carried ``embedding_pending = 0`` while 341 of them had no vector,
+    so a flag-gated backfill reported "0 pending" and silently skipped every
+    claim that actually needed one.
+    """
+    clear_registry()
+    await _setup_vec_claims_at_dim(db, dim=4)
+    await _insert_journal(db, jid="jrn_drift")
+
+    # The drifted state: flag says "done", no embedding_metadata row exists.
+    await db.execute(
+        "INSERT INTO claims (id, source_entry_id, claim_type, content, embedding_pending)"
+        " VALUES ('clm_drift', 'jrn_drift', 'observation', 'drifted claim', 0)"
+    )
+    await db.commit()
+
+    status = register_job()
+    svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=8)
+    result = await svc.run_backfill(status, entity_types=("claim",))
+
+    assert result.total == 1, "the drifted claim must be counted as pending"
+    assert result.processed == 1
+    assert result.state == "complete"
+
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata"
+        " WHERE entity_type = 'claim' AND entity_id = 'clm_drift'"
+    )
+    assert row["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_already_embedded_claim_is_not_reprocessed(db):
+    """The metadata test must not re-embed work that is already done."""
+    clear_registry()
+    await _setup_vec_claims_at_dim(db, dim=4)
+    await _insert_journal(db, jid="jrn_done")
+    ids = await _insert_pending_claims(db, jid="jrn_done", count=2, prefix="clm_done_")
+
+    svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=8)
+    first = await svc.run_backfill(register_job(), entity_types=("claim",))
+    assert first.processed == len(ids)
+
+    second = await svc.run_backfill(register_job(), entity_types=("claim",))
+    assert second.total == 0, "a second run must find nothing pending"

--- a/tests/test_services/test_search.py
+++ b/tests/test_services/test_search.py
@@ -159,3 +159,62 @@ class TestRRFMerge:
         svc = SearchService.__new__(SearchService)
         merged = svc._rrf_merge([], [], 0.3, 0.7)
         assert merged == []
+
+
+# ------------------------------------------------- currency signals on hits
+
+
+@pytest_asyncio.fixture
+async def superseded_svc(db: Database) -> SearchService:
+    """A superseded decision and its replacement, both FTS-indexed."""
+    svc = SearchService(db=db, embeddings=None)
+    for did, q in (
+        ("dec_old", "What is the headline evaluation metric"),
+        ("dec_new", "What is the headline evaluation metric"),
+    ):
+        await db.execute(
+            "INSERT INTO fts_decisions (id, question, rationale) VALUES (?, ?, ?)",
+            [did, q, "rationale text"],
+        )
+    # successor first: decisions.superseded_by is a self-referencing FK
+    await db.execute(
+        "INSERT INTO decisions (id, question, chosen, rationale, decided_by, phase,"
+        " status, project_id)"
+        " VALUES (?, ?, ?, ?, 'pi', 'p1', 'active', 'proj_default')",
+        ["dec_new", "What is the headline evaluation metric", "new choice", "r"],
+    )
+    await db.execute(
+        "INSERT INTO decisions (id, question, chosen, rationale, decided_by, phase,"
+        " status, superseded_by, project_id)"
+        " VALUES (?, ?, ?, ?, 'pi', 'p1', 'superseded', 'dec_new', 'proj_default')",
+        ["dec_old", "What is the headline evaluation metric", "old choice", "r"],
+    )
+    return svc
+
+
+async def test_search_hits_expose_supersession(superseded_svc: SearchService) -> None:
+    """A superseded decision must be distinguishable from a current one.
+
+    Regression: search returned only entity_type/entity_id/title/snippet/score,
+    so an agent could not tell an overturned decision from one still in force
+    and would act on stale knowledge. Every other read surface (ego_graph,
+    multi_hop, operation="entity") already carried status.
+    """
+    hits = {h.entity_id: h for h in await superseded_svc.search("headline evaluation metric")}
+    assert {"dec_old", "dec_new"} <= set(hits)
+
+    assert hits["dec_old"].status == "superseded"
+    assert hits["dec_old"].superseded_by == "dec_new"
+    assert hits["dec_new"].status == "active"
+    assert hits["dec_new"].superseded_by is None
+
+
+async def test_currency_absent_for_types_without_lifecycle(
+    search_svc: SearchService,
+) -> None:
+    """Types whose table carries no lifecycle column stay None, not crash."""
+    hits = await search_svc.search("timing")
+    assert hits, "fixture should produce hits"
+    for hit in hits:
+        assert hit.status is None or isinstance(hit.status, str)
+        assert hit.stale is None or isinstance(hit.stale, bool)


### PR DESCRIPTION
Code half of the Eval-v3 work. The methodology and results ship separately;
this PR is reviewable on its own — 22 files, no eval-harness dependency.

## The question

During research an agent must retrieve the right historical node from the
knowledge graph **and stay consistent across pivots** — not act on a decision
that has since been overturned.

Measured against a five-month-old store of 5 178 real entities: **the graph
layer already does its half; the entry layer was not feeding it.**

Anchored on the right decision, back-tracing is near-perfect — recall
**1.000**, **14/14** pivots surfaced the superseding decision, **0** surfaced
only the stale one, and depth-2 is load-bearing (a depth-1 trace loses
30–41 % of expected context, including *every* parent decision).

## Three defects

**1. A decision could be found by its own verbatim question only 25.8 % of
the time** (n=392, MRR 0.043). Eight entity types ranked in one list, so the
target loses to whichever type carries the most text. Scoping to
`entity_types:["decision"]` → **93.3 %**; with an ~8-word query → **98.0 %**.
Per type, scoped: decision 100, mission 96, literature 95, claim 90,
journal 84.

**2. `/api/search` returned no `status`.** `ego_graph`, `multi_hop` and
`operation="entity"` all carried it — the entry surface, which an agent hits
first, did not. On 15 real supersede chains the current decision outranks its
predecessor 73 % of the time, but the predecessor is usually *also* in the
result set at ranks 12–20 with nothing to mark it.

**3. A backend outage left a permanent index hole.** 1 023 entities across six
projects unembedded, three projects at exactly 0 %. Repointing the backend did
not reconcile because `_backend_signature` ignored `base_url`, and the change
never reached the search path, which caches its client at startup — while
`/test` built a fresh client and passed, so the UI reported success.

## Fixes

| | |
|---|---|
| search hits carry `status` / `superseded_by` / `stale` | filled at the single public exit, so all four retrieval paths are covered — including any added later |
| claims backfill uses the `embedding_metadata` test | the `embedding_pending` flag read 0 for all 976 claims while 341 had no vector, so a flag-gated backfill skipped exactly the rows that needed it |
| `_backend_signature` includes `base_url` | safe by construction: `reshape_all_vec_tables_if_needed` is strictly dim-gated, so this backfills missing rows and never discards an existing vector; an api_key rotation still compares equal |
| `POST /api/config/embedding/backfill` | reconciliation no longer requires a config edit; the no-backfill PUT branch now swaps the cached client |
| `GET /decisions/orphan-supersedes` + `POST /decisions/link-supersession` | exposes the existing `rka admin repair-supersedes` service beyond the shell, with matching MCP operations. `apply` defaults to a preview — a wrong pointer is worse than a missing one |

## Skills and MCP surface

The Brain skill claimed queries over five words "return empty". They do not —
a 24-word query returns a full page. Short queries *are* better (25.8 % →
64.0 % unscoped), but the stated mechanism was wrong and the actual biggest
lever — type scoping — was undocumented, as was the fact that a search hit
could not be told apart from a superseded one.

**61 of 150 MCP operations serve subsystems with zero rows in production.**
`rka_describe('')` now lists 87 and reports what it hid; `include_preview=True`
still shows everything. The v2.7.0 dispatch design is deliberately untouched —
broadcasting 5 tools with `oneOf`+discriminator enum enforcement is the right
answer to agent confusion; only the length of the list behind it was in
question.

The four role skills shared **no** H2 heading, because the same concept was
titled differently in each. The three genuinely shared ones are unified;
`Guardrails` (limits of a role's authority) and `Anti-Patterns` (ways to misuse
the tool) are deliberately **not** merged. `belief_as_of`, `staleness_impact`,
`changes_since`, `contradictions` and `mission_guard` — the operations most
directly aimed at not acting on overturned knowledge — were undocumented and
are now covered. The PI skill had four sections and no retrieval guidance,
despite being the only role that would catch a stale-decision error.

## Verification

**3 139 tests pass. 26 new regression tests, every one failing against the
previous code.**

Two defects were found *only* end-to-end, which is worth recording:

- the literal repair routes were shadowed by `/decisions/{dec_id}` — FastAPI
  matches in registration order, and the unit suite passed because nothing
  called them. Writing an adapter and testing only the service it wraps proves
  nothing about reachability.
- the first hand-written orphan repair missed three of the five steps the
  existing service performs, including a staleness cascade over 51 journal
  entries.

Measured before → after on the author's store: vector coverage 80.2 % →
**100.0 %**, `blind_stale_exposure` 0.133 → **0.0**, and trace_recall / pivot
correctness **unchanged** — no regression in the layer that already worked.

Stated precisely: `stale_only` is still 2/15, so an agent is sometimes still
handed only the superseded decision. What changed is that it is no longer
blind — the hit carries `status=superseded` and the `superseded_by` pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
