### PR TITLE
refactor(context): drop the depth option and its LLM narrative

### DIFF
--- a/rka/api/routes/context.py
+++ b/rka/api/routes/context.py
@@ -36,7 +36,6 @@ async def get_context(
     return await engine.get_context(
         topic=data.topic,
         phase=data.phase,
-        depth=data.depth,
         project_id=project_id,
         anchor_aware_present=data.anchor_aware_present,
         anchor_aware_ids=data.anchor_aware_ids,

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -450,7 +450,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         ),
         "required_fields": ["project_id"],
         "optional_fields": ["query", "filters", "options"],
-        "enums": {"depth": ["summary", "detailed"]},
+        "enums": {},
         "examples": [
             {
                 "description": "Pull current project context.",
@@ -462,7 +462,6 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     "operation": "context",
                     "project_id": "prj_01ABC...",
                     "query": "RAG benchmark methodology",
-                    "options": {"depth": "detailed"},
                 },
             },
         ],

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -3064,7 +3064,6 @@ async def rka_export(format: str = "markdown", scope: str = "state", *, project_
 async def rka_get_context(
     topic: str | None = None,
     phase: str | None = None,
-    depth: str = "summary",
     *,
     project_id: str,
 ) -> str:
@@ -3079,11 +3078,10 @@ async def rka_get_context(
         topic: Search topic for semantic context retrieval. Omit for an
             importance-ranked overview of recent project state.
         phase: Filter to a specific research phase.
-        depth: "summary" (default) returns the ranked list as-is.
             "detailed" adds an LLM-generated narrative if an LLM is configured.
     """
     async with _client(project_id) as c:
-        body = {"topic": topic, "phase": phase, "depth": depth}
+        body = {"topic": topic, "phase": phase}
         r = await c.post("/api/context", json={k: v for k, v in body.items() if v is not None})
         _raise_with_detail(r)
         pkg = r.json()

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -1348,7 +1348,6 @@ async def dispatch_query(
         return await legacy(
             topic=query or f.get("topic"),
             phase=f.get("phase"),
-            depth=o.get("depth", "summary"),
             project_id=project_id,
         )
 

--- a/rka/models/context.py
+++ b/rka/models/context.py
@@ -26,7 +26,6 @@ class ContextRequest(BaseModel):
 
     topic: str | None = None
     phase: str | None = None
-    depth: Literal["summary", "detailed"] = "summary"
     anchor_aware_present: bool = False
     anchor_aware_ids: list[str] | None = None
 

--- a/rka/services/context.py
+++ b/rka/services/context.py
@@ -94,6 +94,12 @@ _DEFAULT_PI_SOURCE_LIFT_NORMALIZED = 0.125
 # (<0.005 recall variance) — the recency-amplification mechanism is real
 # but its magnitude is too small to bridge the structural floor gaps.
 # cfg11 winner pins N=1 (the simplest shape; reproduces the pre-Phase-3.1
+# Per-entry render cap. Previously read from the LLM client
+# (`_evidence_block_limit`), which tied a purely local rendering decision
+# to whether a language model happened to be configured. 400 was the
+# fallback that applied whenever it was not.
+_EVIDENCE_BLOCK_LIMIT = 400
+
 # 1/(1+days) shape exactly). Operator override via RKA_CTX_RECENCY_SHAPE_N
 # preserved for Phase-3.2 candidate-set experimentation.
 _DEFAULT_RECENCY_SHAPE_N = 1.0
@@ -254,7 +260,6 @@ class ContextEngine:
         self,
         topic: str | None = None,
         phase: str | None = None,
-        depth: Literal["summary", "detailed"] = "summary",
         project_id: str = "proj_default",
         anchor_aware_present: bool = False,
         anchor_aware_ids: list[str] | None = None,
@@ -267,8 +272,6 @@ class ContextEngine:
             phase: Optional phase filter for the overview path. If both `topic`
                 and `phase` are None, falls through to the recent-with-importance
                 overview.
-            depth: 'summary' returns the ranked list as-is. 'detailed' adds an
-                LLM-generated narrative if an LLM is configured.
             project_id: Project scope. Defaults to 'proj_default'; callers
                 normally inject from the API request.
             anchor_aware_present: v2.5.4 (D4) signal that anchor-aware
@@ -354,17 +357,6 @@ class ContextEngine:
         rendered = [self._render_entry(entry) for entry in candidates]
         package.entries = rendered
         package.sources = [e["id"] for e in candidates]
-
-        # Optional narrative for callers that ask for `detailed`.
-        if depth == "detailed" and self.llm and candidates:
-            try:
-                narrative = await self.llm.produce_narrative(
-                    {"topic": topic, "phase": current_phase, "entries": rendered}
-                )
-                if narrative:
-                    package.narrative = narrative
-            except Exception as exc:
-                logger.debug("Narrative generation failed: %s", exc)
 
         if topic:
             package.note = (
@@ -645,7 +637,7 @@ class ContextEngine:
         a context-engine token budget.
         """
         if max_len is None:
-            max_len = self.llm._evidence_block_limit if self.llm else 400
+            max_len = _EVIDENCE_BLOCK_LIMIT
         etype = entry.get("entity_type", "unknown")
         eid = entry.get("id", "?")
 

--- a/tests/test_services/test_context_has_no_llm_path.py
+++ b/tests/test_services/test_context_has_no_llm_path.py
@@ -49,6 +49,44 @@ class TestNoLanguageModelInTheContextPath:
         decision changed depending on whether a model was configured."""
         assert context_module._EVIDENCE_BLOCK_LIMIT == 400
 
+    def test_render_size_does_not_track_the_configured_context_window(self):
+        """The property that actually broke.
+
+        `max_len` was `self.llm._evidence_block_limit`, which bands on the
+        model's declared context window: 500 at 4k, 4000 at 128k+. So the
+        same entry rendered ten times larger on an instance whose settings
+        named a large model — including when that model answered nothing,
+        because the client object is truthy regardless of reachability.
+        On this repository's own project that inflated the response from
+        29,933 to 170,995 chars, past the MCP tool-result limit.
+        """
+
+        class _Client:
+            """Stands in for LLMClient, whose limits band on `ctx`."""
+
+            def __init__(self, ctx):
+                self.ctx = ctx
+
+            @property
+            def _evidence_block_limit(self):
+                return 4000 if self.ctx >= 128_000 else 500
+
+        entry = {
+            "entity_type": "journal",
+            "id": "jrn_x",
+            "type": "note",
+            "content": "x" * 9000,
+        }
+        renders = {
+            ContextEngine(db=None, search=None, llm=llm)._render_entry(entry)
+            for llm in (None, _Client(4_000), _Client(262_144))
+        }
+        assert len(renders) == 1, (
+            "context output changed with the configured context window; a local "
+            "render must not be sized by a remote model's advertised capacity"
+        )
+        assert len(renders.pop()) < 1000
+
     def test_narrative_generation_is_gone(self):
         assert "produce_narrative" not in inspect.getsource(context_module)
 

--- a/tests/test_services/test_context_has_no_llm_path.py
+++ b/tests/test_services/test_context_has_no_llm_path.py
@@ -1,0 +1,103 @@
+"""Building context must not touch a language model.
+
+`context` is step one of the documented session start, and everything it does
+is local: it ranks entries by `journal.importance`, `entity_links` centrality
+and recency. One branch was the exception — `depth="detailed"` asked an LLM for
+a narrative paragraph.
+
+That branch was pure cost. Measured against a live instance whose configured
+LLM host was unreachable:
+
+    depth=summary     0.07s   182,719 bytes
+    depth=detailed  226.35s   182,719 bytes   (byte-identical)
+
+Three and a half thousand times slower for the same bytes, because the failure
+is caught and logged at debug. Callers saw a timeout, or an identical answer
+after four minutes, and no indication the narrative had been attempted at all.
+
+`depth` also read as a verbosity control and was not one — it only chose
+whether to append the narrative. A Brain agent hitting the payload-size limit
+retried with `depth="summary"` to shrink it, which by construction could not
+work.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from rka.services import context as context_module
+from rka.services.context import ContextEngine
+
+
+class TestNoLanguageModelInTheContextPath:
+    def test_the_engine_never_calls_an_llm(self):
+        source = inspect.getsource(context_module)
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if "self.llm." in line and not line.strip().startswith("#")
+        ]
+        assert not offenders, (
+            "context is a local ranking operation; an LLM call here makes it "
+            f"fail or hang on an unrelated backend: {offenders}"
+        )
+
+    def test_the_render_cap_is_a_local_constant(self):
+        """It used to be read off the LLM client, so a purely local rendering
+        decision changed depending on whether a model was configured."""
+        assert context_module._EVIDENCE_BLOCK_LIMIT == 400
+
+    def test_narrative_generation_is_gone(self):
+        assert "produce_narrative" not in inspect.getsource(context_module)
+
+
+class TestDepthIsGone:
+    """It named a choice that only ever meant "also call an LLM"."""
+
+    def test_the_engine_signature_has_no_depth(self):
+        assert "depth" not in inspect.signature(ContextEngine.get_context).parameters
+
+    def test_the_request_model_has_no_depth(self):
+        from rka.models.context import ContextRequest
+
+        assert "depth" not in ContextRequest.model_fields
+
+    def test_the_operation_advertises_no_depth_enum(self):
+        from rka.mcp.operations_schema import OPERATIONS_SCHEMA
+
+        assert "depth" not in (OPERATIONS_SCHEMA["context"].get("enums") or {})
+
+    def test_no_example_passes_depth(self):
+        from rka.mcp.operations_schema import OPERATIONS_SCHEMA
+
+        for example in OPERATIONS_SCHEMA["context"]["examples"]:
+            assert "depth" not in (example["call"].get("options") or {})
+
+
+class TestContextStillWorks:
+    """Removing the branch must not remove the operation."""
+
+    @pytest.mark.asyncio
+    async def test_it_returns_a_package_without_an_llm(self, db):
+        from rka.services.search import SearchService
+
+        engine = ContextEngine(db=db, search=SearchService(db=db, embeddings=None), llm=None)
+        package = await engine.get_context(project_id="proj_default")
+        assert package.entries is not None
+        assert package.note
+
+    @pytest.mark.asyncio
+    async def test_an_engine_handed_an_llm_still_ignores_it(self, db):
+        """Nothing should reach the model even if one is wired in."""
+        from rka.services.search import SearchService
+
+        class ExplodingLLM:
+            def __getattr__(self, name):
+                raise AssertionError(f"context reached the LLM: {name}")
+
+        engine = ContextEngine(
+            db=db, search=SearchService(db=db, embeddings=None), llm=ExplodingLLM()
+        )
+        await engine.get_context(project_id="proj_default")


### PR DESCRIPTION
`context` is step one of the documented session start, and everything it does is local — it ranks entries by `journal.importance`, `entity_links` centrality and recency. Two things in it reached for a language model anyway. Neither had to.

## 1. `depth="detailed"` — 226s for byte-identical output

Measured against a live instance whose configured LLM host is unreachable, reproduced twice:

| | wall clock | bytes |
|---|---|---|
| `depth=summary` | 0.07s | 182,719 |
| `depth=detailed` | **226.35s** | 182,719 — byte-identical |

The 226s is three HTTP attempts of ~75s each, since established by measurement:

    wall ≈ 3 × min(llm_request_timeout, ~75s) + SDK backoff + instructor overhead

The three attempts come from the **openai SDK client's** default `max_retries=2`, nested inside litellm — not from `extract()`'s `max_retries`, which instructor consumes as a validation-retry counter and never forwards (0, 1, 2 and 3 all produce exactly 3 sends). Each attempt is capped at ~75s by the connect failure itself, not by `llm_request_timeout=120`, which never fires because 75 < 120; a single attempt at `timeout=200` still measured 75.16s. litellm's `Total attempts: 1` counts a third, separate retry layer that is off.

So `llm_request_timeout` is inert above ~75s on this path. Bounding it is a separate change and not what this PR does.

What matters here is that the failure is caught and logged at `debug`, so a caller sees either a timeout or an identical answer four minutes later, with nothing to say a narrative was ever attempted.

`depth` also reads as a verbosity control and never was one — it only chose whether to append the narrative. A Brain agent that hit the payload-size limit did the reasonable thing and retried with `depth="summary"` to shrink the response. That could not work by construction, and it reported the option as broken. It was not broken; it was named for something it does not do.

## 2. The per-entry render cap was sized by the model's context window

The more consequential one, and the reason this is not a cosmetic change. `_render_entry` opened with:

```python
"""max_len defaults to the LLM's per-evidence-block hint when an LLM is
configured (~400 chars), else 400."""
if max_len is None:
    max_len = self.llm._evidence_block_limit if self.llm else 400
```

The docstring says both branches are ~400. `_evidence_block_limit` returns 500/1000/2000/4000 banded on `ctx`, so on any instance whose configured model declares a large window the live value is **4000** — ten times what the line above it claims, and the branch that never runs is the one that's documented.

`self.llm` is the client object, which is truthy whenever the dependency is wired, independent of `llm_enabled` or reachability. So the cap tracks a number typed into a settings field for a host that may answer nothing.

Measured on this repository's own project, 80 entries, against the live instance:

```
block lengths: max 4,277   median 1,804   min 121
66/80 blocks exceed 400 chars; 23 exceed 4000

at 4000 (live — derived from an unreachable model's declared 262144 window)  170,995 chars
at  400 (module constant)                                                     29,933 chars
                                                            5.7x, ~35k tokens
```

The server's own `token_estimate` for that response is **43,172**, which is over the MCP tool-result limit — `context` was unusable through MCP on a mature project, and this is why. A purely local rendering decision was scaled by an LLM's advertised context window.

## What changed

`depth` removed end to end — engine, request model, route, dispatch, legacy tool, advertised enum, worked example. The cap becomes a module constant at 400, the value the docstring always claimed.

`ContextPackage.narrative` **stays**: the web client reads the field, and it was already permanently null wherever no model answers. Removing it belongs with a UI change.

## Tests

10. Four assert the property rather than the deletion: the engine source contains no `self.llm.` call, the render cap is a local constant, and — the useful one — an engine handed a live LLM object that raises on **any** attribute access still completes. That last one fails if a call is reintroduced anywhere in the path, not just in the branch removed here.

The fourth is the regression test for §2, and it was checked both ways: render one entry through three engines — no client, a client declaring 4k, one declaring 262144 — and require a single distinct result. Against the previous line it produces three.

Full suite: **3311 collected, 3311 passed, 0 failures**.

## Scope

Deliberately narrow. The other 22 LLM call sites are untouched and should stay: `summary.py` and the QA path size their prompts off `_content_limit` / `_evidence_block_limit` / `_max_evidence_blocks` too, but both entry points open with `raise LLMUnavailableError` when no model is configured, so that code is unreachable without one and scaling a prompt to the model's window is correct there. `context` was the one place the pattern leaked into output the caller receives directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
