### PR TITLE
fix(plugin): stop the compatibility gate from refusing newer backends

### DIFF
--- a/plugin/bin/rka-mcp-bridge.py
+++ b/plugin/bin/rka-mcp-bridge.py
@@ -34,10 +34,37 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Plugin compatibility range. Bump when shipping a plugin version that
-# requires a newer RKA backend. Matched as `version.startswith(prefix)`,
-# so "2.3" prefix accepts "2.3.0", "2.3.1", "2.3.2-rc1", "2.3", etc.
-COMPATIBLE_VERSION_PREFIXES = ("2.7", "2.8")
+# Oldest RKA backend this plugin can drive. The check is a *minimum*, not an
+# allowlist of releases: a backend newer than the plugin is the normal state of
+# affairs (the backend ships far more often than the plugin), and rejecting it
+# strands a working install.
+#
+# An allowlist of accepted prefixes used to live here. It had to be widened by
+# hand on every minor release, which is exactly the kind of edit that gets
+# forgotten — and was: the tuple still read ("2.7", "2.8") after the backend
+# reached 2.9.0, so a correctly-reported 2.9.0 was refused by its own plugin.
+MINIMUM_BACKEND_VERSION = (2, 7)
+
+
+def parse_version(version: str) -> tuple[int, ...] | None:
+    """Parse a leading numeric version into a comparable tuple.
+
+    Trailing prerelease markers are ignored: ``2.9.0-rc1`` compares as
+    ``(2, 9, 0)``. Returns None when nothing numeric can be read, which the
+    caller treats as "cannot verify" rather than "incompatible" — refusing to
+    start over an unparseable string would be a worse failure than running.
+    """
+    parts: list[int] = []
+    for chunk in version.strip().split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts) or None
 
 
 def integration_path() -> Path:
@@ -178,16 +205,19 @@ def main() -> None:
     # Version check (only if integration.json supplied a version; PATH-fallback
     # mode skips the check since we have no version metadata to verify against).
     if version is not None:
-        # Use startswith with a trailing dot for "2.3.x", but also accept
-        # bare "2.3" as a valid prerelease/dev marker.
-        compatible = any(
-            version == prefix or version.startswith(prefix + ".")
-            for prefix in COMPATIBLE_VERSION_PREFIXES
-        )
-        if not compatible:
-            expected = ", ".join(f"{prefix}.x" for prefix in COMPATIBLE_VERSION_PREFIXES)
-            err(f"ERROR: RKA version '{version}' is incompatible with this plugin (requires {expected}).")
-            err("Upgrade RKA or install a matching plugin version.")
+        parsed = parse_version(version)
+        minimum = ".".join(str(n) for n in MINIMUM_BACKEND_VERSION)
+        if parsed is None:
+            # Unreadable version string: warn, but do not block. The binary
+            # itself will fail loudly if it really is incompatible.
+            err(f"NOTICE: could not parse RKA version '{version}'; skipping the compatibility check.")
+        elif parsed < MINIMUM_BACKEND_VERSION:
+            err(f"ERROR: RKA version '{version}' is older than this plugin supports (requires {minimum} or newer).")
+            err("Upgrade RKA, or install a plugin version matching your backend.")
+            err(
+                "If RKA is in fact newer than this and you are seeing a stale number, "
+                f"integration.json is reporting it: {integration_path()}"
+            )
             sys.exit(1)
 
     env = os.environ.copy()

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -264,14 +264,19 @@ Detailed operating guidance is available via MCP prompts:
 Use these prompts to load role-specific guidance at session start.
 
 ## Tool Surface (v2.7.0+) — Typed Dispatch Architecture
-RKA ships 5 always-on tools: 3 dispatch tools that route to 150 typed
+RKA ships 5 always-on tools: 3 dispatch tools that route to 152 typed
 operations, plus 2 escape hatches into the legacy surface.
 
+`rka_describe("")` lists 87 of those by default and reports how many it
+withheld. The remainder belong to subsystems that carry no production data
+yet; they stay callable, they are just kept out of the default browse index
+so the choice space matches what is actually in use.
+
 - **Dispatch (always-on):**
-- `rka_query(args={"operation": ..., "project_id": ..., ...})` — 67 read
+- `rka_query(args={"operation": ..., "project_id": ..., ...})` — 68 read
     operations (status, context, journal, decisions, missions, literature,
     research map, etc.). Returns structured data.
-- `rka_execute(args={"operation": ..., "project_id": ..., ...})` — 83
+- `rka_execute(args={"operation": ..., "project_id": ..., ...})` — 84
     write/lifecycle operations (record_note, record_decision, create_mission,
     submit_report, submit_checkpoint, etc.). Returns the created/updated entity.
   - `rka_describe(operation="" | "<op_name>")` — schema lookup. With no
@@ -283,7 +288,7 @@ operations, plus 2 escape hatches into the legacy surface.
     the live tool surface. Useful only for back-compat with old transcripts.
   - `rka_help(name=...)` — deprecated alias for `rka_describe`.
 
-The 150 operations are typed Pydantic models with per-branch enum constraints
+The 152 operations are typed Pydantic models with per-branch enum constraints
 and required-field enforcement at the FastMCP schema layer — illegal values
 (e.g. `confidence="confirmed"`) are rejected at the inputSchema boundary
 before the call goes out.
@@ -8928,7 +8933,7 @@ async def rka_execute(args: _ExecuteArgsUnion) -> str:
 
     v2.7.0 NO-COMPROMISE typed-arg surface. The ``args`` parameter is a
     Pydantic discriminated union (keyed by ``operation``) covering all
-    83 write/lifecycle operations. FastMCP renders the union as JSON
+    84 write/lifecycle operations. FastMCP renders the union as JSON
     Schema ``oneOf`` with per-branch ``required`` arrays + per-branch
     ``enum`` constraints on every Literal-typed field. The LLM CANNOT
     emit ``confidence='confirmed'``, ``decided_by='SUPERVISOR'``,
@@ -9073,7 +9078,7 @@ support; the Skill is authoritative.
 Always begin a session by loading context:
 
 0. **Tool surface (v2.7.0+ typed dispatch).** RKA ships 3 always-on dispatch
-   tools — `rka_query` (67 read ops), `rka_execute` (83 write/lifecycle ops),
+   tools — `rka_query` (68 read ops), `rka_execute` (84 write/lifecycle ops),
    and `rka_describe` (schema lookup) — plus 2 escape hatches (`rka_load_tools`
    for legacy compat and `rka_help` as a deprecated alias of `rka_describe`).
    No activation step is required: every operation is reachable from
@@ -9221,7 +9226,7 @@ Skill is authoritative.
 ## Session Start Protocol
 
 0. **Tool surface (v2.7.0+ typed dispatch).** RKA ships 3 always-on dispatch
-   tools — `rka_query` (67 read ops), `rka_execute` (83 write/lifecycle ops),
+   tools — `rka_query` (68 read ops), `rka_execute` (84 write/lifecycle ops),
    and `rka_describe` (schema lookup) — plus 2 escape hatches (`rka_load_tools`
    for legacy compat and `rka_help` as a deprecated alias of `rka_describe`).
    No activation step is required: every operation is reachable from

--- a/tests/test_infra/test_plugin_version_gate.py
+++ b/tests/test_infra/test_plugin_version_gate.py
@@ -1,0 +1,134 @@
+"""Tests for the plugin's RKA-backend compatibility gate.
+
+The gate exists to refuse a backend too OLD for the plugin. It was written as
+an allowlist of accepted version prefixes, which also refused backends that are
+*newer* — and since the backend ships far more often than the plugin, that is
+the common case. The list read ``("2.7", "2.8")`` while the backend was 2.9.0,
+so a correctly-reported 2.9.0 was rejected by its own plugin.
+
+These tests pin the direction of the check: old is refused, current and newer
+are not.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_BRIDGE = Path(__file__).resolve().parents[2] / "plugin" / "bin" / "rka-mcp-bridge.py"
+_spec = importlib.util.spec_from_file_location("rka_mcp_bridge", _BRIDGE)
+assert _spec and _spec.loader
+bridge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bridge)
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("2.9.0", (2, 9, 0)),
+            ("2.7", (2, 7)),
+            ("2.10.1", (2, 10, 1)),
+            ("3.0.0", (3, 0, 0)),
+            ("2.9.0-rc1", (2, 9, 0)),
+            ("  2.9.0  ", (2, 9, 0)),
+        ],
+    )
+    def test_parses_numeric_prefix(self, raw, expected):
+        assert bridge.parse_version(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["", "   ", "dev", "vNext"])
+    def test_unparseable_returns_none(self, raw):
+        assert bridge.parse_version(raw) is None
+
+    def test_ordering_is_numeric_not_lexicographic(self):
+        """`"2.10" < "2.9"` as strings; the whole point is that it must not be."""
+        assert bridge.parse_version("2.10.0") > bridge.parse_version("2.9.0")
+
+
+class TestGateDirection:
+    """The gate is a floor. Anything at or above the minimum must pass."""
+
+    def test_minimum_is_accepted(self):
+        assert bridge.parse_version("2.7.0") >= bridge.MINIMUM_BACKEND_VERSION
+
+    @pytest.mark.parametrize("raw", ["2.7.0", "2.8.3", "2.9.0", "2.10.0", "3.1.4"])
+    def test_current_and_newer_backends_pass(self, raw):
+        assert bridge.parse_version(raw) >= bridge.MINIMUM_BACKEND_VERSION
+
+    @pytest.mark.parametrize("raw", ["2.3.2", "2.6.9", "1.9.9"])
+    def test_older_backends_are_refused(self, raw):
+        assert bridge.parse_version(raw) < bridge.MINIMUM_BACKEND_VERSION
+
+    def test_shipped_backend_version_satisfies_the_gate(self):
+        """Guards the release that forgets to widen the gate.
+
+        This is the assertion that would have failed when the backend went to
+        2.9.0 while the allowlist still read ("2.7", "2.8").
+        """
+        pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
+        line = next(l for l in pyproject.splitlines() if l.startswith("version"))
+        shipped = line.split("=", 1)[1].strip().strip('"').strip("'")
+        parsed = bridge.parse_version(shipped)
+        assert parsed is not None, f"unparseable version in pyproject.toml: {shipped!r}"
+        assert parsed >= bridge.MINIMUM_BACKEND_VERSION, (
+            f"shipped backend {shipped} is below the plugin's minimum "
+            f"{bridge.MINIMUM_BACKEND_VERSION} — the plugin would refuse its own backend"
+        )
+
+
+def _run_bridge(tmp_path: Path, version: str | None) -> subprocess.CompletedProcess:
+    # A real executable is required: the bridge checks that binary_path is
+    # runnable *before* it looks at the version, so a bogus path would exit
+    # early and never reach the gate under test.
+    stub = tmp_path / "rka-stub"
+    stub.write_text("#!/bin/sh\nexit 0\n")
+    stub.chmod(0o755)
+
+    integration = tmp_path / "integration.json"
+    payload: dict[str, object] = {"binary_path": str(stub)}
+    if version is not None:
+        payload["version"] = version
+    integration.write_text(json.dumps(payload))
+    return subprocess.run(
+        [sys.executable, str(_BRIDGE)],
+        input="",
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "RKA_INTEGRATION_FILE": str(integration)},
+    )
+
+
+class TestEndToEnd:
+    def test_old_backend_is_refused_with_a_version_message(self, tmp_path: Path):
+        result = _run_bridge(tmp_path, "2.3.2")
+        assert result.returncode == 1
+        assert "older than this plugin supports" in result.stderr
+
+    def test_refusal_points_at_the_file_that_reported_the_version(self, tmp_path: Path):
+        """A stale integration.json is the likeliest cause; say so."""
+        result = _run_bridge(tmp_path, "2.3.2")
+        assert "integration.json" in result.stderr
+
+    @pytest.mark.parametrize("raw", ["2.9.0", "2.10.0", "2.99.0", "3.0.0"])
+    def test_newer_backend_runs(self, raw, tmp_path: Path):
+        """A backend newer than the plugin must launch, not be refused.
+
+        Asserted on the exit code rather than on the absence of one phrase:
+        the allowlist this replaced refused newer backends with *different*
+        wording, so a message-absence check would have passed against it.
+        """
+        result = _run_bridge(tmp_path, raw)
+        assert result.returncode == 0, result.stderr
+        assert "incompatible" not in result.stderr
+        assert "older than this plugin supports" not in result.stderr
+
+    def test_unparseable_version_warns_but_does_not_block(self, tmp_path: Path):
+        result = _run_bridge(tmp_path, "dev")
+        assert "skipping the compatibility check" in result.stderr
+        assert "older than this plugin supports" not in result.stderr


### PR DESCRIPTION
Surfaced when the plugin refused to connect:

```
ERROR: RKA version '2.3.2' is incompatible with this plugin (requires 2.7.x, 2.8.x).
```

Two independent defects were behind that one line.

## 1. The gate points the wrong way

`plugin/bin/rka-mcp-bridge.py` gated the backend on an allowlist of accepted version prefixes. A compatibility gate should refuse a backend that is too **old**. An allowlist also refuses one that is too **new** — and since the backend ships far more often than the plugin, that is the ordinary case, not the exception.

It had to be widened by hand on every minor release, and was not. The tuple still read `("2.7", "2.8")` after the backend reached **2.9.0**, so **anyone running RKA.app 2.9.0 is refused by their own plugin** even when everything is correctly installed and integration.json is telling the truth.

Replaced with a minimum-version floor plus a numeric comparison — `2.10` sorted below `2.9` under the old string prefix logic, which would have been the next bug. An unparseable version now warns rather than exiting: refusing to start over a string we cannot read is a worse failure than starting.

The refusal message now names `integration.json`, since a stale copy of it is the likeliest reason a version looks wrong. It is written by RKA.app and never refreshed for installs that run the backend another way — the report above came from a four-month-old file still claiming `2.3.2`.

## 2. Stale counts in the session-start instructions

`rka/mcp/server.py` told every agent it had **150 operations (67 read / 83 write)**. Actual: **152 (68 / 84)**, and the default index lists **87** — the instructions did not mention the maturity filter at all. This is the first thing an agent reads.

## Tests

28 new, in `tests/test_infra/test_plugin_version_gate.py`. Restoring the allowlist turns 7 of them red, including all four `test_newer_backend_runs` cases — `2.9.0` is the exact real-world failure.

One of them, `test_shipped_backend_version_satisfies_the_gate`, reads the version out of `pyproject.toml` and asserts it clears the floor. That is the assertion that would have caught this at the 2.9.0 release instead of in the field.

Two notes on how these were written, both worth stating because the first draft got them wrong:

- `test_newer_backend_runs` originally asserted only that the new refusal wording was **absent**. It passed against the buggy allowlist, which refuses with *different* wording — a test passing for the wrong reason. It now asserts the exit code.
- The end-to-end cases need a real executable stub: the bridge checks that `binary_path` is runnable **before** it reads the version, so a bogus path exits early and never reaches the gate under test.

Full suite: **3366 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, which returns None when `litellm` is absent). It fails identically on unmodified `main` and passes in CI, where the dependency is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)