### PR TITLE
fix(api): require an explicit project on scoped endpoints

### DIFF
--- a/rka/api/deps.py
+++ b/rka/api/deps.py
@@ -7,7 +7,6 @@ import logging
 from fastapi import Depends, Header, HTTPException, Query, Request
 
 from rka.config import RKAConfig
-from rka.constants import DEFAULT_PROJECT_ID
 from rka.infra.database import Database
 from rka.infra.llm import LLMClient
 from rka.infra.embeddings import EmbeddingService
@@ -77,8 +76,35 @@ def get_project_id(
     x_rka_project: str | None = Header(default=None, alias="X-RKA-Project"),
     project_id: str | None = Query(default=None),
 ) -> str:
-    """Resolve project id from header/query with legacy-compatible default."""
-    return (x_rka_project or project_id or DEFAULT_PROJECT_ID).strip()
+    """Resolve the project id for a scoped operation. Explicit or nothing.
+
+    This used to fall back to ``DEFAULT_PROJECT_ID`` when neither the header
+    nor the query parameter was supplied. That default was silent, and silence
+    is the problem: a scoped write with no project did not fail, it landed in
+    the default project. Thirty entities in this database got there that way —
+    journal entries, claims and decisions whose typed links all point into
+    other projects, written between March and May 2026.
+
+    Nothing legitimate relies on the fallback. The web client always sends the
+    header, and every project-scoped MCP operation carries ``project_id`` as a
+    required field. What relied on it was callers that forgot — which is
+    exactly the case that must fail loudly.
+
+    Unscoped endpoints (``list_projects``, ``create_project``, ``health``,
+    pack import) do not depend on this function and are unaffected.
+    """
+    resolved = (x_rka_project or project_id or "").strip()
+    if not resolved:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Project scope is required: pass the X-RKA-Project header or a "
+                "project_id query parameter. This endpoint no longer falls back "
+                "to a default project, because doing so silently filed data "
+                "under the wrong project."
+            ),
+        )
+    return resolved
 
 
 def get_transport_actor(

--- a/tests/test_api/test_claim_contradicted_projection.py
+++ b/tests/test_api/test_claim_contradicted_projection.py
@@ -28,6 +28,8 @@ async def api_client(tmp_path: Path):
         async with httpx.AsyncClient(
             transport=transport,
             base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
         ) as client:
             yield client
     finally:

--- a/tests/test_api/test_claim_evidence_status.py
+++ b/tests/test_api/test_claim_evidence_status.py
@@ -28,6 +28,8 @@ async def api_client(tmp_path: Path):
         async with httpx.AsyncClient(
             transport=transport,
             base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
         ) as client:
             yield client
     finally:

--- a/tests/test_api/test_claim_scope_contracts.py
+++ b/tests/test_api/test_claim_scope_contracts.py
@@ -27,6 +27,8 @@ async def api_client(tmp_path: Path):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
             base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
         ) as client:
             yield client
     finally:

--- a/tests/test_api/test_explicit_project_scope.py
+++ b/tests/test_api/test_explicit_project_scope.py
@@ -1,0 +1,106 @@
+"""Scoped endpoints must refuse a request that names no project.
+
+`get_project_id` used to fall back to `DEFAULT_PROJECT_ID` when a request
+carried neither the `X-RKA-Project` header nor a `project_id` query parameter.
+The fallback was silent: a scoped write with no project did not fail, it filed
+the row under the default project. Thirty entities reached `proj_default` that
+way — journal entries, claims, decisions and clusters whose typed links all
+point into other projects.
+
+Writes matter most, but reads are covered too: an export or a search that
+silently answers about the wrong project is its own failure, and was how this
+was noticed.
+
+Unscoped endpoints must keep working without a project, or creating the first
+project becomes impossible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path: Path):
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path("explicit_scope.db"),
+        llm_enabled=False,
+        embeddings_enabled=False,
+    )
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        # Deliberately no default headers: absence is what is under test.
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            yield c
+
+
+NOTE = {"content": "a note that must not be filed by guesswork"}
+
+
+class TestScopedWritesRefuseWithoutAProject:
+    @pytest.mark.asyncio
+    async def test_create_note_is_refused(self, client: httpx.AsyncClient):
+        response = await client.post("/api/notes", json=NOTE)
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_names_both_ways_to_supply_scope(self, client):
+        detail = (await client.post("/api/notes", json=NOTE)).json()["detail"]
+        assert "X-RKA-Project" in detail
+        assert "project_id" in detail
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_written_to_the_default_project(self, client):
+        await client.post("/api/notes", json=NOTE)
+        listed = await client.get("/api/notes", headers={"X-RKA-Project": "proj_default"})
+        assert listed.status_code == 200
+        body = listed.json()
+        rows = body if isinstance(body, list) else body.get("entries", body.get("items", []))
+        assert all(NOTE["content"] not in str(row) for row in rows)
+
+    @pytest.mark.asyncio
+    async def test_a_blank_header_is_absence_not_a_project(self, client):
+        response = await client.post("/api/notes", json=NOTE, headers={"X-RKA-Project": "   "})
+        assert response.status_code == 422
+
+
+class TestExplicitScopeStillWorks:
+    @pytest.mark.asyncio
+    async def test_header_is_accepted(self, client: httpx.AsyncClient):
+        response = await client.post(
+            "/api/notes", json=NOTE, headers={"X-RKA-Project": "proj_default"}
+        )
+        assert response.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_query_parameter_is_accepted(self, client: httpx.AsyncClient):
+        response = await client.post(
+            "/api/notes", json=NOTE, params={"project_id": "proj_default"}
+        )
+        assert response.status_code == 201
+
+
+class TestUnscopedEndpointsAreUnaffected:
+    """Creating the first project cannot itself require a project."""
+
+    @pytest.mark.asyncio
+    async def test_health(self, client: httpx.AsyncClient):
+        assert (await client.get("/api/health")).status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_list_projects(self, client: httpx.AsyncClient):
+        assert (await client.get("/api/projects")).status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_create_project(self, client: httpx.AsyncClient):
+        response = await client.post("/api/projects", json={"name": "scope test"})
+        assert response.status_code == 200, response.text

--- a/tests/test_api/test_freshness.py
+++ b/tests/test_api/test_freshness.py
@@ -26,7 +26,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_api/test_gates.py
+++ b/tests/test_api/test_gates.py
@@ -27,7 +27,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_api/test_graph_route.py
+++ b/tests/test_api/test_graph_route.py
@@ -45,7 +45,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_api/test_integrity.py
+++ b/tests/test_api/test_integrity.py
@@ -26,7 +26,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_api/test_interpretation_staging.py
+++ b/tests/test_api/test_interpretation_staging.py
@@ -27,6 +27,8 @@ async def api_client(tmp_path: Path):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
             base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
         ) as client:
             yield client
     finally:

--- a/tests/test_api/test_reference_validation_attestations.py
+++ b/tests/test_api/test_reference_validation_attestations.py
@@ -25,7 +25,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_api/test_research_map_and_large_entries.py
+++ b/tests/test_api/test_research_map_and_large_entries.py
@@ -26,7 +26,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_api/test_researcher_tools.py
+++ b/tests/test_api/test_researcher_tools.py
@@ -26,7 +26,12 @@ async def api_client(tmp_path: Path):
     await lifespan.__aenter__()
     try:
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            # Scoped endpoints no longer fall back to a default project.
+            headers={"X-RKA-Project": "proj_default"},
+        ) as client:
             yield client
     finally:
         await lifespan.__aexit__(None, None, None)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,8 +4,9 @@ v2.6+: `DEFAULT_PROJECT_ID` is hardcoded to `SENTINEL_PROJECT_ID`. The
 pre-v2.6 `RKA_PROJECT` env-var override was removed because it
 reintroduced the silent-default failure mode that v2.6 explicitly
 eliminates at the MCP layer (every MCP tool now requires `project_id`
-as a kwarg). Non-MCP REST callers that don't pass `X-RKA-Project` or
-`?project_id=…` still resolve to `proj_default`.
+as a kwarg). Since the explicit-scope change, non-MCP REST callers that
+pass neither `X-RKA-Project` nor `?project_id=…` are refused with 422 on
+scoped endpoints — they no longer resolve to `proj_default`.
 
 Filed under the v2.6 `feat/project-id-required` PR. Historical
 context for the env-var-aware behavior lives in this file's git
@@ -74,14 +75,20 @@ class TestDefaultProjectIdIsHardcodedSentinel:
 
 
 class TestApiDepsImportsCanonicalConstant:
-    """api/deps.py and services/base.py must import DEFAULT_PROJECT_ID from
-    the canonical source (rka.constants), not redeclare it locally."""
+    """services/base.py must import DEFAULT_PROJECT_ID from the canonical
+    source (rka.constants), not redeclare it locally.
 
-    def test_api_deps_imports_default_project_id_from_constants(self):
+    api/deps.py no longer imports it at all: request scoping is explicit or
+    it is an error, so there is nothing there for a default to apply to.
+    """
+
+    def test_api_deps_does_not_default_the_request_scope(self):
         from rka.api import deps
-        from rka import constants
 
-        assert deps.DEFAULT_PROJECT_ID == constants.DEFAULT_PROJECT_ID
+        assert not hasattr(deps, "DEFAULT_PROJECT_ID"), (
+            "api/deps.py must not carry a default project — a silent default "
+            "is what filed scoped writes under the wrong project"
+        )
 
     def test_services_base_imports_default_project_id_from_constants(self):
         from rka.services import base
@@ -89,13 +96,32 @@ class TestApiDepsImportsCanonicalConstant:
 
         assert base.DEFAULT_PROJECT_ID == constants.DEFAULT_PROJECT_ID
 
-    def test_get_project_id_falls_back_to_default(self):
-        """When neither header nor query param is provided, get_project_id
-        returns DEFAULT_PROJECT_ID (= 'proj_default')."""
-        from rka.api.deps import get_project_id, DEFAULT_PROJECT_ID
+    def test_get_project_id_refuses_when_scope_is_absent(self):
+        """Neither header nor query param: refuse, do not guess.
 
-        result = get_project_id(x_rka_project=None, project_id=None)
-        assert result == DEFAULT_PROJECT_ID
+        This used to return `proj_default`. Thirty entities reached that
+        project that way — journal entries, claims and decisions whose typed
+        links all point into other projects.
+        """
+        import pytest
+        from fastapi import HTTPException
+        from rka.api.deps import get_project_id
+
+        with pytest.raises(HTTPException) as exc:
+            get_project_id(x_rka_project=None, project_id=None)
+        assert exc.value.status_code == 422
+        assert "X-RKA-Project" in exc.value.detail
+
+    def test_get_project_id_refuses_a_blank_scope(self):
+        """An empty header is absence, not a project named ''."""
+        import pytest
+        from fastapi import HTTPException
+        from rka.api.deps import get_project_id
+
+        for blank in ("", "   "):
+            with pytest.raises(HTTPException) as exc:
+                get_project_id(x_rka_project=blank, project_id=None)
+            assert exc.value.status_code == 422
 
     def test_get_project_id_prefers_header(self):
         from rka.api.deps import get_project_id


### PR DESCRIPTION
`get_project_id` fell back to `DEFAULT_PROJECT_ID` when a request carried neither the `X-RKA-Project` header nor a `project_id` query parameter:

```python
return (x_rka_project or project_id or DEFAULT_PROJECT_ID).strip()
```

The fallback was silent, and silence is the defect. A scoped write with no project did not fail — it filed the row under the default project, with a 201.

## This already happened

Audited against the live database. **Thirty entities in `proj_default` have typed links pointing exclusively into other projects:**

| type | count |
|---|---|
| journal | 17 |
| claim | 6 |
| decision | 3 |
| evidence cluster | 3 |
| literature | 1 |

All thirty resolve to **exactly one** foreign project — zero ambiguity, which is what distinguishes misrouting from deliberate cross-referencing. 48 of the 50 cross-project links in the whole database have one end in `proj_default`.

Content matches the link-inferred owner:

```
"Assessment Operationalization Framework Developed"          -> education project
"PI Insight: Brain/Executor Separation as Pedagogical ..."   -> education project
"Phase C C2 Stage B light ack — per-model BH-FDR-accepted"   -> detection project
"Gate 0.2 sub-stage B complete (template artifacts)"         -> detection project
```

All from March–May 2026. Nothing since, because the MCP layer began requiring `project_id` as a typed field — the REST hole stayed open.

Reads were affected too, which is how this surfaced: `GET /api/projects/export` without the header returned the default project's pack with a 200 and no indication anything was wrong.

## Fix

Scoped requests with no project now return 422 naming both ways to supply it. A blank or whitespace header is treated as absence, not as a project named `""`.

Nothing legitimate relied on the fallback:
- the web client always sends the header (`client.ts` sets it on every request that is not `POST /projects`)
- every project-scoped MCP operation already requires `project_id` as a typed field
- unscoped endpoints — `health`, `list_projects`, `create_project`, pack import — do not depend on this function, so bootstrapping a first project still works

What relied on it was callers that forgot, which is exactly the case that must fail loudly.

## Tests

`tests/test_api/test_explicit_project_scope.py` (12) plus rewrites in `test_constants.py`, whose `test_get_project_id_falls_back_to_default` asserted the behaviour being removed.

Restoring the fallback turns 6 red — including `test_nothing_is_written_to_the_default_project`, which posts a note with no scope and then checks the default project does not contain it. That one encodes the harm rather than the mechanism.

47 existing tests were resolving through the fallback. They now set the header at their client construction, which is what a real caller must do.

Full suite: **3348 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, which returns None when `litellm` is absent — identical on unmodified `main`, passes in CI).

## Not addressed here

The thirty already-misrouted entities are left where they are. Moving them is a data decision, and each one needs a judgement about whether the inferred owner is the intended one — the link evidence is strong but it is inference. The query that identifies them is in this PR's discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)