### PR TITLE
fix(decisions): refuse to link a decision as superseding itself

### DIFF
--- a/rka/api/routes/decisions.py
+++ b/rka/api/routes/decisions.py
@@ -143,6 +143,10 @@ async def link_supersession_route(
         "old_decision_id": body.old_decision_id,
         "new_decision_id": body.new_decision_id,
         "rolled_back": report.rolled_back,
+        # Surfaced so a refused pair says why. Without it a caller sees only
+        # `applied: false` plus a FAILED step and has to guess which
+        # pre-flight check rejected the pair.
+        "failure_reason": report.failure_reason,
         "steps": [
             {"step": s.name, "state": s.state, "detail": s.detail}
             for s in report.steps

--- a/rka/services/admin_repair.py
+++ b/rka/services/admin_repair.py
@@ -147,6 +147,8 @@ async def _validate_pair(
     `(ok, error_message, old_row, new_row)`.
 
     Refuses to repair when:
+        - old and new are the same decision (a decision cannot supersede
+          itself; see below)
         - old or new decision does not exist in the given project
         - old.status != 'superseded' (not actually an orphan)
         - old.superseded_by is already set (the supersede link is
@@ -154,6 +156,21 @@ async def _validate_pair(
         - old.superseded_by points at a DIFFERENT new decision (real
           supersede; refuse to overwrite)
     """
+    # A self-link is the one bad pair that every other check would wave
+    # through: both rows exist, the status is right, and superseded_by is
+    # empty. Applying it sets superseded_by to the row's own id and writes a
+    # `supersedes` self-loop, which makes the decision permanently its own
+    # replacement — it reads as stale forever, and that is precisely the
+    # currency signal this repair exists to restore.
+    if old_id == new_id:
+        return (
+            False,
+            f"old and new decision are the same ({old_id}) — "
+            f"a decision cannot supersede itself",
+            None,
+            None,
+        )
+
     old_row = await db.fetchone(
         "SELECT id, status, superseded_by, scope_version, phase, project_id "
         "FROM decisions WHERE id = ? AND project_id = ?",

--- a/tests/test_services/test_self_supersede_guard.py
+++ b/tests/test_services/test_self_supersede_guard.py
@@ -1,0 +1,77 @@
+"""A decision must never be recorded as superseding itself.
+
+Every other pre-flight check in `_validate_pair` waves a self-link through:
+both rows exist (they are the same row), the status is `superseded`, and
+`superseded_by` is empty. Applying it would set `superseded_by` to the row's
+own id and write a `supersedes` self-loop, leaving the decision permanently its
+own replacement — it reads as stale forever, which is exactly the currency
+signal this repair exists to restore.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rka.services.admin_repair import repair_orphan_supersedes
+
+
+PROJECT = "proj_default"
+DEC = "dec_01SELFSUPERSEDE0000000000"
+
+
+async def _seed_superseded_decision(db) -> None:
+    await db.execute(
+        "INSERT INTO decisions (id, project_id, question, chosen, rationale, "
+        "decided_by, kind, phase, status, scope_version) "
+        "VALUES (?, ?, ?, ?, ?, 'pi', 'decision', 'test', 'superseded', 1)",
+        [DEC, PROJECT, "q", "c", "r"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_self_pair_is_refused_in_dry_run(db):
+    await _seed_superseded_decision(db)
+    (report,) = await repair_orphan_supersedes(db, PROJECT, {DEC: DEC}, dry_run=True)
+
+    assert report.applied is False
+    assert report.failure_reason is not None
+    assert "cannot supersede itself" in report.failure_reason
+    assert [s.state for s in report.steps] == ["FAILED"]
+
+
+@pytest.mark.asyncio
+async def test_self_pair_writes_nothing_when_applied(db):
+    await _seed_superseded_decision(db)
+    (report,) = await repair_orphan_supersedes(db, PROJECT, {DEC: DEC}, dry_run=False)
+
+    assert report.applied is False
+
+    row = await db.fetchone("SELECT superseded_by, scope_version FROM decisions WHERE id = ?", [DEC])
+    assert row["superseded_by"] is None
+    assert row["scope_version"] == 1
+
+    loops = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM entity_links "
+        "WHERE link_type = 'supersedes' AND source_id = ? AND target_id = ?",
+        [DEC, DEC],
+    )
+    assert loops["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_pair_still_repairs(db):
+    """The guard must not block the case the repair exists for."""
+    await _seed_superseded_decision(db)
+    new_id = "dec_01SELFSUPERSEDE1111111111"
+    await db.execute(
+        "INSERT INTO decisions (id, project_id, question, chosen, rationale, "
+        "decided_by, kind, phase, status, scope_version) "
+        "VALUES (?, ?, ?, ?, ?, 'pi', 'decision', 'test', 'active', 1)",
+        [new_id, PROJECT, "q2", "c2", "r2"],
+    )
+
+    (report,) = await repair_orphan_supersedes(db, PROJECT, {DEC: new_id}, dry_run=False)
+
+    assert report.failure_reason is None
+    row = await db.fetchone("SELECT superseded_by FROM decisions WHERE id = ?", [DEC])
+    assert row["superseded_by"] == new_id


### PR DESCRIPTION
Follow-up defect in #91, found by smoke-testing the new endpoint after deploying it.

## The bug

`POST /api/decisions/link-supersession` accepted `old_decision_id == new_decision_id`. Every pre-flight check in `_validate_pair` passes for that input — the row exists, its status is `superseded`, `superseded_by` is empty — so the repair ran the full sequence:

```
WOULD  superseded_by_fk         old.superseded_by: None -> '<its own id>'
WOULD  supersedes_entity_link   link_type='supersedes'  X -> X
WOULD  decision_superseded_event
```

Removing the guard in a test confirms it isn't merely planned — it applies, and emits the event.

A decision that supersedes itself is permanently its own replacement: it reads as stale forever, which is precisely the currency signal #91 added this repair to restore, and the self-loop lands in the same edge set supersede-chain traversal walks.

## The fix

One guard in `_validate_pair`, which is where REST, MCP and CLI all converge — putting it in the route would have left the other two paths open.

Also surfaces `failure_reason` in the route response. Before this, a refused pair returned `applied: false` and a FAILED step with no reason, so the caller had to guess which check rejected it.

## Tests

Three, in `tests/test_services/test_self_supersede_guard.py`: the dry run refuses; an apply writes nothing (no FK, no scope bump, no self-loop); and a genuine pair still repairs, so the guard doesn't block the case the repair exists for. Reverting the guard turns the first two red.

Full suite: **3263 passed**.

One note on that number — an initial run reported 13 failures. They were identical on unmodified `main` and traced to `fastembed` / `sqlite-vec` / `numpy` being absent from the ephemeral test environment, not to any code change. With those installed the suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)