### PR TITLE
fix(mcp): let the currency signal and orphan_supersedes reach the agent

### DIFF
--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -2280,6 +2280,31 @@ async def rka_evaluate_gate(
 # Retrieval & Search
 # ============================================================
 
+def _currency_marker(hit: dict) -> str:
+    """Render a search hit's currency as text, or empty when it is current.
+
+    `/api/search` returns `status`, `superseded_by` and `stale` per hit, but
+    this tool renders hits as lines of text and used to emit only type, id,
+    title and snippet. The fields arrived and were dropped, which left the
+    exact failure they were added to prevent: a superseded decision printed
+    identically to the one that replaced it, and a reader ranking on relevance
+    alone could not tell which was in force.
+
+    The marker goes on the header line rather than the snippet, because a
+    snippet is truncated and a reader skimming ids should not have to
+    read prose to notice that a result is dead.
+    """
+    superseded_by = hit.get("superseded_by")
+    if superseded_by:
+        return f"  ⚠ SUPERSEDED → {superseded_by}"
+    status = (hit.get("status") or "").strip().lower()
+    if status in {"superseded", "retracted", "abandoned"}:
+        return f"  ⚠ {status.upper()}"
+    if hit.get("stale"):
+        return "  ⚠ STALE"
+    return ""
+
+
 @tool(tier="always_on", category="core")
 async def rka_search(
     query: str,
@@ -2336,7 +2361,10 @@ async def rka_search(
             return f"No results for '{query}'{degraded_line}{backlog_line}"
         lines = []
         for res in results:
-            lines.append(f"[{res['entity_type']}] {res['entity_id']}: {res['title']}")
+            lines.append(
+                f"[{res['entity_type']}] {res['entity_id']}: {res['title']}"
+                f"{_currency_marker(res)}"
+            )
             if res.get("snippet"):
                 lines.append(f"  {res['snippet'][:500]}")
         return "\n".join(lines) + degraded_line + backlog_line

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -1161,6 +1161,15 @@ async def dispatch_query(
             project_id=project_id,
         )
 
+    # Takes nothing but the project. It was registered in the scope->tool map
+    # and listed in the operations index without a branch here, so it resolved
+    # to a tool name and then fell through to `invalid_scope` — advertised and
+    # uncallable. That left an asymmetry worth naming: link_supersession could
+    # repair an orphaned supersede chain, but nothing could enumerate which
+    # chains needed repairing.
+    if scope == "orphan_supersedes":
+        return await legacy(project_id=project_id)
+
     if scope == "graph":
         return await legacy(
             include_types=f.get("include_types"),

--- a/tests/test_mcp/test_currency_reaches_the_agent.py
+++ b/tests/test_mcp/test_currency_reaches_the_agent.py
@@ -1,0 +1,109 @@
+"""Two gaps between a fix landing and an agent being able to see it.
+
+`/api/search` returns `status`, `superseded_by` and `stale` per hit. The MCP
+`rka_search` tool renders hits as lines of text and emitted only type, id,
+title and snippet — the fields arrived and were dropped. Agents read the
+rendered text, not the JSON, so the currency signal did not reach the only
+consumer that needed it: a superseded decision printed identically to the
+decision that replaced it.
+
+`orphan_supersedes` was registered in the scope->tool map and listed in the
+operations index, but had no branch in the dispatch chain. It resolved to a
+tool name and then fell through to `invalid_scope` — advertised and uncallable.
+
+The second class is the more dangerous one, so it gets a general test rather
+than a single case: every scope the index advertises must actually dispatch.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from rka.mcp import verb_dispatch
+from rka.mcp.server import _currency_marker
+
+
+class TestCurrencyMarker:
+    def test_superseded_by_is_named_so_the_reader_can_follow_it(self):
+        marker = _currency_marker({"superseded_by": "dec_01NEW", "status": "superseded"})
+        assert "SUPERSEDED" in marker
+        assert "dec_01NEW" in marker
+
+    def test_superseded_without_a_successor_still_warns(self):
+        """An orphaned chain has no pointer, but is still not current."""
+        marker = _currency_marker({"status": "superseded", "superseded_by": None})
+        assert "SUPERSEDED" in marker
+
+    @pytest.mark.parametrize("status", ["retracted", "abandoned"])
+    def test_other_dead_states_warn(self, status):
+        assert status.upper() in _currency_marker({"status": status})
+
+    def test_stale_warns_when_status_is_otherwise_fine(self):
+        assert "STALE" in _currency_marker({"status": "active", "stale": True})
+
+    @pytest.mark.parametrize(
+        "hit",
+        [
+            {},
+            {"status": "active"},
+            {"status": "active", "stale": False, "superseded_by": None},
+            {"status": "to_read"},
+        ],
+    )
+    def test_current_hits_are_unmarked(self, hit):
+        """Marking everything is the same as marking nothing."""
+        assert _currency_marker(hit) == ""
+
+    def test_status_case_and_padding_do_not_hide_a_dead_hit(self):
+        assert "SUPERSEDED" in _currency_marker({"status": "  Superseded  "})
+
+
+class TestSearchRenderingCarriesTheMarker:
+    def test_the_render_calls_the_marker(self):
+        """Pins the wiring: the marker existing is not the same as it being used."""
+        from rka.mcp import server
+
+        source = inspect.getsource(server.rka_search)
+        assert "_currency_marker" in source
+
+    def test_the_marker_is_on_the_header_line_not_the_snippet(self):
+        """A snippet is truncated; a reader skimming ids must still see it."""
+        from rka.mcp import server
+
+        source = inspect.getsource(server.rka_search)
+        header = re.search(r"lines\.append\(\s*\n?\s*f\"\[\{res\['entity_type'\]\}\].*?\)", source, re.S)
+        assert header and "_currency_marker" in header.group(0)
+
+
+class TestEveryAdvertisedScopeDispatches:
+    """The general form of the `orphan_supersedes` bug.
+
+    A scope can be listed in the operations index and mapped to a legacy tool
+    and still have no branch in the dispatch chain, in which case it falls
+    through to `invalid_scope`. Nothing caught that, because each layer was
+    individually consistent.
+    """
+
+    @staticmethod
+    def _dispatch_source() -> str:
+        return inspect.getsource(verb_dispatch.dispatch_query)
+
+    def test_every_mapped_scope_has_a_dispatch_branch(self):
+        source = self._dispatch_source()
+        missing = [
+            scope
+            for scope in verb_dispatch._QUERY_DISPATCH
+            if f'scope == "{scope}"' not in source and f'"{scope}"' not in source
+        ]
+        assert not missing, (
+            "scopes mapped to a tool but never matched in dispatch_query — "
+            f"they resolve to invalid_scope: {missing}"
+        )
+
+    def test_orphan_supersedes_specifically(self):
+        """The instance that surfaced this."""
+        assert "orphan_supersedes" in verb_dispatch._QUERY_DISPATCH
+        assert 'scope == "orphan_supersedes"' in self._dispatch_source()


### PR DESCRIPTION
Both reported from a live session on the deployed build. Both are gaps in my own retrieval work — the fixes landed a layer below the one that matters.

## 1. The currency fields never reached the agent

`/api/search` returns `status`, `superseded_by` and `stale` per hit. `rka_search` renders hits as text:

```python
lines.append(f"[{res['entity_type']}] {res['entity_id']}: {res['title']}")
if res.get("snippet"):
    lines.append(f"  {res['snippet'][:500]}")
```

Four fields rendered. The three currency fields arrived from the API and were dropped on the floor.

**Agents read the rendered text, not the JSON.** So the fix never reached the only consumer it was written for. The reporting session searched a real supersede chain — `dec_01KMX18F…` with `status: superseded` and a `superseded_by` pointer — and got both decisions back at ranks 1 and 2, visually identical, with no way to tell which was in force. That is verbatim the failure the fields were added to prevent.

The marker goes on the header line, not the snippet: a snippet is truncated at 500 chars, and a reader skimming ids should not have to read prose to notice a result is dead.

```
[decision] dec_01KMX18F…: Should the plugin bridge gate on version?  ⚠ SUPERSEDED → dec_01M071K2…
```

## 2. `orphan_supersedes` was advertised and uncallable

```json
{"error": "invalid_scope", "message": "rka_query: scope 'orphan_supersedes' not yet wired"}
```

It was in the scope→tool map, in the operations index, and had a working legacy tool and REST route — but no branch in `dispatch_query`'s `if scope == …` chain, so it fell through to the `invalid_scope` tail. Reproduced under every project.

That left a pointed asymmetry: `link_supersession` could repair an orphaned supersede chain, but nothing could enumerate which chains needed repairing.

## Tests

14 new. Restoring either bug turns 4 red.

The load-bearing one is `test_every_mapped_scope_has_a_dispatch_branch` — the general form of bug 2. Nothing caught the original because **every layer was individually consistent**: the map had the entry, the index listed it, the tool existed. Only the composition was broken. That test asserts the composition.

Full suite: **3398 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, which returns None when `litellm` is absent — identical on unmodified `main`, passes in CI).

## Also reported, not a bug

The same session reported `present_decision` still failing both ways. Re-verified against the deployed binary from a neutral working directory: it is fixed. Their check ran before #97 was deployed. Worth noting the trap — running `python -c` from the repo root imports the working tree's `rka` package instead of the installed one, which is how I first mis-measured it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)