### PR TITLE
fix(db): scope tag uniqueness to the project

### DIFF
--- a/rka/db/migrations/051_scope_tags_primary_key_per_project.sql
+++ b/rka/db/migrations/051_scope_tags_primary_key_per_project.sql
@@ -1,0 +1,88 @@
+-- Migration 051: make the tags primary key project-scoped.
+--
+-- `tags` was created with PRIMARY KEY (tag, entity_type, entity_id) before
+-- RKA was multi-project. Migration 004 added `project_id` as a nullable
+-- column but left the key alone, so tag uniqueness is global while every
+-- other table's uniqueness is per-project.
+--
+-- That is invisible in normal use, because entity ids are unique across
+-- projects anyway. It bites when a knowledge pack is imported into a
+-- database that already holds its source project: import preserves entity
+-- ids, so the first duplicated tag aborts the whole import with
+--
+--     UNIQUE constraint failed: tags.tag, tags.entity_type, tags.entity_id
+--
+-- Cloning a project for testing is exactly that operation, and so is
+-- importing the published example pack into an instance that already has it.
+--
+-- No row is lost or merged: at the time of writing every existing row is
+-- already unique under the new key. `project_id` stays nullable so the
+-- pre-multi-project rows keep their current meaning rather than being
+-- assigned to a project this migration cannot know.
+
+ALTER TABLE tags RENAME TO tags_legacy_051;
+
+CREATE TABLE tags (
+    tag TEXT NOT NULL COLLATE NOCASE,
+    entity_type TEXT NOT NULL CHECK (entity_type IN (
+        'decision', 'literature', 'journal', 'mission'
+    )),
+    entity_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    project_id TEXT,
+    PRIMARY KEY (project_id, tag, entity_type, entity_id)
+);
+
+INSERT INTO tags (tag, entity_type, entity_id, created_at, project_id)
+SELECT tag, entity_type, entity_id, created_at, project_id
+FROM tags_legacy_051;
+
+DROP TABLE tags_legacy_051;
+
+CREATE INDEX IF NOT EXISTS idx_tags_entity ON tags(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
+CREATE INDEX IF NOT EXISTS idx_tags_project ON tags(project_id);
+
+-- Recreate the change-tracking triggers. A table rebuild drops them along
+-- with the old table, and their absence is silent: writes keep working and
+-- the change cursor simply stops seeing tag edges.
+--
+-- They are recreated *after* the row copy on purpose. Creating them first
+-- would emit one change event per copied row — eleven thousand of them here —
+-- for a migration that changes no tag.
+
+CREATE TRIGGER trg_change_tags_insert
+AFTER INSERT ON tags
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id, details
+    ) VALUES (
+        COALESCE(NEW.project_id, 'proj_default'),
+        'tags', 'insert', NEW.entity_type, NEW.entity_id,
+        json_object('tag', NEW.tag)
+    );
+END;
+
+CREATE TRIGGER trg_change_tags_update
+AFTER UPDATE ON tags
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id, details
+    ) VALUES (
+        COALESCE(NEW.project_id, OLD.project_id, 'proj_default'),
+        'tags', 'update', NEW.entity_type, NEW.entity_id,
+        json_object('tag', NEW.tag, 'previous_tag', OLD.tag)
+    );
+END;
+
+CREATE TRIGGER trg_change_tags_delete
+AFTER DELETE ON tags
+BEGIN
+    INSERT INTO change_events (
+        project_id, source_table, operation, entity_type, entity_id, details
+    ) VALUES (
+        COALESCE(OLD.project_id, 'proj_default'),
+        'tags', 'delete', OLD.entity_type, OLD.entity_id,
+        json_object('tag', OLD.tag)
+    );
+END;

--- a/tests/test_db/test_tags_project_scoped_key.py
+++ b/tests/test_db/test_tags_project_scoped_key.py
@@ -1,0 +1,104 @@
+"""Tag uniqueness is per project, not global.
+
+`tags` predates multi-project RKA: its primary key was
+`(tag, entity_type, entity_id)`, and migration 004 added `project_id` as a
+column without touching the key. Every other table's uniqueness is
+project-scoped; this one stayed global.
+
+Invisible in normal use, because entity ids are unique across projects anyway.
+It bites when a knowledge pack is imported into a database that already holds
+its source project — import preserves entity ids, so the first duplicated tag
+aborts the whole import with
+
+    UNIQUE constraint failed: tags.tag, tags.entity_type, tags.entity_id
+
+Cloning a project for testing is that operation, and so is importing the
+published example pack into an instance that already has it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+
+async def _tag(db, *, project_id: str, entity_id: str = "jrn_shared", tag: str = "phase-1") -> None:
+    await db.execute(
+        "INSERT INTO tags (tag, entity_type, entity_id, project_id) VALUES (?, 'journal', ?, ?)",
+        [tag, entity_id, project_id],
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_the_same_tag_and_entity_id_can_exist_in_two_projects(db):
+    """The regression: a pack import re-creating entity ids must not collide."""
+    await _tag(db, project_id="prj_one")
+    await _tag(db, project_id="prj_two")
+
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM tags WHERE entity_id = 'jrn_shared' AND tag = 'phase-1'"
+    )
+    assert row["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_a_duplicate_within_one_project_is_still_refused(db):
+    """The guard against the fix over-relaxing: uniqueness still holds."""
+    await _tag(db, project_id="prj_one")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await _tag(db, project_id="prj_one")
+
+
+@pytest.mark.asyncio
+async def test_the_primary_key_names_the_project(db):
+    row = await db.fetchone("SELECT sql FROM sqlite_master WHERE name = 'tags'")
+    key = row["sql"].split("PRIMARY KEY")[1]
+    assert "project_id" in key, (
+        "tag uniqueness must be project-scoped; a global key aborts any pack "
+        "import into a database that already holds the source project"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_change_triggers_survived_the_rebuild(db):
+    """A rebuild drops triggers with the old table, and silently.
+
+    Writes keep working; the change cursor just stops seeing tag edges. This
+    assertion was missing from the first draft of the migration, and three
+    existing change-tracking tests caught it.
+    """
+    rows = await db.fetchall(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'tags'"
+    )
+    names = {r["name"] for r in rows}
+    assert names >= {
+        "trg_change_tags_insert",
+        "trg_change_tags_update",
+        "trg_change_tags_delete",
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_tag_write_still_lands_in_the_change_cursor(db):
+    """Trigger presence is not the same as trigger function."""
+    before = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM change_events WHERE source_table = 'tags'"
+    )
+    await _tag(db, project_id="prj_cursor", entity_id="jrn_cursor")
+    after = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM change_events WHERE source_table = 'tags'"
+    )
+    assert after["n"] == before["n"] + 1
+
+
+@pytest.mark.asyncio
+async def test_the_lookup_indexes_survived_the_rebuild(db):
+    """A table rebuild silently drops indexes that are not recreated."""
+    rows = await db.fetchall(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'tags'"
+    )
+    names = {r["name"] for r in rows}
+    assert {"idx_tags_entity", "idx_tags_tag", "idx_tags_project"} <= names


### PR DESCRIPTION
Importing a knowledge pack into a database that already holds its source project aborts partway:

```
UNIQUE constraint failed: tags.tag, tags.entity_type, tags.entity_id
```

`tags` predates multi-project RKA. Its primary key is `(tag, entity_type, entity_id)`; migration 004 added `project_id` as a column and left the key alone. Tag uniqueness stayed global while every other table's became per-project — it is the only such table in the schema.

Invisible in normal use, because entity ids are unique across projects anyway. It surfaces the moment two projects share an entity id, which is precisely what pack import produces: **import preserves ids**. Cloning a project for testing is that operation, and so is importing `examples/rka_development.rka-pack.zip` into an instance that already has that project — the pack this repository ships for people to try.

## Migration

Rebuild with `PRIMARY KEY (project_id, tag, entity_type, entity_id)`.

`project_id` stays nullable. Fifteen pre-multi-project rows have none, and this migration cannot know which project they belong to; assigning them would be a guess dressed as a fix.

Verified against a copy of a live database: **11,256 rows, zero collisions under the new key, none lost, integrity ok.** Cross-project duplicates now coexist; a duplicate within one project is still refused.

## The first draft was wrong, and the suite said so

A table rebuild drops the triggers attached to the old table. My first version silently removed the three change-tracking triggers on `tags` — writes keep working, the change cursor just stops seeing tag edges. Three existing tests failed (`test_migration_035`, two in `test_change_tracking`), which is the system working.

They are recreated **after** the row copy, so the migration emits no change events for a change it did not make. On the same live copy: 177 tag events before and after, and a subsequent write produces exactly one.

I had written an assertion that indexes survived the rebuild and not one for triggers — the new tests now cover both, plus a functional check that a tag write still reaches the cursor, since a trigger existing is not the same as a trigger working.

## Not changed

`schema.sql`. It is the pre-004 baseline and has no `project_id` column at all, so referencing it there would break fresh-database creation. A new database reaches the right shape by running 004 and then this.

Full suite: **3416 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, `litellm` absent — identical on unmodified `main`, passes in CI).

## Context

Found while cloning a real project to stand up an end-to-end multi-agent test. It is the third defect that setup has surfaced, after #102 and the pair in #100 — all of them on paths that unit tests covered individually and nothing had ever walked end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)