### PR TITLE
fix(api): importing a knowledge pack needs no request project

### DIFF
--- a/rka/api/deps.py
+++ b/rka/api/deps.py
@@ -420,12 +420,22 @@ def get_scoped_artifact_service(
 
 
 def get_knowledge_pack_service(
-    project_id: str = Depends(get_project_id),
     db: Database = Depends(get_db),
     llm: LLMClient | None = Depends(get_llm),
     embeddings: EmbeddingService | None = Depends(get_embeddings),
 ) -> KnowledgePackService:
-    return KnowledgePackService(db, llm=llm, embeddings=embeddings, project_id=project_id)
+    """Pack service for the one operation that has no request project: import.
+
+    Importing a pack *creates* the project — its target comes from the upload
+    or the form, never from the request scope. This factory used to resolve a
+    request project anyway and hand it over unused, which was harmless while
+    an unsupplied scope silently became `proj_default`. Once that default was
+    removed, importing a pack started failing with "Project scope is required"
+    — an error about a value the operation does not read.
+
+    Use `get_scoped_knowledge_pack_service` for export, which is scoped.
+    """
+    return KnowledgePackService(db, llm=llm, embeddings=embeddings)
 
 
 def get_scoped_knowledge_pack_service(

--- a/tests/test_api/test_explicit_project_scope.py
+++ b/tests/test_api/test_explicit_project_scope.py
@@ -104,3 +104,45 @@ class TestUnscopedEndpointsAreUnaffected:
     async def test_create_project(self, client: httpx.AsyncClient):
         response = await client.post("/api/projects", json={"name": "scope test"})
         assert response.status_code == 200, response.text
+
+    @pytest.mark.asyncio
+    async def test_importing_a_pack_does_not_require_a_project(self, client):
+        """Import *creates* the project; its target comes from the upload.
+
+        This regressed when the default scope was removed: the pack service
+        factory resolved a request project and handed it over unused, so
+        importing failed with "Project scope is required" — an error about a
+        value the operation never reads. Asserted on the failure mode rather
+        than on success, because a valid pack is not needed to prove the
+        request got past scoping.
+        """
+        import io
+        import json
+        import zipfile
+
+        # A structurally valid pack: the point is to get past scoping, so the
+        # upload must not fail earlier on being unreadable. Bad bytes raise
+        # BadZipFile before the request reaches any of this, which would make
+        # the test fail in both the fixed and the broken state.
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr(
+                "manifest.json",
+                json.dumps(
+                    {
+                        "project": {"id": "prj_01IMPORTPROBE000000000000", "name": "import probe"},
+                        "tables": {},
+                    }
+                ),
+            )
+
+        response = await client.post(
+            "/api/projects/import",
+            files={"file": ("p.rka-pack.zip", buffer.getvalue(), "application/zip")},
+            data={"project_name": "import probe"},
+        )
+
+        assert "Project scope is required" not in response.text, (
+            "importing a pack must not demand a request project — its target "
+            f"comes from the upload (got {response.status_code}: {response.text[:200]})"
+        )


### PR DESCRIPTION
```
POST /api/projects/import
422 Project scope is required: pass the X-RKA-Project header or a project_id query parameter
```

Import **creates** the project. Its target comes from the uploaded manifest or the `project_name` form field — never from the request scope.

`get_knowledge_pack_service` resolved a request project anyway and passed it to a constructor that does not read it. That was invisible while an unsupplied scope silently became `proj_default`: the value was wrong and unused. #98 removed the default, which turned an unused value into a hard failure whose error names a parameter the operation ignores.

Export is unaffected — it uses the scoped factory, because export is scoped.

## How it was found

By cloning a real project to set up an end-to-end test. That was the first thing to exercise import since the default was removed.

No test covered it. `TestUnscopedEndpointsAreUnaffected` enumerated `health`, `list_projects` and `create_project` — a hand-written list, and import was not on it. Import is the least obvious member of that set, which is exactly why it was the one missed.

I also checked the other thirteen unscoped service factories: none is referenced by any route, so this was the only live instance.

## On the test

It posts a structurally valid pack rather than junk bytes. Junk raises `BadZipFile` before the request reaches scoping, so the assertion failed in **both** the fixed and the broken state — I wrote it that way first and reverting proved it discriminated nothing. It now asserts on the absence of the scope error rather than on success, since a valid *import* is not needed to show the request got past scoping.

Full suite: **3410 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, `litellm` absent — identical on unmodified `main`, passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)