### PR TITLE
fix(researcher-tools): index the rows it writes

### DIFF
--- a/rka/services/researcher_tools.py
+++ b/rka/services/researcher_tools.py
@@ -6,10 +6,47 @@ import json
 
 from rka.infra.ids import generate_id
 from rka.services.base import BaseService, _now, _precise_now
+from rka.services.jobs import JobQueue
+
+# entity_type -> the embed job the rest of the service layer enqueues for it.
+_EMBED_JOB = {
+    "journal": "note_embed",
+    "claim": "claim_embed",
+}
 
 
 class ResearcherToolsService(BaseService):
     """Lightweight tools that compose existing data — no new tables, no LLM, no background jobs."""
+
+    async def _index_new_row(
+        self, entity_type: str, entity_id: str, fts_data: dict,
+    ) -> None:
+        """Index a row this service inserted with raw SQL.
+
+        Every write here bypasses the service that owns the entity, so it
+        also bypassed the indexing those services do. The rows existed and
+        were reachable by id, and were invisible to both keyword and semantic
+        search — including all 15 recorded RQ conclusions, which is the
+        answer to a research question and the thing most worth finding later.
+
+        `_sync_fts` becomes a savepoint when the caller already owns the
+        connection, so this is safe inside the aggregate mutations in
+        `_merge_clusters` and `split_cluster`.
+        """
+        await self._sync_fts(entity_type, entity_id, fts_data)
+        job = _EMBED_JOB.get(entity_type)
+        if job and self.embeddings:
+            await JobQueue(self.db).enqueue(
+                job,
+                project_id=self.project_id,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                # Same shape the owning services use — notes.py builds
+                # "{project}:journal:{id}:{op}", claims.py "{project}:claim:…"
+                # — so a row written here dedupes against one written there.
+                dedupe_key=f"{self.project_id}:{entity_type}:{entity_id}:embed",
+                priority=125,
+            )
 
     # ------------------------------------------------------------------
     # 1. Changelog
@@ -305,6 +342,10 @@ class ResearcherToolsService(BaseService):
                    VALUES (?, ?, ?, 'emerging', 0, 'llm', ?, ?, ?)""",
                 [cluster_id, rq_id, spec["label"], self.project_id, _now(), _now()],
             )
+            await self._index_new_row(
+                "cluster", cluster_id,
+                {"label": spec["label"], "synthesis": ""},
+            )
 
             claim_ids = spec.get("claim_ids", [])
             for claim_id in claim_ids:
@@ -452,6 +493,10 @@ class ResearcherToolsService(BaseService):
             [target_id, research_question_id, target_label, target_synthesis,
              "brain" if target_synthesis else "llm", self.project_id, _now(), _now()],
         )
+        await self._index_new_row(
+            "cluster", target_id,
+            {"label": target_label, "synthesis": target_synthesis or ""},
+        )
 
         total_moved = 0
         for sid in normalized_source_ids:
@@ -555,6 +600,9 @@ class ResearcherToolsService(BaseService):
                        ?, ?, ?, ?)""",
             [journal_id, journal_content, related_lit, self.project_id, now, now],
         )
+        await self._index_new_row(
+            "journal", journal_id, {"content": journal_content, "summary": ""},
+        )
 
         # Create entity link: journal -> literature
         link_id = generate_id("link")
@@ -578,6 +626,9 @@ class ResearcherToolsService(BaseService):
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 [claim_id, journal_id, ann["claim_type"], ann["passage"],
                  ann.get("confidence", 0.5), self.project_id, now, now],
+            )
+            await self._index_new_row(
+                "claim", claim_id, {"content": ann["passage"]},
             )
 
             # derived_from link
@@ -744,6 +795,10 @@ class ResearcherToolsService(BaseService):
                            ?, ?, ?, ?)""",
                 [journal_id, f"RQ Conclusion ({status}): {conclusion}",
                  related_dec, self.project_id, now, now],
+            )
+            await self._index_new_row(
+                "journal", journal_id,
+                {"content": f"RQ Conclusion ({status}): {conclusion}", "summary": ""},
             )
             # Link journal -> decision
             link_id = generate_id("link")

--- a/tests/test_services/test_researcher_tools_indexing.py
+++ b/tests/test_services/test_researcher_tools_indexing.py
@@ -1,0 +1,129 @@
+"""Rows this service writes must be findable.
+
+`ResearcherToolsService` inserts journal entries, claims and clusters with
+raw SQL, bypassing the services that own those entities — and with them, the
+FTS and embedding sync those services perform. The rows existed and were
+reachable by id; they were invisible to both keyword and semantic search.
+
+Measured on the live instance before the fix: 15 recorded RQ conclusions, 0
+of them in `fts_journal`. That is the answer to a research question — the
+single thing most worth finding again — and no search could reach any of
+them. Also 21 journal rows and 31 claims across five projects.
+"""
+
+import inspect
+import re
+
+import pytest
+
+from rka.infra.database import Database
+from rka.services import researcher_tools as rt_module
+from rka.services.researcher_tools import ResearcherToolsService
+
+
+async def _project(db: Database, pid: str) -> None:
+    await db.execute(
+        "INSERT OR IGNORE INTO projects (id, name, description, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        [pid, pid, pid, "system"],
+    )
+    await db.commit()
+
+
+def _svc(db: Database, pid: str = "prj_rt") -> ResearcherToolsService:
+    return ResearcherToolsService(db, project_id=pid)
+
+
+class TestEveryRawInsertIndexes:
+    """The structural check: no insert may be added without indexing it."""
+
+    def test_no_raw_insert_is_left_unindexed(self):
+        src = inspect.getsource(rt_module)
+        indexed_entities = {"journal", "claims", "evidence_clusters"}
+        inserts = re.findall(r"INSERT INTO (\w+)", src)
+        relevant = [t for t in inserts if t in indexed_entities]
+        assert relevant, "guard against the extraction matching nothing"
+        assert len(re.findall(r"_index_new_row\(", src)) >= len(relevant), (
+            f"{len(relevant)} inserts into indexed tables but fewer "
+            "_index_new_row calls — a row was added that nothing can find"
+        )
+
+    def test_the_helper_covers_fts_and_embeddings(self):
+        src = inspect.getsource(ResearcherToolsService._index_new_row)
+        assert "_sync_fts" in src
+        assert "enqueue" in src
+
+
+class TestAnRqConclusionIsSearchable:
+    """The one that mattered most: 15 existed, 0 were findable."""
+
+    @pytest.mark.asyncio
+    async def test_the_conclusion_reaches_fts(self, db: Database):
+        await _project(db, "prj_rt")
+        svc = _svc(db)
+
+        await db.execute(
+            "INSERT INTO decisions (id, project_id, question, chosen, rationale, "
+            "decided_by, kind, phase, status) VALUES "
+            "(?, ?, ?, '', '', 'brain', 'research_question', 'p', 'active')",
+            ["dec_rq", "prj_rt", "Does the sampler drift?"],
+        )
+        await db.commit()
+
+        await svc.advance_rq(
+            "dec_rq", status="answered",
+            conclusion="The pelagic sampler drifts by 4% per hour.",
+        )
+
+        rows = await db.fetchall(
+            "SELECT id FROM fts_journal WHERE fts_journal MATCH ?", ["pelagic"],
+        )
+        assert rows, (
+            "the recorded answer to a research question is not searchable"
+        )
+
+    @pytest.mark.asyncio
+    async def test_it_is_queued_for_embedding_too(self, db: Database):
+        await _project(db, "prj_rt")
+        svc = _svc(db)
+        svc.embeddings = object()  # presence is what gates the enqueue
+
+        await db.execute(
+            "INSERT INTO decisions (id, project_id, question, chosen, rationale, "
+            "decided_by, kind, phase, status) VALUES "
+            "(?, ?, ?, '', '', 'brain', 'research_question', 'p', 'active')",
+            ["dec_rq2", "prj_rt", "Q?"],
+        )
+        await db.commit()
+
+        await svc.advance_rq("dec_rq2", status="answered", conclusion="Yes.")
+
+        jobs = await db.fetchall(
+            "SELECT job_type FROM jobs WHERE project_id = ?", ["prj_rt"],
+        )
+        assert "note_embed" in {j["job_type"] for j in jobs}
+
+
+class TestPaperProcessingIsSearchable:
+    @pytest.mark.asyncio
+    async def test_the_reading_note_and_its_claims_reach_fts(self, db: Database):
+        await _project(db, "prj_rt")
+        svc = _svc(db)
+
+        await db.execute(
+            "INSERT INTO literature (id, project_id, title, status) "
+            "VALUES (?, ?, ?, 'read')",
+            ["lit_x", "prj_rt", "A paper"],
+        )
+        await db.commit()
+
+        await svc.process_paper(
+            "lit_x",
+            annotations=[{"passage": "Quorble resonance is measurable.",
+                          "claim_type": "result"}],
+            summary="Notes on quorble.",
+        )
+
+        assert await db.fetchall(
+            "SELECT id FROM fts_claims WHERE fts_claims MATCH ?", ["quorble"],
+        ), "claims extracted from a paper are not searchable"


### PR DESCRIPTION
Five raw `INSERT`s — two clusters, two journal entries, one claim — bypass the services that own those entities, and with them the FTS and embedding sync those services perform. The rows existed and were reachable by id. **Nothing could find them.**

## The worst case is `advance_rq`

Measured on the live instance:

```
15 recorded RQ conclusions,  0 of them in fts_journal
```

That row is the **answer to a research question**, written at the moment the question is settled. It was invisible to keyword and semantic search from the instant it was stored.

Also missing, from `process_paper` reading notes and the claims extracted alongside them:

| | rows missing from FTS | in real projects |
|---|---|---|
| journal | 21 | 12 |
| claims | 31 | 27 |

CPSEval alone is missing 18 claims and 5 journal entries.

## The fix

All five route through one helper that syncs FTS and enqueues the same embed job the owning service would.

The reason this was left alone before is the transaction shape — `split_cluster` and `_merge_clusters` hold the connection across an aggregate mutation, so routing the writes themselves through `NoteService` / `ClaimService` / `ClusterService` risks deadlock or a partial commit. That concern does not apply to **indexing** alone: `_sync_fts` becomes a savepoint when the caller already owns the connection, which its docstring states explicitly, so a failure between its DELETE and INSERT restores the previous index row without rolling back the caller's mutation.

The dedupe key is built inline in the shape the owning services already use — `{project}:journal:{id}:embed`, `{project}:claim:{id}:embed` — rather than adding a fourth `_job_dedupe_key`, so a row written here dedupes against one written there.

## Tests

5, all failing against `main`.

One is structural: it counts `INSERT INTO` statements against indexed tables and compares to the number of `_index_new_row` calls, so a sixth raw insert cannot be added without indexing it. That is the shape of the defect — not one missing call, but a whole file that never learned the convention.

The rest go through the real service against a real DB and assert the row comes back from `fts_journal` / `fts_claims`.

Full suite: **3557 passed** — run with the bare `python -m pytest` from the repo root, which is what CI runs and 163 tests wider than the `pytest tests/` I had been using before #114 caught me on it.

## Scope

Does not repair the existing rows. `rka admin reindex` restores FTS, and the backfill anti-join already picks these up for embeddings; both belong with the reconciliation work alongside the 808 orphaned vectors and 2913 orphaned FTS rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)