### PR TITLE
fix(embeddings): re-embed when the model changes, not only the dimension

### DIFF
--- a/rka/services/embedding_backfill.py
+++ b/rka/services/embedding_backfill.py
@@ -124,10 +124,21 @@ def clear_registry() -> None:
 class _EntityBackfillConfig:
     """Parameterises the backfill cursor + write path for one entity type.
 
-    `pending_cursor_sql` MUST take two `?` placeholders for `last_id`
-    and `LIMIT`; `pending_count_sql` takes no placeholders. The cursor
-    must `SELECT id, project_id, ...content_columns...` so the loop
-    can compose text + write metadata under the right project.
+    Placeholder order is `(model_name, dimensions, last_id, LIMIT)` for
+    `pending_cursor_sql` and `(model_name, dimensions)` for
+    `pending_count_sql`. The cursor must `SELECT id, project_id,
+    ...content_columns...` so the loop can compose text + write metadata
+    under the right project.
+
+    The anti-join matches the *current* model and dim, not merely the
+    presence of a metadata row. Presence alone meant that swapping the
+    model at an unchanged dimension re-embedded nothing: `reshape` no-ops
+    when the dim is equal, so every metadata row survived and the cursor
+    found no pending work — leaving vectors from the retired model in the
+    index while queries were encoded by the new one, which is silent and
+    makes the similarity scores meaningless. `EmbeddingService.needs_reembed`
+    already gates on the full identity tuple; the cursor is what disagreed
+    with it.
     """
 
     entity_type: str
@@ -183,6 +194,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'claim' AND m.entity_id = c.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ") AND c.id > ? "
             "ORDER BY c.id LIMIT ?"
         ),
@@ -191,6 +203,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'claim' AND m.entity_id = c.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ")"
         ),
         post_embed_sql="UPDATE claims SET embedding_pending = 0 WHERE id = ?",
@@ -205,6 +218,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'journal' AND m.entity_id = j.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ") AND j.id > ? "
             "ORDER BY j.id LIMIT ?"
         ),
@@ -213,6 +227,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'journal' AND m.entity_id = j.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ")"
         ),
     ),
@@ -226,6 +241,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'decision' AND m.entity_id = d.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ") AND d.id > ? "
             "ORDER BY d.id LIMIT ?"
         ),
@@ -234,6 +250,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'decision' AND m.entity_id = d.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ")"
         ),
     ),
@@ -247,6 +264,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'literature' AND m.entity_id = l.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ") AND l.id > ? "
             "ORDER BY l.id LIMIT ?"
         ),
@@ -255,6 +273,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'literature' AND m.entity_id = l.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ")"
         ),
     ),
@@ -269,6 +288,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'mission' AND m.entity_id = mi.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ") AND mi.id > ? "
             "ORDER BY mi.id LIMIT ?"
         ),
@@ -277,6 +297,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'mission' AND m.entity_id = mi.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ")"
         ),
     ),
@@ -291,6 +312,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'artifact' AND m.entity_id = a.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ") AND a.id > ? "
             "ORDER BY a.id LIMIT ?"
         ),
@@ -299,6 +321,7 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
             "WHERE NOT EXISTS ("
             "  SELECT 1 FROM embedding_metadata m "
             "  WHERE m.entity_type = 'artifact' AND m.entity_id = a.id"
+            "    AND m.model_name = ? AND m.dimensions = ?"
             ")"
         ),
     ),
@@ -376,10 +399,18 @@ class BackfillService:
                     )
 
         # Step 1: snapshot per-type pending counts; total is the sum.
+        # Counted against the current model + dim, matching what the cursor
+        # will actually select — a count taken on metadata presence alone
+        # would report zero work for a model swap that has a full re-embed
+        # ahead of it.
+        count_model: str = getattr(self._embeddings, "model_name", "unknown")
+        count_dim: int = int(getattr(self._embeddings, "dim", 0) or 0)
         per_type_totals: dict[str, int] = {}
         for et in types:
             cfg = _ENTITY_BACKFILL_CONFIGS[et]
-            row = await self._db.fetchone(cfg.pending_count_sql)
+            row = await self._db.fetchone(
+                cfg.pending_count_sql, [count_model, count_dim]
+            )
             per_type_totals[et] = int((row or {}).get("n") or 0)
         status.total = sum(per_type_totals.values())
         await _emit_progress(progress_callback, status)
@@ -437,7 +468,8 @@ class BackfillService:
         last_id = ""
         while True:
             rows = await self._db.fetchall(
-                cfg.pending_cursor_sql, [last_id, self._batch_size]
+                cfg.pending_cursor_sql,
+                [model_name, embed_dim, last_id, self._batch_size],
             )
             if not rows:
                 break
@@ -503,8 +535,20 @@ class BackfillService:
                     if vec_available:
                         vec_blob = struct.pack(f"{len(vec)}f", *vec)
                         async with self._db.transaction():
+                            # sqlite-vec's vec0 tables do not honour the
+                            # REPLACE conflict clause — re-embedding an entity
+                            # that already has a vector raises "UNIQUE
+                            # constraint failed on <table> primary key".
+                            # Until now nothing re-embedded in place: the only
+                            # path here was a dimension change, and reshape
+                            # DROPs the table first, so no row ever pre-existed.
+                            # A same-dim model swap does re-embed in place.
                             await self._db.execute(
-                                f"INSERT OR REPLACE INTO {cfg.vec_table} "
+                                f"DELETE FROM {cfg.vec_table} WHERE id = ?",
+                                [entity_id],
+                            )
+                            await self._db.execute(
+                                f"INSERT INTO {cfg.vec_table} "
                                 "(id, embedding) VALUES (?, ?)",
                                 [entity_id, vec_blob],
                             )

--- a/tests/test_services/test_backfill_model_swap.py
+++ b/tests/test_services/test_backfill_model_swap.py
@@ -1,0 +1,134 @@
+"""Swapping the embedding model must re-embed, even at an unchanged dimension.
+
+`reshape_all_vec_tables_if_needed` keys on dimension: at an equal dim it is a
+no-op and every `embedding_metadata` row survives. The backfill cursor decided
+"pending" by the *presence* of such a row, so after a same-dim model swap it
+found nothing to do. The index kept vectors produced by the retired model while
+queries were encoded by the new one — two different embedding spaces compared
+by cosine similarity, silently, with no error anywhere.
+
+`EmbeddingService.needs_reembed` already gates on the full identity tuple
+(content_hash, model_name, dimensions). The per-row gate was right; the query
+that chose which rows to look at disagreed with it. These tests pin the two
+together.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from rka.services.embedding_backfill import (
+    BackfillService,
+    clear_registry,
+    register_job,
+)
+from rka.services.embedding_reshape import reshape_vec_claims
+
+
+@dataclass
+class FakeEmbedder:
+    """Deterministic vectors, with a model identity the backfill can read."""
+
+    model_name: str = "model-a"
+    dim: int = 4
+    calls: list[list[str]] = field(default_factory=list)
+
+    async def embed_batch(self, texts: list[str], *, is_query: bool = False) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[float(i)] * self.dim for i in range(len(texts))]
+
+
+async def _seed(db, *, count: int = 3) -> list[str]:
+    if db.vec_available:
+        await reshape_vec_claims(db, dim=4)
+    await db.execute(
+        "INSERT INTO journal (id, type, content, source, created_at) "
+        "VALUES ('jrn_swap', 'note', 'x', 'pi', strftime('%Y-%m-%dT%H:%M:%SZ','now'))"
+    )
+    ids = [f"clm_swap_{i:03d}" for i in range(count)]
+    for cid in ids:
+        await db.execute(
+            "INSERT INTO claims (id, source_entry_id, claim_type, content, embedding_pending) "
+            "VALUES (?, 'jrn_swap', 'observation', ?, 1)",
+            [cid, f"text-{cid}"],
+        )
+    await db.commit()
+    return ids
+
+
+async def _run(db, embedder) -> object:
+    clear_registry()
+    return await BackfillService(db=db, embeddings=embedder, batch_size=8).run_backfill(
+        register_job(), entity_types=("claim",)
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_pass_embeds_everything(db):
+    ids = await _seed(db)
+    result = await _run(db, FakeEmbedder(model_name="model-a"))
+    assert result.processed == len(ids)
+
+
+@pytest.mark.asyncio
+async def test_rerunning_the_same_model_is_a_no_op(db):
+    """The guard against the fix over-firing: same model must stay done."""
+    await _seed(db)
+    await _run(db, FakeEmbedder(model_name="model-a"))
+
+    second = await _run(db, FakeEmbedder(model_name="model-a"))
+
+    assert second.total == 0
+    assert second.processed == 0
+
+
+@pytest.mark.asyncio
+async def test_a_model_swap_at_the_same_dim_re_embeds(db):
+    """The regression. Same dim, different model — everything is pending."""
+    ids = await _seed(db)
+    await _run(db, FakeEmbedder(model_name="model-a", dim=4))
+
+    swapped = FakeEmbedder(model_name="model-b", dim=4)
+    result = await _run(db, swapped)
+
+    assert result.total == len(ids), (
+        "a same-dim model swap must report the full corpus as pending; "
+        "reshape no-ops at an equal dim, so nothing else will catch it"
+    )
+    assert result.processed == len(ids)
+    assert swapped.calls, "the new model must actually be asked to embed"
+
+
+@pytest.mark.asyncio
+async def test_metadata_records_the_new_model_after_a_swap(db):
+    ids = await _seed(db)
+    await _run(db, FakeEmbedder(model_name="model-a"))
+    await _run(db, FakeEmbedder(model_name="model-b"))
+
+    rows = await db.fetchall(
+        "SELECT DISTINCT model_name FROM embedding_metadata "
+        "WHERE entity_type = 'claim' AND entity_id IN "
+        "(" + ",".join(["?"] * len(ids)) + ")",
+        ids,
+    )
+    assert [r["model_name"] for r in rows] == ["model-b"], (
+        "stale metadata left behind would make the corpus look pending forever"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_reported_total_matches_what_gets_processed(db):
+    """The count and the cursor must agree.
+
+    They are separate SQL statements. If only one learned about the model,
+    the job would report 0 pending and then embed the whole corpus, or the
+    reverse — progress that never completes.
+    """
+    ids = await _seed(db, count=5)
+    await _run(db, FakeEmbedder(model_name="model-a"))
+
+    result = await _run(db, FakeEmbedder(model_name="model-b"))
+
+    assert result.total == result.processed == len(ids)


### PR DESCRIPTION
Swapping the embedding model for another of the **same dimension** re-embedded nothing.

```
reshape_all_vec_tables_if_needed(db, dim=target_dim)   # keys on dim → no-op at equal dim
                    ↓
     every embedding_metadata row survives
                    ↓
WHERE NOT EXISTS (SELECT 1 FROM embedding_metadata m
                  WHERE m.entity_type = ? AND m.entity_id = ?)   # presence only
                    ↓
            cursor finds nothing pending
```

The index kept vectors produced by the retired model while queries were encoded by the new one — two embedding spaces compared by cosine similarity. Silently: no error, nothing in the logs, no degraded-mode banner. It presents as "retrieval quality got worse for no reason."

`embedding_metadata` stores `model_name` and `dimensions`, and `EmbeddingService.needs_reembed` has gated on the full identity tuple since v2.5.5 — its docstring names this exact failure. **The per-row gate was already correct; the query choosing which rows to look at disagreed with it.**

## Fix

Match the anti-join on the current model and dim across all twelve cursor/count statements, and pass them at both call sites so the reported total and the work actually done agree.

## The second break, found by the first test

With the right rows finally selected, the write failed:

```
UNIQUE constraint failed on vec_claims primary key
```

sqlite-vec's `vec0` tables do not honour the `REPLACE` conflict clause, and the failure was swallowed as a per-row "leaving pending for retry". **Nothing had ever re-embedded in place before** — the only route into this code was a dimension change, and `reshape` DROPs the table first, so no row pre-existed. A same-dim swap is the first case that re-embeds over an existing vector. Delete the row, then insert.

So the path was broken in two places, and each hid the other: the predicate never selected the rows, so the write that would have failed was never reached.

## Tests

5 in `test_backfill_model_swap.py`. Reverting **either** break turns 3 of them red — verified separately, since a single fix passing both would not prove either was needed.

Two of the five guard the fix rather than the bug:
- re-running the *same* model must stay a no-op, or every restart re-embeds the corpus
- the reported total must equal what the cursor processes — they are separate SQL statements, and if only one learned about the model the job would report zero pending and then embed everything, or show progress that never completes

Full suite: **3403 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, which returns None when `litellm` is absent — identical on unmodified `main`, passes in CI).

## Scope

The predicate matches model and dim, not `content_hash`. Content drift is handled on the write path where the text changes; adding it here would make every backfill re-embed edited entities, which is a larger behaviour change and belongs in its own decision.

No re-embed is triggered on the current database by this change: all 5,153 vectors carry the configured model and dim, so the corpus reads as up to date, which it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)