### PR TITLE
docs(mcp): say that nine of the twelve note types are rewritten on write

### DIFF
--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -1440,7 +1440,9 @@ class RecordNoteArgs(ProjectScopedArgs):
     ] = "executor"
     type: Annotated[
         NoteTypeLit,
-        Field(default="note", description="Journal entry type."),
+        Field(default="note", description=(
+            "Journal entry type. Only `note`, `log` and `directive` are stored: the other nine are legacy aliases, normalized on write (`methodology`→`log`, `pi_instruction`→`directive`, and the rest→`note`). Reading an entry back returns the canonical type, not the alias you sent."
+        )),
     ] = "note"
     confidence: Annotated[
         ConfidenceLit,
@@ -1552,7 +1554,13 @@ class IngestDocumentArgs(ProjectScopedArgs):
         NoteTypeLit,
         Field(
             default="finding",
-            description="Default note type for emitted entries.",
+            description=(
+                "Default type for emitted entries. Note that the default is a "
+                "legacy alias: `finding` is stored as `note`. Only `note`, "
+                "`log` and `directive` are stored; the other nine normalize on "
+                "write (`methodology`→`log`, `pi_instruction`→`directive`, the "
+                "rest→`note`)."
+            ),
         ),
     ] = "finding"
     split_by_headings: Annotated[
@@ -3813,7 +3821,12 @@ class UpdateNoteArgs(ProjectScopedArgs):
     ] = None
     type: Annotated[
         Optional[NoteTypeLit],
-        Field(default=None, description="New journal type (v2 canonical or legacy-accepted)."),
+        Field(default=None, description=(
+            "New journal type. Only `note`, `log` and `directive` are stored; "
+            "the other nine are legacy aliases normalized on write "
+            "(`methodology`→`log`, `pi_instruction`→`directive`, the rest→"
+            "`note`), so a read-back returns the canonical type."
+        )),
     ] = None
     confidence: Annotated[
         Optional[ConfidenceLit],

--- a/tests/test_mcp/test_note_type_collapse_is_documented.py
+++ b/tests/test_mcp/test_note_type_collapse_is_documented.py
@@ -1,0 +1,88 @@
+"""The note-type enum must say that nine of its twelve values collapse.
+
+`note`, `log` and `directive` are the only stored journal types. The other
+nine are legacy aliases, normalized on write by `JOURNAL_TYPE_MAP` — sending
+`finding` stores `note`.
+
+That is deliberate and the source says so, but the comment lives in
+`_enums.py` and never reaches the wire. What an agent sees is the JSON Schema:
+twelve enum values and, until now, the description "Journal entry type." So an
+agent picks `finding`, gets `note` back, and has nothing to reconcile the two
+with.
+
+That cost is not hypothetical. A Brain agent working a real session reported
+this as a defect, having reproduced it twice — effort spent, and a false bug
+report, because the surface asserted a choice the system does not offer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rka.models.journal import JOURNAL_TYPE_MAP, normalize_journal_type
+from rka.mcp.operation_args import IngestDocumentArgs, RecordNoteArgs, UpdateNoteArgs
+
+CANONICAL = {"note", "log", "directive"}
+ALIASES = sorted(set(JOURNAL_TYPE_MAP) - CANONICAL)
+
+
+def _description(model, field: str) -> str:
+    return model.model_fields[field].description or ""
+
+
+class TestTheCollapseIsRealAndDeliberate:
+    @pytest.mark.parametrize("alias", ALIASES)
+    def test_every_alias_normalizes_to_a_canonical_type(self, alias):
+        assert normalize_journal_type(alias) in CANONICAL
+
+    @pytest.mark.parametrize("canonical", sorted(CANONICAL))
+    def test_canonical_types_are_left_alone(self, canonical):
+        assert normalize_journal_type(canonical) == canonical
+
+    def test_there_really_are_nine_aliases(self):
+        """Pins the count the descriptions quote."""
+        assert len(ALIASES) == 9
+
+
+class TestTheSurfaceSaysSo:
+    """These descriptions are what reaches the agent as `inputSchema`."""
+
+    @pytest.mark.parametrize(
+        "model,field",
+        [
+            (RecordNoteArgs, "type"),
+            (UpdateNoteArgs, "type"),
+            (IngestDocumentArgs, "default_type"),
+        ],
+    )
+    def test_the_description_names_the_canonical_set(self, model, field):
+        description = _description(model, field)
+        for canonical in CANONICAL:
+            assert canonical in description, (
+                f"{model.__name__}.{field} offers twelve values without naming "
+                f"the three that are stored"
+            )
+
+    @pytest.mark.parametrize(
+        "model,field",
+        [
+            (RecordNoteArgs, "type"),
+            (UpdateNoteArgs, "type"),
+            (IngestDocumentArgs, "default_type"),
+        ],
+    )
+    def test_the_description_says_the_rest_are_rewritten(self, model, field):
+        description = _description(model, field).lower()
+        assert "normaliz" in description, (
+            f"{model.__name__}.{field} must say the other values are rewritten "
+            f"on write, not merely that they are accepted"
+        )
+
+    def test_ingest_document_flags_that_its_own_default_is_an_alias(self):
+        """`default_type` defaults to `finding`, which is stored as `note`."""
+        field = IngestDocumentArgs.model_fields["default_type"]
+        assert field.default == "finding"
+        assert normalize_journal_type(field.default) == "note"
+        assert "legacy alias" in (field.description or "").lower(), (
+            "a default that is silently rewritten must say so at the default"
+        )


### PR DESCRIPTION
`note`, `log` and `directive` are the only journal types stored. The other nine are legacy aliases normalized on write by `JOURNAL_TYPE_MAP` — sending `finding` stores `note`.

This is deliberate and `_enums.py` says so:

```python
# Journal type — v2 canonical set plus legacy-accepted superset (silently
# normalized via ``JOURNAL_TYPE_MAP``).
```

**But a comment never reaches the wire.** What an agent receives is the JSON Schema: twelve enum values and

```python
Field(default="note", description="Journal entry type.")
```

So it picks `finding`, reads back `note`, and has nothing to reconcile the two with.

## The cost is measured, not hypothetical

A Brain agent running a real session reported this as a defect. It reproduced it twice with a minimal probe, confirmed the persisted value via `entity`, and checked that `type=finding` rows exist historically before filing. All correct work, all wasted — the surface asserted a choice the system does not offer.

## What changed

The three field descriptions that carry the enum, because those are what land in `inputSchema`. `ingest_document.default_type` gets an extra line: its own default is `finding`, an alias that stores as `note` — a default that is silently rewritten should say so at the default.

No behaviour change.

## Why the mapping stays

Traced to `dec_01KMX18FDAMN7T5YVZ7V8HV6QZ` — "How should entity types and classifications be redesigned for v2.0?", chosen: *simplify to 3 record types, push fine typing to the claims layer*. Its rationale retires the nine-type scheme on measured grounds:

- categories overlapped in practice (`finding` vs `observation` vs `insight`)
- `hypothesis` was simultaneously a type and a confidence level
- 37 of 38 entries sat at the default, so the fine typing was not actually being used

And the structural reason, which still holds: *a single entry contains multiple types of knowledge*, so classifying the entry is the wrong layer regardless of how many options it offers. Fine typing moved to claims, where an extractor assigns hypothesis/evidence/method/result per claim.

The 34 non-canonical rows in the live database are all dated 2026-03-15..17 — the days that decision landed. Nothing since.

## Tests

20. Nine parametrised cases pin that every alias still normalizes to a canonical type, and the rest assert the descriptions name both the stored set and the rewriting. Reverting a description to `"Journal entry type."` turns two red.

Full suite: **3436 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, `litellm` absent — identical on unmodified `main`, passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)