### PR TITLE
fix(routing): unblock the research map, and two shadowed-route classes

### DIFF
--- a/rka/api/routes/academic.py
+++ b/rka/api/routes/academic.py
@@ -1,4 +1,9 @@
-"""Academic import routes — BibTeX, DOI enrichment, Mermaid export, batch import."""
+"""Academic import routes — BibTeX, DOI enrichment, batch import.
+
+The Mermaid decision export lives in `decisions.py`: it is a `/decisions/`
+path, and this router is included after that one, so a literal registered
+here is shadowed by `/decisions/{dec_id}`.
+"""
 
 from __future__ import annotations
 
@@ -67,17 +72,6 @@ async def enrich_from_doi(
 
 
 # ---- Mermaid Decision Tree Export ----
-
-@router.get("/decisions/mermaid")
-async def export_mermaid(
-    phase: str | None = None,
-    active_only: bool = False,
-    svc: AcademicImportService = Depends(get_scoped_academic_service),
-):
-    """Export the decision tree as a Mermaid flowchart diagram."""
-    mermaid = await svc.export_decisions_mermaid(phase=phase, active_only=active_only)
-    return {"mermaid": mermaid}
-
 
 # ---- Document Ingestion ----
 

--- a/rka/api/routes/decisions.py
+++ b/rka/api/routes/decisions.py
@@ -35,9 +35,11 @@ from rka.services.decisions import DecisionService
 from rka.services.decision_options import DecisionOptionsService
 from rka.services.calibration import CalibrationService
 from rka.infra.database import Database
+from rka.services.academic import AcademicImportService
 from rka.api.deps import (
     get_db,
     require_project,
+    get_scoped_academic_service,
     get_scoped_decision_service,
     get_scoped_decision_options_service,
     get_scoped_calibration_service,
@@ -159,6 +161,23 @@ async def link_supersession_route(
 # swallows "orphan-supersedes" as a decision id (404 "Decision
 # orphan-supersedes not found"). `/decisions/tree` sits above it for the
 # same reason.
+@router.get("/decisions/mermaid")
+async def export_decisions_mermaid(
+    phase: str | None = None,
+    active_only: bool = False,
+    svc: AcademicImportService = Depends(get_scoped_academic_service),
+):
+    """Export the decision tree as a Mermaid flowchart diagram.
+
+    The handler belongs to the academic-import service but the route must be
+    declared here: `academic.py`'s router is included after this one, so
+    `/decisions/mermaid` declared there is matched by `/decisions/{dec_id}`
+    first and answered with "Decision mermaid not found".
+    """
+    mermaid = await svc.export_decisions_mermaid(phase=phase, active_only=active_only)
+    return {"mermaid": mermaid}
+
+
 @router.get("/decisions/{dec_id}", response_model=Decision)
 async def get_decision(dec_id: str, svc: DecisionService = Depends(get_scoped_decision_service)):
     dec = await svc.get(dec_id)

--- a/rka/services/research_map.py
+++ b/rka/services/research_map.py
@@ -91,34 +91,55 @@ class ResearchMapService(BaseService):
         return result
 
     async def get_claims_for_cluster(self, cluster_id: str) -> list[dict]:
-        """Get individual claims in a cluster with provenance."""
+        """Get individual claims in a cluster with provenance.
+
+        `scope_readiness` is derived, not stored: it comes from joining the
+        claim's current scope contract and assessing it. This hand-built
+        projection omitted it while the research-map UI rendered it as a
+        required string, so opening any cluster threw on `undefined`.
+
+        The scope projection, join and assessment are reused from
+        ClaimsService rather than reimplemented, so readiness here means the
+        same thing it means everywhere else — and keeps meaning it when the
+        assessment rules change.
+        """
+        from rka.services.claims import ClaimService
+
         claims = await self.db.fetchall(
-            """SELECT c.*, j.content as source_content, j.type as source_type,
-                      j.source as source_actor
+            f"""SELECT c.*, j.content as source_content, j.type as source_type,
+                      j.source as source_actor,
+                      {ClaimService._SCOPE_PROJECTION}
                FROM claims c
                JOIN claim_edges ce ON ce.source_claim_id = c.id AND ce.relation = 'member_of'
                LEFT JOIN journal j ON j.id = c.source_entry_id
+               {ClaimService._SCOPE_JOIN}
                WHERE ce.cluster_id = ? AND c.project_id = ?
                ORDER BY c.confidence DESC""",
             [cluster_id, self.project_id],
         )
-        return [
-            {
-                "id": c["id"],
-                "claim_type": c["claim_type"],
-                "content": c["content"],
-                "confidence": c.get("confidence", 0.5),
-                "verified": bool(c.get("verified", 0)),
-                "evidence_status": c.get("evidence_status", "unassessed"),
-                "stale": bool(c.get("stale", 0)),
-                "source_entry_id": c["source_entry_id"],
-                "source_offset_start": c.get("source_offset_start"),
-                "source_offset_end": c.get("source_offset_end"),
-                "source_type": c.get("source_type"),
-                "source_actor": c.get("source_actor"),
-            }
-            for c in claims
-        ]
+
+        rows: list[dict] = []
+        for c in claims:
+            scope = ClaimService._scope_projection_to_model(c)
+            readiness, _findings = ClaimService._assess_scope(c, scope)
+            rows.append(
+                {
+                    "id": c["id"],
+                    "claim_type": c["claim_type"],
+                    "content": c["content"],
+                    "confidence": c.get("confidence", 0.5),
+                    "verified": bool(c.get("verified", 0)),
+                    "evidence_status": c.get("evidence_status", "unassessed"),
+                    "scope_readiness": readiness,
+                    "stale": bool(c.get("stale", 0)),
+                    "source_entry_id": c["source_entry_id"],
+                    "source_offset_start": c.get("source_offset_start"),
+                    "source_offset_end": c.get("source_offset_end"),
+                    "source_type": c.get("source_type"),
+                    "source_actor": c.get("source_actor"),
+                }
+            )
+        return rows
 
     async def get_cluster_detail(self, cluster_id: str) -> dict | None:
         """Get a cluster with claims, contradiction edges, and pending review items."""

--- a/tests/test_api/test_no_shadowed_routes.py
+++ b/tests/test_api/test_no_shadowed_routes.py
@@ -1,0 +1,102 @@
+"""No literal route may be shadowed by an earlier parameterised one.
+
+FastAPI matches in registration order, so `/decisions/{dec_id}` registered
+before `/decisions/mermaid` answers the latter with "Decision mermaid not
+found". It is a silent class of bug: the route exists, appears in OpenAPI, and
+returns a plausible 404 that reads like missing data rather than a missing
+route.
+
+Two instances have shipped — `/decisions/orphan-supersedes` (caught only when
+someone called it) and `/decisions/mermaid` (found by sweeping every literal
+GET). `decisions.py` carries a NOTE about the ordering requirement, which was
+not enough on its own: the second instance was declared in a different module
+whose router is included later, so the file-local convention could not see it.
+
+This test checks the assembled application, which is where the ordering
+actually resolves.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+
+
+def _routes(app) -> list[tuple[str, set[str]]]:
+    """Every (path, methods) pair in registration order."""
+    found: list[tuple[str, set[str]]] = []
+
+    def walk(node, prefix: str = "") -> None:
+        for route in getattr(node, "routes", []) or []:
+            path = getattr(route, "path", "") or ""
+            methods = getattr(route, "methods", None)
+            children = getattr(route, "routes", None)
+            if children:
+                walk(route, prefix + path)
+                continue
+            if path and methods:
+                found.append((prefix + path, set(methods)))
+
+    walk(app.router)
+    return found
+
+
+def _segments(path: str) -> list[str]:
+    return [s for s in path.strip("/").split("/") if s]
+
+
+def _is_param(segment: str) -> bool:
+    return segment.startswith("{") and segment.endswith("}")
+
+
+@pytest.fixture(scope="module")
+def app(tmp_path_factory):
+    return create_app(
+        RKAConfig(
+            project_dir=tmp_path_factory.mktemp("routes"),
+            db_path=Path("routes.db"),
+            llm_enabled=False,
+            embeddings_enabled=False,
+        )
+    )
+
+
+def test_the_route_table_is_readable(app):
+    """Guards the test itself: a traversal that finds nothing proves nothing."""
+    routes = _routes(app)
+    assert len(routes) > 100, f"only {len(routes)} routes found — traversal is wrong"
+    assert any(p == "/api/health" for p, _ in routes)
+
+
+def test_no_literal_route_is_shadowed(app):
+    routes = _routes(app)
+    shadowed: list[str] = []
+
+    for index, (path, methods) in enumerate(routes):
+        segments = _segments(path)
+        if any(_is_param(s) for s in segments):
+            continue  # only literal paths can be shadowed
+        for earlier_index in range(index):
+            earlier, earlier_methods = routes[earlier_index]
+            earlier_segments = _segments(earlier)
+            if len(earlier_segments) != len(segments):
+                continue
+            if not methods & earlier_methods:
+                continue
+            if not any(_is_param(s) for s in earlier_segments):
+                continue
+            if all(
+                _is_param(a) or a == b
+                for a, b in zip(earlier_segments, segments)
+            ):
+                shadowed.append(
+                    f"{sorted(methods)} {path} is matched first by {earlier} "
+                    f"(registered at #{earlier_index}, this at #{index})"
+                )
+                break
+
+    assert not shadowed, "literal routes unreachable behind a parameterised route:\n  " + "\n  ".join(shadowed)

--- a/tests/test_api/test_no_shadowed_routes.py
+++ b/tests/test_api/test_no_shadowed_routes.py
@@ -27,21 +27,39 @@ from rka.config import RKAConfig
 
 
 def _routes(app) -> list[tuple[str, set[str]]]:
-    """Every (path, methods) pair in registration order."""
+    """Every (path, methods) pair in registration order.
+
+    Two shapes to handle. Up to FastAPI 0.135 `include_router` flattens its
+    routes into the parent. From 0.141 it inserts an `_IncludedRouter` that
+    keeps the sub-router intact and carries the prefix on an include context,
+    so a walker that only follows `.routes` sees five top-level routes and
+    nothing else — which is why `test_the_route_table_is_readable` exists.
+    """
     found: list[tuple[str, set[str]]] = []
 
-    def walk(node, prefix: str = "") -> None:
-        for route in getattr(node, "routes", []) or []:
+    def children(route):
+        """(sub-routes, prefix) for a route that contains other routes."""
+        included = getattr(route, "original_router", None)
+        if included is not None:
+            context = getattr(route, "include_context", None)
+            return getattr(included, "routes", None), getattr(context, "prefix", "") or ""
+        nested = getattr(route, "routes", None)
+        if nested:
+            return nested, getattr(route, "path", "") or ""
+        return None, ""
+
+    def walk(routes, prefix: str = "") -> None:
+        for route in routes or []:
+            sub, sub_prefix = children(route)
+            if sub:
+                walk(sub, prefix + sub_prefix)
+                continue
             path = getattr(route, "path", "") or ""
             methods = getattr(route, "methods", None)
-            children = getattr(route, "routes", None)
-            if children:
-                walk(route, prefix + path)
-                continue
             if path and methods:
                 found.append((prefix + path, set(methods)))
 
-    walk(app.router)
+    walk(getattr(app.router, "routes", []))
     return found
 
 

--- a/tests/test_services/test_cluster_claims_scope_readiness.py
+++ b/tests/test_services/test_cluster_claims_scope_readiness.py
@@ -1,0 +1,101 @@
+"""Cluster claims must carry `scope_readiness`.
+
+`scope_readiness` is derived, not stored: it comes from joining a claim's
+current scope contract and assessing it. `get_claims_for_cluster` hand-built
+its result dicts and omitted the field, while the research-map UI rendered it
+as a required string — so opening any cluster threw
+`Cannot read properties of undefined (reading 'replaceAll')` and blanked the
+page. Every claim in every cluster, since the field was introduced.
+
+The type said the field was there, which is why nothing caught it: the
+frontend contract and the endpoint disagreed and neither side could see the
+other.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rka.services.claims import ClaimService
+from rka.services.research_map import ResearchMapService
+
+PROJECT = "proj_default"
+
+
+async def _seed_cluster_with_claim(db) -> tuple[str, str]:
+    await db.execute(
+        "INSERT INTO journal (id, project_id, content, type, source) "
+        "VALUES ('jrn_scope_probe', ?, 'source entry', 'finding', 'executor')",
+        [PROJECT],
+    )
+    await db.execute(
+        "INSERT INTO evidence_clusters (id, project_id, label) "
+        "VALUES ('ecl_scope_probe', ?, 'probe cluster')",
+        [PROJECT],
+    )
+    await db.execute(
+        "INSERT INTO claims (id, project_id, source_entry_id, claim_type, content, confidence) "
+        "VALUES ('clm_scope_probe', ?, 'jrn_scope_probe', 'evidence', 'a claim', 0.7)",
+        [PROJECT],
+    )
+    await db.execute(
+        "INSERT INTO claim_edges (id, project_id, source_claim_id, cluster_id, relation) "
+        "VALUES ('cle_scope_probe', ?, 'clm_scope_probe', 'ecl_scope_probe', 'member_of')",
+        [PROJECT],
+    )
+    await db.commit()
+    return "ecl_scope_probe", "clm_scope_probe"
+
+
+@pytest.mark.asyncio
+async def test_cluster_claims_include_scope_readiness(db):
+    cluster_id, _ = await _seed_cluster_with_claim(db)
+    svc = ResearchMapService(db, project_id=PROJECT)
+
+    claims = await svc.get_claims_for_cluster(cluster_id)
+
+    assert claims, "seeded claim should be returned"
+    for claim in claims:
+        assert "scope_readiness" in claim, (
+            "the research-map UI renders this as a required string; omitting it "
+            "throws on undefined and blanks the page"
+        )
+        assert isinstance(claim["scope_readiness"], str)
+        assert claim["scope_readiness"]
+
+
+@pytest.mark.asyncio
+async def test_a_claim_with_no_scope_contract_reads_missing(db):
+    """Not an error state — most claims have no contract yet."""
+    cluster_id, _ = await _seed_cluster_with_claim(db)
+    svc = ResearchMapService(db, project_id=PROJECT)
+
+    (claim,) = await svc.get_claims_for_cluster(cluster_id)
+
+    assert claim["scope_readiness"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_readiness_agrees_with_the_claims_service(db):
+    """One definition of readiness, not two.
+
+    A second implementation here would drift the moment the assessment rules
+    change, and the drift would be invisible — both sides would return a
+    plausible string.
+    """
+    cluster_id, claim_id = await _seed_cluster_with_claim(db)
+
+    from_map = (await ResearchMapService(db, project_id=PROJECT).get_claims_for_cluster(cluster_id))[0]
+    from_claims = await ClaimService(db, project_id=PROJECT).get(claim_id)
+
+    assert from_map["scope_readiness"] == from_claims.scope_readiness
+
+
+@pytest.mark.asyncio
+async def test_cluster_detail_carries_it_too(db):
+    """The detail endpoint reuses the same projection."""
+    cluster_id, _ = await _seed_cluster_with_claim(db)
+    detail = await ResearchMapService(db, project_id=PROJECT).get_cluster_detail(cluster_id)
+
+    assert detail is not None
+    assert all("scope_readiness" in c for c in detail["claims"])

--- a/web/src/pages/ResearchMap.tsx
+++ b/web/src/pages/ResearchMap.tsx
@@ -732,8 +732,11 @@ function ClaimCard({ claim }: { claim: Claim }) {
               {claim.verified && <CheckCircle className="h-4 w-4 text-green-500" />}
               {claim.stale && <Badge variant="destructive">stale</Badge>}
               <Link to="/claim-scopes">
+                {/* Derived server-side and absent from older payloads. A badge
+                    is not worth taking the page down for, so treat a missing
+                    value as "unknown" rather than reading through it. */}
                 <Badge variant={claim.scope_readiness === "ready" ? "default" : "secondary"}>
-                  scope {claim.scope_readiness.replaceAll("_", " ")}
+                  scope {(claim.scope_readiness ?? "unknown").replaceAll("_", " ")}
                 </Badge>
               </Link>
               <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
Two user-visible failures found while auditing routing end to end, plus the general tests for each class.

## 1. Every evidence cluster in the web UI blanked the page

```
TypeError: Cannot read properties of undefined (reading 'replaceAll')
```

`ResearchMap.tsx` renders `claim.scope_readiness.replaceAll("_", " ")` and the TypeScript type declares the field non-optional — but `get_claims_for_cluster` hand-builds its result dicts and never included it. Every claim, every cluster, since the field was introduced on 2026-08-15.

The type asserted a contract the endpoint did not honour, which is why nothing caught it: each side was self-consistent and neither could see the other.

`scope_readiness` is derived, not stored — it comes from joining the claim's current scope contract and assessing it. Fixed by reusing `ClaimService`'s projection, join and assessment rather than reimplementing them, so readiness here means what it means everywhere else and keeps meaning it when the rules change. A test asserts the two agree, because a second implementation would drift silently — both sides would return a plausible string.

Also stopped the UI from taking the page down over one badge. Both halves are wanted: the endpoint should send the field, and a research map should not be unreachable when it doesn't.

## 2. `GET /api/decisions/mermaid` answered "Decision mermaid not found"

Declared in `academic.py`, whose router is included after `decisions.py`, so `/decisions/{dec_id}` matched first and read "mermaid" as a decision id.

`decisions.py` already carries a NOTE that literal `/decisions/…` paths must sit above the parameterised route. That convention could not catch this one — the route was in a different module, and a file-local comment cannot see across include order. Moved the declaration to where the ordering holds; the handler still delegates to the academic-import service.

**Second instance of this class.** The first was `/decisions/orphan-supersedes`, caught only when someone tried to call it.

## The audit behind it

| surface | checked | result |
|---|---|---|
| MCP read operations | 68 called live | all dispatch, 0 `invalid_scope` |
| MCP write operations | 84 | all present in `EXECUTE_OPERATIONS` |
| REST literal GET endpoints | 61 called live | **1 shadowed**, 0 × 5xx |
| Web client → OpenAPI | 86 call sites | all resolve |

The route sweep is now `test_no_shadowed_routes.py`, over the assembled application — which is where ordering actually resolves, and the only place that can see across modules. Restoring the old placement fails it with the registration indices named (`#49` vs `#91`). It carries a guard test of its own, because a traversal that finds nothing would pass vacuously.

Full suite: **3404 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, which returns None when `litellm` is absent — identical on unmodified `main`, passes in CI). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)