### PR TITLE
fix(mcp): make submit_report's list fields reachable

### DIFF
--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -3487,7 +3487,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     "project_id": "prj_01ABC...",
                     "mission_id": "mis_01XYZ...",
                     "summary": "Embedding-model swap landed; latency budget met.",
-                    "findings": "p99 dropped 30%.",
+                    # A list: the typed model declares list[str], matching
+                    # MissionReportCreate. A bare string is refused before
+                    # the call is emitted.
+                    "findings": ["p99 dropped 30%.", "cold-start regressed 2x."],
                     "recommended_next": "Run scale test.",
                 },
             },

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -1894,13 +1894,38 @@ async def rka_update_mission(
         return f"Updated mission {id} fields={','.join(changed)}"
 
 
+def _report_lines(value: str | list[str] | None) -> list[str] | None:
+    """Normalise a report's list-or-lines field to a list of non-empty strings.
+
+    Both shapes arrive and both are legitimate. This tool's own contract is
+    newline-separated text, but the typed `submit_report` operation declares
+    `list[str]` — matching `MissionReportCreate`, which is also `list[str]` —
+    and the dispatcher passes that list straight through.
+
+    Accepting only a string left `findings`, `anomalies` and `questions`
+    unreachable from the typed surface: a list died here on `.strip()` with
+    `'list' object has no attribute 'strip'`, a string was refused by the
+    typed model before the call was ever emitted, and omitting them was the
+    only thing that worked. Reports were filed with their findings silently
+    dropped.
+
+    Module-level rather than nested, so it can be tested without reaching
+    into a closure.
+    """
+    if value is None:
+        return None
+    items = value if isinstance(value, list) else str(value).splitlines()
+    cleaned = [str(item).strip() for item in items if str(item).strip()]
+    return cleaned or None
+
+
 @tool(category="mission")
 async def rka_submit_report(
     mission_id: str,
     summary: str | None = None,
-    findings: str = "",
-    anomalies: str = "",
-    questions: str = "",
+    findings: str | list[str] = "",
+    anomalies: str | list[str] = "",
+    questions: str | list[str] = "",
     codebase_state: str = "",
     recommended_next: str = "",
     *,
@@ -1924,9 +1949,9 @@ async def rka_submit_report(
         mission_id: Mission ID
         summary: Full report text — methodology, results, what was
             done (PRIMARY FIELD).
-        findings: Key findings, one per line (optional)
-        anomalies: Unexpected observations or issues, one per line (optional)
-        questions: Open questions for the PI, one per line (optional)
+        findings: Key findings — a list, or newline-separated text (optional)
+        anomalies: Unexpected observations — a list, or newline-separated text (optional)
+        questions: Open questions for the PI — a list, or newline-separated text (optional)
         codebase_state: Description of codebase state after mission (optional)
         recommended_next: Suggested next steps as a single string (optional)
         content: v2.6.1 additive alias for `summary` — accepted so
@@ -1951,11 +1976,6 @@ async def rka_submit_report(
             "required"
         )
 
-    def _split(text: str) -> list[str] | None:
-        if not text or not text.strip():
-            return None
-        return [line.strip() for line in text.strip().splitlines() if line.strip()]
-
     body: dict = {
         # v2.6.1 — persist `summary` as a first-class field. Keep
         # tasks_completed=[summary] as back-compat for one release
@@ -1963,9 +1983,9 @@ async def rka_submit_report(
         # value where they expect it.
         "summary": summary,
         "tasks_completed": [summary],
-        "findings": _split(findings),
-        "anomalies": _split(anomalies),
-        "questions": _split(questions),
+        "findings": _report_lines(findings),
+        "anomalies": _report_lines(anomalies),
+        "questions": _report_lines(questions),
         "codebase_state": codebase_state.strip() or None,
         "recommended_next": recommended_next.strip() or None,
     }
@@ -8513,9 +8533,9 @@ async def rka_mission(
     status: MissionStatusLiteral | None = None,
     summary: str | None = None,
     content: str | None = None,
-    findings: str = "",
-    anomalies: str = "",
-    questions: str = "",
+    findings: str | list[str] = "",
+    anomalies: str | list[str] = "",
+    questions: str | list[str] = "",
     codebase_state: str = "",
     recommended_next: str = "",
     conclusion: str | None = None,

--- a/tests/test_mcp/test_submit_report_list_fields.py
+++ b/tests/test_mcp/test_submit_report_list_fields.py
@@ -1,0 +1,92 @@
+"""`submit_report`'s list fields must be reachable.
+
+`findings`, `anomalies` and `questions` could not be populated in any shape.
+The typed `submit_report` operation declares `list[str]` — matching
+`MissionReportCreate`, which is also `list[str]` — but the legacy tool the
+dispatcher calls accepted only newline-separated text and ran `.strip()` on
+whatever it got. So a list crashed the adapter with `'list' object has no
+attribute 'strip'`, a string was refused by the typed model before the call
+was emitted, and omitting the fields was the only thing that worked. Reports
+went in with their findings silently dropped.
+
+The two ends already agreed; the tool in the middle was the odd one out, so it
+is the one that learns both shapes.
+
+Found by an Executor agent running a real mission, not by the type checker —
+each layer was internally consistent.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from rka.mcp import server
+from rka.mcp.operation_args import SubmitReportArgs
+from rka.mcp.operations_schema import OPERATIONS_SCHEMA
+from rka.models.mission import MissionReportCreate
+
+
+from rka.mcp.server import _report_lines
+
+
+class TestNormaliser:
+    def test_a_list_survives(self):
+        assert _report_lines(["one", "two"]) == ["one", "two"]
+
+    def test_newline_text_still_splits(self):
+        assert _report_lines("one\ntwo") == ["one", "two"]
+
+    @pytest.mark.parametrize("value", [None, "", "   ", [], ["", "  "]])
+    def test_empty_shapes_become_none(self, value):
+        assert _report_lines(value) is None
+
+    def test_blank_entries_are_dropped_from_a_list(self):
+        assert _report_lines(["one", "", "  ", "two"]) == ["one", "two"]
+
+    def test_entries_are_stripped(self):
+        assert _report_lines(["  padded  "]) == ["padded"]
+
+
+class TestLayersAgree:
+    def test_the_typed_model_and_the_rest_model_declare_the_same_shape(self):
+        typed = SubmitReportArgs.model_fields["findings"].annotation
+        rest = MissionReportCreate.model_fields["findings"].annotation
+        assert "list" in str(typed) and "list" in str(rest)
+
+    @pytest.mark.parametrize("field", ["findings", "anomalies", "questions"])
+    def test_the_tool_accepts_both_shapes(self, field):
+        parameter = inspect.signature(server.rka_submit_report).parameters[field]
+        assert "list" in str(parameter.annotation), (
+            f"{field} must accept the list the typed layer sends"
+        )
+
+    def test_a_list_the_typed_model_accepts_reaches_the_rest_model(self):
+        """End to end across the three layers, without a live server."""
+        findings = ["p99 dropped 30%.", "cold start regressed."]
+        SubmitReportArgs(
+            project_id="prj_01TEST0000000000000000000",
+            mission_id="mis_01TEST0000000000000000000",
+            summary="done",
+            findings=findings,
+        )
+        assert _report_lines(findings) == findings
+        MissionReportCreate(summary="done", findings=_report_lines(findings))
+
+
+class TestDocumentedExample:
+    """The example is what an agent copies; it must be a shape that works."""
+
+    def test_the_example_findings_validate_against_both_models(self):
+        example = OPERATIONS_SCHEMA["submit_report"]["examples"][0]["call"]
+        findings = example.get("findings")
+        if findings is None:
+            pytest.skip("the example does not set findings")
+        SubmitReportArgs(
+            project_id="prj_01TEST0000000000000000000",
+            mission_id="mis_01TEST0000000000000000000",
+            summary="done",
+            findings=findings,
+        )
+        MissionReportCreate(summary="done", findings=_report_lines(findings))


### PR DESCRIPTION
`findings`, `anomalies` and `questions` on `submit_report` could not be populated in **any** shape:

```
list  ->  Error executing tool rka_execute: 'list' object has no attribute 'strip'
str   ->  args.submit_report.findings / Input should be a valid list [type=list_type]
omit  ->  succeeds, and the report is filed without them
```

## Which layer is wrong

```
typed SubmitReportArgs.findings      Optional[list[str]]   ✓
REST  MissionReportCreate.findings   list[str] | None      ✓
legacy rka_submit_report(findings)   str = ""              ✗  runs .strip()
```

The two ends already agree. The tool between them is the odd one out, so it is the one that learns both shapes.

Consequence: any caller that followed the typed schema correctly had its findings dropped — either crashing, or succeeding with the fields null after giving up and omitting them. That is what the reporting agent did, and the stored report confirms all three are `null`.

## Changes

- The normaliser accepts a list or newline-separated text, and moves from a closure to module scope so it can be tested directly rather than through `exec` on extracted source. My first attempt did the latter, and the resulting test failed identically in both the fixed and broken states — it discriminated nothing.
- Both entry points widen. `rka_mission` forwards these fields to `rka_submit_report`, so it carried the same hole.
- The worked example in `rka_describe('submit_report')` showed `findings` as a bare string — the exact shape the typed model refuses. An agent copying the documentation could not succeed.

## Tests

15. Reverting the normaliser to string-only turns 5 red; reverting the example to a string turns 1 red — checked separately, since one fix passing both would not show either was needed.

The load-bearing one walks a list through all three layers: typed model accepts it, normaliser preserves it, REST model accepts the result. That crossing is what nothing asserted.

Full suite: **3431 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, `litellm` absent — identical on unmodified `main`, passes in CI).

## Context

Found by an Executor agent submitting a real mission report during an end-to-end run, not by the type checker — each layer was internally consistent and separately tested. Same shape as #97 (`present_decision`), which was also a typed-vs-adapter disagreement that only a real call could surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)