### PR TITLE
fix(journal): stop the write path corrupting and hiding what it records

### DIFF
--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -3814,6 +3814,17 @@ class UpdateNoteArgs(ProjectScopedArgs):
         Optional[str],
         Field(default=None, description="New content body."),
     ] = None
+    summary: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description=(
+                "New short summary. RecordNoteArgs could write this and "
+                "UpdateNoteArgs could not correct it, so a summary written "
+                "through the agent surface was uneditable there."
+            ),
+        ),
+    ] = None
     type: Annotated[
         Optional[NoteTypeLit],
         Field(default=None, description=(

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -2123,13 +2123,14 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "summary": "Update a journal entry (content, type, confidence, links).",
         "signature": (
             "rka_execute(operation='update_note', *, project_id, id, "
-            "content=None, type=None, confidence=None, importance=None, "
-            "tags=None, phase=None, related_decisions=None, "
+            "content=None, summary=None, type=None, confidence=None, "
+            "importance=None, tags=None, phase=None, related_decisions=None, "
             "related_literature=None, related_mission=None)"
         ),
         "required_fields": ["project_id", "id"],
         "optional_fields": [
             "content",
+            "summary",
             "type",
             "confidence",
             "importance",

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -2129,6 +2129,29 @@ EXECUTE_OPERATIONS = (
 )
 
 
+# Operations that MODIFY an existing row, where `source`, `confidence` and
+# `importance` must never be supplied by dispatch_execute's own signature
+# defaults. Threading them in rewrote fields the caller never mentioned: a PI
+# directive became an executor note and a `verified` finding reverted to
+# `hypothesis`, while `verbatim_input` survived the demotion so the row went
+# on to assert the Executor had written the PI's exact words.
+# The signature defaults for the three fields above, kept beside the set that
+# governs them so the two cannot drift apart.
+_IDENTITY_FIELD_DEFAULTS = {
+    "source": "executor",
+    "confidence": "hypothesis",
+    "importance": "normal",
+}
+
+_IDENTITY_SENSITIVE_UPDATES = frozenset({
+    "update_note",
+    "update_decision",
+    "update_literature",
+    "update_status",
+    "bulk_update",
+})
+
+
 async def dispatch_execute(
     operation: str,
     *,
@@ -2802,9 +2825,19 @@ async def dispatch_execute(
     }
     if op in _REVIEW_OP_MAP:
         payload = dict(kw)
-        # Always thread the operation-common kwargs into the payload
-        # when they're not already present — preserves the existing
-        # dispatch_review payload semantics.
+        # Thread the operation-common kwargs into the payload when they are
+        # not already present.
+        #
+        # On an update, three of them must not be threaded in unless the
+        # caller actually asked for them. They are lifted into named
+        # arguments by dispatch_execute_typed, so by the time they arrive
+        # here an omitted field and one the caller passed look identical —
+        # the only thing left to compare against is the default itself.
+        #
+        # A value that differs from the default was passed. A value equal to
+        # it either was omitted, or was passed and is a no-op write on an
+        # update; skipping both is correct, because writing "hypothesis" over
+        # a stored `verified` is exactly the damage.
         for k, v in (
             ("source", source),
             ("confidence", confidence),
@@ -2813,6 +2846,12 @@ async def dispatch_execute(
             ("phase", phase),
             ("tags", tags),
         ):
+            if (
+                op in _IDENTITY_SENSITIVE_UPDATES
+                and k in _IDENTITY_FIELD_DEFAULTS
+                and v == _IDENTITY_FIELD_DEFAULTS[k]
+            ):
+                continue
             payload.setdefault(k, v)
         return await dispatch_review(
             _REVIEW_OP_MAP[op],

--- a/rka/models/journal.py
+++ b/rka/models/journal.py
@@ -67,7 +67,20 @@ class JournalEntryCreate(BaseModel):
     content: str
     type: AnyJournalType = "note"
     summary: str | None = None
-    source: Literal["brain", "executor", "pi", "web_ui", "llm"] = "pi"
+    # Defaults to `executor`, matching RecordNoteArgs on the MCP surface.
+    # It defaulted to `pi` here, so any REST caller that omitted the field
+    # silently claimed PI authorship — the strongest provenance signal in the
+    # system, asserted by omission. 46 live entries claim source='pi' with no
+    # verbatim record, 22 of them in real research projects, and none of them
+    # came from a caller that meant to say it.
+    #
+    # The `source='pi' requires verbatim_input` rule is NOT enforced here.
+    # verbatim_input guards restatement — an agent putting the PI's meaning
+    # in its own words — and RecordNoteArgs enforces it on the surface where
+    # that happens. This model also serves workspace ingest, where `content`
+    # IS the PI's document and there is nothing to restate. The layer cannot
+    # tell the two apart, so it declines to guess.
+    source: Literal["brain", "executor", "pi", "web_ui", "llm"] = "executor"
     phase: str | None = None
     verbatim_input: str | None = None
     related_decisions: list[str] | None = None

--- a/rka/models/workspace.py
+++ b/rka/models/workspace.py
@@ -118,7 +118,7 @@ class WorkspaceIngestRequest(BaseModel):
         description="Tags to add to all ingested entries.",
     )
     phase: str | None = None
-    source: Literal["brain", "executor", "pi", "web_ui", "llm"] = "pi"
+    source: Literal["brain", "executor", "pi", "web_ui", "llm"] = "executor"
     dry_run: bool = False
 
 
@@ -202,6 +202,6 @@ class IngestFileRequest(BaseModel):
     content_type: str  # "text" | "bibtex" | "code" | "pdf_metadata"
     metadata: dict = Field(default_factory=dict)
     tags: list[str] = Field(default_factory=list)
-    source: str = "pi"
+    source: str = "executor"
     phase: str | None = None
     proposed_type: str = "finding"

--- a/rka/services/notes.py
+++ b/rka/services/notes.py
@@ -74,9 +74,15 @@ class NoteService(BaseService):
 
             # If superseding another entry, update the back-reference.
             if data.supersedes:
+                # `status` is what list() filters on for hide_superseded
+                # (see the `status != 'superseded'` condition below); setting
+                # only `confidence` meant the flag never hid anything. 26
+                # superseded entries were live, 0 of them filterable.
+                # `decisions.py` has always set status here.
                 await self.db.execute(
                     "UPDATE journal SET superseded_by = ?, confidence = 'superseded', "
-                    "updated_at = ? WHERE id = ? AND project_id = ?",
+                    "status = 'superseded', updated_at = ? "
+                    "WHERE id = ? AND project_id = ?",
                     [entry_id, _now(), data.supersedes, self.project_id],
                 )
 
@@ -121,10 +127,14 @@ class NoteService(BaseService):
                 )
 
             # Sync cheap deterministic FTS now; enrichment is queued.
+            # `summary` is the condensed restatement — the text most likely
+            # to be searched for. Passing "" here left it unsearchable until
+            # someone edited the entry or ran a reindex; update() has always
+            # passed the real row.
             await self._sync_fts(
                 "journal",
                 entry_id,
-                {"content": data.content, "summary": ""},
+                {"content": data.content, "summary": data.summary or ""},
             )
             await self._enqueue_enrichment_jobs(
                 entry_id,

--- a/tests/test_services/test_journal_write_path.py
+++ b/tests/test_services/test_journal_write_path.py
@@ -1,0 +1,289 @@
+"""What a journal entry is, and who wrote it.
+
+Five defects in one write path, each of which corrupted or hid the record
+rather than failing:
+
+  A1  a partial update rewrote `source`, `confidence` and `importance` to the
+      dispatcher's create-time defaults, so a PI directive became an executor
+      note and a `verified` finding reverted to `hypothesis` — while
+      `verbatim_input` survived, leaving the row asserting that the Executor
+      had written the PI's exact words.
+  A5  superseding set `confidence` but not `status`, and `hide_superseded`
+      filters on `status`. 26 superseded entries were live; 0 were filterable.
+  A6  `summary` was written to FTS as the empty string at create time.
+  B5  REST defaulted `source` to 'pi' and never checked `verbatim_input`,
+      so omitting a field claimed PI authorship. 46 live entries claim it
+      with no verbatim record, 22 in real research projects.
+  D3  `record_note` could write `summary`; `update_note` could not correct it.
+"""
+
+import inspect
+
+import pytest
+
+from rka.infra.database import Database
+
+from rka.mcp import verb_dispatch
+from rka.mcp.operation_args import RecordNoteArgs, UpdateNoteArgs
+from rka.models.journal import JournalEntryCreate, JournalEntryUpdate
+
+
+class TestAnUpdateDoesNotFabricateIdentity:
+    """A1 — the one that corrupted data at rest."""
+
+    @pytest.mark.asyncio
+    async def test_update_note_sends_only_what_the_caller_set(self, monkeypatch):
+        captured: dict = {}
+
+        async def _fake_review(op, *, project_id, payload, **kw):
+            captured["op"] = op
+            captured["payload"] = payload
+            return "{}"
+
+        monkeypatch.setattr(verb_dispatch, "dispatch_review", _fake_review)
+        await verb_dispatch.dispatch_execute(
+            "update_note", project_id="prj_x", id="jrn_x", content="revised",
+        )
+
+        payload = captured["payload"]
+        for field in ("source", "confidence", "importance"):
+            assert field not in payload or payload[field] is None, (
+                f"update_note fabricated {field}={payload.get(field)!r}; the "
+                "caller never mentioned it, and writing it rewrites the row"
+            )
+        assert payload.get("content") == "revised"
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_value_still_reaches_the_payload(self, monkeypatch):
+        """Skipping the defaults must not skip what the caller asked for."""
+        captured: dict = {}
+
+        async def _fake_review(op, *, project_id, payload, **kw):
+            captured.update(payload)
+            return "{}"
+
+        monkeypatch.setattr(verb_dispatch, "dispatch_review", _fake_review)
+        await verb_dispatch.dispatch_execute(
+            "update_note", project_id="prj_x", id="jrn_x",
+            confidence="verified", source="pi", verbatim_input="exact words",
+        )
+        assert captured["confidence"] == "verified"
+        assert captured["source"] == "pi"
+
+    @pytest.mark.asyncio
+    async def test_creates_still_get_their_defaults(self, monkeypatch):
+        """The defaults exist for a reason; only updates must skip them."""
+        captured: dict = {}
+
+        async def _fake_review(op, *, project_id, payload, **kw):
+            captured.update(payload)
+            return "{}"
+
+        monkeypatch.setattr(verb_dispatch, "dispatch_review", _fake_review)
+        await verb_dispatch.dispatch_execute(
+            "create_cluster", project_id="prj_x", label="c",
+        )
+        assert captured.get("source") == "executor"
+
+    def test_the_recorded_defaults_match_the_real_signature(self):
+        """The rule compares against a copy of the signature defaults.
+
+        If the signature changes and the copy does not, the comparison
+        silently stops matching and every update starts fabricating again.
+        """
+        sig = inspect.signature(verb_dispatch.dispatch_execute)
+        for field, recorded in verb_dispatch._IDENTITY_FIELD_DEFAULTS.items():
+            assert sig.parameters[field].default == recorded, (
+                f"dispatch_execute({field}=...) defaults to "
+                f"{sig.parameters[field].default!r}, but the rule compares "
+                f"against {recorded!r}"
+            )
+
+    def test_every_mutating_op_in_the_map_is_covered(self):
+        """A new update op added to _REVIEW_OP_MAP must join the skip set.
+
+        Scoped to that map specifically: dispatch_execute contains other
+        op->action dicts, and `update_mission` lives in one of them and takes
+        a different path entirely.
+        """
+        import re
+
+        src = inspect.getsource(verb_dispatch.dispatch_execute)
+        block = src.split("_REVIEW_OP_MAP = {")[1].split("}")[0]
+        mapped = set(re.findall(r'"(\w+)":', block))
+        mutating = {o for o in mapped if o.startswith("update_") or o == "bulk_update"}
+        assert mutating, "guard against the extraction silently matching nothing"
+        assert mutating <= set(verb_dispatch._IDENTITY_SENSITIVE_UPDATES), (
+            f"{sorted(mutating - set(verb_dispatch._IDENTITY_SENSITIVE_UPDATES))} "
+            "mutate an existing row but would still receive fabricated defaults"
+        )
+
+
+class TestSupersedingHides:
+    """A5."""
+
+    def test_supersede_sets_the_field_the_filter_reads(self):
+        from rka.services import notes
+
+        create_src = inspect.getsource(notes.NoteService.create)
+        stmt = create_src.split("superseded_by = ?")[1][:200]
+        assert "status = 'superseded'" in stmt, (
+            "hide_superseded filters on status; setting only confidence "
+            "meant the flag never hid anything"
+        )
+
+    def test_the_filter_still_reads_status(self):
+        """If the filter moves, the fix above is aimed at the wrong column."""
+        from rka.services import notes
+
+        assert "status != 'superseded'" in inspect.getsource(notes.NoteService.list)
+
+
+class TestTheSummaryIsSearchable:
+    """A6 + D3 — together, a summary was unsearchable and uncorrectable."""
+
+    def test_create_indexes_the_summary_it_was_given(self):
+        from rka.services import notes
+
+        src = inspect.getsource(notes.NoteService.create)
+        assert '"summary": data.summary or ""' in src
+        assert '{"content": data.content, "summary": ""}' not in src
+
+    def test_update_note_can_correct_a_summary(self):
+        assert "summary" in UpdateNoteArgs.model_fields, (
+            "record_note could write summary and update_note could not fix it"
+        )
+
+    def test_the_advertised_schema_agrees(self):
+        from rka.mcp.operations_schema import OPERATIONS_SCHEMA
+
+        entry = OPERATIONS_SCHEMA["update_note"]
+        assert "summary" in entry["optional_fields"]
+        assert "summary=None" in entry["signature"]
+
+
+class TestPiAuthorshipIsClaimedNotAssumed:
+    """B5."""
+
+    def test_omitting_source_does_not_claim_pi(self):
+        assert JournalEntryCreate(content="x").source == "executor"
+
+    def test_the_two_surfaces_now_agree(self):
+        assert (
+            JournalEntryCreate.model_fields["source"].default
+            == RecordNoteArgs.model_fields["source"].default
+        )
+
+    def test_an_explicit_pi_claim_is_still_allowed(self):
+        """The rule lives on the MCP surface, not here.
+
+        `verbatim_input` guards restatement — an agent putting the PI's
+        meaning in its own words — and RecordNoteArgs enforces it there.
+        This model also serves workspace ingest, where `content` IS the PI's
+        document and there is nothing to restate, so enforcing at this layer
+        would reject a legitimate claim it cannot distinguish from a false
+        one. Only the silent default was the defect.
+        """
+        assert JournalEntryCreate(content="x", source="pi").source == "pi"
+
+    def test_the_mcp_surface_still_enforces_it(self):
+        from rka.mcp.operation_args import RecordNoteArgs
+
+        with pytest.raises(ValueError, match="verbatim_input"):
+            RecordNoteArgs(operation="record_note", project_id="prj_x",
+                           content="x", source="pi")
+
+    def test_a_partial_update_that_omits_source_is_untouched(self):
+        assert JournalEntryUpdate(content="y").source is None
+
+    def test_workspace_ingest_no_longer_defaults_to_pi_either(self):
+        """The same silent claim existed in the ingest request models."""
+        from rka.models.workspace import WorkspaceIngestRequest
+
+        assert WorkspaceIngestRequest.model_fields["source"].default == "executor"
+
+
+async def _ensure_project(db, project_id: str) -> None:
+    await db.execute(
+        "INSERT OR IGNORE INTO projects (id, name, description, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        [project_id, "T", "T", "system"],
+    )
+
+
+class TestTheRoundTrip:
+    """End to end, against a real DB: the corruption A1 caused."""
+
+    @pytest.mark.asyncio
+    async def test_a_content_edit_does_not_demote_a_pi_directive(self, db: Database):
+        from rka.services.notes import NoteService
+
+        await _ensure_project(db, "prj_rt")
+        svc = NoteService(db, llm=None, embeddings=None, project_id="prj_rt")
+
+        entry = await svc.create(
+            JournalEntryCreate(
+                content="Paraphrase of what the PI asked for.",
+                type="directive",
+                source="pi",
+                verbatim_input="Do it this way, exactly.",
+                confidence="verified",
+                importance="critical",
+            ),
+        )
+
+        # Take the payload dispatch_execute actually builds and apply it.
+        # Calling svc.update directly would pass on main too — the service
+        # was never the problem; the fabrication happened one layer up, and a
+        # round-trip that skips that layer proves nothing.
+        captured: dict = {}
+
+        async def _capture(op, *, project_id, payload, **kw):
+            captured.update(payload)
+            return "{}"
+
+        import pytest as _pytest  # noqa: F401
+        from _pytest.monkeypatch import MonkeyPatch
+
+        mp = MonkeyPatch()
+        try:
+            mp.setattr(verb_dispatch, "dispatch_review", _capture)
+            await verb_dispatch.dispatch_execute(
+                "update_note", project_id="prj_rt", id=entry.id,
+                content="Revised paraphrase.",
+            )
+        finally:
+            mp.undo()
+
+        captured.pop("id", None)
+        await svc.update(entry.id, JournalEntryUpdate(**captured))
+
+        after = await svc.get(entry.id)
+        assert after.content == "Revised paraphrase."
+        assert after.source == "pi", (
+            "the PI directive became an executor note on a content edit"
+        )
+        assert after.confidence == "verified", "a verified finding reverted"
+        assert after.importance == "critical"
+        assert after.verbatim_input == "Do it this way, exactly.", (
+            "verbatim survived the demotion, which is what made the row assert "
+            "that the Executor had written the PI's exact words"
+        )
+
+    @pytest.mark.asyncio
+    async def test_superseding_hides_the_old_entry(self, db: Database):
+        from rka.services.notes import NoteService
+
+        await _ensure_project(db, "prj_sup")
+        svc = NoteService(db, llm=None, embeddings=None, project_id="prj_sup")
+
+        old = await svc.create(JournalEntryCreate(content="First finding."))
+        await svc.create(
+            JournalEntryCreate(content="Corrected.", supersedes=old.id),
+        )
+
+        hidden = {e.id for e in await svc.list(hide_superseded=True)}
+        assert old.id not in hidden, "hide_superseded did not hide it"
+
+        shown = {e.id for e in await svc.list(hide_superseded=False)}
+        assert old.id in shown, "it must still be reachable when not hidden"


### PR DESCRIPTION
Five defects in one path. Each wrote or concealed something rather than failing, so none of them looked like an error. First of the work plan's nine PRs; ranked first because these corrupt data at rest, and every day they run the damage grows.

## A partial update rewrote `source`, `confidence` and `importance`

`dispatch_execute` threads its own signature defaults into every payload it builds, and update operations went through the same loop as creates. Editing an entry's **content** also wrote `source='executor'`, `confidence='hypothesis'`, `importance='normal'` over whatever was there.

A PI directive became an executor note. A `verified` finding reverted to `hypothesis`. And `verbatim_input` survived the demotion — so the row went on to assert that **the Executor had written the PI's exact words**. Only on the MCP surface: the one Brain and Executor actually use.

### The obvious fix is wrong

Skipping those keys on updates drops the caller's explicit values too. `dispatch_execute_typed` lifts them into *named arguments*, so by the time `dispatch_execute` sees them, a value the caller passed and one it defaulted are indistinguishable. My first attempt did exactly this and a test caught it.

The rule compares against the default instead:

| caller | value | action |
|---|---|---|
| passed something else | differs | keep |
| passed the default | equal | skip — and skipping is right, a no-op write on an update |
| omitted | equal | skip |

Writing `"hypothesis"` over a stored `"verified"` is precisely the damage, so the middle row is not a compromise. A test pins the recorded defaults against the real signature, so the comparison cannot silently stop matching.

## Superseding never hid anything

`list(hide_superseded=True)` filters on `status != 'superseded'`. `create()` set only `confidence`. **26 live entries carry `superseded_by`; 0 were filterable.** `decisions.py` has always set `status`.

## The summary was indexed as the empty string

`create()` passed `{"summary": ""}` to FTS while `update()` passed the real row — so a summary was unsearchable until someone happened to edit the entry. 23 live rows affected.

Compounding it: `UpdateNoteArgs` had no `summary` field at all. `record_note` could write one and `update_note` could not correct it. Added, with the advertised schema kept in step.

## REST claimed PI authorship by omission

`JournalEntryCreate` defaulted `source` to `'pi'`; the MCP surface defaults to `'executor'`. A caller that omitted the field asserted the strongest provenance signal in the system.

**46 live entries claim `source='pi'` with no verbatim record, 22 in real research projects, and none came from a caller that meant to say it** — I checked `bootstrap_log`, and zero are ingest artifacts. The workspace ingest request models carried the same default. All now match MCP.

### One rule deliberately not mirrored

I first added `source='pi' requires verbatim_input` to these models, matching `RecordNoteArgs`. It broke six workspace-ingest tests that were right to pass, and that is the finding: `verbatim_input` guards **restatement** — an agent putting the PI's meaning in its own words. `JournalEntryCreate` also serves ingest, where `content` **is** the PI's document and there is nothing to restate. The layer cannot tell the two apart, so it declines to guess. MCP still enforces it where restatement happens. Only the silent default was the defect.

## Tests

18. The two round-trips run the payload `dispatch_execute` actually builds through the service against a real DB.

An earlier version called the service directly — and **passed against `main`**, because the service was never the problem and a round-trip that skips the guilty layer proves nothing. Rewritten to go through dispatch, it fails on `main` with `assert 'executor' == 'pi'`.

Against `main`, 11 of 18 fail.

Full suite: **3363 passed**.

## Scope

Deliberately excludes the other eight PRs in the plan. Nothing here needs a migration, and the historical rows are left alone: backfilling `status='superseded'` for the 26, and reindexing the 23 summaries, belong with the reconciliation PR that also repairs the orphaned index rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)