### PR TITLE
fix(llm): bound the connect attempt and stop retrying refused connections

### DIFF
--- a/rka/infra/llm.py
+++ b/rka/infra/llm.py
@@ -14,6 +14,19 @@ from rka.config import RKAConfig
 logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
+# Establishing a TCP connection either succeeds in well under a second or the
+# host is not going to answer. Passing a bare number as `timeout` replaces
+# openai's whole httpx.Timeout — connect included — so a request budget meant
+# for generation silently became the connect budget too, and an unreachable
+# host burned it in full on every attempt.
+_CONNECT_TIMEOUT_S = 5.0
+
+# The openai SDK client defaults to max_retries=2, i.e. three sends per call,
+# nested inside litellm. Retrying a connection that was refused cannot succeed
+# for a different reason the second time, so the budget only multiplies the
+# stall. litellm maps `num_retries` onto that client-level setting.
+_HEALTH_PROBE_TIMEOUT_S = 60
+
 
 # ---------- Instructor response models ----------
 
@@ -353,7 +366,10 @@ class LLMClient:
                 model=self.model,
                 messages=[{"role": "user", "content": "ping"}],
                 max_tokens=1,
-                timeout=60,
+                timeout=httpx.Timeout(
+                    _HEALTH_PROBE_TIMEOUT_S, connect=_CONNECT_TIMEOUT_S
+                ),
+                num_retries=0,
             )
             if self.config.llm_api_base:
                 kwargs["api_base"] = self.config.llm_api_base
@@ -392,7 +408,13 @@ class LLMClient:
                 messages=messages,
                 temperature=temperature,
                 max_retries=max_retries,
-                timeout=self.config.llm_request_timeout,
+                timeout=httpx.Timeout(
+                    self.config.llm_request_timeout, connect=_CONNECT_TIMEOUT_S
+                ),
+                # instructor consumes `max_retries` above as its own
+                # response-validation counter and never forwards it; this is
+                # the one that reaches the HTTP client.
+                num_retries=0,
                 think=self.config.llm_think,
             )
             if self.config.llm_api_base:

--- a/tests/test_api/test_llm_health.py
+++ b/tests/test_api/test_llm_health.py
@@ -110,16 +110,21 @@ async def test_is_available_falls_back_to_minimal_completion(monkeypatch: pytest
 
     assert await client.is_available() is True
     assert client.available is True
-    assert completion_calls == [
-        {
-            "model": "openai/qwen3.5-35b-a3b",
-            "messages": [{"role": "user", "content": "ping"}],
-            "max_tokens": 1,
-            "timeout": 60,
-            "api_base": "http://example.test/v1",
-            "api_key": "lm-studio",
-        }
-    ]
+    assert len(completion_calls) == 1
+    call = completion_calls[0]
+    timeout = call.pop("timeout")
+    assert call == {
+        "model": "openai/qwen3.5-35b-a3b",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+        "num_retries": 0,
+        "api_base": "http://example.test/v1",
+        "api_key": "lm-studio",
+    }
+    # A bare number would replace openai's whole Timeout, connect included,
+    # and let an unreachable host hold the probe open for the full budget.
+    assert timeout.connect == 5.0
+    assert timeout.read == 60
 
 
 @pytest.mark.asyncio
@@ -157,4 +162,7 @@ async def test_extract_uses_configured_timeout(monkeypatch: pytest.MonkeyPatch):
     )
 
     assert result.answer == "ok"
-    assert captured["timeout"] == 37
+    assert captured["timeout"].read == 37
+    assert captured["timeout"].connect == 5.0
+    # instructor eats `max_retries`; `num_retries` is what reaches the client.
+    assert captured["num_retries"] == 0

--- a/tests/test_infra/test_llm_call_is_bounded.py
+++ b/tests/test_infra/test_llm_call_is_bounded.py
@@ -1,0 +1,102 @@
+"""An unreachable backend must fail fast, not hold the caller for minutes.
+
+Measured against a black-holed host with `llm_request_timeout=120`:
+
+    as shipped                     227.89s   3 HTTP sends
+    + num_retries=0                 75.04s   1 send
+    + httpx.Timeout(connect=5.0)    16.27s   3 sends
+    + both                           5.04s   1 send
+
+Two separate causes, and neither is the setting that looks responsible:
+
+  * Three sends come from the openai SDK client's own `max_retries=2`
+    default, nested inside litellm. `extract()`'s `max_retries` is consumed
+    by instructor as a response-validation counter and never reaches the
+    HTTP client — 0, 1, 2 and 3 all produce exactly three sends.
+  * Passing a bare number as `timeout` replaces openai's whole
+    `httpx.Timeout`, connect included, so a budget meant for generation
+    became the connect budget as well.
+"""
+
+import inspect
+
+import httpx
+
+from rka.config import RKAConfig
+from rka.infra import llm as llm_module
+from rka.infra.llm import LLMClient
+
+
+def _kwargs_from(monkeypatch, coro_factory):
+    captured: dict = {}
+
+    class _FakeCompletions:
+        async def create(self, **kw):
+            captured.update(kw)
+            raise RuntimeError("stop here; only the kwargs matter")
+
+    class _FakeChat:
+        completions = _FakeCompletions()
+
+    class _FakeInstructor:
+        chat = _FakeChat()
+
+    monkeypatch.setattr(LLMClient, "_get_instructor", lambda self: _FakeInstructor())
+    return captured
+
+
+class TestConnectIsBoundedSeparately:
+    def test_the_connect_budget_is_not_the_request_budget(self):
+        assert llm_module._CONNECT_TIMEOUT_S == 5.0
+
+    def test_extract_passes_a_split_timeout(self, monkeypatch):
+        import asyncio
+
+        from pydantic import BaseModel
+
+        class _R(BaseModel):
+            answer: str
+
+        captured = _kwargs_from(monkeypatch, None)
+        client = LLMClient(
+            RKAConfig(
+                llm_enabled=True,
+                llm_model="openai/test",
+                llm_api_base="http://example.test/v1",
+                llm_request_timeout=90,
+            )
+        )
+        try:
+            asyncio.run(client.extract(_R, messages=[{"role": "user", "content": "x"}]))
+        except Exception:
+            pass
+
+        timeout = captured.get("timeout")
+        assert isinstance(timeout, httpx.Timeout), (
+            "a bare number replaces openai's whole Timeout, connect included, "
+            "so an unreachable host holds the call for the full request budget"
+        )
+        assert timeout.connect == 5.0
+        assert timeout.read == 90
+
+
+class TestConnectionFailuresAreNotRetried:
+    def test_extract_pins_the_client_level_retry_count(self):
+        src = inspect.getsource(LLMClient.extract)
+        assert "num_retries=0" in src, (
+            "without num_retries the openai SDK client retries twice more; "
+            "a refused connection fails identically each time"
+        )
+
+    def test_max_retries_is_not_mistaken_for_the_http_retry_count(self):
+        """instructor eats `max_retries`; it never reaches the HTTP client."""
+        src = inspect.getsource(LLMClient.extract)
+        assert "max_retries=max_retries" in src and "num_retries=0" in src, (
+            "both must be present and distinct; collapsing them re-creates the "
+            "228s stall while looking like it bounds retries"
+        )
+
+    def test_the_health_probe_is_bounded_too(self):
+        src = inspect.getsource(LLMClient.is_available)
+        assert "num_retries=0" in src
+        assert "_CONNECT_TIMEOUT_S" in src


### PR DESCRIPTION
An LLM call against a backend that does not answer held the caller for nearly four minutes. Measured against a black-holed host with the shipped default `llm_request_timeout=120`, HTTP sends counted at the httpx layer:

| | wall clock | sends |
|---|---|---|
| as shipped | **227.89s** | 3 |
| `+ num_retries=0` | 75.04s | 1 |
| `+ httpx.Timeout(connect=5.0)` | 16.27s | 3 |
| **both** | **5.04s** | 1 |

Two independent causes. Neither is the setting that looks responsible.

## Three sends, not one

They come from the openai SDK client's own `DEFAULT_MAX_RETRIES = 2`, which litellm passes into the `AsyncOpenAI` constructor. `extract()`'s `max_retries` never reaches it — instructor consumes that as its own **response-validation** counter, and `0`, `1`, `2` and `3` all produce exactly three sends. litellm's `Total attempts: 1` in the logs counts a *third* retry layer, which is off.

Three layers named almost the same thing, and the one the code sets is the one that does not apply. Retrying a refused connection cannot succeed for a different reason the second time, so the budget only multiplies the stall. `num_retries` is what litellm maps onto the client-level setting.

## 75s per attempt, not 120

Passing a bare number as `timeout` replaces openai's entire `httpx.Timeout` — **connect included** — so a budget meant for generation became the connect budget too. Every attempt then ended as `ConnectError` at the platform's ~75s ceiling rather than as `ConnectTimeout` at 120s.

Which means `llm_request_timeout` was **inert above ~75s**. A single attempt at `timeout=200` still measured 75.16s. Raising it was never going to help, and lowering it would have been the wrong knob to present as the fix. The in-repo precedent for the split form is `server.py:355`, which already uses `Timeout(connect=30, read=120, …)`.

## Verified on the edited source

Not on a patched variant — the file as committed, loaded from a temp path so the running container's `/app` stayed untouched:

```
extract()       227.89s -> 6.38s     3 sends -> 1
is_available()  194.15s -> 15.07s
```

10.06s of the remaining 15.07s is `_probe_models_endpoint`'s two-endpoint sweep, already bounded at 5s each; litellm itself now sends once.

## Scope

No capability changes. A reachable backend takes the same path it always did; only the failure case is bounded. Retries on transient 429/5xx are given up along with retries on refused connections — if those turn out to matter, `num_retries=1` is the conservative middle.

This is the cost half only. Making the failure *visible* — `workspace.py` swallows per-file LLM failures at `logger.debug` and returns HTTP 200 with `warnings=[]`; six services report `reason: "llm_disabled"` when the backend is enabled-but-dead — is a separate change, as is the startup probe at `app.py:87`, which retries six times and can spend ~20 minutes per container start with nothing surfaced.

## Tests

5 new, plus two existing locks rewritten. Both asserted the old shape by exact equality — one on the whole litellm kwargs dict, one on `timeout == 37` — so they had to move with the change; they now pin the new property (split connect/read, `num_retries=0`) rather than the old literal.

One test is deliberately awkward: it requires `max_retries=max_retries` **and** `num_retries=0` to both be present and distinct. Collapsing them looks like tidying and silently restores the 228s stall.

Full suite: **3316 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)