### PR TITLE
fix(embeddings): replace an entity's vector instead of keeping the old one

### DIFF
--- a/rka/infra/embeddings.py
+++ b/rka/infra/embeddings.py
@@ -176,8 +176,25 @@ class EmbeddingService:
             import struct
 
             vec_blob = struct.pack(f"{len(embedding)}f", *embedding)
+            # sqlite-vec vec0 tables do not honour the REPLACE conflict
+            # clause: re-embedding an entity that already has a vector raises
+            # "UNIQUE constraint failed on <table> primary key". The caller
+            # swallowed that, so an edited entity kept the vector for its
+            # withdrawn text — semantically retrievable by wording that is no
+            # longer there, and unretrievable by the wording that is. FTS
+            # updated correctly, so the entry looked repaired. It never
+            # self-healed: every later edit raised and was swallowed again.
+            #
+            # DELETE-then-INSERT is the form already proven in
+            # embedding_backfill.py. Both statements share the commit below,
+            # so a failed INSERT cannot leave the entity with no vector at all
+            # — which would be worse than a stale one.
             await self.db.execute(
-                f"INSERT OR REPLACE INTO {table} (id, embedding) VALUES (?, ?)",
+                f"DELETE FROM {table} WHERE id = ?",
+                [entity_id],
+            )
+            await self.db.execute(
+                f"INSERT INTO {table} (id, embedding) VALUES (?, ?)",
                 [entity_id, vec_blob],
             )
             await self.db.execute(

--- a/rka/services/base.py
+++ b/rka/services/base.py
@@ -258,7 +258,15 @@ class BaseService:
                 project_id=self.project_id,
             )
         except Exception as exc:
-            logger.debug("Embedding sync failed for %s/%s: %s", entity_type, entity_id, exc)
+            # Was `debug`, i.e. off by default, so a permanently stale vector
+            # produced no signal anywhere. Matches the wording _sync_fts has
+            # always used for the same class of failure.
+            logger.warning(
+                "Embedding sync failed for %s/%s: %s — vector index NOT updated "
+                "for this entity; it remains searchable by its previous text. "
+                "Run an embedding backfill to repair.",
+                entity_type, entity_id, exc,
+            )
 
     async def _sync_indexes(self, entity_type: str, entity_id: str, data: dict) -> None:
         """Sync both FTS5 and embedding indexes for an entity."""

--- a/tests/test_infra/test_vector_reembed_in_place.py
+++ b/tests/test_infra/test_vector_reembed_in_place.py
@@ -1,0 +1,137 @@
+"""Re-embedding an entity must replace its vector, not keep the old one.
+
+`vec0` virtual tables do not honour the REPLACE conflict clause. The write
+path used `INSERT OR REPLACE`, so every re-embed of an entity that already
+had a vector raised `UNIQUE constraint failed on <table> primary key` — and
+`BaseService._sync_embedding` swallowed that at `logger.debug`, which is off
+by default.
+
+The result: an edited entry kept the vector for its withdrawn text. It stayed
+semantically retrievable by wording that is no longer in it, and was
+unretrievable by the wording that is. FTS updated correctly, so the entry
+looked repaired. It never self-healed — every later edit raised and was
+swallowed again.
+
+Nothing in this suite re-embedded in place before, which is why the defect
+survived the PRs (#101, #106) that fixed the same bug in the backfill path.
+"""
+
+import inspect
+import struct
+
+import pytest
+
+from rka.infra.database import Database
+from rka.services.base import BaseService
+
+
+def _vec(*values: float) -> bytes:
+    return struct.pack(f"{len(values)}f", *values)
+
+
+class TestVec0RejectsReplace:
+    """The premise. If this ever stops being true, the fix is unnecessary."""
+
+    def test_insert_or_replace_raises_on_a_vec0_table(self):
+        import sqlite3
+
+        import sqlite_vec
+
+        conn = sqlite3.connect(":memory:")
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        conn.execute(
+            "CREATE VIRTUAL TABLE t USING vec0(id TEXT PRIMARY KEY, embedding float[4])"
+        )
+        conn.execute("INSERT INTO t (id, embedding) VALUES (?, ?)", ["a", _vec(1, 0, 0, 0)])
+
+        with pytest.raises(Exception, match="UNIQUE constraint failed"):
+            conn.execute(
+                "INSERT OR REPLACE INTO t (id, embedding) VALUES (?, ?)",
+                ["a", _vec(0, 1, 0, 0)],
+            )
+
+    def test_delete_then_insert_does_not(self):
+        import sqlite3
+
+        import sqlite_vec
+
+        conn = sqlite3.connect(":memory:")
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        conn.execute(
+            "CREATE VIRTUAL TABLE t USING vec0(id TEXT PRIMARY KEY, embedding float[4])"
+        )
+        conn.execute("INSERT INTO t (id, embedding) VALUES (?, ?)", ["a", _vec(1, 0, 0, 0)])
+        conn.execute("DELETE FROM t WHERE id = ?", ["a"])
+        conn.execute("INSERT INTO t (id, embedding) VALUES (?, ?)", ["a", _vec(0, 1, 0, 0)])
+
+        assert conn.execute("SELECT count(*) FROM t").fetchone()[0] == 1
+
+
+class _StubBackend:
+    """Returns a different vector per text, so a stale write is detectable."""
+
+    model_name = "stub"
+    dim = 768  # matches the vec_journal column the schema creates
+
+    async def embed(self, text: str, is_query: bool = False) -> list[float]:
+        return self._for(text)
+
+    async def embed_batch(
+        self, texts: list[str], is_query: bool = False
+    ) -> list[list[float]]:
+        return [self._for(t) for t in texts]
+
+    @staticmethod
+    def _for(text: str) -> list[float]:
+        v = [0.0] * 768
+        v[0 if "original" in text else 1] = 1.0
+        return v
+
+
+class TestTheStoredVectorFollowsTheText:
+    @pytest.mark.asyncio
+    async def test_re_embedding_replaces_the_vector(self, db: Database):
+        from rka.infra.embeddings import EmbeddingService
+
+        if not db.vec_available:
+            pytest.skip("sqlite-vec not loaded in this environment")
+
+        svc = EmbeddingService(model_name="stub", db=db, backend=_StubBackend())
+
+        await svc.store_embedding(
+            "journal", "jrn_x", "the original wording", project_id="prj_t",
+        )
+        await svc.store_embedding(
+            "journal", "jrn_x", "the revised wording", project_id="prj_t",
+        )
+
+        rows = await db.fetchall(
+            "SELECT embedding FROM vec_journal WHERE id = ?", ["jrn_x"],
+        )
+        assert len(rows) == 1, "re-embedding must not leave two vectors"
+
+        stored = struct.unpack("768f", rows[0]["embedding"])
+        assert (stored[0], stored[1]) == pytest.approx((0.0, 1.0)), (
+            "the stored vector still matches the withdrawn text; the entity is "
+            "retrievable by wording it no longer contains"
+        )
+
+
+class TestTheFailureIsNoLongerSilent:
+    def test_embedding_sync_logs_at_the_same_level_as_fts_sync(self):
+        src = inspect.getsource(BaseService._sync_embedding)
+        assert "logger.warning" in src, (
+            "debug is off by default, so a permanently stale vector produced "
+            "no signal anywhere"
+        )
+        assert "logger.debug" not in src
+
+    def test_the_message_says_what_to_do(self):
+        src = inspect.getsource(BaseService._sync_embedding)
+        assert "backfill" in src.lower(), (
+            "a warning a reader cannot act on is only noise"
+        )


### PR DESCRIPTION
sqlite-vec `vec0` tables do not honour the REPLACE conflict clause. The write path used `INSERT OR REPLACE`, so re-embedding an entity that already had a vector raised `UNIQUE constraint failed on <table> primary key` — and `BaseService._sync_embedding` swallowed it at `logger.debug`, which is off by default.

**An edited entry kept the vector for its withdrawn text.** It stayed semantically retrievable by wording it no longer contains, and unretrievable by the wording it does. FTS updates correctly on the same path, so the entry looked repaired. It never self-healed: every later edit raised and was swallowed again.

## The live database carries the fingerprint

```
jobs.last_error LIKE '%UNIQUE constraint failed%vec_%'
   8  note_embed
   7  mission_embed
   2  decision_embed
      verbatim: "UNIQUE constraint failed on vec_journal primary key"
```

And 808 vector rows with no matching `embedding_metadata` row:

| | metadata | vec rows | delta |
|---|---|---|---|
| journal | 4773 | 4989 | +216 |
| claim | 1118 | 1495 | +377 |
| decision | 542 | 620 | +78 |
| literature | 641 | 765 | +124 |
| mission | 304 | 317 | +13 |

12 of the ~18-21 currently-stale entities are **missions** — exactly what `mission_guard` searches.

## Its twin was already fixed

#101/#106 found this in the *backfill* path and left a comment there explaining why REPLACE cannot work:

> `sqlite-vec vec0 tables do not honour the REPLACE conflict clause — re-embedding an entity that already has a vector raises "UNIQUE constraint failed". Until now nothing re-embedded in place... **a same-dim model swap does re-embed in place.**`

This path was missed. It now uses the same DELETE-then-INSERT form, inside the commit that already covered both statements — so a failed INSERT cannot leave the entity with **no** vector, which would be worse than a stale one.

## The swallow

Raised from `debug` to `warning`, with the wording `_sync_fts` has always used for the same class of failure and a pointer to the repair. This surfaces failures that were previously invisible; that is the point, but expect noise on the first embedding-backend outage.

## Tests

5. Two establish the premise **directly against a `vec0` table** — REPLACE raises, DELETE-then-INSERT does not. If sqlite-vec ever changes, the reason for this shape fails loudly rather than surviving as folklore in a comment.

The third re-embeds through the real service against a real table and asserts the stored vector matches the **new** text. On `main` it fails with the production error verbatim:

```
sqlite3.OperationalError: UNIQUE constraint failed on vec_journal primary key
```

**Nothing in this suite re-embedded in place before.** That is why the defect survived the PRs that fixed its twin, and it is the gap this closes.

Full suite: **3350 passed**.

## Scope

Does **not** repair the 808 orphans or re-embed the currently-stale entities. Both belong with the reconciliation PR, and both need this write path correct first — repairing before fixing would just re-accumulate. The work plan also requires this PR to land before any `vec0` partition-key migration, since that rebuilds every vector through this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)