### PR TITLE
fix(search): stop sorting each branch's best hit to the back of its own list

### DIFF
--- a/rka/services/search.py
+++ b/rka/services/search.py
@@ -259,11 +259,34 @@ class SearchService:
                 # a metadata-only listing of matching journal entries.
                 hits = await self._metadata_only_journal(constraints, limit * 4)
             constrained = await self._apply_constraints(hits, constraints, limit)
-            return await self._attach_currency(constrained)
+            return self._current_first(await self._attach_currency(constrained))
         plain = await self._search_unconstrained(
             query, types, limit, keyword_weight, semantic_weight
         )
-        return await self._attach_currency(plain)
+        return self._current_first(await self._attach_currency(plain))
+
+    @staticmethod
+    def _current_first(hits: list[SearchHit]) -> list[SearchHit]:
+        """Rank a retired entity below a live one, never above.
+
+        The currency signals above were attached for reading, not ranking, so
+        a superseded decision could outrank the decision that replaced it —
+        which is the failure their own comment describes, arrived at by a
+        different route. `hide_superseded` already takes this position for
+        journal listings; this is the same position for search.
+
+        A stable partition: relative order inside each group is whatever the
+        fusion produced, so this decides only the current-vs-retired tie and
+        leaves every other ranking alone.
+        """
+        def retired(h: SearchHit) -> bool:
+            return bool(
+                h.status == "superseded"
+                or h.superseded_by
+                or h.stale
+            )
+
+        return sorted(hits, key=retired)
 
     async def _attach_currency(self, hits: list[SearchHit]) -> list[SearchHit]:
         """Fill status / superseded_by / stale on every hit that has one.
@@ -486,7 +509,7 @@ class SearchService:
                 ))
 
         # Sort by FTS rank (lower is better)
-        results.sort(key=lambda h: h.fts_rank or 999)
+        results.sort(key=lambda h: 999 if h.fts_rank is None else h.fts_rank)
         return results
 
     async def _vector_search(
@@ -543,7 +566,7 @@ class SearchService:
                 ))
 
         # Sort by distance (lower distance = more similar)
-        results.sort(key=lambda h: h.vec_rank or 999)
+        results.sort(key=lambda h: 999 if h.vec_rank is None else h.vec_rank)
         return results
 
     async def _tag_search(

--- a/tests/test_services/test_branch_rank_sort.py
+++ b/tests/test_services/test_branch_rank_sort.py
@@ -1,0 +1,202 @@
+"""A branch's best hit must not be sorted to the back of its own list.
+
+`_fts_search` and `_vector_search` number their hits from zero, so the best
+one carries rank 0 — and both sorted with `h.fts_rank or 999`. Since
+`0 or 999 == 999`, the best hit went to the END of its branch list. `_rrf_merge`
+then takes each hit's rank from its `enumerate()` position over that list, not
+from the rank attribute, so the best hit received the WORST reciprocal-rank
+contribution.
+
+Both branches are built at `limit * 2`, so the branch grows with `limit` and
+the demoted hit sits at `len(branch) - 1`. Its fused score is therefore
+
+    0.3/(60 + len_fts) + 0.7/(59 + len_vec)
+
+which strictly decreases as `limit` grows, while every competitor's score is
+limit-invariant. Measured against the live instance on a token appearing once
+in the whole corpus:
+
+    limit=3  -> rank 1      limit=10 -> absent
+    limit=5  -> rank 1      limit=20 -> absent
+    limit=8  -> rank 6      limit=30 -> absent
+
+Enlarging a cap removed the answer. The caller's natural response to a
+disappointing search — ask for more results — made it strictly worse.
+"""
+
+import inspect
+
+import pytest
+
+from rka.infra.database import Database
+from rka.services.search import SearchHit, SearchService
+
+
+async def _project(db: Database, pid: str) -> None:
+    await db.execute(
+        "INSERT OR IGNORE INTO projects (id, name, description, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        [pid, pid, pid, "system"],
+    )
+    await db.commit()
+
+
+async def _entry(db: Database, pid: str, eid: str, content: str) -> None:
+    await db.execute(
+        "INSERT INTO journal (id, project_id, type, content, source, confidence, "
+        "importance, status) VALUES (?, ?, 'note', ?, 'executor', 'hypothesis', "
+        "'normal', 'active')",
+        [eid, pid, content],
+    )
+    await db.execute(
+        "INSERT INTO fts_journal (id, content, summary) VALUES (?, ?, '')",
+        [eid, content],
+    )
+    await db.commit()
+
+
+class TestZeroIsARankNotAMissingValue:
+    def test_the_sentinel_no_longer_swallows_rank_zero(self):
+        """`0 or 999` is 999. That one expression is the whole defect."""
+        src = inspect.getsource(SearchService)
+        assert "fts_rank or 999" not in src
+        assert "vec_rank or 999" not in src
+
+    @pytest.mark.asyncio
+    async def test_a_branch_returns_its_hits_best_first(self, db: Database):
+        """Needs two hits in ONE entity type — with one per type both carry
+        rank 0 and the stable sort hides the inversion."""
+        await _project(db, "prj_r")
+        await _entry(db, "prj_r", "jrn_best", "calibration calibration calibration")
+        await _entry(db, "prj_r", "jrn_worse", "calibration of something else entirely")
+
+        svc = SearchService(db=db, embeddings=None, project_id="prj_r")
+        hits = await svc._fts_search("calibration", ["journal"], 10)
+
+        ranks = [h.fts_rank for h in hits]
+        assert ranks == sorted(ranks), (
+            f"branch returned ranks {ranks}; rank 0 was sorted to the back"
+        )
+
+
+class _StubBackend:
+    """Every document gets a vector; the needle gets a distinct one."""
+
+    model_name = "stub"
+    dim = 768
+
+    async def embed(self, text: str, is_query: bool = False) -> list[float]:
+        v = [0.0] * 768
+        v[0 if "vorplezium" in text else 1] = 1.0
+        return v
+
+    async def embed_batch(self, texts, is_query: bool = False):
+        return [await self.embed(t) for t in texts]
+
+
+class TestWideningTheLimitCannotLoseAnAnswer:
+    """The user-visible symptom, and it needs BOTH branches.
+
+    A keyword-only harness cannot show it: with one branch there is nothing
+    for the demoted hit's shrinking contribution to lose to, and the test
+    passes over a live bug. This one embeds the corpus so the vector branch
+    contributes competitors whose scores do not move with `limit`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_rank_never_degrades_as_the_limit_grows(self, db: Database):
+        """The contract `limit` actually breaks.
+
+        Asserting mere presence is not enough and passes over the live bug:
+        the corpus has to exceed `limit * 2` before the vector branch grows
+        with the limit at all, and even then the answer degrades before it
+        disappears. Measured here against main — the needle sits at vector
+        position 5, 19, 39, 59 for limits 3, 10, 20, 30, and its final rank
+        goes 1, 1, 1, 6. Against the fix it is position 0 and rank 1 at every
+        limit.
+        """
+        from rka.infra.embeddings import EmbeddingService
+
+        if not db.vec_available:
+            pytest.skip("sqlite-vec not loaded in this environment")
+
+        emb = EmbeddingService(model_name="stub", db=db, backend=_StubBackend())
+        await _project(db, "prj_m")
+
+        await _entry(db, "prj_m", "jrn_needle", "identifier vorplezium appears here")
+        await emb.store_embedding(
+            "journal", "jrn_needle", "identifier vorplezium appears here",
+            project_id="prj_m",
+        )
+        # Must exceed 2 * the largest limit below, or the vector branch is
+        # capped by the corpus and stops growing.
+        for i in range(70):
+            text = f"identifier of some other kind number {i}"
+            await _entry(db, "prj_m", f"jrn_noise{i}", text)
+            await emb.store_embedding("journal", f"jrn_noise{i}", text, project_id="prj_m")
+
+        svc = SearchService(db=db, embeddings=emb, project_id="prj_m")
+        ranks = {}
+        for limit in (3, 10, 20, 30):
+            ids = [h.entity_id for h in await svc.search("vorplezium", limit=limit)]
+            ranks[limit] = ids.index("jrn_needle") + 1 if "jrn_needle" in ids else None
+
+        assert all(r is not None for r in ranks.values()), (
+            f"the answer disappeared: {ranks}"
+        )
+        # Non-INCREASING: a bigger limit may improve the rank or leave it
+        # alone, never worsen it. Asserting the list is sorted ascending — my
+        # first attempt — is satisfied by exactly the degradation it was
+        # meant to catch, since [1, 1, 1, 6] is already in ascending order.
+        ordered = sorted(ranks)
+        offenders = [
+            (a, ranks[a], b, ranks[b])
+            for a, b in zip(ordered, ordered[1:])
+            if ranks[b] > ranks[a]
+        ]
+        assert not offenders, (
+            f"rank degraded as the limit grew: {ranks} — widening a cap made "
+            "the answer worse, which is the caller's natural response to a "
+            f"disappointing search. Offending steps: {offenders}"
+        )
+
+
+class TestARetiredEntityRanksBelowItsReplacement:
+    """Exposed by the sort fix, decided on its own merits.
+
+    `test_supersession_correctness` passed before only because the reversed
+    sort happened to lift the replacement above the superseded entity. With
+    the branches ordered correctly the stale one wins on match quality, so
+    the tie has to be decided rather than left to an accident.
+    """
+
+    def test_retired_hits_sort_after_current_ones(self):
+        hits = [
+            SearchHit(entity_type="decision", entity_id="old", title="", snippet="",
+                      status="superseded"),
+            SearchHit(entity_type="decision", entity_id="new", title="", snippet="",
+                      status="active"),
+        ]
+        assert [h.entity_id for h in SearchService._current_first(hits)] == ["new", "old"]
+
+    def test_the_partition_is_stable(self):
+        """It decides the current-vs-retired tie and nothing else."""
+        hits = [
+            SearchHit(entity_type="journal", entity_id=f"a{i}", title="", snippet="")
+            for i in range(5)
+        ]
+        assert [h.entity_id for h in SearchService._current_first(hits)] == [
+            "a0", "a1", "a2", "a3", "a4",
+        ]
+
+    def test_every_currency_signal_demotes(self):
+        for field, value in (("status", "superseded"),
+                             ("superseded_by", "dec_new"),
+                             ("stale", True)):
+            hits = [
+                SearchHit(entity_type="claim", entity_id="retired", title="",
+                          snippet="", **{field: value}),
+                SearchHit(entity_type="claim", entity_id="current", title="", snippet=""),
+            ]
+            order = [h.entity_id for h in SearchService._current_first(hits)]
+            assert order == ["current", "retired"], f"{field} did not demote"


### PR DESCRIPTION
```python
rank_map = {row["id"]: i for i, row in enumerate(rows)}   # 0-indexed: best hit is rank 0
results.sort(key=lambda h: h.fts_rank or 999)             # 0 or 999 == 999
```

Each branch sorted its **best** hit to the **end** of its own list. `_rrf_merge` then takes each hit's rank from its `enumerate()` position over that list — not from the rank attribute — so the best hit received the **worst** reciprocal-rank contribution.

Both branches are built at `limit * 2`, so the branch grows with `limit` and the demoted hit sits at `len(branch) - 1`. Its fused score is

```
0.3/(60 + len_fts) + 0.7/(59 + len_vec)
```

strictly decreasing in `limit`, while every competitor's score is limit-invariant. That closed form predicts all seven observed values.

## Measured against the live instance

A token appearing exactly once in the whole corpus:

| limit | 3 | 5 | 8 | 10 | 15 | 20 | 30 |
|---|---|---|---|---|---|---|---|
| rank | 1 | 1 | 6 | — | — | — | — |

**Widening a cap removed the answer.** The caller's natural response to a disappointing search — ask for more results — made it strictly worse.

## This is not B3, and B3 does not exist

B3 was reported as "an exact match is pushed out of the window," which predicts failure at *small* limits and recovery at large ones. The dependence is the exact inverse, and instrumentation shows the target is **never absent from the fused set** before truncation — fused position 0/0/5/11/31/48 for those limits. The window was never the problem; the sort key was.

What *is* real and separate: the vector branch runs a global KNN and filters by project only during hydration — the same defect #114 fixed for FTS, still open.

## Blast radius: avoided

An earlier plan deferred RRF work because "rebalancing changes every ranking." This is not a rebalancing. Weights, `k`, pool size and the merge are untouched; it restores the ordering the code already documents.

## What it exposed

`test_supersession_correctness` passed **only because of the bug** — the reversed sort happened to lift a replacement decision above the decision it superseded. Correctly ordered, the stale one wins on match quality.

The currency signals (`status`, `superseded_by`, `stale`) were attached *after* ranking, for reading only, so a superseded decision could outrank its replacement — which is the failure [their own comment](rka/services/search.py) describes, reached by a different route. Search now sorts retired entities after current ones: a **stable partition** that decides that tie and leaves every other ordering alone. `hide_superseded` already takes this position for journal listings.

## Deliberately excluded

- **Exposing `keyword_weight`/`semantic_weight` on the MCP surface.** It does not fix this and makes it worse: `keyword_weight=0.9` makes the same token absent at *every* limit from 5 to 200 — worse than the 0.3/0.7 default, which returns it at rank 1. Shipping the knob would hand agents a lever that degrades the case it was proposed to fix.
- **Decoupling the candidate pool from `limit`.** That one does carry the "changes every ranking" blast radius.

Also worth recording: CI returns a **false green** in exactly the direction a reweighting would move — `keyword_weight` at 0.9 and at 1.0/0.0 both pass the full suite. A green run is not evidence that a reweighting is safe.

## Tests

6, all failing against `main`. Two took correcting before they were worth having, and both failure modes are the same one this series keeps finding — a test that looks like coverage and proves nothing:

1. The first asserted mere **presence**, which passes over the live bug: the corpus must exceed `limit * 2` before the branch grows at all, so a small fixture never reproduces it.
2. The second asserted the rank list was **sorted ascending** — satisfied by exactly the degradation it was meant to catch, since `[1, 1, 1, 6]` is already ascending.

It now asserts the rank is non-increasing in the limit, and fails on `main` with `{3: 1, 10: 1, 20: 1, 30: 6}`.

Full suite: **3571 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)