### PR TITLE
fix(mcp): make present_decision callable again

### DIFF
--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -4325,11 +4325,23 @@ class SupersedeDecisionArgs(ProjectScopedArgs):
 class PresentDecisionArgs(ProjectScopedArgs):
     """Present a decision to the PI for ratification.
 
-    Phase-X²' polish: ``options`` MUST be non-empty (TWO-TAP autonomy
-    contract is semantically void if there are no choices to ratify).
-    Each option dict MUST carry an ``id`` key so downstream
-    ``record_pi_selection.selected_option_id`` references are
-    dereferenceable.
+    ``options`` MUST be non-empty — the TWO-TAP autonomy contract is
+    semantically void with no choices to ratify.
+
+    Option ids are assigned by the server, not supplied by the caller. This
+    model used to require an ``id`` on every option so that
+    ``record_pi_selection.selected_option_id`` would be dereferenceable, but
+    the REST payload it feeds (``DecisionOptionCreate``) declares
+    ``extra="forbid"`` and has no ``id`` field, so an option carrying one was
+    rejected with HTTP 422. Requiring it here and forbidding it there made the
+    operation impossible to call: without ``id`` this model refused, with
+    ``id`` the API did.
+
+    The ids to use in ``record_pi_selection`` come back in this operation's
+    own response, as ``presented_option_ids``.
+
+    Each option must otherwise match ``DecisionOptionCreate`` in full — see
+    the field description below.
     """
 
     operation: Literal["present_decision"] = "present_decision"
@@ -4347,8 +4359,16 @@ class PresentDecisionArgs(ProjectScopedArgs):
         Field(
             min_length=1,
             description=(
-                "Non-empty list of option dicts (each MUST include an 'id' "
-                "key; typical shape {id, label, ...})."
+                "Non-empty list of DecisionOptionCreate-shaped dicts. Required "
+                "per option: label, summary, justification, explanation, pros "
+                "(exactly 3), cons (exactly 3), confidence_verbal "
+                "(low|moderate|high), confidence_numeric (0.0-1.0), "
+                "confidence_evidence_strength (weak|moderate|strong), "
+                "confidence_known_unknowns (1-2 items), effort_time "
+                "(S|M|L|XL), effort_reversibility "
+                "(reversible|costly|irreversible), presentation_order_seed. "
+                "Do NOT pass 'id' — the server assigns option ids and returns "
+                "them as presented_option_ids."
             ),
         ),
     ]
@@ -4361,17 +4381,23 @@ class PresentDecisionArgs(ProjectScopedArgs):
     ] = None
 
     @model_validator(mode="after")
-    def _enforce_id_on_every_option(self) -> "PresentDecisionArgs":
-        # Mirrors BulkUpdateArgs._enforce_id_on_every_item — downstream
-        # record_pi_selection.selected_option_id must be dereferenceable.
+    def _reject_caller_supplied_option_id(self) -> "PresentDecisionArgs":
+        """Catch a caller-supplied ``id`` here rather than as a REST 422.
+
+        ``DecisionOptionCreate`` forbids extra keys, so an option carrying an
+        ``id`` fails at the API boundary with ``extra_forbidden`` — an error
+        that reads like a schema mismatch rather than "you do not assign these".
+        Rejecting it at the typed surface says which it is.
+        """
         for idx, opt in enumerate(self.options):
             if not isinstance(opt, dict):
                 raise ValueError(f"present_decision: options[{idx}] is not a dict.")
-            if "id" not in opt or not opt["id"]:
+            if "id" in opt:
                 raise ValueError(
-                    f"present_decision: options[{idx}] missing required "
-                    "'id' key (TWO-TAP record_pi_selection references "
-                    "options by id)."
+                    f"present_decision: options[{idx}] must not carry an 'id' — "
+                    "the server assigns option ids and returns them as "
+                    "presented_option_ids, which is what record_pi_selection "
+                    "takes as selected_option_id."
                 )
         return self
 

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -2405,9 +2405,41 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     "project_id": "prj_01ABC...",
                     "decision_id": "dec_01XYZ...",
                     "confirmation_brief": "Choose embedding model for v2.",
+                    # No "id": the server assigns option ids and returns
+                    # them as presented_option_ids. Every other field here is
+                    # required — DecisionOptionCreate forbids extras and
+                    # accepts exactly three pros and three cons.
                     "options": [
-                        {"id": "A", "label": "nomic-embed-v1.5"},
-                        {"id": "B", "label": "bge-m3"},
+                        {
+                            "label": "nomic-embed-v1.5",
+                            "summary": "Swap the embedding backend to nomic-embed-v1.5.",
+                            "justification": "Best recall/latency trade-off measured on our corpus.",
+                            "explanation": "768-dim, runs locally, no per-call cost.",
+                            "pros": ["Highest recall", "Local inference", "No API cost"],
+                            "cons": ["Reindex required", "768-dim storage", "Newer, less battle-tested"],
+                            "confidence_verbal": "high",
+                            "confidence_numeric": 0.8,
+                            "confidence_evidence_strength": "strong",
+                            "confidence_known_unknowns": ["Behaviour on non-English entries"],
+                            "effort_time": "M",
+                            "effort_reversibility": "reversible",
+                            "presentation_order_seed": 1,
+                        },
+                        {
+                            "label": "bge-m3",
+                            "summary": "Swap the embedding backend to bge-m3.",
+                            "justification": "Stronger multilingual coverage.",
+                            "explanation": "1024-dim, multilingual, larger index.",
+                            "pros": ["Multilingual", "Mature", "Long-context"],
+                            "cons": ["Larger index", "Slower", "Higher memory"],
+                            "confidence_verbal": "moderate",
+                            "confidence_numeric": 0.6,
+                            "confidence_evidence_strength": "moderate",
+                            "confidence_known_unknowns": ["Latency at our corpus size"],
+                            "effort_time": "L",
+                            "effort_reversibility": "reversible",
+                            "presentation_order_seed": 2,
+                        },
                     ],
                 },
             },

--- a/tests/test_mcp/test_present_decision_option_contract.py
+++ b/tests/test_mcp/test_present_decision_option_contract.py
@@ -1,0 +1,117 @@
+"""The present_decision option contract must agree across its two layers.
+
+`present_decision` was uncallable on 2.9.0. The typed-args model required an
+`id` on every option so that `record_pi_selection.selected_option_id` would be
+dereferenceable; the REST payload it feeds, `DecisionOptionCreate`, declares
+`extra="forbid"` and has no `id` field. Without `id` the MCP model refused;
+with `id` the API returned 422 `extra_forbidden`. No call could satisfy both.
+
+Option ids are server-assigned and come back as `presented_option_ids`.
+
+These tests pin the agreement between the two layers, and check the documented
+example against the model that actually receives it — the check whose absence
+let a worked example ship that fails twice over: it carried an `id`, and it
+omitted all twelve other required fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from rka.mcp.operation_args import PresentDecisionArgs
+from rka.mcp.operations_schema import OPERATIONS_SCHEMA
+from rka.models.decision_option import DecisionOptionCreate
+
+
+def valid_option(**overrides) -> dict:
+    option = {
+        "label": "Option A",
+        "summary": "Do the thing.",
+        "justification": "Measured best on our corpus.",
+        "explanation": "Longer rationale.",
+        "pros": ["fast", "cheap", "reversible"],
+        "cons": ["new", "unproven", "needs reindex"],
+        "confidence_verbal": "moderate",
+        "confidence_numeric": 0.6,
+        "confidence_evidence_strength": "moderate",
+        "confidence_known_unknowns": ["behaviour at scale"],
+        "effort_time": "M",
+        "effort_reversibility": "reversible",
+        "presentation_order_seed": 1,
+    }
+    option.update(overrides)
+    return option
+
+
+def present(options: list[dict]) -> PresentDecisionArgs:
+    return PresentDecisionArgs(
+        project_id="prj_01TEST0000000000000000000",
+        decision_id="dec_01TEST0000000000000000000",
+        confirmation_brief="brief",
+        options=options,
+    )
+
+
+class TestLayersAgree:
+    def test_an_option_the_api_accepts_is_accepted_here(self):
+        """The regression: this shape used to be refused for lacking an id."""
+        option = valid_option()
+        DecisionOptionCreate.model_validate(option)  # REST layer accepts it
+        assert present([option]).options == [option]
+
+    def test_an_option_carrying_an_id_is_refused_by_both_layers(self):
+        option = valid_option(id="A")
+
+        with pytest.raises(ValidationError) as rest:
+            DecisionOptionCreate.model_validate(option)
+        assert "extra" in str(rest.value).lower()
+
+        with pytest.raises(ValidationError) as mcp:
+            present([option])
+        assert "must not carry an 'id'" in str(mcp.value)
+
+    def test_the_refusal_says_where_the_id_comes_from(self):
+        """A bare 'extra_forbidden' reads as a schema mismatch, not a rule."""
+        with pytest.raises(ValidationError) as exc:
+            present([valid_option(id="A")])
+        message = str(exc.value)
+        assert "presented_option_ids" in message
+        assert "record_pi_selection" in message
+
+    def test_empty_options_still_refused(self):
+        """TWO-TAP is void with nothing to ratify."""
+        with pytest.raises(ValidationError):
+            present([])
+
+    def test_non_dict_option_still_refused(self):
+        with pytest.raises(ValidationError):
+            present(["not a dict"])
+
+
+class TestDocumentedExample:
+    """The worked example must survive the model that receives it."""
+
+    @staticmethod
+    def _example_calls() -> list[dict]:
+        return [ex["call"] for ex in OPERATIONS_SCHEMA["present_decision"]["examples"]]
+
+    def test_example_options_validate_against_the_rest_model(self):
+        for call in self._example_calls():
+            for index, option in enumerate(call["options"]):
+                try:
+                    DecisionOptionCreate.model_validate(option)
+                except ValidationError as exc:  # pragma: no cover - failure path
+                    pytest.fail(
+                        f"documented present_decision example options[{index}] "
+                        f"is rejected by DecisionOptionCreate: {exc}"
+                    )
+
+    def test_example_validates_against_the_typed_args_model(self):
+        for call in self._example_calls():
+            present(call["options"])
+
+    def test_example_does_not_show_a_caller_supplied_id(self):
+        for call in self._example_calls():
+            for option in call["options"]:
+                assert "id" not in option


### PR DESCRIPTION
`present_decision` cannot be called through MCP on 2.9.0. Its two validation layers contradict each other:

```
without id  ->  PresentDecisionArgs: options[0] missing required 'id' key
with id     ->  HTTP 422  extra_forbidden  ['body', 0, 'id']
```

Both reproduced against the running 2.9.0 backend, after confirming the reporting session was not on a stale MCP process.

## Why

The typed-args model required an `id` per option so `record_pi_selection.selected_option_id` would be dereferenceable. But `DecisionOptionCreate` — the REST payload those options feed — declares `extra="forbid"` and has no `id` field, because **the server assigns option ids**. `present_decision` POSTs to `/api/decisions/{id}/options/bulk` and returns the created ids as `presented_option_ids`; those are what `record_pi_selection` consumes. The caller was being asked to invent an id the API then refused.

## Fix

Drop the requirement, and reject a caller-supplied `id` instead — at the typed boundary, with a message naming `presented_option_ids`. A bare `extra_forbidden` from two layers down reads like a schema mismatch rather than "you do not assign these."

The worked example in `rka_describe('present_decision')` was broken in both directions:

```json
"options": [{"id": "A", "label": "nomic-embed-v1.5"}]
```

It carries the forbidden `id`, and omits all twelve other required fields (`summary`, `justification`, `explanation`, `pros` ×3, `cons` ×3, `confidence_verbal`, `confidence_numeric`, `confidence_evidence_strength`, `confidence_known_unknowns`, `effort_time`, `effort_reversibility`, `presentation_order_seed`). An agent following the documentation could not succeed. Replaced with two complete options, and the full shape is now spelled out in the field description.

## Tests

8 new, in `tests/test_mcp/test_present_decision_option_contract.py`. Restoring the old validator and example turns **5 of 8** red.

The load-bearing one is `test_example_options_validate_against_the_rest_model`: it feeds the documented example to `DecisionOptionCreate` itself. That cross-layer assertion is what was missing — each layer was internally consistent and separately tested, so nothing caught that they disagreed.

Full suite: **3346 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, which returns None when `litellm` is absent — fails identically on unmodified `main`, passes in CI).

Independent of #96, which fixes the plugin's version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)