### PR TITLE
feat(import): return once the rows are durable, and report the index build

### DIFF
--- a/rka/api/routes/project.py
+++ b/rka/api/routes/project.py
@@ -5,8 +5,20 @@ from __future__ import annotations
 import os
 import sqlite3
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse
+import logging
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
+from fastapi.responses import FileResponse, JSONResponse
 from starlette.background import BackgroundTask
 
 from rka.api.deps import (
@@ -17,8 +29,19 @@ from rka.api.deps import (
 )
 from rka.models.knowledge_pack import KnowledgePackImportResult
 from rka.models.project import ProjectCreate, ProjectInfo, ProjectState, ProjectStateUpdate
+# Aliased: this module already defines a route handler called `get_status`
+# (project state), which would shadow the registry lookup — and shadow it
+# silently, since both are callables and the failure only shows at runtime.
+from rka.services.embedding_backfill import (
+    JobStatus,
+    get_status as get_job_status,
+    latest_status as latest_job_status,
+    register_job,
+)
 from rka.services.knowledge_pack import KnowledgePackService
 from rka.services.project import ProjectService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -155,20 +178,65 @@ async def export_project_pack(
     )
 
 
-@router.post("/projects/import", response_model=KnowledgePackImportResult)
+async def _index_imported_project(
+    svc: KnowledgePackService, project_id: str, status: JobStatus
+) -> None:
+    """Background half of an import: build the indexes, reporting progress."""
+    status.state = "running"
+    try:
+        status.total = await svc.count_indexable(project_id)
+        await svc.index_project(project_id, status=status)
+        status.state = "complete"
+    except Exception as exc:  # noqa: BLE001
+        status.state = "failed"
+        status.error = str(exc)
+        logger.exception("import indexing failed for %s", project_id)
+
+
+@router.post("/projects/import", status_code=202)
 async def import_project_pack(
+    background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     project_id: str | None = Form(default=None),
     project_name: str | None = Form(default=None),
     svc: KnowledgePackService = Depends(get_knowledge_pack_service),
 ):
+    """Import a knowledge pack. Rows land synchronously; indexes follow.
+
+    Returns 202 once every row is durable, with a job to poll for the index
+    build. The two phases differ by orders of magnitude — rows insert in
+    seconds, while indexing embeds each entity and runs for tens of minutes on
+    a real pack. Done inline it outlives any reasonable HTTP timeout, and the
+    caller is left with a failed request for an import that succeeded and is
+    still working; meanwhile the project is partly searchable with nothing to
+    say more is coming.
+    """
     if not file.filename:
         raise HTTPException(status_code=400, detail="Knowledge pack file is required")
     try:
-        return await svc.import_pack(
+        result = await svc.import_pack(
             fileobj=file.file,
             project_id=project_id,
             project_name=project_name,
+            defer_indexing=True,
+        )
+        status_obj = register_job("imp")
+        background_tasks.add_task(
+            _index_imported_project, svc, result.project_id, status_obj
+        )
+        return JSONResponse(
+            status_code=202,
+            content={
+                **result.model_dump(),
+                "indexing": {
+                    "job_id": status_obj.job_id,
+                    "status_url": f"/api/projects/import/status?job_id={status_obj.job_id}",
+                    "note": (
+                        "Rows are durable. Search and semantic recall are "
+                        "incomplete until this job reports complete."
+                    ),
+                },
+            },
         )
     except ValueError as exc:
         message = str(exc)
@@ -176,3 +244,16 @@ async def import_project_pack(
         raise HTTPException(status_code=status_code, detail=message) from exc
     finally:
         await file.close()
+
+
+@router.get("/projects/import/status")
+async def import_status(job_id: str | None = Query(default=None)):
+    """Poll an import's index build. Omit `job_id` for the most recent."""
+    status = get_job_status(job_id) if job_id else latest_job_status()
+    if status is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No import job found for job_id={job_id!r}" if job_id
+            else "No import job has run in this process",
+        )
+    return status.snapshot()

--- a/rka/services/embedding_backfill.py
+++ b/rka/services/embedding_backfill.py
@@ -88,8 +88,15 @@ class JobStatus:
 _REGISTRY: dict[str, JobStatus] = {}
 
 
-def register_job() -> JobStatus:
-    job_id = f"bf_{uuid.uuid4().hex[:12]}"
+def register_job(prefix: str = "bf") -> JobStatus:
+    """Register a job and return its live status handle.
+
+    `prefix` names the kind of work in the job id. It defaults to `bf` so
+    existing backfill callers are unchanged; knowledge-pack import passes
+    `imp`. The registry is shared because the status shape and the polling
+    contract are the same — only the work differs.
+    """
+    job_id = f"{prefix}_{uuid.uuid4().hex[:12]}"
     status = JobStatus(
         job_id=job_id,
         state="pending",
@@ -97,7 +104,7 @@ def register_job() -> JobStatus:
         _started_perf=time.monotonic(),
     )
     _REGISTRY[job_id] = status
-    logger.info("registered backfill job %s", job_id)
+    logger.info("registered %s job %s", prefix, job_id)
     return status
 
 

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 import shutil
 import tempfile
@@ -18,6 +19,8 @@ from rka.models.knowledge_pack import KnowledgePackImportResult
 from rka.models.planning import validate_planning_payload
 from rka.models.semantic_patch import SemanticPatchProposalCreate
 from rka.services.base import BaseService, _now
+
+logger = logging.getLogger(__name__)
 from rka.services.outline_integrity import validate_unit_hierarchy
 
 PACK_SCHEMA_VERSION = 7
@@ -1018,6 +1021,7 @@ class KnowledgePackService(BaseService):
         fileobj: BinaryIO,
         project_id: str | None = None,
         project_name: str | None = None,
+        defer_indexing: bool = False,
     ) -> KnowledgePackImportResult:
         with zipfile.ZipFile(fileobj) as archive:
             manifest = self._load_manifest(archive)
@@ -1177,12 +1181,21 @@ class KnowledgePackService(BaseService):
                     shutil.rmtree(artifact_project_root, ignore_errors=True)
                 raise
 
-        # Success path. Sync indexes for the (now committed) rows + repair
-        # non-critical findings so the import doesn't land with stale derived
-        # counts (Brain-ratified addition during the upfront Backbrief).
-        await self._sync_imported_indexes(tables, target_project_id)
+        # Success path. Repair non-critical findings so the import doesn't land
+        # with stale derived counts (Brain-ratified addition during the upfront
+        # Backbrief).
+        #
+        # Index building is separated from row insertion because the two have
+        # wildly different costs: the rows land in seconds, while indexing
+        # embeds every entity one at a time and takes tens of minutes on a
+        # real pack. Run inline it exceeds any sane HTTP timeout, and the
+        # caller sees a failed request for an import that in fact succeeded
+        # and is still working. `defer_indexing` lets the route return as
+        # soon as the rows are durable and drive the rest as a job.
         if any(i.get("category") == "claim_count_mismatch" for i in integrity_issues):
             await self._recompute_cluster_claim_counts(target_project_id)
+        if not defer_indexing:
+            await self._sync_imported_indexes(tables, target_project_id)
 
         return KnowledgePackImportResult(
             project_id=target_project_id,
@@ -2085,6 +2098,68 @@ class KnowledgePackService(BaseService):
             f"INSERT INTO [{table}] ({column_sql}) VALUES ({placeholders})",
             [row[column] for column in columns],
         )
+
+    # entity_type -> (source table, columns _sync_indexes reads)
+    _INDEXABLE: dict[str, tuple[str, list[str]]] = {
+        "journal": ("journal", ["id", "content", "summary"]),
+        "decision": ("decisions", ["id", "question", "rationale"]),
+        "literature": ("literature", ["id", "title", "abstract", "notes"]),
+        "mission": ("missions", ["id", "objective", "context"]),
+        "claim": ("claims", ["id", "content"]),
+        "cluster": ("evidence_clusters", ["id", "label", "synthesis"]),
+    }
+
+    async def count_indexable(self, project_id: str) -> int:
+        """How many entities `index_project` will visit."""
+        total = 0
+        for _etype, (table, _cols) in self._INDEXABLE.items():
+            row = await self.db.fetchone(
+                f"SELECT COUNT(*) AS n FROM {table} WHERE project_id = ?", [project_id]
+            )
+            total += int((row or {}).get("n") or 0)
+        return total
+
+    async def index_project(
+        self,
+        project_id: str,
+        *,
+        status: Any | None = None,
+    ) -> int:
+        """Build FTS + vector indexes for every entity in one project.
+
+        Reads the rows back from the database rather than taking the parsed
+        manifest, so it can run after `import_pack` has returned and its
+        manifest is gone — and so a re-run repairs a partial pass instead of
+        needing the original upload.
+
+        `status`, when given, is a `JobStatus` whose `processed` counter is
+        advanced per entity. Indexing a real pack takes tens of minutes; a job
+        that reports nothing until it finishes is indistinguishable from one
+        that has hung, and while it runs the project is partly searchable with
+        no signal that more is coming.
+
+        Per-entity failures are logged and skipped rather than aborting: one
+        unembeddable row should not strand the remaining thousands.
+        """
+        indexer = BaseService(self.db, embeddings=self.embeddings, project_id=project_id)
+        done = 0
+        for etype, (table, cols) in self._INDEXABLE.items():
+            rows = await self.db.fetchall(
+                f"SELECT {', '.join(cols)} FROM {table} WHERE project_id = ? ORDER BY id",
+                [project_id],
+            )
+            for row in rows:
+                try:
+                    await indexer._sync_indexes(etype, row["id"], dict(row))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "index_project: %s %s failed (skipped): %s",
+                        etype, row.get("id"), exc,
+                    )
+                done += 1
+                if status is not None:
+                    status.processed = done
+        return done
 
     async def _sync_imported_indexes(
         self,

--- a/tests/test_api/test_import_progress.py
+++ b/tests/test_api/test_import_progress.py
@@ -1,0 +1,165 @@
+"""Importing a pack returns as soon as the rows are durable, not when indexed.
+
+The two phases of an import differ by orders of magnitude. Rows insert in
+seconds; indexing embeds every entity one at a time and ran for over thirty
+minutes on a 9,365-row pack. Done inline, the HTTP request times out long
+before the work finishes — the caller sees a failure for an import that
+succeeded and is still going, and the project is meanwhile partly searchable
+with nothing to say more is coming.
+
+That gap is not hypothetical: measuring the half-built index during one of
+those windows produced a confident and wrong conclusion that import does not
+build indexes at all.
+
+So: 202 once the rows land, plus a job to poll.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+from rka.services.embedding_backfill import clear_registry
+from rka.services.knowledge_pack import PACK_SCHEMA_VERSION
+
+HEADERS = {"X-RKA-Project": "proj_default"}
+
+
+def _pack(project_id: str = "prj_01IMPORTPROGRESS0000000000") -> bytes:
+    buffer = io.BytesIO()
+    manifest = {
+        "pack_format_version": PACK_SCHEMA_VERSION,
+        "schema_version": 21,
+        "project": {"id": project_id, "name": "import progress", "created_by": "system"},
+        "project_state": None,
+        "tables": {
+            "journal": [
+                {
+                    "id": f"jrn_01IMPORTPROGRESS{index:09d}",
+                    "project_id": project_id,
+                    "type": "note",
+                    "content": f"imported entry {index}",
+                    "source": "executor",
+                }
+                for index in range(3)
+            ]
+        },
+        "table_counts": {"journal": 3},
+    }
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+    return buffer.getvalue()
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path: Path):
+    clear_registry()
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path("import_progress.db"),
+        llm_enabled=False,
+        embeddings_enabled=False,
+    )
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+            yield c
+
+
+async def _import(client: httpx.AsyncClient) -> httpx.Response:
+    return await client.post(
+        "/api/projects/import",
+        files={"file": ("p.rka-pack.zip", _pack(), "application/zip")},
+        data={"project_name": "import progress"},
+        headers=HEADERS,
+    )
+
+
+class TestTheImportReturnsEarly:
+    @pytest.mark.asyncio
+    async def test_it_answers_202_not_200(self, client):
+        response = await _import(client)
+        assert response.status_code == 202, response.text
+
+    @pytest.mark.asyncio
+    async def test_it_names_a_job_to_poll(self, client):
+        body = (await _import(client)).json()
+        assert body["indexing"]["job_id"].startswith("imp_")
+        assert body["indexing"]["job_id"] in body["indexing"]["status_url"]
+
+    @pytest.mark.asyncio
+    async def test_it_says_search_is_not_ready_yet(self, client):
+        """Silence here is what made a half-built index look like a missing one."""
+        note = (await _import(client)).json()["indexing"]["note"].lower()
+        assert "search" in note
+
+    @pytest.mark.asyncio
+    async def test_the_rows_are_already_durable(self, client):
+        """202 must not mean "queued" — the import itself is done."""
+        body = (await _import(client)).json()
+        listed = await client.get(
+            "/api/notes", headers={"X-RKA-Project": body["project_id"]}
+        )
+        assert listed.status_code == 200
+        assert len(listed.json()) == 3
+
+    @pytest.mark.asyncio
+    async def test_the_result_still_carries_the_import_summary(self, client):
+        body = (await _import(client)).json()
+        assert body["project_name"] == "import progress"
+        assert body["imported_counts"]["journal"] == 3
+
+
+class TestTheStatusEndpoint:
+    @pytest.mark.asyncio
+    async def test_the_job_is_reportable(self, client):
+        job_id = (await _import(client)).json()["indexing"]["job_id"]
+        status = await client.get("/api/projects/import/status", params={"job_id": job_id})
+        assert status.status_code == 200
+        assert status.json()["job_id"] == job_id
+
+    @pytest.mark.asyncio
+    async def test_it_reports_a_total_to_measure_progress_against(self, client):
+        """`processed` alone cannot distinguish slow from stuck."""
+        job_id = (await _import(client)).json()["indexing"]["job_id"]
+        body = (await client.get("/api/projects/import/status", params={"job_id": job_id})).json()
+        assert "total" in body and "processed" in body
+        assert body["state"] in {"pending", "running", "complete"}
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_job_is_404_not_an_empty_success(self, client):
+        response = await client.get(
+            "/api/projects/import/status", params={"job_id": "imp_nosuchjob"}
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_no_job_id_returns_the_latest(self, client):
+        job_id = (await _import(client)).json()["indexing"]["job_id"]
+        body = (await client.get("/api/projects/import/status")).json()
+        assert body["job_id"] == job_id
+
+
+class TestIndexingIsRerunnable:
+    @pytest.mark.asyncio
+    async def test_index_project_reads_rows_back_from_the_database(self, client, tmp_path):
+        """It must not need the manifest, which is gone once import returns."""
+        from rka.api.deps import get_db
+        from rka.services.knowledge_pack import KnowledgePackService
+
+        body = (await _import(client)).json()
+        project_id = body["project_id"]
+
+        app = client._transport.app  # type: ignore[attr-defined]
+        svc = KnowledgePackService(app.state.db)
+        assert await svc.count_indexable(project_id) == 3
+        assert await svc.index_project(project_id) == 3


### PR DESCRIPTION
Importing a knowledge pack ran row insertion and index building in one request. The two differ by orders of magnitude:

| phase | 9,365-row pack |
|---|---|
| rows insert | seconds |
| index build | **> 30 minutes** — embeds every entity, one at a time |

The HTTP request times out long before that finishes. The caller sees a failed import for one that succeeded and is still working; the project is meanwhile partly searchable, with nothing to say more is coming.

## That silence already cost a wrong conclusion

Measuring the index mid-build looked exactly like an index that is never built. I reported "knowledge-pack import does not populate FTS" on the strength of `decisions 1/146`, `literature 0/159`, `claims 0/142` — and was about to file it. A second measurement showed the numbers climbing; they reached 100% on every type. The finding was an artifact of watching a slow job with no progress signal.

## Change

`POST /api/projects/import` answers **202** as soon as every row is durable, with a job id and a status url. Rows are committed — 202 here means "imported, still indexing", not "queued".

```
GET /api/projects/import/status?job_id=imp_…
{"job_id": "imp_…", "state": "running", "processed": 4210, "total": 9365, …}
```

`total` matters as much as `processed`: a counter with nothing to measure against cannot distinguish slow from stuck, which is the failure this fixes.

The index build reads its rows back from the database rather than holding the parsed manifest. So it outlives the request that started it, and a re-run repairs a partial pass without needing the original upload. Per-entity failures are logged and skipped — one unembeddable row should not strand the remaining thousands.

`register_job` gains a `prefix` argument, defaulting to `bf` so every backfill caller is untouched. The status shape and the polling contract are identical; only the work differs, so the registry is shared rather than duplicated.

## Two things worth flagging

**A silent shadow.** `project.py` already defines a route handler named `get_status`. Importing the registry's `get_status` was shadowed by it — both are callables, so nothing complained until the endpoint returned a coroutine. The registry lookups are now imported under aliases, with a comment saying why.

**The web client is unaffected.** It gates on `res.ok`, and 202 is 2xx. The response body keeps every previous field and adds `indexing`.

## Tests

10. They assert the behaviour rather than the plumbing: that the rows are queryable *before* indexing finishes (202 must not mean "queued"), that the response says search is not ready yet, that the status reports a total and not just a count, and that an unknown job is a 404 rather than an empty success.

`TestIndexingIsRerunnable` pins the property that makes recovery possible — `index_project` reads from the database, so it does not need the manifest that is gone by the time it runs.

Full suite: **3426 passed**, 1 pre-existing failure (`test_retention.py::test_completer_timeout_is_configurable`, `litellm` absent — identical on unmodified `main`, passes in CI). No existing test depended on the 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)