### PR TITLE
fix(mcp): stop advertising a context option nothing reads

### DIFF
--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -261,13 +261,8 @@ class QueryContextArgs(ProjectScopedArgs):
         Optional[dict[str, Any]],
         Field(default=None, description="Optional filters (e.g. {'phase': str})."),
     ] = None
-    options: Annotated[
-        Optional[dict[str, Any]],
-        Field(
-            default=None,
-            description="Optional options (e.g. {'depth': 'summary'|'detailed'}).",
-        ),
-    ] = None
+    # No `options`: it carried only `depth`, and once that was removed
+    # nothing in dispatch_query read it. See test_context_surface_is_honest.
 
 
 class QuerySearchArgs(ProjectScopedArgs):

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -446,10 +446,10 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "summary": "Load current project state + recent knowledge for a topic.",
         "signature": (
             "rka_query(operation='context', *, project_id, query=None, "
-            "filters={'phase': str}, options={'depth': 'summary'|'detailed'})"
+            "filters={'phase': str})"
         ),
         "required_fields": ["project_id"],
-        "optional_fields": ["query", "filters", "options"],
+        "optional_fields": ["query", "filters"],
         "enums": {},
         "examples": [
             {
@@ -457,7 +457,7 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                 "call": {"operation": "context", "project_id": "prj_01ABC..."},
             },
             {
-                "description": "Topic-scoped detailed context.",
+                "description": "Topic-scoped context.",
                 "call": {
                     "operation": "context",
                     "project_id": "prj_01ABC...",

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -7663,7 +7663,7 @@ async def _rka_query_legacy_impl(
     if s == "status":
         return await _query_get(project_id, "/api/status")
     if s == "context":
-        body = {"topic": query, "phase": f.get("phase"), "depth": f.get("depth", "summary")}
+        body = {"topic": query, "phase": f.get("phase")}
         return await _query_post(project_id, "/api/context", body)
     if s == "search":
         if not query:

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -3078,7 +3078,6 @@ async def rka_get_context(
         topic: Search topic for semantic context retrieval. Omit for an
             importance-ranked overview of recent project state.
         phase: Filter to a specific research phase.
-            "detailed" adds an LLM-generated narrative if an LLM is configured.
     """
     async with _client(project_id) as c:
         body = {"topic": topic, "phase": phase}

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -982,7 +982,6 @@ async def dispatch_query(
     query: str | None = None,
     limit: int | None = None,
     filters: dict[str, Any] | None = None,
-    options: dict[str, Any] | None = None,
     ids: list[str] | None = None,
     include_sources: bool = False,
     include_edges: bool = False,
@@ -1009,8 +1008,6 @@ async def dispatch_query(
         query: Query string for search-shaped scopes (search, multi_hop).
         limit: Result limit (folded into filters when applicable).
         filters: Per-scope filter dict.
-        options: Per-scope option dict (e.g. {'depth': 'detailed'} for
-            'context').
         ids: Entity IDs for the bounded ``resolve_entities`` operation.
         include_sources: Include terminal claim-source closure when resolving.
         include_edges: Include same-project typed edges when resolving.
@@ -1030,7 +1027,6 @@ async def dispatch_query(
     tool_name = _QUERY_DISPATCH[scope]
     legacy = _legacy(tool_name)
     f = filters or {}
-    o = options or {}
 
     # --- Scopes with NO kwargs other than project_id ---
     if scope in (
@@ -2992,7 +2988,6 @@ async def dispatch_query_typed(args: "BaseModel") -> str:  # type: ignore[name-d
             query=kw_all.get("query"),
             limit=kw_all.get("limit"),
             filters=typed_filters or None,
-            options=kw_all.get("options"),
             ids=kw_all.get("ids"),
             include_sources=kw_all.get("include_sources", False),
             include_edges=kw_all.get("include_edges", False),

--- a/tests/test_mcp/test_context_surface_is_honest.py
+++ b/tests/test_mcp/test_context_surface_is_honest.py
@@ -1,0 +1,126 @@
+"""The advertised `context` surface must match what the dispatcher reads.
+
+`depth` was removed from the context engine in #107 because it cost 226s to
+return byte-identical output. The removal left three doc surfaces still
+naming it and one preserved legacy body still building it into the request,
+and it orphaned `options` — which existed only to carry `depth`, so after the
+removal nothing in `dispatch_query` read it at all.
+
+An advertised parameter that nothing reads is worse than a missing one: a
+caller passes it, sees a normal 200, and believes it took effect.
+"""
+
+import inspect
+import json
+import re
+
+import pytest
+
+from rka.mcp import operations_schema as schema_module
+from rka.mcp import verb_dispatch
+from rka.mcp.operation_args import QueryContextArgs
+
+
+def _context_branch_source() -> str:
+    """The body of `if scope == "context":` inside dispatch_query."""
+    src = inspect.getsource(verb_dispatch.dispatch_query)
+    m = re.search(r'if scope == "context":\n(.*?)(?=\n    if scope|\n    # )', src, re.S)
+    assert m, "could not locate the context branch in dispatch_query"
+    return m.group(1)
+
+
+class TestNothingAdvertisesDepth:
+    def test_the_operation_schema_does_not_name_depth(self):
+        entry = json.dumps(schema_module.OPERATIONS_SCHEMA["context"])
+        assert "depth" not in entry, (
+            "rka_describe('context') still advertises `depth`; the typed model "
+            "rejects it with extra_forbidden, so the docs teach a call that fails"
+        )
+
+    def test_the_typed_model_does_not_name_depth(self):
+        blob = json.dumps(QueryContextArgs.model_json_schema())
+        assert "depth" not in blob
+
+    def test_the_preserved_legacy_body_does_not_build_depth(self):
+        from rka.mcp import server
+
+        src = inspect.getsource(server._rka_query_legacy_impl)
+        branch = re.search(r'if s == "context":\n(.*?)\n    if s ==', src, re.S)
+        assert branch, "could not locate the context branch in the legacy impl"
+        assert "depth" not in branch.group(1)
+
+
+def _local_aliases() -> dict[str, str]:
+    """dispatch_query rebinds its dict params: `f = filters or {}`.
+
+    Resolve those so a branch reading `f.get(...)` counts as consuming
+    `filters`. Without this the check produces false positives on every
+    aliased parameter.
+    """
+    src = inspect.getsource(verb_dispatch.dispatch_query)
+    return {
+        param: local
+        for local, param in re.findall(r"^    (\w+) = (\w+) or \{\}$", src, re.M)
+    }
+
+
+class TestNoAdvertisedParameterIsInert:
+    """Forwarding is not consuming.
+
+    `options` survived #107 because `dispatch_query_typed` still forwarded it
+    while the context branch had stopped reading it. Any check that accepts
+    forwarding as evidence misses exactly this case, so this one looks only at
+    the branch that has to act on the value.
+    """
+
+    def test_every_advertised_field_is_consumed_by_the_context_branch(self):
+        branch = _context_branch_source()
+        aliases = _local_aliases()
+
+        advertised = set(QueryContextArgs.model_fields) - {"operation", "project_id"}
+        assert advertised, "guard against the set silently becoming empty"
+
+        def _used(name: str) -> bool:
+            # Word boundaries matter: the alias for `options` is the single
+            # character `o`, which substring-matches "topic", "or" and
+            # "project_id" in any branch body.
+            return bool(re.search(rf"\b{re.escape(name)}\b", branch))
+
+        unread = sorted(
+            f for f in advertised
+            if not _used(f) and not _used(aliases.get(f, "\0"))
+        )
+        assert not unread, (
+            f"QueryContextArgs advertises {unread}, which the context dispatch "
+            "branch never reads. A caller passing it gets a normal 200 and no "
+            "effect — advertise it only once something consumes it."
+        )
+
+    def test_options_is_gone_from_the_query_dispatcher(self):
+        assert "options" not in inspect.signature(verb_dispatch.dispatch_query).parameters, (
+            "dispatch_query still takes `options`; no read scope consumes it"
+        )
+
+    def test_no_read_scope_consumes_options(self):
+        """Not just context — `options` was read exactly once, for depth."""
+        src = inspect.getsource(verb_dispatch.dispatch_query)
+        assert not re.search(r"\bo\.get\(|\bo\[", src), (
+            "something reads a local `o` again; if a scope needs options, "
+            "restore the parameter and update this test"
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_still_dispatches(monkeypatch):
+    """Removal must not break the operation itself."""
+    seen = {}
+
+    async def _fake(**kw):
+        seen.update(kw)
+        return {"entries": [], "sources": []}
+
+    monkeypatch.setattr(verb_dispatch, "_legacy", lambda name: _fake)
+    await verb_dispatch.dispatch_query(
+        "context", project_id="prj_x", query="topic", filters={"phase": "p"},
+    )
+    assert seen == {"topic": "topic", "phase": "p", "project_id": "prj_x"}

--- a/tests/test_mcp/test_context_surface_is_honest.py
+++ b/tests/test_mcp/test_context_surface_is_honest.py
@@ -41,6 +41,18 @@ class TestNothingAdvertisesDepth:
         blob = json.dumps(QueryContextArgs.model_json_schema())
         assert "depth" not in blob
 
+    def test_the_legacy_tool_docstring_does_not_promise_a_narrative(self):
+        """#107 deleted the `depth:` parameter doc but left its second line,
+        which then read as though `phase` accepted "detailed"."""
+        from rka.mcp import server
+
+        doc = inspect.getdoc(server.rka_get_context) or ""
+        for phrase in ("detailed", "narrative"):
+            assert phrase not in doc.lower(), (
+                f"rka_get_context's docstring still promises {phrase!r}; the "
+                "context engine has produced no narrative since 443a50d"
+            )
+
     def test_the_preserved_legacy_body_does_not_build_depth(self):
         from rka.mcp import server
 


### PR DESCRIPTION
Follow-up to #107. That PR claimed `depth` was removed "end to end — engine, request model, route, dispatch, legacy tool, advertised enum, worked example." Four surfaces still named it, and the removal orphaned the parameter that carried it.

## What still advertised `depth`

| surface | why it matters |
|---|---|
| `operations_schema` signature | this is what `rka_describe('context')` prints |
| `QueryContextArgs.options` description | reaches the MCP `inputSchema` the client sees |
| `dispatch_query` docstring | internal |
| `_rka_query_legacy_impl` | still built `"depth"` into the POST body |

The first two are the harmful ones. They told a caller to pass `options={'depth': 'detailed'}` — and the typed model rejects unknown keys with `extra_forbidden`, so the documentation described a call that could only fail.

## `options` had nothing left to carry

Counting reads of the local `o` inside `dispatch_query`:

```
before #107   1    depth=o.get("depth", "summary")
after  #107   0    across all 68 read operations
```

It existed solely to carry `depth`. After #107 it was an advertised parameter that provably does nothing, which is worse than a missing one: a caller passes it, gets a normal 200, and believes it took effect.

Removed from `QueryContextArgs`, from `dispatch_query`'s signature, and from the typed pass-through in `dispatch_query_typed`. The `options` on `RecordDecisionArgs`, `PresentDecisionArgs` and `SubmitCheckpointArgs` is a decision-option list — a different thing, live, untouched.

Also drops "detailed" from the worked example's description, where it no longer names anything.

## A fifth leftover, found by an adversarial sweep

`rka_get_context`'s Args block lost the `depth:` entry in #107 but kept its continuation line, which then hung under the parameter above it:

```
        phase: Filter to a specific research phase.
            "detailed" adds an LLM-generated narrative if an LLM is configured.
```

Read as written, `phase` accepts `"detailed"`. It does not, and nothing has produced a narrative since 443a50d.

The same sweep confirmed `LLMClient.produce_narrative` (`rka/infra/llm.py:502`) now has zero callers. Left in place — dead but harmless, and deleting it is a separate call.

## Tests

7, checked in both directions: 5 fail against `main`, each naming the defect it catches.

The consumption check took two corrections before it was worth having, and both are the kind of flaw that makes a test look green while proving nothing:

1. It first accepted **forwarding** as evidence of consumption. `dispatch_query_typed` still passed `options=kw_all.get("options")` down to a branch that had stopped reading it — which is precisely how `options` survived #107. A check that counts forwarding cannot catch that.
2. It then matched the parameter's local alias as a **substring**. The alias for `options` is the single character `o`, which matches "topic", "or" and "project_id" in any branch body, so it passed unconditionally.

It now resolves `f = filters or {}` style rebinds and matches on word boundaries. An existing guard, `test_v270_model_drift`, caught the schema half independently — `optional_fields` still listed `options` after the model dropped it.

Full suite: **3318 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
