### PR TITLE
fix(api): let project blockers be written as the list they are advertised as

### DIFF
--- a/rka/models/project.py
+++ b/rka/models/project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ProjectState(BaseModel):
@@ -38,8 +38,30 @@ class ProjectStateUpdate(BaseModel):
     current_phase: str | None = None
     phases_config: list[str] | None = None
     summary: str | None = None
-    blockers: str | None = None
+    blockers: str | list[str] | None = None
     metrics: dict[str, Any] | None = None
+
+    @field_validator("blockers", mode="before")
+    @classmethod
+    def _blockers_to_text(cls, v: Any) -> Any:
+        """Accept a list, store the free text the column is declared as.
+
+        `project_status.blockers` is `TEXT -- Current blockers (free text)`,
+        and this model matched it. The typed MCP surface advertises
+        `Optional[list[str]]`, so every list sent through the connector died
+        at this boundary with `Input should be a valid string` — the two
+        halves of one field disagreed, and the half a caller reads in
+        `rka_describe` was the half that could not be written.
+
+        Widening here rather than joining in the MCP dispatcher fixes it for
+        REST and the web UI too, and leaves storage and the read model alone.
+        Entries are joined verbatim, without renumbering: callers that
+        already number their own lines must not get numbered twice.
+        """
+        if isinstance(v, list):
+            joined = "\n".join(str(item).strip() for item in v if str(item).strip())
+            return joined or None
+        return v
 
 
 class ProjectInfo(BaseModel):

--- a/tests/test_api/test_blockers_accepts_a_list.py
+++ b/tests/test_api/test_blockers_accepts_a_list.py
@@ -1,0 +1,62 @@
+"""The two halves of `blockers` disagreed about its type.
+
+`UpdateStatusArgs.blockers` — the typed MCP surface, and what
+`rka_describe('update_status')` shows a caller — is `Optional[list[str]]`.
+`ProjectStateUpdate.blockers` was `str | None`, matching the column, which is
+`TEXT -- Current blockers (free text)`.
+
+So every list sent through the connector died at the REST boundary with
+`Input should be a valid string`. The half a caller reads was the half that
+could not be written, and the field stayed stale in this project's own status
+for long enough that the staleness was itself recorded as a blocker.
+"""
+
+import pytest
+
+from rka.mcp.operation_args import UpdateStatusArgs
+from rka.models.project import ProjectStateUpdate
+
+
+class TestTheAdvertisedTypeIsWritable:
+    def test_the_mcp_surface_still_advertises_a_list(self):
+        """If this changes, the fix below is aimed at the wrong half."""
+        assert UpdateStatusArgs.model_fields["blockers"].annotation == (
+            list[str] | None
+        )
+
+    def test_a_list_is_accepted(self):
+        assert ProjectStateUpdate(blockers=["first", "second"]).blockers == (
+            "first\nsecond"
+        )
+
+    def test_a_string_still_is(self):
+        """Existing REST and web-UI callers must not break."""
+        assert ProjectStateUpdate(blockers="one long line").blockers == "one long line"
+
+    def test_none_stays_none(self):
+        assert ProjectStateUpdate(blockers=None).blockers is None
+
+
+class TestJoiningDoesNotEditTheCaller:
+    def test_entries_are_not_renumbered(self):
+        """Callers that number their own lines must not be numbered twice."""
+        out = ProjectStateUpdate(blockers=["1. alpha", "2. beta"]).blockers
+        assert out == "1. alpha\n2. beta"
+        assert "1. 1." not in out
+
+    def test_blank_entries_are_dropped(self):
+        assert ProjectStateUpdate(blockers=["a", "", "   ", "b"]).blockers == "a\nb"
+
+    def test_an_empty_list_clears_rather_than_storing_an_empty_string(self):
+        assert ProjectStateUpdate(blockers=[]).blockers is None
+
+
+class TestTheRestOfTheModelIsUnchanged:
+    def test_unknown_fields_are_still_rejected(self):
+        """extra='forbid' guards against silent write failures —
+        see mis_01KQJH9MB65AR0GSVPQBT8707X."""
+        with pytest.raises(Exception):
+            ProjectStateUpdate(blockrs=["typo"])
+
+    def test_other_list_fields_are_untouched(self):
+        assert ProjectStateUpdate(phases_config=["a", "b"]).phases_config == ["a", "b"]


### PR DESCRIPTION
The two halves of one field disagreed about its type.

| | type |
|---|---|
| `UpdateStatusArgs.blockers` — the typed MCP surface, and what `rka_describe('update_status')` shows a caller | `Optional[list[str]]` |
| `ProjectStateUpdate.blockers` — the REST boundary | `str \| None` |
| `project_status.blockers` — storage | `TEXT -- Current blockers (free text)` |

So every list sent through the connector died at the boundary:

```
HTTP 422: blockers=[...]: Input should be a valid string
```

**The half a caller reads was the half that could not be written.** This repository's own RKA project status carried the consequence: three stale blockers nobody could remove, and a note in the summary explaining that the field *"cannot currently be replaced through the connector"* — the defect had become a blocker about itself.

## Where to fix it

At the boundary where the two shapes meet, not by joining in the MCP dispatcher. Joining in the dispatcher would leave a REST or web-UI caller sending a list still getting a 422, so the field would be writable from exactly one of the three surfaces that touch it. Widening `ProjectStateUpdate` fixes all three and leaves storage and the read model alone — the column is free text by design and stays that way.

Entries are joined with newlines, **verbatim**: callers that number their own lines must not be numbered twice. Blank entries are dropped, so an all-empty list clears the field rather than storing `""`.

## Tests

9, four of which fail against `main`.

One of them asserts that the MCP surface *still advertises a list*. If that half is ever changed instead, this fix would be left aimed at the wrong side and silently pointless — that test fails loudly instead.

Full suite: **3345 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)