### PR TITLE
fix(project): delete a project's index rows with it, and report the ones already stranded

### DIFF
--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -3412,6 +3412,127 @@ class KnowledgePackService(BaseService):
                 }
             )
 
+        issues.extend(await self._index_integrity_issues(pid))
+
+        return issues
+
+    # Index tables carry no project_id, so these checks are deliberately
+    # database-wide rather than project-scoped: an orphan's project is gone,
+    # which is precisely why it is an orphan.
+    _INDEX_SOURCES: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("journal", ("vec_journal", "fts_journal")),
+        ("decisions", ("vec_decisions", "fts_decisions")),
+        ("literature", ("vec_literature", "fts_literature")),
+        ("missions", ("vec_missions", "fts_missions")),
+        ("claims", ("vec_claims", "fts_claims")),
+        ("evidence_clusters", ("fts_clusters",)),
+        ("artifacts", ("vec_artifacts",)),
+    )
+
+    async def _index_integrity_issues(self, project_id: str) -> list[dict]:
+        """Index rows with no entity, and entities with no project.
+
+        Neither condition was detectable before: `check_integrity` reported
+        zero issues on an instance carrying 808 orphaned vector rows, 2913
+        orphaned FTS rows, and 35 journal entries whose project had been
+        deleted — rows that exist in the database and cannot be reached by
+        any product surface.
+
+        Reported, not repaired. `rka admin reindex` rebuilds FTS, an
+        embedding backfill rebuilds vectors, and re-homing stranded entities
+        is a judgement call about someone's research content, not a sweep.
+        """
+        issues: list[dict] = []
+
+        orphan_vec, orphan_fts = [], []
+        unreadable: list[str] = []
+        for source, index_tables in self._INDEX_SOURCES:
+            for index_table in index_tables:
+                # `vec_*` is a virtual table and needs the sqlite-vec module
+                # loaded to read. Its `_rowids` shadow is a plain table with
+                # the same ids, so the check works whether or not the
+                # extension is present — an integrity check that cannot look
+                # must not report "no problem".
+                target = (
+                    f"{index_table}_rowids"
+                    if index_table.startswith("vec_")
+                    else index_table
+                )
+                try:
+                    rows = await self.db.fetchall(
+                        f"""SELECT id FROM {target}
+                            WHERE id NOT IN (SELECT id FROM {source})
+                            LIMIT 50""",
+                    )
+                except Exception:
+                    # A pre-migration database without this index table.
+                    unreadable.append(target)
+                    continue
+                bucket = orphan_vec if index_table.startswith("vec_") else orphan_fts
+                bucket.extend(r["id"] for r in rows)
+
+        for cat, found, what, fix in (
+            ("orphaned_vector_rows", orphan_vec, "vectors", "an embedding backfill"),
+            ("orphaned_fts_rows", orphan_fts, "FTS rows", "`rka admin reindex`"),
+        ):
+            if found:
+                issues.append({
+                    "category": cat,
+                    "severity": self._severity_for(cat),
+                    "count": len(found),
+                    "ids": found[:10],
+                    "description": (
+                        f"{what} whose entity no longer exists; they consume "
+                        "candidate slots in every search before the project "
+                        "filter runs"
+                    ),
+                    "fix_action": f"Delete them, then repopulate with {fix}",
+                })
+
+        if unreadable:
+            cat = "index_check_incomplete"
+            issues.append({
+                "category": cat,
+                "severity": self._severity_for(cat),
+                "count": len(unreadable),
+                "ids": unreadable[:10],
+                "description": (
+                    "index tables this check could not read, so their "
+                    "contents are unverified rather than known-good"
+                ),
+                "fix_action": "Apply pending migrations, then re-run",
+            })
+
+        stranded: list[str] = []
+        for source, _ in self._INDEX_SOURCES:
+            try:
+                rows = await self.db.fetchall(
+                    f"""SELECT id FROM {source}
+                        WHERE project_id IS NOT NULL
+                          AND project_id NOT IN (SELECT id FROM projects)
+                        LIMIT 50""",
+                )
+            except Exception:
+                continue
+            stranded.extend(r["id"] for r in rows)
+
+        if stranded:
+            cat = "stranded_entities"
+            issues.append({
+                "category": cat,
+                "severity": self._severity_for(cat),
+                "count": len(stranded),
+                "ids": stranded[:10],
+                "description": (
+                    "entities whose project row is gone; they exist in the "
+                    "database and no API path can read them"
+                ),
+                "fix_action": (
+                    "Re-home them to a live project, or recreate the projects "
+                    "row. Do not purge — this is real content"
+                ),
+            })
+
         return issues
 
     @staticmethod

--- a/rka/services/project.py
+++ b/rka/services/project.py
@@ -216,6 +216,28 @@ class ProjectService(BaseService):
 
     # All project-scoped tables that must be cascade-deleted.
     # Order: dependents first (reverse of insert order).
+    # source table -> the index tables keyed by its ids.
+    #
+    # Neither `vec_*` nor `fts_*` carries a project_id, so they cannot be
+    # deleted by the project-scoped loop below and were simply left behind:
+    # 808 orphaned vector rows and 2913 orphaned FTS rows on this instance,
+    # from projects deleted months ago. They kept competing for slots in
+    # every live search — 26% of the vec_claims KNN window on average, 92%
+    # at worst — and the only reason they never appeared in results is that
+    # hydration filtered them out after they had already taken the slot.
+    #
+    # Deleted through a subquery against the source table, which means this
+    # must run BEFORE the source rows go.
+    _INDEX_TABLES: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("journal", ("vec_journal", "fts_journal")),
+        ("decisions", ("vec_decisions", "fts_decisions")),
+        ("literature", ("vec_literature", "fts_literature")),
+        ("missions", ("vec_missions", "fts_missions")),
+        ("claims", ("vec_claims", "fts_claims")),
+        ("evidence_clusters", ("fts_clusters",)),
+        ("artifacts", ("vec_artifacts",)),
+    )
+
     _DELETE_TABLES = (
         # Native manuscript and immutable validation histories.
         "manuscript_source_events",
@@ -673,6 +695,24 @@ class ProjectService(BaseService):
                WHERE project_id = ?""",
             [project_id],
         )
+
+        # Index rows first: they are keyed by the source ids and have no
+        # project_id of their own, so once the source rows are gone there is
+        # nothing left to identify them by.
+        for source, index_tables in self._INDEX_TABLES:
+            for index_table in index_tables:
+                try:
+                    await self.db.execute(
+                        f"DELETE FROM {index_table} WHERE id IN "
+                        f"(SELECT id FROM {source} WHERE project_id = ?)",
+                        [project_id],
+                    )
+                except sqlite3.OperationalError as exc:
+                    # sqlite-vec may be unavailable, and pre-migration
+                    # databases do not have every index table.
+                    if "no such table" not in str(exc).lower() and \
+                       "no such module" not in str(exc).lower():
+                        raise
 
         # Cascade delete in reverse dependency order
         for table in self._DELETE_TABLES:

--- a/tests/test_services/test_index_lifecycle.py
+++ b/tests/test_services/test_index_lifecycle.py
@@ -1,0 +1,156 @@
+"""Index rows must die with their entities, and be visible when they do not.
+
+`_DELETE_TABLES` lists 72 project-scoped tables and not one `vec_*` or
+`fts_*`. Those tables carry no `project_id`, so the scoped loop could not
+reach them and deleting a project simply left them behind: 774 vector rows
+and 2914 FTS rows on this instance, from projects removed months ago.
+
+They never appeared in results — hydration filters them out — but they were
+filtered *after* taking a slot in the ranked window, so a live entry ranked
+below them was never fetched. `check_integrity` reported none of it, and also
+missed 35 journal entries whose project row is gone: rows that exist in the
+database and no API path can read.
+"""
+
+import inspect
+
+import pytest
+
+from rka.infra.database import Database
+from rka.services.knowledge_pack import KnowledgePackService
+from rka.services.project import ProjectService
+
+
+async def _project(db: Database, pid: str) -> None:
+    await db.execute(
+        "INSERT OR IGNORE INTO projects (id, name, description, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        [pid, pid, pid, "system"],
+    )
+    await db.commit()
+
+
+async def _entry(db: Database, pid: str, eid: str) -> None:
+    await db.execute(
+        "INSERT INTO journal (id, project_id, type, content, source, confidence, "
+        "importance, status) VALUES (?, ?, 'note', 'content', 'executor', "
+        "'hypothesis', 'normal', 'active')",
+        [eid, pid],
+    )
+    await db.execute(
+        "INSERT INTO fts_journal (id, content, summary) VALUES (?, 'content', '')",
+        [eid],
+    )
+    await db.commit()
+
+
+class TestDeletionTakesTheIndexWithIt:
+    @pytest.mark.asyncio
+    async def test_deleting_a_project_removes_its_fts_rows(self, db: Database):
+        await _project(db, "prj_doomed")
+        await _entry(db, "prj_doomed", "jrn_doomed")
+
+        svc = ProjectService(db)
+        await svc.delete_project("prj_doomed", confirm=True)
+
+        left = await db.fetchall(
+            "SELECT id FROM fts_journal WHERE id = ?", ["jrn_doomed"],
+        )
+        assert not left, (
+            "the index row outlived its entity and goes on competing for "
+            "slots in every search"
+        )
+
+    @pytest.mark.asyncio
+    async def test_another_projects_index_rows_survive(self, db: Database):
+        """The subquery must be scoped, or deletion becomes destructive."""
+        await _project(db, "prj_doomed")
+        await _project(db, "prj_keep")
+        await _entry(db, "prj_doomed", "jrn_doomed")
+        await _entry(db, "prj_keep", "jrn_keep")
+
+        await ProjectService(db).delete_project("prj_doomed", confirm=True)
+
+        kept = await db.fetchall("SELECT id FROM fts_journal WHERE id = ?", ["jrn_keep"])
+        assert kept, "deleting one project destroyed another's index"
+
+    def test_index_cleanup_runs_before_the_source_delete(self):
+        """Order is the whole correctness argument.
+
+        The index tables have no project_id; they can only be identified by
+        joining the source rows, so once those are gone nothing identifies
+        them.
+        """
+        src = inspect.getsource(ProjectService._delete_project)
+        assert src.index("_INDEX_TABLES") < src.index("for table in self._DELETE_TABLES")
+
+    def test_every_indexed_entity_is_covered(self):
+        """A new indexed entity must join the map, or leak on delete."""
+        from rka.services.base import BaseService
+
+        fts_sources = {
+            "journal": "journal", "decision": "decisions",
+            "literature": "literature", "mission": "missions",
+            "claim": "claims", "cluster": "evidence_clusters",
+        }
+        covered = {src for src, _ in ProjectService._INDEX_TABLES}
+        for etype in BaseService._FTS_CONFIG:
+            assert fts_sources[etype] in covered, (
+                f"{etype} has an FTS index but its source table is not in "
+                "_INDEX_TABLES; deleting a project would leak its rows"
+            )
+
+
+class TestIntegrityCanSeeThem:
+    @pytest.mark.asyncio
+    async def test_an_orphaned_fts_row_is_reported(self, db: Database):
+        await _project(db, "prj_x")
+        await db.execute(
+            "INSERT INTO fts_journal (id, content, summary) VALUES (?, 'x', '')",
+            ["jrn_ghost"],
+        )
+        await db.commit()
+
+        issues = await KnowledgePackService(db, project_id="prj_x").check_integrity()
+        cats = {i["category"] for i in issues}
+        assert "orphaned_fts_rows" in cats
+
+    @pytest.mark.asyncio
+    async def test_a_stranded_entity_is_reported(self, db: Database):
+        await _project(db, "prj_x")
+        await db.execute(
+            "INSERT INTO journal (id, project_id, type, content, source, "
+            "confidence, importance, status) VALUES (?, 'prj_vanished', 'note', "
+            "'x', 'executor', 'hypothesis', 'normal', 'active')",
+            ["jrn_stranded"],
+        )
+        await db.commit()
+
+        issues = await KnowledgePackService(db, project_id="prj_x").check_integrity()
+        found = [i for i in issues if i["category"] == "stranded_entities"]
+        assert found, "35 of these exist live and nothing reported them"
+        assert "jrn_stranded" in found[0]["ids"]
+
+    @pytest.mark.asyncio
+    async def test_a_clean_database_reports_neither(self, db: Database):
+        await _project(db, "prj_x")
+        await _entry(db, "prj_x", "jrn_ok")
+
+        issues = await KnowledgePackService(db, project_id="prj_x").check_integrity()
+        cats = {i["category"] for i in issues}
+        assert "orphaned_fts_rows" not in cats
+        assert "stranded_entities" not in cats
+
+    def test_the_vector_check_does_not_depend_on_the_extension(self):
+        """It reads the `_rowids` shadow, which is a plain table.
+
+        Querying `vec_*` directly raises "no such module: vec0" wherever
+        sqlite-vec is not loaded, and the first version of this check
+        swallowed that and reported zero orphans — a clean bill of health
+        from a check that never looked.
+        """
+        src = inspect.getsource(KnowledgePackService._index_integrity_issues)
+        assert "_rowids" in src
+        assert "index_check_incomplete" in src, (
+            "a check that cannot read a table must say so, not imply it is clean"
+        )


### PR DESCRIPTION
`_DELETE_TABLES` lists 72 project-scoped tables and **not one** `vec_*` or `fts_*`. Those tables carry no `project_id`, so the scoped loop could not reach them: deleting a project removed its entities and left their index rows behind.

On this instance — **774 vector rows and 2914 FTS rows**, from projects removed months ago.

They never appeared in results (hydration filters them) but only *after* they had taken a slot in the ranked window, so a live entry ranked below them was never fetched. #114's JOIN removed the FTS half of that tax as a side effect; the vector half still needs the rows gone.

## Order is the correctness argument

Index rows can only be identified *through* their source table, so once those rows are gone nothing identifies them. The deletes now run by subquery **before** the source deletes, and a test asserts that ordering directly:

```python
assert src.index("_INDEX_TABLES") < src.index("for table in self._DELETE_TABLES")
```

Another asserts every entity type in `BaseService._FTS_CONFIG` has its source table covered, so adding an indexed entity cannot silently reintroduce the leak.

## Detection

`check_integrity` reported none of this, and also missed **35 journal entries whose project row is gone** — rows that exist in the database and no API path can read. Three categories added: `orphaned_vector_rows`, `orphaned_fts_rows`, `stranded_entities`.

### The vector check reads the shadow table

My first version queried the `vec_*` virtual table and caught the exception. Wherever sqlite-vec is not loaded that reports **zero orphans** — a clean bill of health from a check that never looked, which is the exact failure mode this whole series has been about, and I walked straight into it. It now reads the `_rowids` shadow, which is a plain table, and anything still unreadable is reported as `index_check_incomplete` rather than counted as clean.

## Detection only, by request

The existing 774 + 2914 + 35 are **not** repaired here. FTS is rebuilt by `rka admin reindex`, vectors by an embedding backfill, and re-homing a stranded entity is a judgement about someone's research content rather than a sweep.

Both repairs are safe to run *now* — #113 fixed the vector write path and #115 fixed the researcher-tools indexing gap, so a repair will no longer re-accumulate. Before those, it would have.

## A correction

I reported **808 orphaned vectors** when this investigation started. That figure was `vec_*_rowids` minus `embedding_metadata` — vectors missing a *metadata* row, a different condition. Measured against the entity tables, orphans are **774**. The number appears in #113's description and in an RKA journal entry; both are corrected by this one.

## Tests

8, six failing against `main`.

Full suite: **3565 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)