### PR TITLE
docs: define RKA ecosystem repository roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,23 @@ See [Architecture](docs/ARCHITECTURE.md) for the runtime model, data layers, pro
 
 ## Roadmap
 
-The next product milestones concentrate on reducing the cognitive load between doing research and communicating it:
+The immediate priority is to harden RKA as an independently usable research-
+knowledge core. Optional products will then move to separate repositories under
+one RKA Ecosystem project:
 
-1. **Knowledge smoothing and readiness** — improve the path from noisy journal entries to reviewed claims, clusters, research questions, and scoped publication arguments.
-2. **Manuscript drafting workbench** — provide an interactive surface for discussing, navigating, editing, and auditing the paper spine and evolving draft.
-3. **ARA interoperability** — define a semantic crosswalk and deterministic materialization path from RKA projects to standards-conforming agent-native artifacts.
-4. **Dual-output evaluation** — test whether one longitudinal workflow can reduce authoring effort while improving paper traceability and ARA completeness.
+1. **Core reliability** — harden journal correctness, provenance, project
+   isolation, retrieval, claim edges, migrations, export/import, and recovery.
+2. **Stable integration contract** — freeze the supported REST/MCP surface and
+   provide version, capability, and compatibility discovery.
+3. **RKA Agentic extraction** — move Brain/Executor orchestration and runtime
+   state to `infinitywings/rka-agentic`.
+4. **RKA Writer extraction** — move the Writer skill, manuscript semantics,
+   academic-writing tools, and Workbench to `infinitywings/rka-writer`.
+5. **Core 3.0 and ecosystem validation** — slim the Core distribution only
+   after legacy-state migration and downstream compatibility tests pass.
+
+The Workbench, ARA interoperability, and dual-output evaluation remain planned
+Writer/ecosystem work; they are not the immediate Core implementation target.
 
 The dependency-ordered plan lives in the repository [Roadmap](ROADMAP.md), with
 active work tracked through [GitHub milestones](https://github.com/infinitywings/rka/milestones).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,22 @@
 # RKA Roadmap
 
-This roadmap turns the detailed [epistemic pipeline and manuscript workbench
+This roadmap now prioritizes a reliable, independently usable RKA research-
+knowledge core. Writer/Workbench and Agentic orchestration continue as related
+products, but will move to separately released repositories under the same
+RKA Ecosystem project.
+
+The repository and authority decision is recorded in
+[ADR 0012](docs/adr/0012-rka-ecosystem-repository-boundaries.md). The active
+execution source is the
+[RKA Ecosystem Repository Separation Plan](docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md).
+The proposed repository-local milestones, cross-repository Project fields,
+issue slate, and disposition of the previous M6 backlog are recorded in the
+[RKA Ecosystem GitHub Slate](docs/superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md).
+
+The earlier detailed [epistemic pipeline and manuscript workbench
 plan](docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md)
-into implementation milestones. It combines the ARA-inspired research-artifact
-substrate with a researcher-facing manuscript drafting workbench.
+remains the design and implementation history for the future `rka-writer`
+repository. It is no longer the immediate Core implementation priority.
 
 The M0 authority, stage, proposal, and provider decisions are recorded in
 [ADR 0001](docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md).
@@ -32,11 +45,37 @@ proportionate-readiness boundary is recorded in
 The conflict-safe Markdown/LaTeX source, stable-anchor, recovery, and
 public/private drafting boundary is recorded in
 [ADR 0011](docs/adr/0011-conflict-safe-manuscript-source-synchronization.md).
+The ecosystem repository, authority, integration, migration, packaging, and
+release boundaries are recorded in
+[ADR 0012](docs/adr/0012-rka-ecosystem-repository-boundaries.md).
 
 The roadmap is ordered by dependency, not by invented delivery dates. Every
 milestone must satisfy its exit gate before dependent work is treated as ready.
 
-## Now
+## Current strategic priority
+
+RKA Core reliability comes first. No new Writer/Workbench or autonomous
+orchestration capability should be added to Core while the boundaries and
+public contracts are being stabilized.
+
+| Order | Ecosystem milestone | Outcome | Exit gate summary |
+|---|---|---|---|
+| **E0** | **Boundary freeze and inventory** | Fix authority, repository, API, plugin, and migration ownership before moving code. | Every table, route, MCP operation, skill, and major directory has one owner or explicit legacy disposition. |
+| **E1** | **Core reliability baseline** | Harden journal, provenance, project isolation, retrieval, claim edges, migrations, export/import, and recovery. | Core-only install/tests pass; no cross-project leakage; real backup upgrade and integrity pass. |
+| **E2** | **Stable external contract** | Freeze supported REST/MCP behavior and provide capability/version discovery plus legacy Writer export. | Public-contract-only clients complete core workflows and legacy Writer export round-trips. |
+| **E3** | **Agentic repository extraction** | Create `infinitywings/rka-agentic` from preserved history. | Agentic runs only through public Core contracts and tests independently. |
+| **E4** | **Writer repository extraction** | Create `infinitywings/rka-writer`, migrate Writer state, and move Workbench ownership. | Writer runs independently, imports legacy state, and detects stale Core references. |
+| **E5** | **RKA Core 3.0** | Remove active Writer/Agentic code from Core while preserving compatibility export and migration history. | Core and both downstream compatibility suites pass without destructive database changes. |
+| **E6** | **Ecosystem integration** | Maintain independent releases under one GitHub Project and compatibility matrix. | Core-only and supported combined deployments have reproducible smoke tests. |
+
+The detailed deliverables, rollback paths, and decision checkpoints for E0-E6
+are in the active execution plan linked above.
+
+## Previous Workbench program status
+
+The following section preserves the completed and audited Workbench program
+history. Its behavioral designs remain inputs to `rka-writer`; they do not
+override the current Core-first E0-E6 sequence.
 
 **M0 through M4 are complete on `main`. M5 / PR 9 (issue #60), the progressive
 outline and manuscript-unit editor, merged in PR
@@ -151,7 +190,7 @@ application, exact-text PI ratification, and restart/resume. The validation
 record is
 [`2026-08-15-workbench-m4-pr7-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m4-pr7-exit-evidence.md).
 
-## Dependency map
+## Previous Workbench dependency map
 
 ```mermaid
 flowchart LR
@@ -168,7 +207,7 @@ flowchart LR
 M1 and M2 may proceed in parallel after M0. M2 must label missing experiment
 semantics rather than pretending that M1 is already complete.
 
-## Milestones
+## Previous Workbench milestones
 
 | Order | Milestone | Outcome | Planned work items | Exit gate |
 |---|---|---|---|---|
@@ -180,7 +219,7 @@ semantics rather than pretending that M1 is already complete.
 | **M5** | **Outline and drafting** | Turn the ratified spine into an expandable, evidence-linked manuscript. | PR 9 progressive outline and unit editor; PR 9.1 integrity hardening; PR 9.2 typed semantic core; PR 10 narrow Markdown source synchronization. | The researcher can expand and condense hierarchical units, draft in Markdown/LaTeX, navigate provenance, and apply conflict-safe writes without automatic Git operations. |
 | **M6** | **Intake, artifact views, and hardening** | Complete source intake, deterministic ARA-inspired views, grounded foresight, and production-quality reliability. | PR 11 Source Inbox; PR 12A artifact profile and deterministic viewer; PR 12B grounded research foresight; PR 13 end-to-end reliability and usability. | Imported sources are safe and traceable; projections are deterministic rather than authoritative; foresight is advisory; real-project, security, accessibility, migration, and concurrency suites pass. |
 
-## Tracking convention
+## Previous Workbench tracking convention
 
 - One GitHub milestone corresponds to each roadmap milestone above.
 - One GitHub issue corresponds to each planned PR-sized work item.
@@ -193,7 +232,7 @@ semantics rather than pretending that M1 is already complete.
   satisfied. A rendered UI, an LLM response, or green unit tests alone do not
   establish workflow correctness.
 
-## Cross-cutting constraints
+## Previous Workbench cross-cutting constraints
 
 - RKA remains the semantic authority; workbench and ARA-style views are
   projections over native RKA objects.
@@ -209,7 +248,7 @@ semantics rather than pretending that M1 is already complete.
 - Readiness is categorical (`Ready`, `Needs review`, `Blocked`, or
   `Exploratory`), never a paper score or acceptance prediction.
 
-## First useful release
+## Previous Workbench first useful release
 
 The first useful release spans M0–M5. It is reached when a researcher can start
 with an insight, develop and ratify a traceable paper spine, connect it to

--- a/docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md
+++ b/docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md
@@ -1,7 +1,8 @@
 # ADR 0001: Manuscript Workbench Authority, Stage, and AI Boundary
 
-- Status: accepted for M0 prototype; M1 schema details remain provisional
-  pending researcher review of the completed walkthrough
+- Status: accepted as the historical M0 Workbench decision; manuscript
+  authority and repository placement are superseded by ADR 0012, while the
+  evidence/AI/proposal safety principles remain in force
 - Date: 2026-08-14
 - Scope: roadmap issues #50 and #51
 - Related plan:

--- a/docs/adr/0012-rka-ecosystem-repository-boundaries.md
+++ b/docs/adr/0012-rka-ecosystem-repository-boundaries.md
@@ -1,0 +1,220 @@
+# ADR 0012: RKA ecosystem repository and authority boundaries
+
+- Status: accepted for E0 boundary freeze
+- Date: 2026-08-25
+- Decision owner: Chenglong Fu
+- Scope: repository ownership, data authority, integration contracts, migration,
+  packaging, and release sequencing for RKA Core, RKA Writer, and RKA Agentic
+- Detailed execution plan:
+  [`2026-08-25-rka-ecosystem-repository-separation.md`](../superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md)
+
+## Context
+
+The current `infinitywings/rka` repository contains a stable research-knowledge
+core together with substantial manuscript, Writer, Workbench, plugin, and
+agent-orchestration work. These layers have different users, release cadences,
+data lifecycles, and failure modes. Continuing to develop all of them inside one
+repository makes it difficult to focus testing on the durable journal,
+provenance, retrieval, and research-graph guarantees that give RKA its value.
+
+The separation must not reduce RKA Core to journal CRUD. Claims, evidence,
+clusters, research questions, scientific decisions, experiment evidence,
+freshness, and provenance are part of the durable research record. Conversely,
+paper spines, manuscript units, editorial choices, authoring files, and agent
+runtime state should not be required in order to install or validate the core.
+
+Existing databases already contain migrations and schemas for manuscript and
+planning features. Existing Workbench ADRs and implementation evidence also
+record useful behavior. The separation therefore needs an explicit authority
+change and compatibility migration rather than deletion or a history rewrite.
+
+## Decision
+
+### 1. One ecosystem, three independently released repositories
+
+The RKA ecosystem will consist of:
+
+| Repository | Product responsibility |
+|---|---|
+| `infinitywings/rka` | Local-first research knowledge, provenance, retrieval, integrity, and stable REST/MCP interfaces |
+| `infinitywings/rka-writer` | Manuscript semantics, Writer skill and tools, academic-writing workflows, and the manuscript Workbench |
+| `infinitywings/rka-agentic` | Brain/Executor orchestration, runs, scheduling, approvals, interrupts, and runtime checkpoints |
+
+The repositories remain under the existing `infinitywings` account. A GitHub
+Project named **RKA Ecosystem** will provide the shared roadmap and milestones.
+Creating a GitHub organization or a fourth umbrella repository is not required
+for this separation.
+
+### 2. RKA Core owns canonical research knowledge
+
+RKA Core owns:
+
+- projects and project isolation;
+- journals, literature, research decisions, mission records, and reports;
+- claims, evidence, evidence clusters, research questions, and their lifecycle;
+- experiment definitions, runs, observations, result evidence, and artifact
+  locators, but not execution of experiments;
+- typed provenance, entity links, claim edges, tags, change history, temporal
+  validity, staleness, contradictions, and integrity;
+- import, export, backup, migration, full-text/vector/graph retrieval, and
+  deterministic research-context assembly;
+- the stable REST, MCP, CLI, and minimal research-record maintenance UI.
+
+Core does not own paper organization, prose, venue behavior, Writer sessions,
+model-provider orchestration, or agent runtime state.
+
+### 3. RKA Writer owns canonical manuscript semantics
+
+RKA Writer owns:
+
+- manuscripts, manuscript claims, spines, units, outlines, and planning
+  branches;
+- problem/gap/contribution/evaluation structures and editorial decisions;
+- PI ratification of manuscript wording and manuscript-specific readiness;
+- Writer conversations, revision proposals, review state, citation validation,
+  venue/style configuration, and selected related-work language conventions;
+- Markdown, LaTeX, Word, figures, tables, source synchronization, and Workbench
+  UI state.
+
+Writer stores versioned references to Core records using at least
+`project_id`, `entity_id`, entity type, revision, content hash, and source
+locator. A Writer reference never copies authority from Core: Core remains the
+authority for the research claim or evidence, and Writer remains the authority
+for how that material is organized and expressed in a manuscript.
+
+### 4. RKA Agentic owns execution and orchestration state
+
+RKA Agentic owns:
+
+- agent runs, sessions, queues, schedules, retries, interrupts, and resumes;
+- Brain/Executor/PI orchestration policy, tool/model selection, approval state,
+  runtime transcripts, and runtime checkpoints;
+- deployment and observability for the orchestration process.
+
+Agentic may create or update mission, journal, decision, and evidence records
+through Core's public interfaces. It may not read or write the Core database.
+A research checkpoint recorded as durable project knowledge belongs to Core;
+an execution checkpoint used to resume an agent belongs to Agentic.
+
+### 5. Public contracts replace shared internals
+
+- REST is the deterministic service-to-service contract.
+- MCP is the agent-facing discovery and action contract.
+- Every project-scoped request carries an explicit `project_id`.
+- Writes that can be retried use an idempotency key.
+- Returned records expose the revision or content hash needed by consumers.
+- Core exposes version and capability information, an OpenAPI contract, and a
+  change cursor or `changes_since` mechanism.
+- Writer and Agentic do not import `rka.services`, `rka.models`, or `rka.db`,
+  and do not open `rka.db` directly.
+- Cross-repository compatibility is declared and tested; releases are not
+  lockstep.
+
+No event bus, shared-model repository, or mandatory client SDK is introduced
+in the first separation. Those additions require demonstrated need.
+
+### 6. Existing Writer state migrates without destructive database surgery
+
+Core's existing manuscript and planning interfaces are frozen: they may receive
+correctness fixes, but no new Workbench capability. They become preview and
+then deprecated compatibility surfaces.
+
+The migration path is:
+
+1. export legacy Writer state with IDs, revisions, links, and checksums;
+2. import it into Writer staging storage while preserving existing identifiers;
+3. compare counts, hashes, references, ratifications, and version lineage;
+4. explicitly switch Writer authority after verification;
+5. leave legacy Core state read-only for a compatibility window.
+
+Existing manuscript migrations and tables are not automatically dropped.
+Schema compaction is a later major-version decision and is not an exit condition
+for repository separation.
+
+### 7. Plugins and skills follow product ownership
+
+- Core distributes the connector, credential support, core usage, retrieval,
+  provenance, integrity, and maintenance guidance.
+- Writer distributes the Writer skill, manuscript bootstrap, venue/reference
+  tools, style adaptation, and Workbench integration.
+- Agentic distributes Brain, Executor, PI, and orchestration-specific commands
+  and runtime configuration.
+
+Core retains a small agent-usage skill so an agent can use the research record
+correctly without installing the autonomous orchestrator.
+
+### 8. Separation is phased
+
+The active milestone sequence is:
+
+1. E0 boundary freeze;
+2. E1 Core reliability baseline;
+3. E2 stable external contracts and legacy Writer export;
+4. E3 Agentic repository extraction;
+5. E4 Writer repository extraction and state migration;
+6. E5 Core 3.0 slimming;
+7. E6 ecosystem compatibility and integration validation.
+
+No repository extraction starts before E1 and E2 pass their exit gates.
+
+## Relationship to earlier ADRs
+
+This ADR supersedes the repository and authority placement in ADR 0001 where
+RKA itself owned canonical manuscript semantics. The safety principles remain:
+research evidence and manuscript prose are distinct, AI output cannot silently
+become evidence, and human/AI edits use reviewable mutation paths.
+
+ADRs 0005 through 0011 remain the behavioral design record for planning,
+semantic proposals, contribution/evaluation structures, outlines, typed
+academic-writing semantics, and source synchronization. Their eventual
+implementation owner becomes `rka-writer`, not RKA Core.
+
+ADRs 0002 through 0004 remain Core decisions because interpretation staging,
+claim scope, and experiment evidence are part of canonical research knowledge.
+
+## Consequences
+
+### Positive
+
+- Core correctness and retrieval can be tested without Writer or orchestrator
+  dependencies.
+- Optional applications can evolve and release independently.
+- Research knowledge, manuscript semantics, and runtime state have explicit,
+  non-overlapping owners.
+- Existing Workbench and Agentic work is preserved rather than discarded.
+
+### Costs and risks
+
+- Existing manuscript state requires an export/import compatibility path.
+- Cross-repository version skew must be detected and explained.
+- Some currently shared enums and models need generated or pinned contract
+  snapshots.
+- Integration testing becomes explicit rather than being implied by a monorepo
+  test run.
+
+### Rejected alternatives
+
+- **Keep the monorepo and only rename directories:** does not isolate data,
+  release, or testing boundaries.
+- **Reduce Core to journal save/retrieve:** forces consumers to recreate the
+  research graph and provenance semantics.
+- **Move code immediately:** risks data loss and freezes an accidental API as
+  the cross-repository contract.
+- **Drop old manuscript tables during extraction:** creates avoidable migration
+  and recovery risk.
+- **Create an organization and umbrella repository now:** adds governance and
+  release overhead without solving the current reliability problem.
+
+## E0 exit gate
+
+E0 is complete when:
+
+- this ADR and the detailed execution plan are reviewed;
+- every current table, REST route, MCP operation, skill, and major directory
+  has a target owner or an explicit legacy disposition;
+- the active roadmap prioritizes Core reliability over new Writer/Workbench
+  features;
+- extraction work is based on a clean `origin/main` worktree rather than the
+  existing dirty checkout;
+- no runtime code, database data, installed plugin, or remote repository has
+  been changed as part of the boundary freeze.

--- a/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
+++ b/docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md
@@ -1,9 +1,9 @@
 # RKA Epistemic Pipeline and Manuscript Drafting Workbench
 
-Status: roadmap design source; M0 through M3 and M4 PR 7 are complete on
-`main`. M4 PR 8, the evaluation contract and results trace, has passed its
-feature-branch release gate under ADR 0008 and awaits review and merge in
-draft PR [#79](https://github.com/infinitywings/rka/pull/79).
+Status: preserved Writer/Workbench design and implementation history. Repository
+ownership and active sequencing are superseded by ADR 0012 and the
+2026-08-25 RKA Ecosystem Repository Separation Plan. Completed behavioral
+contracts remain inputs to the future `rka-writer` repository.
 
 Date: 2026-08-14
 

--- a/docs/superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md
+++ b/docs/superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md
@@ -1,0 +1,403 @@
+# RKA Ecosystem GitHub Milestone and Issue Slate
+
+- Status: prepared from a read-only GitHub snapshot; no remote changes applied
+- Snapshot date: 2026-08-25
+- Repository inspected: `infinitywings/rka`
+- Governing decision: ADR 0012
+- Active execution plan:
+  `2026-08-25-rka-ecosystem-repository-separation.md`
+
+## 1. Tracking model
+
+GitHub milestones are repository-specific. E0-E6 span three repositories, so
+they should not all be created as milestones in `infinitywings/rka`.
+
+Use two coordinated layers:
+
+1. A user-level GitHub Project named **RKA Ecosystem**, with a single-select
+   field `Ecosystem phase` containing E0 through E6.
+2. Repository-local milestones for the work owned by each repository.
+
+Recommended Project fields:
+
+| Field | Values |
+|---|---|
+| Ecosystem phase | E0 Boundary; E1 Core reliability; E2 Contract; E3 Agentic extraction; E4 Writer extraction; E5 Core 3.0; E6 Integration |
+| Component | Core; Writer; Agentic; Integration |
+| Status | Backlog; Ready; In progress; Review; Blocked; Done |
+| Release gate | Not started; Partial; Passed |
+
+The Project is the cross-repository roadmap. Repository milestones remain
+release-sized containers and can be closed independently.
+
+## 2. Existing milestone disposition
+
+The live repository currently has seven Workbench-era milestones.
+
+| Existing milestone | Live issue state | Recommended disposition |
+|---|---:|---|
+| M0 Foundation and validation | 0 open / 2 closed | Already closed; retain as history |
+| M1 Epistemic research substrate | 0 open / 3 closed | Already closed; retain as history |
+| M2 Read-only manuscript workbench MVP | 0 open / 1 closed | Already closed; retain as history |
+| M3 Deliberation and safe editing | 0 open / 2 closed | Close after the roadmap pivot is merged |
+| M4 Contribution and evaluation workflow | 0 open / 2 closed | Close after the roadmap pivot is merged |
+| M5 Outline and drafting | 0 open / 3 closed | Close after the roadmap pivot is merged |
+| M6 Intake, artifact views, and hardening | 4 open / 0 closed | Reclassify #62-#65, then close or rename as a historical backlog |
+
+Issue #61 is closed but still carries `priority: next`. Remove that label when
+the new E1 claim-edge issue is created, and apply `priority: next` to exactly
+one open E1 issue.
+
+## 3. New repository-local milestones
+
+### `infinitywings/rka`
+
+Create after the documentation branch is reviewed:
+
+1. **E0 — Core boundary freeze**
+2. **E1 — Core reliability baseline**
+3. **E2 — Stable external contract**
+4. **E5 — RKA Core 3.0**
+
+### Future `infinitywings/rka-agentic`
+
+Create after the repository exists:
+
+1. **A1 — Repository extraction and contract-only runtime** (ecosystem E3)
+2. **A2 — Core integration and independent release gate** (ecosystem E6)
+
+### Future `infinitywings/rka-writer`
+
+Create after the repository exists:
+
+1. **W1 — Skill/tools extraction** (ecosystem E4)
+2. **W2 — Legacy state migration and Workbench authority** (ecosystem E4)
+3. **W3 — Core integration and independent release gate** (ecosystem E6)
+
+Do not create E3/E4/E6 as placeholder milestones in the Core repository. Until
+the downstream repositories exist, track those phases as draft items in the
+RKA Ecosystem Project.
+
+## 4. Labels
+
+Reuse current labels where their meaning remains accurate:
+
+- `roadmap`
+- `documentation`
+- `enhancement`
+- `priority: next`
+- `area: substrate` for canonical research semantics
+
+Add only the missing labels:
+
+| Label | Purpose |
+|---|---|
+| `area: core` | Core runtime, storage, retrieval, contracts, packaging |
+| `area: agentic` | Agent orchestration and runtime |
+| `area: integration` | Cross-repository compatibility and deployment |
+| `type: contract` | REST/MCP/version/capability contract |
+| `type: migration` | Database, state, or repository extraction migration |
+| `breaking-change` | Requires a major-version or explicit compatibility plan |
+
+Keep `area: writer`, `area: workbench`, and `area: artifact` on historical
+issues. New Writer work receives those labels in the future Writer repository,
+not as active Core work.
+
+## 5. PR-sized issue slate
+
+### E0 — Core boundary freeze
+
+#### E0.1 Ratify ADR 0012 and the repository ownership inventory
+
+Scope:
+
+- merge ADR 0012, the active roadmap, execution plan, GitHub slate, and complete
+  ownership inventory;
+- mark prior Workbench ownership decisions as superseded in part without
+  deleting their behavioral history.
+
+Acceptance:
+
+- every table, REST route family, MCP operation, skill, entry point, web page,
+  and major test family has one target owner or legacy disposition;
+- local Markdown links and repository documentation checks pass;
+- no runtime, database, plugin, or remote repository changed.
+
+Labels: `roadmap`, `documentation`, `area: core`, `type: contract`.
+
+#### E0.2 Freeze optional-layer feature growth inside Core
+
+Scope:
+
+- add contributor guidance that new manuscript, Workbench, and orchestration
+  behavior targets downstream backlogs;
+- allow only correctness, security, migration, and compatibility fixes on
+  legacy optional surfaces.
+
+Acceptance:
+
+- contributor instructions state the freeze and exception policy;
+- no Core build requires a future downstream repository.
+
+Labels: `roadmap`, `documentation`, `area: core`.
+
+#### E0.3 Reclassify the Workbench-era backlog
+
+Scope:
+
+- close completed M3-M5 milestones;
+- remove `priority: next` from closed issue #61;
+- apply the #62-#65 dispositions in Section 6;
+- create the RKA Ecosystem Project and fields after explicit review.
+
+Acceptance:
+
+- one open issue carries `priority: next`;
+- no Workbench issue appears as immediate Core work;
+- historical milestones and issues remain discoverable.
+
+Labels: `roadmap`, `documentation`, `area: integration`.
+
+### E1 — Core reliability baseline
+
+#### E1.1 Make claim-edge membership and cluster linking idempotent
+
+Candidate: `fix/claim-edge-integrity` at `eb9faa3`.
+
+Audit and remediation evidence:
+[`2026-08-25-claim-edge-integrity-audit.md`](../specs/2026-08-25-claim-edge-integrity-audit.md).
+
+Acceptance:
+
+- duplicate membership migration is safe and deterministic;
+- repeated assignment does not create duplicate edges;
+- merge/split preserves claim membership and linked answers;
+- knowledge-pack and integrity checks agree with the repaired graph;
+- independent audit has no unresolved P0/P1 finding.
+
+Labels: `roadmap`, `area: core`, `area: substrate`, `priority: next`.
+
+#### E1.2 Enforce project partitioning for vector retrieval
+
+Acceptance:
+
+- no vector search result crosses `project_id`;
+- fresh and upgraded databases carry the partition key;
+- migration and re-embedding cost is measured on a disposable copy;
+- live re-embedding requires separate approval and a verified backup;
+- FTS, vector, graph, and hybrid retrieval isolation tests pass.
+
+Labels: `roadmap`, `area: core`, `type: migration`.
+
+#### E1.3 Add journal and provenance round-trip regression coverage
+
+Acceptance:
+
+- create/read/update/supersede retains attribution and verbatim PI input;
+- decision, mission, journal, literature, and artifact links round-trip;
+- retries do not duplicate durable entities or edges;
+- project isolation is tested at service, REST, and MCP layers.
+
+Labels: `roadmap`, `area: core`, `area: substrate`.
+
+#### E1.4 Establish the Core-only install, startup, and test profile
+
+Acceptance:
+
+- Core installs without Writer extras;
+- Core embedding dependencies such as `sqlite-vec` are separated from
+  Agentic LLM-provider dependencies rather than sharing the current `llm`
+  optional group;
+- REST, MCP, worker, migrations, and minimal web dashboard start;
+- Core tests are independently selectable and documented;
+- Writer/Workbench tests are excluded without being deleted;
+- package metadata contains no mandatory Writer backend dependency.
+
+Baseline evidence:
+[`2026-08-25-rka-core-only-baseline.md`](../specs/2026-08-25-rka-core-only-baseline.md).
+
+Labels: `roadmap`, `area: core`.
+
+#### E1.5 Validate real-backup upgrade, export/import, and recovery
+
+Acceptance:
+
+- a disposable copy of a current real database upgrades successfully;
+- pre/post counts, IDs, links, revisions, and integrity findings are compared;
+- knowledge-pack export/import preserves canonical Core state;
+- rollback restores the backup and previous runtime version.
+
+Labels: `roadmap`, `area: core`, `type: migration`.
+
+#### E1.6 Fix the retrieval quality and latency baseline
+
+Acceptance:
+
+- journal, claim, decision, literature, and linked-neighborhood tasks have
+  recorded recall and latency baselines;
+- project isolation and stale/superseded filtering are included;
+- no Writer task is required for the Core release gate;
+- regression thresholds and environment are documented.
+
+Labels: `roadmap`, `area: core`.
+
+### E2 — Stable external contract
+
+#### E2.1 Publish Core version and capability discovery
+
+Acceptance:
+
+- REST and MCP consumers can discover Core version and stable capabilities;
+- preview/deprecated operations are distinguishable;
+- unsupported combinations produce an actionable error.
+
+Labels: `roadmap`, `area: core`, `type: contract`.
+
+#### E2.2 Snapshot and test the supported REST/MCP contract
+
+Acceptance:
+
+- OpenAPI and MCP operation snapshots cover the stable Core surface;
+- accidental breaking changes fail CI;
+- a fixture client imports no Core service/model/database modules;
+- `project_id`, revision/hash, and idempotency expectations are documented.
+
+Labels: `roadmap`, `area: core`, `type: contract`.
+
+#### E2.3 Export and verify legacy Writer state
+
+Acceptance:
+
+- export includes manuscript/planning IDs, revisions, bindings, ratifications,
+  source references, and checksums;
+- export is read-only and runs against a disposable backup;
+- a staging importer round-trips the bundle before any authority switch;
+- missing/unsupported records fail visibly.
+
+Labels: `roadmap`, `area: core`, `type: migration`.
+
+#### E2.4 Deprecate optional Core surfaces without removing them
+
+Acceptance:
+
+- manuscript/Workbench operations are hidden from the default stable index;
+- documentation points new development to Writer;
+- existing callers receive a compatibility notice rather than data loss;
+- removal is deferred to E5/Core 3.0.
+
+Labels: `roadmap`, `area: core`, `breaking-change`.
+
+### E3 — Agentic extraction draft items
+
+Create these in the RKA Ecosystem Project now and move them into
+`infinitywings/rka-agentic` after that repository exists:
+
+1. Preserve and extract `orchestrator/` history.
+2. Replace Core internal mirrors with a pinned/generated public contract.
+3. Establish independent packaging, CI, deployment, and version checks.
+4. Pass mission pickup, checkpoint, report, and provenance integration tests.
+
+### E4 — Writer extraction draft items
+
+Create these in the RKA Ecosystem Project now and move them into
+`infinitywings/rka-writer` after that repository exists:
+
+1. Extract Writer skill, tools, templates, tests, and history.
+2. Establish Writer-owned state and Core-reference schema.
+3. Import and verify legacy manuscript/planning state.
+4. Move Workbench services, UI, source synchronization, and provider adapters.
+5. Pass real-project claim-to-draft and stale-reference tests.
+
+### E5 — RKA Core 3.0
+
+#### E5.1 Remove active Writer and Agentic code from Core
+
+Acceptance:
+
+- active Core packages, routes, MCP operations, UI, and dependencies contain no
+  downstream implementation;
+- legacy export and migration history remain available;
+- existing databases open without destructive table removal;
+- downstream compatibility suites pass.
+
+Labels: `roadmap`, `area: core`, `breaking-change`.
+
+#### E5.2 Split plugin distribution by component
+
+Acceptance:
+
+- Core plugin contains connector/core-use/maintenance guidance;
+- Writer and Agentic plugins install independently;
+- version/capability mismatch guidance is visible;
+- local clients can use Core without Agentic.
+
+Labels: `roadmap`, `area: integration`, `breaking-change`.
+
+#### E5.3 Publish the Core 3.0 migration and recovery guide
+
+Acceptance:
+
+- clean install, 2.x upgrade, backup, rollback, Writer export, and plugin
+  transition are tested from disposable environments;
+- no step assumes deletion of legacy manuscript tables;
+- release checklist cites exact test and compatibility evidence.
+
+Labels: `roadmap`, `documentation`, `area: core`, `type: migration`.
+
+### E6 — Ecosystem integration draft items
+
+Track at Project level and assign to the repository that owns the failing
+boundary:
+
+1. Publish the Core/Writer/Agentic compatibility matrix.
+2. Test Core-only, Core+Writer, Core+Agentic, and all-three deployments.
+3. Test clean install, upgrade, backup, rollback, and unsupported-version UX.
+4. Publish one ecosystem release checklist without requiring lockstep tags.
+
+## 6. Existing open issue disposition
+
+### #62: Source Inbox
+
+Split after E0:
+
+- Core issue: safe source registration, hashing, provenance, and interpretation
+  admission into canonical research knowledge.
+- Writer draft item: manuscript-specific source selection and Workbench UX.
+
+Close #62 as superseded only after both successor items exist.
+
+### #63: ARA-inspired artifact profile and viewer
+
+Remove from immediate Core priority. Keep as an E6 Project-level draft item
+until its authority is narrowed. Deterministic export of canonical research
+records may belong to Core; interactive artifact/paper views belong to Writer
+or a future integration component. Do not create a fourth repository now.
+
+### #64: Grounded research foresight
+
+Move to the future Agentic backlog. Core may expose the evidence and temporal
+queries it needs, but advisory next-step generation is orchestration behavior.
+
+### #65: End-to-end reliability and usability hardening
+
+Split:
+
+- Core correctness/retrieval/migration parts become E1 issues;
+- Writer/Workbench usability moves to Writer;
+- combined deployment and compatibility parts become E6 Project items.
+
+Close #65 as superseded only after the successor items exist.
+
+## 7. Remote-change gate
+
+This document is a proposal slate, not authorization to mutate GitHub. After
+the documentation branch is reviewed, apply remote changes in this order:
+
+1. merge the roadmap documentation;
+2. close completed M3-M5 milestones;
+3. create the RKA Ecosystem Project and fields;
+4. create Core E0/E1/E2/E5 milestones and labels;
+5. create E0-E2 issues, setting exactly one E1 issue to `priority: next`;
+6. reclassify #62-#65 without deleting their history;
+7. create downstream repositories and their milestones only at their approved
+   extraction gates.

--- a/docs/superpowers/plans/2026-08-25-rka-ecosystem-ownership-inventory.md
+++ b/docs/superpowers/plans/2026-08-25-rka-ecosystem-ownership-inventory.md
@@ -1,0 +1,421 @@
+# RKA Ecosystem E0 Component Ownership Inventory
+
+- Status: E0 review draft under ADR 0012
+- Date: 2026-08-25
+- Inventory baseline: `origin/main` at `57fa8f07bf6f298bc5b3a9cf113cf492898d8a03`
+- Scope: current files in `infinitywings/rka`; the `agentic` branch is noted but
+  is not treated as part of this baseline
+- Authority: [ADR 0012](../../adr/0012-rka-ecosystem-repository-boundaries.md)
+
+## 1. Purpose and disposition vocabulary
+
+This inventory assigns one target disposition to every current component
+family before repository extraction begins. The dispositions are deliberately
+about the end state, not about where a file happens to live today.
+
+| Disposition | Meaning |
+|---|---|
+| `core` | Remains an active, supported part of `infinitywings/rka`. |
+| `writer` | Moves with history to `infinitywings/rka-writer`; no active copy remains in Core after the compatibility window. |
+| `agentic` | Moves with history to `infinitywings/rka-agentic`; no active copy remains in Core after the compatibility window. |
+| `core-legacy` | Remains readable or callable in Core only for compatibility; receives no feature development. |
+| `writer-legacy-export` | Remains in Core only long enough to read, verify, and export historical Writer state. |
+| `remove-after-migration` | Has no continuing authority after its replacement is verified; remove only after its stated migration gate. |
+
+No row below has two dispositions. When a current source file contains more
+than one product responsibility, the inventory splits the file by endpoint or
+subcomponent and records the required refactor.
+
+## 2. Coverage and counting method
+
+The inventory was produced by static inspection of the baseline above:
+
+- SQL `CREATE TABLE` and `CREATE VIRTUAL TABLE` declarations were collected
+  from `schema.sql`, `schema_phase2.sql`, migrations 001--051, and the migration
+  runner's `schema_migrations` table. SQLite-generated FTS shadow tables were
+  excluded. Three `*_v2` names are migration staging tables, not independent
+  end-state authorities, but are included so every declaration is accounted
+  for.
+- REST endpoints were counted from the 38 mounted route modules using FastAPI
+  `@router.get/post/put/patch/delete` decorators. The application health route
+  is counted separately in the package-entry-point section because it is
+  declared in `rka/api/app.py`, not a route module.
+- MCP typed operations were read from `OPERATIONS_SCHEMA`; its `tool` field is
+  the count authority. Compatibility functions and dispatch plumbing are
+  inventoried separately rather than double-counted as additional operations.
+- Test counts include files named `test_*.py`, exclude macOS `._*` AppleDouble
+  files, and count `tests/` plus all three eval-harness generations.
+- Generated `web/dist`, caches, captured eval results, and AppleDouble files
+  are not product components and are excluded.
+
+| Surface | Count at baseline |
+|---|---:|
+| SQL-declared table names | 94 |
+| Migration files | 51 |
+| REST route modules | 38 |
+| REST endpoints in route modules | 230 |
+| Typed MCP operations | 152 (68 query, 84 execute) |
+| Model modules, excluding `__init__.py` | 25 |
+| Service modules, excluding `__init__.py` | 56 |
+| Python tests in `tests/` | 218 |
+| Eval-harness Python tests | 14 |
+| Web page modules | 16 (17 route entries) |
+| Web source files | 80 |
+| Mirrored role-skill families | 5 (`brain`, `executor`, `pi`, `writer`, `mcp-credentials`) |
+| Python package console scripts | 2 |
+
+### Contract-count finding
+
+`OPERATIONS_SCHEMA` contains 152 callable typed operations: 68
+`rka_query` branches and 84 `rka_execute` branches. The active instructions in
+`rka/mcp/server.py` agree. `CLAUDE.md` still says 150 (67 + 83), while
+`.claude-plugin/marketplace.json` advertises an older 109-operation surface.
+Disposition: `core`. Recommendation: make one generated contract-count test
+and use its output in release/plugin documentation during E2.
+
+## 3. Database tables and migrations
+
+### 3.1 Table inventory
+
+The following 94 names cover every explicit table declaration.
+
+| Disposition | Count | Tables | Reason / next action |
+|---|---:|---|---|
+| `core` | 57 | `artifacts`, `audit_log`, `bootstrap_log`, `calibration_outcomes`, `change_events`, `checkpoints`, `claim_edges`, `claim_evidence_relations`, `claim_scope_versions`, `claims`, `context_snapshots`, `decision_options`, `decisions`, `embedding_metadata`, `entity_links`, `entity_topics`, `events`, `evidence_clusters`, `evidence_locators`, `experiment_observations`, `experiment_plan_versions`, `experiment_run_events`, `experiment_runs`, `experiments`, `figures`, `fts_claims`, `fts_clusters`, `fts_decisions`, `fts_journal`, `fts_literature`, `fts_missions`, `graph_views`, `hook_executions`, `hooks`, `interpretation_candidate_hints`, `interpretation_candidates`, `interpretation_promotions`, `interpretation_review_events`, `jobs`, `journal`, `keynodes`, `kv_store`, `literature`, `missions`, `project_deletion_authorizations`, `project_states`, `projects`, `review_queue`, `schema_migrations`, `tags`, `topics`, `vec_artifacts`, `vec_claims`, `vec_decisions`, `vec_journal`, `vec_literature`, `vec_missions` | Canonical research knowledge, evidence, provenance, retrieval, integrity, async Core jobs, and generic Core lifecycle hooks. |
+| `writer-legacy-export` | 29 | `manuscript_checkpoints`, `manuscript_claim_evidence`, `manuscript_claim_ratifications`, `manuscript_claim_units`, `manuscript_claim_verification_attestations`, `manuscript_claim_versions`, `manuscript_claims`, `manuscript_evaluation_events`, `manuscript_migration_issues`, `manuscript_planning_artifact_versions`, `manuscript_planning_artifacts`, `manuscript_planning_branch_events`, `manuscript_planning_branches`, `manuscript_planning_evidence_bindings`, `manuscript_planning_promotion_events`, `manuscript_reference_members`, `manuscript_source_events`, `manuscript_source_proposals`, `manuscript_unit_citations`, `manuscript_unit_evidence`, `manuscript_unit_outline_profiles`, `manuscript_units`, `manuscripts`, `reference_validation_attestations`, `reference_validation_migration_issues`, `semantic_patch_context_manifests`, `semantic_patch_proposal_events`, `semantic_patch_proposals`, `semantic_patch_provider_events` | Preserve IDs, revisions, ratifications, references, ledgers, and checksums for export to Writer staging. No new schema features in Core. |
+| `core-legacy` | 7 | `project_state`, `journal_v2`, `events_v2`, `checkpoints_v2`, `exploration_summaries`, `qa_sessions`, `qa_logs` | The singleton/project migration remnants and old LLM summary/Q&A records remain readable for compatibility. `*_v2` names are transient migration tables and must never become public entities. |
+| `agentic` | 1 | `brain_notifications` | The queue is named for and consumed by the orchestration role. Migrate still-actionable notifications or explicitly expire them before removing the Core table; Core keeps generic hooks and hook-execution audit. |
+
+`project_deletion_authorizations` is classified `core`, despite first appearing
+in a manuscript migration, because Core claim-scope, interpretation, and
+experiment immutability triggers now depend on it. Its API should be made a
+generic integrity primitive before the Writer export is removed.
+
+### 3.2 Migration-family inventory
+
+All migration files remain in Core history so existing databases can upgrade.
+Disposition controls active ownership and future feature work, not whether a
+historical SQL file is deleted.
+
+| Files | Count | Disposition | Scope |
+|---|---:|---|---|
+| `001`--`031` | 31 | `core` | Artifacts, retrieval, multi-project scoping, jobs, claims/clusters, temporal state, hooks, decisions, Zotero, review/freshness, and claim evidence status. |
+| `032`--`034` | 3 | `writer-legacy-export` | Reference validation, native manuscript aggregate, and legacy manuscript backfill. |
+| `035` | 1 | `core` | Generic monotonic semantic change cursor. Writer-specific impact projection is not part of this ownership. |
+| `036` | 1 | `writer-legacy-export` | Async manuscript-reference validation. |
+| `037` | 1 | `core` | Generic Core job lease fencing. |
+| `038`--`039` | 2 | `writer-legacy-export` | Reference manifest and immutable Writer ledgers. Before removing active Writer use, preserve the generic `project_deletion_authorizations` primitive in Core. |
+| `040`--`042` | 3 | `core` | Interpretation staging, claim-scope contracts, and experiment evidence substrate. |
+| `043`--`050` | 8 | `writer-legacy-export` | Planning, semantic proposals, promotions, evaluation ledger, outline, academic-writing semantics, and source synchronization. |
+| `051` | 1 | `core` | Project-scoped tag primary key and change events. |
+
+Totals: 37 `core` migrations and 14 `writer-legacy-export` migrations.
+
+## 4. REST API ownership
+
+The endpoint count in this table is exact and sums to 230. Mixed modules are
+split by endpoint so each family has one disposition.
+
+| Route module / endpoint family | Endpoints | Disposition | Extraction rule |
+|---|---:|---|---|
+| `academic.py` | 5 | `core` | BibTeX/document ingestion and literature metadata. |
+| `artifacts.py` | 6 | `core` | Research artifacts and figures. |
+| `audit.py` | 2 | `core` | Core audit log and counts. |
+| `changes.py`: `/changes` | 1 | `core` | Generic project change cursor. |
+| `changes.py`: `/manuscripts/{id}/impact` | 1 | `writer` | Reimplement in Writer using Core `changes_since` and Writer-owned bindings. |
+| `checkpoints.py` | 4 | `core` | Durable research checkpoints, not agent runtime checkpoints. |
+| `claims.py` | 7 | `core` | Claims, scope versions, and claim edges. |
+| `clusters.py` | 4 | `core` | Evidence clusters. |
+| `config.py` | 5 | `core` | Embedding configuration and re-embedding lifecycle. |
+| `context.py`: context + eviction | 2 | `core` | Deterministic context assembly and rule-based archival proposal. |
+| `context.py`: `/summarize` | 1 | `agentic` | Model-driven synthesis moves behind an Agentic client of Core. |
+| `decisions.py` | 20 | `core` | Research decisions, options, supersession, PI selection, and outcomes. |
+| `enrich.py` | 1 | `agentic` | LLM-driven semantic linking becomes an Agentic workflow using public Core mutations. |
+| `entities.py` | 1 | `core` | Bounded Core entity resolution. |
+| `events.py` | 1 | `core` | Durable research event log. |
+| `experiments.py` | 13 | `core` | Scientific plans/runs/observations/evidence remain canonical; actual execution is Agentic. |
+| `graph.py` | 8 | `core` | Graph reads, refresh, traversal, timeline, and report context. |
+| `hooks.py`: hook CRUD, executions, fire | 8 | `core` | Generic lifecycle integration and execution audit. |
+| `hooks.py`: notification list + clear | 2 | `agentic` | Move with the Brain notification queue. |
+| `interpretations.py` | 5 | `core` | Auditable staging and promotion into canonical knowledge. |
+| `literature.py` | 5 | `core` | Literature registry and Zotero binding. |
+| `llm.py` | 4 | `agentic` | Provider/model configuration and probing are orchestration concerns. |
+| `maintenance.py` | 3 | `core` | Backlog, summary, and research-health checks. |
+| `manuscript_sources.py` | 7 | `writer` | Writer-owned source snapshots and proposals. |
+| `manuscripts.py` | 20 | `writer` | Active manuscript aggregate, spine, outline, checkpoints, and validation API. |
+| `missions.py` | 6 | `core` | Durable mission objective/report; Agentic owns execution state. |
+| `notes.py` | 4 | `core` | Journal create/read/update. |
+| `onboarding.py` | 1 | `core` | Core client onboarding; remove role-specific Agentic prose from its template. |
+| `planning.py` | 17 | `writer` | Writer planning branches, contributions, evaluation mapping, and outline proposals. |
+| `project.py` | 10 | `core` | Projects, capabilities, status, import/export, and deletion. |
+| `research_map.py` | 4 | `core` | Research questions, clusters, and claim navigation. |
+| `researcher_tools.py` | 10 | `core` | Evidence assembly, cluster lifecycle, RQ advancement, freshness, and integrity. |
+| `review_queue.py` | 4 | `core` | Canonical interpretation/review queue. |
+| `search.py` | 1 | `core` | Project-scoped hybrid search. |
+| `semantic_patches.py` | 9 | `writer` | Writer semantic edits and LM Studio proposal path. |
+| `summary.py`: generate + ask | 2 | `agentic` | LLM execution moves to Agentic. |
+| `summary.py`: list/get/bless + Q&A history/verify | 6 | `core-legacy` | Read historical records during compatibility; do not add new Core Q&A features. |
+| `tags.py` | 1 | `core` | Project-scoped research tags. |
+| `topics.py` | 6 | `core` | Research topics and hierarchy. |
+| `verification.py` | 5 | `core` | Provenance, mission guard, as-of belief, and staleness. |
+| `workspace.py` | 5 | `core` | Workspace discovery/ingestion into research knowledge. |
+| `zotero_config.py` | 3 | `core` | Literature connector configuration. |
+
+Disposition totals: 160 `core`, 54 `writer`, 10 `agentic`, and 6
+`core-legacy` endpoints.
+
+The `/api/health` route in `rka/api/app.py` is `core`. The SPA fallback is
+`core` infrastructure; after extraction it serves only the minimal Core UI.
+
+## 5. MCP ownership
+
+### 5.1 Typed operation inventory
+
+| Operation family | Count | Disposition | Operations |
+|---|---:|---|---|
+| Core/session/capabilities | 11 | `core` | `status`, `context`, `search`, `entity`, `resolve_entities`, `changes_since`, `changelog`, `update_status`, `bulk_update`, `list_projects`, `health` |
+| Project creation | 1 | `core` | `create_project` |
+| Journal/ingestion | 5 | `core` | `journal`, `record_note`, `ingest_document`, `update_note`, `batch_import` |
+| Decisions/calibration | 10 | `core` | `decision_tree`, `record_decision`, `update_decision`, `orphan_supersedes`, `link_supersession`, `supersede_decision`, `present_decision`, `record_pi_selection`, `record_outcome`, `calibration_metrics` |
+| Literature | 7 | `core` | `literature`, `record_literature`, `update_literature`, `import_bibtex`, `enrich_doi`, `link_literature_to_zotero`, `process_paper` |
+| Missions/checkpoints | 13 | `core` | `mission`, `report`, `mission_guard`, `create_mission`, `update_mission`, `update_mission_status`, `submit_report`, `advance_rq`, `checkpoints`, `submit_checkpoint`, `resolve_checkpoint`, `create_gate`, `evaluate_gate` |
+| Claims/research map/review | 19 | `core` | `research_map`, `review_queue`, `clusters`, `claims`, `claim_scope`, `interpretation_candidates`, `evidence`, `extract_claims`, `create_interpretation_candidate`, `add_interpretation_hint`, `triage_interpretation_candidate`, `set_claim_scope`, `review_claims`, `create_cluster`, `assign_claims_to_cluster`, `split_cluster`, `merge_clusters`, `review_cluster`, `resolve_contradiction` |
+| Experiments | 10 | `core` | `experiments`, `experiment_runs`, `experiment_observations`, `create_experiment`, `append_experiment_plan`, `transition_experiment`, `create_experiment_run`, `transition_experiment_run`, `record_experiment_observation`, `add_evidence_locator` |
+| Graph/provenance | 9 | `core` | `graph`, `ego_graph`, `graph_stats`, `graph_mermaid`, `provenance`, `multi_hop`, `collect_report_context`, `staleness_impact`, `belief_as_of` |
+| Maintenance | 7 | `core` | `freshness`, `contradictions`, `integrity`, `pending_maintenance`, `flag_stale`, `eviction_sweep`, `bootstrap_review` |
+| Workspace | 4 | `core` | `workspace_tree`, `workspace_scan`, `bootstrap_workspace`, `scan_workspace` |
+| Hooks | 6 | `core` | `hooks`, `hook_executions`, `hook_add`, `hook_enable`, `hook_disable`, `hook_delete` |
+| Manuscript | 19 | `writer` | `manuscript`, `manuscript_reference_manifest`, `manuscript_context`, `manuscript_readiness`, `manuscript_spine`, `manuscript_outline`, `manuscript_writing_candidates`, `manuscript_impact`, `register_manuscript`, `create_manuscript`, `update_manuscript`, `upsert_argument_spine`, `replace_manuscript_reference_manifest`, `ratify_manuscript_claim`, `transition_manuscript_phase`, `create_manuscript_checkpoint`, `resolve_manuscript_checkpoint`, `record_verification_attestation`, `prepare_manuscript_outline_proposal` |
+| Manuscript planning | 16 | `writer` | `planning_branches`, `planning_resume`, `planning_compare`, `planning_artifact_versions`, `planning_argument_workflow`, `planning_promotions`, `planning_evaluation_workflow`, `planning_evaluation_events`, `create_planning_branch`, `transition_planning_branch`, `append_planning_artifact_version`, `promote_planning_rq`, `prepare_planning_contribution`, `ratify_planning_contribution`, `create_planning_evaluation_mission`, `prepare_planning_evaluation_result` |
+| Semantic patches | 7 | `writer` | `semantic_patch_proposals`, `semantic_patch_schema`, `prepare_semantic_patch_context`, `create_semantic_patch_proposal`, `apply_semantic_patch_proposal`, `reject_semantic_patch_proposal`, `generate_lm_studio_semantic_patch` |
+| Citation validation | 2 | `writer` | `reference_validation_status`, `validate_reference` |
+| Model-driven synthesis/notification/runtime | 5 | `agentic` | `summarize`, `generate_summary`, `brain_notifications`, `brain_notifications_clear`, `session_digest` |
+| Obsolete session reset | 1 | `core-legacy` | `reset_session` |
+
+Totals: 102 `core`, 44 `writer`, 5 `agentic`, and 1 `core-legacy`.
+
+### 5.2 MCP transport and compatibility surface
+
+| Component | Disposition | Action |
+|---|---|---|
+| `rka_query`, `rka_execute`, `rka_describe` | `core` | Keep the dispatch pattern; remove Writer/Agentic branches from Core only after clients pass E2 contracts. |
+| `rka_load_tools`, `rka_help`, deferred per-tool wrappers | `core-legacy` | Preserve through the final 2.x compatibility release; Core 3.0 may remove wrappers not needed by supported clients. |
+| `rka_list_skills`, `rka_read_skill`, `rka_start_session` | `core` | Keep the adapter mechanism but reduce Core payloads to the thin Core-usage skill. Writer and Agentic publish their own skills. |
+| Six MCP prompts in `server.py` | `agentic` | Role/decision/execution prompts move with Agentic; Core retains only neutral API-usage instructions. |
+| `operation_args.py`, `operation_args_batch_c.py`, `_enums.py`, `operations_schema.py`, `verb_dispatch.py` | `core` | Split generated/curated Writer and Agentic branches during E2; then publish Core's contract snapshot for downstream generation. |
+
+Legacy functions in `server.py` follow the disposition of their corresponding
+typed operation and are not a second authority.
+
+## 6. Models and services
+
+### 6.1 Model modules
+
+| Modules | Count | Disposition |
+|---|---:|---|
+| `audit`, `calibration`, `checkpoint`, `claim`, `context`, `decision`, `decision_option`, `event`, `experiment`, `hooks`, `interpretation`, `journal`, `knowledge_pack`, `literature`, `mission`, `project`, `review_queue`, `topic`, `workspace` | 19 | `core` |
+| `manuscript_native`, `manuscript_source`, `outline`, `planning`, `reference_validation`, `semantic_patch` | 6 | `writer` |
+
+`knowledge_pack` is classified `core`, but its Writer record definitions must
+move into the legacy Writer exporter/importer rather than remain in the Core
+pack schema indefinitely.
+
+### 6.2 Service modules
+
+| Modules | Count | Disposition |
+|---|---:|---|
+| `academic`, `admin_repair`, `artifacts`, `audit`, `backfill`, `base`, `calibration`, `change_tracking`, `checkpoints`, `claims`, `classify`, `clusters`, `context`, `decision_options`, `decisions`, `embedding_backfill`, `embedding_config`, `embedding_reshape`, `entity_resolver`, `events`, `experiments`, `graph`, `hook_dispatcher`, `hooks_service`, `interpretation`, `jobs`, `knowledge_pack`, `literature`, `maintenance`, `missions`, `notes`, `onboarding`, `pareto`, `project`, `reindex`, `rendering`, `research_map`, `researcher_tools`, `review_queue`, `search`, `topics`, `verification`, `worker`, `workspace`, `zotero_config`, `zotero_linker` | 46 | `core` |
+| `manuscript`, `manuscript_native`, `manuscript_source`, `outline`, `outline_integrity`, `planning`, `reference_validation`, `semantic_patch`, `lm_studio_proposals` | 9 | `writer` |
+| `summary` | 1 | `agentic` |
+
+Required splits before extraction:
+
+- `context` keeps deterministic retrieval in Core; its LLM summarization path
+  moves to Agentic.
+- `worker` keeps Core import/embedding jobs; reference-validation jobs move to
+  Writer.
+- `knowledge_pack` keeps Core research records; Writer rows become the
+  versioned legacy export payload.
+- `summary` moves its generation logic to Agentic, while old summary/Q&A rows
+  remain `core-legacy` data until an explicit retention decision.
+
+The provider modules `rka/infra/llm.py` and `rka/infra/llm_models.py` are
+`agentic`; database/files/IDs and embedding infrastructure are `core`.
+
+## 7. Skills, plugin, and package entry points
+
+### 7.1 Skill and plugin inventory
+
+The same role material is currently mirrored under `rka/skills/` and
+`plugin/skills/`. Each row applies to both copies.
+
+| Skill / plugin component | Disposition | Action |
+|---|---|---|
+| `brain`, `executor`, `pi` | `agentic` | Extract role policy and workflows to the Agentic plugin. |
+| `writer` and all references, venue registry, scripts, templates, and Writer MCP tools | `writer` | Extract with history to Writer and retain its human-writing-quality tests. |
+| `mcp-credentials` | `core` | Keep connector credentials needed by Core literature/retrieval integrations; remove provider credentials used only by downstream products. |
+| `rka/skills/SKILL.md` umbrella | `core` | Replace role router with a small Core usage/retrieval/provenance guide. |
+| `plugin/.claude-plugin/plugin.json`, `.mcp.json`, bridge, SessionStart health hook | `core` | Keep as the Core connector plugin and remove Writer/Agentic claims after their plugins exist. |
+| Commands `rka-status`, `rka-search`, `rka-pending`, `rka-setup-claude-desktop` | `core` | Keep with the Core connector. |
+| Command `rka-set-project` | `core-legacy` | It is already a deprecated no-op; remove after supported clients use explicit `project_id`. |
+| Command and helper `rka-start-manuscript` | `writer` | Move to Writer. |
+| Marketplace entry `.claude-plugin/marketplace.json` | `core` | Continue distributing Core only; update stale operation and skill counts. Writer and Agentic get their own manifests. |
+
+Do not keep two manually edited skill sources after extraction. Each target
+repository owns one source tree and generates or verifies its packaged plugin
+copy in CI.
+
+### 7.2 Package and process entry points
+
+| Entry point | Disposition | Action |
+|---|---|---|
+| Console script `rka = rka.cli:main` | `core` | Retain Core serve/MCP/worker/status/backup/migrate/admin/credential commands. |
+| `rka writer ...` subcommand group | `writer` | Move to Writer CLI and remove its registration from Core after compatibility. |
+| Console script `rka-writer-tools` | `writer` | Move unchanged in responsibility, then version independently. |
+| `rka.api.app:app`, `rka serve`, Docker `CMD`, Compose `rka` service | `core` | Core REST and minimal UI runtime. |
+| `rka mcp` | `core` | Core agent-facing connector. |
+| `rka worker` | `core` | Retain Core jobs only; Writer validation workers move out. |
+| `web/src/main.tsx` SPA | `core` | Remains Core shell; extract Workbench routes/components and split mixed API types. |
+| `scripts/rka_mcp_oauth_proxy.py`, `scripts/tunnel.sh` | `core` | Core HTTP MCP/ChatGPT connector deployment. |
+| `scripts/sanitize_knowledge_pack.py` | `core` | Core pack integrity utility; add Writer export sanitization in Writer, not here. |
+
+The `writer-tools` optional dependency group is `writer`. The general `llm`
+provider dependencies become `agentic`, except embeddings (`fastembed`,
+`sqlite-vec`) which remain `core`. `academic`, `workspace`, and `dev` remain
+Core groups after Writer-only packages and tests move.
+
+## 8. Test ownership
+
+There are 232 Python test files: 218 under `tests/` and 14 in the eval
+harness. Every file receives a disposition by the rules below.
+
+| Test set | Count | Disposition |
+|---|---:|---|
+| All tests not named in the following rows | 163 | `core` |
+| `tests/skills/writer/test_*.py` | 30 | `writer` |
+| Root `tests/test_manuscript_native_models.py` | 1 | `writer` |
+| API: `test_change_tracking_routes`, `test_manuscript_planning`, `test_manuscript_sources`, `test_native_manuscripts`, `test_reference_validation_attestations`, `test_semantic_patches` | 6 | `writer` |
+| DB: migrations `032`, `033`, `034`, `036`, `038`, `039`, `043`, `044`, `047`, `048`, `049`, `050` | 12 | `writer` |
+| MCP: `test_manuscript_planning`, `test_native_manuscript_operations`, `test_reference_validation_attestations` | 3 | `writer` |
+| Services: `test_async_reference_validation`, `test_evaluation_contract`, `test_knowledge_pack_native`, `test_knowledge_pack_planning`, `test_knowledge_pack_semantic_patch`, `test_manuscript_planning`, `test_manuscript_project_scope`, `test_manuscript_source`, `test_native_manuscript_service`, `test_outline`, `test_reference_validation_attestations`, `test_semantic_patch` | 12 | `writer` |
+| `eval-harness/v3/tests/test_writing_metrics.py` | 1 | `writer` |
+| API `test_llm_health`, infra `test_llm_call_is_bounded`, services `test_llm_failure_is_visible` and `test_summary_qa` | 4 | `agentic` |
+| `eval-harness/v3/tests/test_writing_metrics.py` is already counted above; no additional Agentic eval test exists on `origin/main` | 0 | `agentic` |
+
+The table totals 232: 163 `core`, 65 `writer`, and 4 `agentic`.
+
+Several `core` files are mixed integration tests and must be split rather than
+copied wholesale: `test_knowledge_pack.py`, `test_project.py`,
+`test_update_scope_guards.py`, `test_app_lifespan.py`,
+`test_skill_adapter_tools.py`, and `test_skills_packaging.py`. Core retains the
+Core assertions; Writer or Agentic receives the downstream scenarios.
+
+`eval-harness/`, `v2`, and the v3 retention/currency/tracing/self-study suites
+are `core`. `eval-harness/v3/writer/` and its writing metrics are `writer`.
+Captured results remain historical evidence in their owning repository but
+are not executable product code.
+
+## 9. Web UI ownership
+
+### 9.1 Pages and routes
+
+| Pages/routes | Count | Disposition |
+|---|---:|---|
+| `Dashboard`, `Journal`, `Decisions`, `Literature`, `Missions`, `Timeline`, `KnowledgeGraph`, `ResearchMap`, `InterpretationStaging`, `ClaimScopeReview`, `ResearchHealth`, `ReportContext`, `AuditLog`, `ContextInspector`, `Settings` | 15 page modules / 15 routes | `core` |
+| `ManuscriptWorkbench` at `/workbench` and `/manuscripts/:manuscriptId/workbench` | 1 page module / 2 routes | `writer` |
+
+`Settings` remains `core`, but its server-side LLM provider controls move to
+Agentic and any LM Studio Workbench controls move to Writer.
+
+### 9.2 Components, hooks, and API client
+
+| Component family | Disposition | Action |
+|---|---|---|
+| `components/workbench/*` (9 files) | `writer` | Extract with the Workbench page. |
+| `useManuscriptOutline`, `useManuscriptSources`, `useManuscriptWorkbench`, `usePlanningBranches`, `useSemanticPatches` | `writer` | Extract with Writer API bindings. |
+| Remaining layout/shared/UI components, project provider, and Core hooks | `core` | Keep minimal research-record UI. |
+| `api/client.ts`, `api/types.ts` | `core` | Split Writer and provider-specific methods/types into generated downstream clients; Core file retains only the Core OpenAPI surface. |
+| Sidebar/header navigation | `core` | Remove Workbench navigation after Writer has its own entry point. |
+
+## 10. Major directory and documentation disposition
+
+| Current area | Disposition | Boundary action |
+|---|---|---|
+| `rka/db`, Core models/services/routes, `rka/infra` except LLM provider modules | `core` | Harden and publish stable contracts. |
+| `rka/skills/writer`, Writer models/services/routes and `rka/cli_writer.py` | `writer` | Extract after E2. |
+| `rka/skills/{brain,executor,pi}` and LLM-provider modules | `agentic` | Extract with the agentic branch runtime after E2. |
+| `plugin/` | `core` | Split role skills/commands; retain connector shell. |
+| `web/` | `core` | Extract Workbench page/components/hooks; retain maintenance UI. |
+| `eval-harness/` | `core` | Extract only `v3/writer`; keep retrieval/reliability evaluation. |
+| `tests/` | `core` | Apply the exact test split in section 8. |
+| `examples/` | `core` | Knowledge-pack example remains Core; do not embed manuscript-only fixtures in future packs. |
+| `scripts/` | `core` | Connector/tunnel and Core pack sanitation. |
+| `.github/workflows/` | `core` | Core CI remains; downstream repositories create independent CI rather than importing Core workflow internals. |
+| `docs/adr/0001`, `0005`--`0011`; Writer plans/specs/walkthroughs | `writer` | Preserve history and cross-link from Core's migration docs. |
+| `docs/adr/0002`--`0004`; Core architecture/manual/connector/retrieval docs | `core` | Remain authoritative for Core. |
+| `docs/adr/0012`, ecosystem roadmap/slate/separation documents | `core` | Remain in Core as the ecosystem's origin decision record; downstream repos link back. |
+| `docs/paper/` | `core-legacy` | Historical project papers are not product runtime; retain until an archival policy is approved. |
+| `docs/archive/` | `core-legacy` | Preserve repository history; do not move as active product documentation. |
+| Root Docker/Compose/install/user docs | `core` | Remove Writer/Agentic setup only after replacements exist. |
+
+There is no `orchestrator/` directory on this `origin/main` baseline. Its actual
+runtime must be inventoried from the `agentic` branch during E3 and cannot be
+assumed to match the role skills currently on main.
+
+## 11. Resolved ambiguities and required refactors
+
+These cases looked cross-owned in the current monorepo. E0 resolves each to one
+authority and records the work needed to make that authority real.
+
+1. **Core is more than journal CRUD.** Claims, evidence clusters, RQs,
+   interpretations, experiment evidence, artifacts, freshness, provenance,
+   graph retrieval, and change history are `core`.
+2. **Mission versus agent run.** Mission objective, status, checkpoint, and
+   final report are `core`; scheduler state, model transcript, retries,
+   interrupts, and resumable runtime checkpoints are `agentic`.
+3. **Experiment run versus execution runtime.** A reviewed plan, run identity,
+   status transition, observation, and evidence locator are durable science and
+   therefore `core`. Commands, environments, queues, and retry machinery used
+   to execute them are `agentic`.
+4. **Change cursor versus Writer impact.** `change_events` and `/changes` are
+   `core`; the projection from Core changes to affected manuscript units is
+   `writer`.
+5. **Knowledge packs.** The Core pack contains canonical research knowledge.
+   Existing manuscript tables are `writer-legacy-export`; future Writer state
+   has its own export/import format linked by Core IDs and hashes.
+6. **Reference validation.** Literature identity and metadata remain `core`.
+   Citation/manuscript-reference attestation and readiness are `writer`.
+7. **Hooks, jobs, and Brain notifications.** Generic Core event hooks, hook
+   audit, and Core job leases remain `core`; the Brain notification queue is
+   `agentic`. No generic Core job may become an agent-run scheduler.
+8. **LLM and embeddings.** Model-provider probing, LLM summarization, and
+   auto-enrichment are `agentic`; embedding generation and vector indexes used
+   for deterministic Core retrieval are `core`.
+9. **Historical summary/Q&A data.** Old `exploration_summaries`, `qa_sessions`,
+   and `qa_logs` are `core-legacy`, while new model-driven synthesis is
+   `agentic`. Decide retention/export before removing the legacy read surface.
+10. **Dual skill mirrors.** Product ownership follows the skill, not its
+    current copy. Extraction must establish one source-of-truth per repository
+    and CI verification of packaged output.
+
+## 12. E0 extraction blockers and acceptance checks
+
+The inventory removes authority ambiguity, but the following refactors are
+prerequisites for code movement:
+
+1. Add a contract-generated count check and correct the 152/150/109
+   documentation drift.
+2. Split mixed `context`, `changes`, `hooks`, `summary`, `worker`,
+   `knowledge_pack`, Settings, MCP-schema, and API-client modules.
+3. Define the Writer legacy export schema for the 29 Writer tables, including
+   IDs, revisions, immutable ledgers, reference bindings, and checksums.
+4. Make `project_deletion_authorizations` an explicit generic Core integrity
+   primitive instead of an accidental dependency introduced by Writer.
+5. Inventory the `agentic` branch separately before E3 extraction.
+6. Keep all 51 historical migrations in Core until the oldest supported
+   database can upgrade and Writer export passes on a disposable copy.
+
+The inventory is complete for `origin/main` when reviewers confirm the counts,
+the six dispositions, and the ten resolved boundary decisions above. It does
+not authorize creating repositories, moving code, changing a live database,
+or deleting compatibility state.

--- a/docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md
+++ b/docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md
@@ -1,0 +1,340 @@
+# RKA Ecosystem Repository Separation Execution Plan
+
+- Status: accepted execution source under ADR 0012; E0 documentation in progress
+- Date: 2026-08-25
+- Decision owner: Chenglong Fu
+- Current repository: `infinitywings/rka`
+- Clean planning baseline: `origin/main` at `57fa8f0`
+- Related integrity candidate: `fix/claim-edge-integrity` at `eb9faa3`
+- Ownership inventory:
+  [`2026-08-25-rka-ecosystem-ownership-inventory.md`](2026-08-25-rka-ecosystem-ownership-inventory.md)
+- GitHub tracking slate:
+  [`2026-08-25-rka-ecosystem-github-slate.md`](2026-08-25-rka-ecosystem-github-slate.md)
+- Core-only baseline:
+  [`2026-08-25-rka-core-only-baseline.md`](../specs/2026-08-25-rka-core-only-baseline.md)
+- Claim-edge audit and remediation evidence:
+  [`2026-08-25-claim-edge-integrity-audit.md`](../specs/2026-08-25-claim-edge-integrity-audit.md)
+
+## 1. Objective
+
+Separate the current RKA implementation into three independently installable
+and releasable products while preserving the existing research database,
+provenance, implementation history, and already validated Writer/Workbench
+behavior:
+
+1. `infinitywings/rka`: research-knowledge core;
+2. `infinitywings/rka-writer`: academic-writing application and Workbench;
+3. `infinitywings/rka-agentic`: agent orchestration runtime.
+
+The immediate product priority is Core correctness and retrieval. Repository
+extraction is a controlled consequence of that priority, not a reason to pause
+or dilute Core reliability work.
+
+## 2. Constraints
+
+- Preserve the current `infinitywings/rka` repository and its public URL.
+- Preserve all user databases and identifiers.
+- Do not develop new Writer/Workbench behavior inside Core after E0.
+- Do not use the dirty root checkout as an extraction source.
+- Do not require Writer or Agentic to run Core.
+- Do not permit Writer or Agentic to import Core internals or open its database.
+- Do not automatically drop legacy manuscript/planning tables.
+- Do not require lockstep releases or a new GitHub organization.
+- Do not add an event bus, shared-model repository, or fourth umbrella
+  repository without measured need.
+
+## 3. Component ownership
+
+| Current area | Target owner | Disposition |
+|---|---|---|
+| `rka/db`, general models, project/journal/literature/decision/mission services | Core | Keep and harden |
+| claims, clusters, RQs, provenance, freshness, experiments, artifacts | Core | Keep and harden |
+| FTS/vector/graph retrieval, knowledge packs, integrity, migration | Core | Keep and harden |
+| Core REST/MCP/CLI and minimal maintenance UI | Core | Keep and stabilize |
+| `rka/skills/writer`, `plugin/skills/writer`, Writer tools/tests | Writer | Extract with history |
+| manuscript, manuscript-claim/unit, outline, planning and source-sync services | Writer | Migrate behind compatibility export |
+| Workbench-specific web components and routes | Writer | Extract after API boundary is stable |
+| Brain/Executor/PI autonomous orchestration runtime | Agentic | Extract from the agentic branch |
+| agent runs, scheduling, interrupts, runtime checkpoints and transcripts | Agentic | Store outside Core |
+| generic Core usage/retrieval/provenance guidance | Core | Retain as a small connector skill |
+| legacy manuscript tables and migrations | Core legacy | Preserve read-only during compatibility window |
+
+Before extraction, E0 produces a machine-readable or tabular inventory of all
+tables, API routes, MCP operations, skills, tests, package entry points, and web
+pages. Ambiguous items block extraction until one owner is selected.
+
+## 4. Integration contract
+
+### 4.1 Core contract
+
+Core provides:
+
+- version and capability discovery;
+- an OpenAPI contract and MCP operation descriptions;
+- explicit project scoping;
+- revision/content-hash information for durable references;
+- idempotent retry support for consumer writes;
+- change-cursor retrieval for detecting stale downstream references;
+- export/import and integrity reports.
+
+REST is the deterministic application contract. MCP is the agent-facing
+contract. Neither contract exposes database paths or service-layer classes.
+
+### 4.2 Writer references to Core
+
+A durable Writer binding contains:
+
+```json
+{
+  "project_id": "prj_...",
+  "entity_id": "clm_...",
+  "entity_type": "claim",
+  "revision": 7,
+  "content_hash": "sha256:...",
+  "locator": "source-specific locator"
+}
+```
+
+Writer uses Core's change cursor to recheck these bindings. A changed or
+missing reference becomes a Writer review finding; Writer never overwrites the
+Core record to make its draft appear current.
+
+### 4.3 Agentic references to Core
+
+Agentic records durable research outcomes through Core and stores only runtime
+execution details locally. Mission IDs, decision IDs, journal IDs, and artifact
+IDs are references across the boundary. Agent retry state, model messages,
+interrupt positions, and scheduler leases are not Core journal content unless
+the agent explicitly promotes a bounded research result.
+
+## 5. Milestones and exit gates
+
+### E0: Boundary freeze and inventory
+
+Deliverables:
+
+- ADR 0012;
+- this execution plan;
+- active roadmap update;
+- component/operation/table ownership inventory;
+- initial GitHub issue and milestone slate.
+
+Exit gate:
+
+- no ambiguous authority owner;
+- old Workbench design remains discoverable but is no longer Core's active
+  implementation priority;
+- no runtime or database change has been made.
+
+Rollback: revert documentation only. No product state is affected.
+
+### E1: Core reliability baseline
+
+Scope:
+
+- journal create/read/update and provenance round trips;
+- project isolation across SQL, tags, FTS, vector retrieval, graph traversal,
+  imports, and background jobs;
+- claim-edge uniqueness and cluster merge/split integrity;
+- freshness/staleness behavior;
+- export/import, backup/restore, and migration correctness;
+- deterministic retrieval-quality and latency baselines;
+- Core-only installation and test profile.
+
+Candidate PR sequence:
+
+1. claim-edge membership and merge/split integrity;
+2. project-scoped vector partitioning and migration decision;
+3. journal/retrieval/integrity regression suite;
+4. Core-only packaging and startup gate.
+
+Exit gate:
+
+- exact journal round trip passes;
+- no cross-project retrieval leakage in any backend;
+- repeated writes and edge assignments are idempotent;
+- a real database backup upgrades and passes integrity;
+- export/import preserves IDs, links, revisions, and hashes;
+- Core starts and passes its supported tests without Writer dependencies.
+
+Rollback: restore the pre-migration database backup and previous container;
+every migration must be tested on a disposable copy before live use.
+
+### E2: Stable external contract and Writer compatibility export
+
+Scope:
+
+- freeze stable Core REST/MCP operations;
+- publish capability and version information;
+- snapshot the OpenAPI and MCP contracts in tests;
+- classify optional operations as preview/deprecated;
+- add legacy Writer-state export with counts, versions, and checksums;
+- document compatibility errors and supported version ranges.
+
+Exit gate:
+
+- a client using only the public contract can complete a project/journal/
+  claim/cluster/RQ/evidence workflow;
+- mock Writer and Agentic clients contain no imports from `rka.services`,
+  `rka.models`, or `rka.db`;
+- legacy Writer export round-trips on a disposable database copy.
+
+Rollback: consumers continue using the prior Core version; no authority switch
+occurs in E2.
+
+### E3: Agentic repository extraction
+
+Scope:
+
+- extract the `orchestrator/` history from the agentic branch;
+- create `infinitywings/rka-agentic`;
+- make `RKA_API_URL` and supported Core versions explicit;
+- replace manually synchronized Core internals with a generated or pinned
+  public-contract snapshot;
+- establish independent tests, packaging, and deployment documentation.
+
+Exit gate:
+
+- Core and Agentic each install and test independently;
+- Agentic does not import Core internals or open Core storage;
+- a real integration test performs mission pickup, checkpoint, report, and
+  provenance recording through the public contract;
+- failure on an incompatible Core version is immediate and actionable.
+
+Rollback: the existing agentic branch remains available until the extracted
+repository passes the integration gate.
+
+### E4: Writer repository extraction and state migration
+
+Scope:
+
+- extract Writer skill, tools, tests, templates, and history;
+- create `infinitywings/rka-writer`;
+- introduce Writer-owned state and Workbench service boundaries;
+- import legacy manuscript/planning state while preserving identifiers;
+- move Writer-specific UI and provider integration;
+- establish stale-Core-reference detection and end-to-end manuscript tests.
+
+Migration gate for each database:
+
+1. export legacy state from an online or offline backup;
+2. import into Writer staging;
+3. compare entity counts, IDs, hashes, bindings, ratifications, and lineage;
+4. run a read-only Workbench acceptance pass;
+5. explicitly activate Writer authority;
+6. retain the Core copy read-only for recovery.
+
+Exit gate:
+
+- Writer installs without Core source code;
+- Core runs without Writer;
+- a real project completes Core claim -> Writer spine -> outline -> draft ->
+  provenance inspection;
+- a revised Core claim causes a visible Writer stale-reference finding;
+- the approved human writing-quality pilot remains passing.
+
+Rollback: switch back to the legacy Core Writer surface; do not delete either
+copy until the compatibility window ends.
+
+### E5: Core 3.0 slimming
+
+Scope:
+
+- remove Writer skills, tools, routes, MCP operations, services, optional
+  dependencies, and Workbench UI from the active Core distribution;
+- remove orchestration-specific mirrors and documentation;
+- retain the narrow legacy Writer export path and migration history;
+- update installation, plugin, and user documentation.
+
+Exit gate:
+
+- no active Core operation depends on Writer or Agentic packages;
+- Core-only tests, migration tests, retrieval evaluation, packaging, Docker,
+  MCP, and REST smoke tests pass;
+- Writer and Agentic compatibility suites pass against the release candidate;
+- existing databases open without destructive schema changes.
+
+Rollback: remain on the final 2.x compatibility release. Core 3.0 is not
+published until downstream suites pass.
+
+### E6: Ecosystem integration and release discipline
+
+Scope:
+
+- maintain the `RKA Ecosystem` GitHub Project;
+- publish a compact compatibility matrix;
+- test Core alone, Core+Writer, Core+Agentic, and all three together;
+- document installation, upgrade, backup, and recovery for each supported
+  combination.
+
+Exit gate:
+
+- every supported combination has a reproducible smoke test;
+- independent releases do not require lockstep tags;
+- unsupported combinations fail with a clear version message;
+- the integration documentation is tested from a clean machine or disposable
+  environment.
+
+## 6. Release sequence
+
+1. Final RKA 2.x compatibility release: stable contracts, deprecations, and
+   Writer export.
+2. RKA Agentic 1.0: public-contract-only orchestrator.
+3. RKA Writer 1.0: public-contract-only Writer and verified legacy import.
+4. RKA Core 3.0: active optional-layer code removed after downstream gates.
+
+The releases are independent. Each downstream repository publishes the Core
+major versions it supports.
+
+## 7. Git and worktree discipline
+
+- Do not modify the currently dirty repository root.
+- Start each change from a clean worktree based on `origin/main`.
+- Keep Core reliability fixes separate from architecture documentation and
+  extraction work.
+- Extract repository history rather than copying a snapshot when new remote
+  repositories are created.
+- Preserve the current remote branches until extraction and compatibility
+  gates pass.
+- Do not merge, push, create remote repositories, or migrate live data as an
+  incidental part of documentation work.
+
+## 8. Work that can start immediately
+
+The following work is safe to complete before creating either downstream
+repository:
+
+1. Review and merge the boundary ADR and roadmap documentation.
+2. Produce the complete ownership inventory for tables, routes, MCP operations,
+   skills, entry points, tests, and web pages.
+3. Freeze new Writer/Workbench features inside Core and route new proposals to
+   the future Writer backlog.
+4. Review the existing `fix/claim-edge-integrity` candidate independently and,
+   if accepted, merge it as the first E1 Core reliability change.
+5. Decide and test the project-scoped vector partition migration on a
+   disposable database copy; do not run the expensive live re-embedding without
+   explicit approval.
+6. Prepare the cross-repository GitHub Project phases, repository-local
+   milestones, and initial PR-sized issues after the documentation branch is
+   reviewed; do not model cross-repository E3/E4/E6 work as Core milestones.
+7. Define the Core-only test profile and record the current test, retrieval,
+   migration, and startup baseline.
+
+Do not start today:
+
+- remote repository creation;
+- live Writer-state migration;
+- deletion of manuscript tables or routes;
+- Core 3.0 removal work;
+- installed plugin/runtime replacement;
+- merging unrelated dirty-root changes.
+
+## 9. Decision checkpoints
+
+Human confirmation is required before:
+
+- creating the two new GitHub repositories;
+- switching legacy manuscript authority from Core to Writer;
+- running a long live re-embedding or irreversible data migration;
+- publishing RKA Core 3.0;
+- deleting any legacy branch, table, compatibility code, or remote artifact.

--- a/docs/superpowers/specs/2026-08-25-claim-edge-integrity-audit.md
+++ b/docs/superpowers/specs/2026-08-25-claim-edge-integrity-audit.md
@@ -1,0 +1,109 @@
+# Claim-edge integrity independent audit and remediation record
+
+- Status: remediated candidate; ready for final review before commit
+- Date: 2026-08-25
+- Baseline: `origin/main` at `57fa8f0`
+- Candidate branch: `fix/claim-edge-integrity`
+- Candidate commit before follow-up: `eb9faa3`
+- Worktree:
+  `/Volumes/FuSpace/Projects/rka/.claude/worktrees/rka-performance-eval-2d20e9`
+- Safety: no live database, service rebuild, merge, commit, push, or remote
+  change occurred during this audit and remediation
+
+## 1. Audit verdict before remediation
+
+The original candidate had the correct overall direction and a safe
+transactional migration, but was not merge-ready. The independent review found:
+
+1. **P1: retry was not a semantic no-op.** Reusing an existing `member_of`
+   edge still updated the parent cluster, which appended a false immutable
+   `change_events` row and advanced downstream cursors.
+2. **P2: NULL cluster counts escaped repair.** Migration 052 and the integrity
+   query used `!=`; SQLite treats `NULL != N` as unknown, so a legacy
+   `claim_count=NULL` remained undetected.
+3. **P2: split/merge accepted non-RQ decisions.** The path checked only project
+   membership, not `kind='research_question'`, and could emit a semantically
+   false `answers` link.
+4. **P2: mixed-RQ merge silently selected the first RQ.** Merging clusters from
+   different research questions without an explicit target reassigned evidence
+   according to source order.
+
+## 2. Remediation
+
+The follow-up changed only the isolated candidate worktree.
+
+- Duplicate membership creation now performs no cluster write and creates no
+  change event when the existing cached count is correct.
+- A genuinely stale cached count is still repaired on create or retry.
+- Migration 052 and `check_integrity` use SQLite's NULL-safe `IS NOT`
+  comparison.
+- Split and merge require an in-project decision whose semantic kind is
+  `research_question`.
+- A merge across multiple source RQs requires an explicit valid target RQ.
+- Full legacy knowledge-pack import now exercises duplicate-membership
+  normalization and count repair.
+- Two independent SQLite connections now exercise concurrent creation of the
+  same membership.
+
+Changed candidate files:
+
+- `rka/db/migrations/052_claim_edge_membership_integrity.sql`
+- `rka/services/claims.py`
+- `rka/services/knowledge_pack.py`
+- `rka/services/researcher_tools.py`
+- `tests/test_db/test_migration_052.py`
+- `tests/test_services/test_knowledge_pack.py`
+- `tests/test_services/test_researcher_tools_transactions.py`
+
+## 3. Database-copy validation
+
+Migration 052 was run only against a temporary copy of the real database.
+
+| Measure | Before | After |
+|---|---:|---:|
+| `member_of` rows | 971 | 967 |
+| distinct memberships | 967 | 967 |
+| duplicate memberships | 4 | 0 |
+| cluster count mismatches | 3 | 0 |
+| NULL cluster members | 0 | 0 |
+| NULL claim counts | 0 | 0 |
+
+The migration runner performs deletion, index creation, count repair, and
+ledger registration in one transaction, so a failure rolls back the entire
+migration.
+
+## 4. Verification
+
+| Gate | Result |
+|---|---:|
+| New and focused regression tests | 15 passed |
+| Claim/cluster/graph/knowledge-pack expanded regression | 93 passed |
+| Complete Core gate: DB + services + API + MCP | 2,804 passed |
+| `git diff --check` | passed |
+| Ruff critical syntax/undefined-name checks | passed |
+
+The complete gate produced one existing Pydantic forward-reference warning.
+The repository's default Ruff profile still reports 44 pre-existing lint items,
+including executable-bit, import-order, and broad-exception debt; they were not
+expanded into this bounded correctness change.
+
+## 5. Residual risks and explicit non-goals
+
+- Legacy pack normalization preserves the first duplicate membership in input
+  order. Choosing a survivor by timestamp or provenance would be a separate
+  policy decision.
+- Source clusters remain as empty clusters after merge and retain their
+  original `answers` links. This is existing behavior and needs a separate
+  lifecycle decision if it should change.
+- The database schema can still represent a `member_of` edge with
+  `cluster_id=NULL` when bypassing the public service. Services reject it and
+  integrity detects it; a relation-shape database constraint is future
+  hardening.
+- This Core gate does not include Writer-skill or frontend tests.
+
+## 6. Recommendation
+
+The initial `changes requested` verdict is resolved. The candidate is suitable
+for final human/code review and then a commit on `fix/claim-edge-integrity`.
+It should not be merged or pushed until that final review and the normal PR
+authorization occur.

--- a/docs/superpowers/specs/2026-08-25-claim-edge-integrity-audit.md
+++ b/docs/superpowers/specs/2026-08-25-claim-edge-integrity-audit.md
@@ -1,14 +1,15 @@
 # Claim-edge integrity independent audit and remediation record
 
-- Status: remediated candidate; ready for final review before commit
+- Status: remediated, post-push reviewed, and ready for pull-request review
 - Date: 2026-08-25
 - Baseline: `origin/main` at `57fa8f0`
 - Candidate branch: `fix/claim-edge-integrity`
-- Candidate commit before follow-up: `eb9faa3`
+- Candidate commits: `eb9faa3` (initial fix) and `a16bd40` (audit remediation)
 - Worktree:
   `/Volumes/FuSpace/Projects/rka/.claude/worktrees/rka-performance-eval-2d20e9`
-- Safety: no live database, service rebuild, merge, commit, push, or remote
-  change occurred during this audit and remediation
+- Safety: validation used only temporary databases; no live database mutation,
+  service rebuild, or merge occurred. The candidate commits were pushed to the
+  isolated branch only after regression testing and explicit PI authorization.
 
 ## 1. Audit verdict before remediation
 
@@ -103,7 +104,7 @@ expanded into this bounded correctness change.
 
 ## 6. Recommendation
 
-The initial `changes requested` verdict is resolved. The candidate is suitable
-for final human/code review and then a commit on `fix/claim-edge-integrity`.
-It should not be merged or pushed until that final review and the normal PR
-authorization occur.
+The initial `changes requested` verdict is resolved. Remote candidate
+`a16bd40` on `fix/claim-edge-integrity` passed the post-push code review and the
+complete 2,804-test Core gate. It is ready for normal pull-request review; it
+should be merged only through the repository's ordinary PR authorization.

--- a/docs/superpowers/specs/2026-08-25-rka-core-only-baseline.md
+++ b/docs/superpowers/specs/2026-08-25-rka-core-only-baseline.md
@@ -1,0 +1,280 @@
+# RKA Core-only baseline
+
+- Status: E0 measurement baseline
+- Date: 2026-08-25
+- Source baseline: `origin/main` at `57fa8f07bf6f298bc5b3a9cf113cf492898d8a03`
+- Worktree: `rka-ecosystem-roadmap`
+- Authority: [ADR 0012](../../adr/0012-rka-ecosystem-repository-boundaries.md)
+- Detailed ownership inventory: [E0 Component Ownership Inventory](../plans/2026-08-25-rka-ecosystem-ownership-inventory.md)
+
+## 1. Purpose
+
+This document establishes what can currently be treated and tested as RKA
+Core without changing the live Docker database or rebuilding/restarting a live
+service. It is a baseline, not a claim that the repository is already
+physically separable.
+
+The intended Core boundary is the canonical research-knowledge substrate:
+projects, journal entries, literature, decisions, missions, claims, evidence
+clusters, research questions, experiments, provenance, retrieval, integrity,
+import/export, and stable REST/MCP contracts. Manuscript semantics belong to
+Writer, and agent runtime/model-driven synthesis belongs to Agentic.
+
+## 2. Safety boundary used for this run
+
+The following were deliberately not used:
+
+- the running `rka-server` or `rka-worker` containers;
+- the `rka-data` Docker volume or any real `rka.db`;
+- Docker rebuild, restart, or force-recreate;
+- the installed MCP connector as a data client;
+- network-dependent academic, citation, or model-provider calls;
+- Writer workspaces or user manuscripts.
+
+Database and API checks used `tempfile.TemporaryDirectory()` and test fixtures
+backed by `tmp_path`. Imports ran with `PYTHONDONTWRITEBYTECODE=1`, so they did
+not create `__pycache__` files in the worktree.
+
+The repository has no local virtual environment. The installed RKA uv-tool
+Python 3.13 runtime provided the application dependencies, while a temporary
+`/tmp/rka-core-baseline-pytest` directory supplied only pytest and
+pytest-asyncio. This was sufficient for an isolated baseline, but it is not a
+replacement for the clean CI environment defined in `.github/workflows/pytest.yml`.
+
+## 3. Current test ownership
+
+The repository contains 232 Python test files: 218 under `tests/` and 14 in
+the eval harnesses. The detailed inventory assigns them as follows:
+
+| Owner | Files | Current disposition |
+|---|---:|---|
+| Core | 163 | Remain with Core, although six mixed files require assertion-level splitting. |
+| Writer | 65 | Move to `rka-writer`; this includes 30 Writer-skill tests and manuscript/planning/reference-validation tests. |
+| Agentic | 4 | Move to `rka-agentic`; these cover LLM health, bounded LLM calls, visible LLM failure, and summary/Q&A. |
+
+The six mixed Core files are:
+
+- `tests/test_services/test_knowledge_pack.py`
+- `tests/test_services/test_project.py`
+- `tests/test_services/test_update_scope_guards.py`
+- `tests/test_api/test_app_lifespan.py`
+- `tests/test_mcp/test_skill_adapter_tools.py`
+- `tests/test_skills_packaging.py`
+
+They should be split during extraction rather than copied into multiple
+repositories. Today there are no pytest ownership markers, so a Core-only run
+must be assembled through explicit paths/exclusions. Adding stable `core`,
+`writer`, `agentic`, and `requires_vec` markers is therefore an E1 prerequisite
+for a durable Core CI job.
+
+## 4. Dependency and process boundary findings
+
+### 4.1 Package dependencies
+
+`pyproject.toml` currently declares 10 base dependencies and five optional
+groups: `academic`, `dev`, `llm`, `workspace`, and `writer-tools`.
+
+The base set is a plausible Core runtime foundation:
+
+- MCP, FastAPI/Uvicorn, aiosqlite, Pydantic/settings;
+- HTTPX, Click, dotenv, and ULID support.
+
+The optional groups are not yet aligned with the target repository boundary:
+
+- `writer-tools` is entirely Writer-owned and should move.
+- `llm` mixes Agentic provider packages (`litellm`, `instructor`) with
+  Core-owned embedding packages (`fastembed`, `sqlite-vec`). It must be split;
+  otherwise Core cannot test vector retrieval without installing Agentic
+  dependencies.
+- `academic` and `workspace` remain useful Core capabilities after
+  Writer-specific callers are removed.
+
+The current installed uv-tool runtime did not contain `sqlite_vec`. As a
+result, a base-style installation could start in non-vector mode but applied
+only 49 of the 51 migration files to a fresh temporary database: the two
+vector-dependent migrations were skipped. Integrity then correctly reported
+six unverified vector index tables. This is the principal packaging gap found
+by this baseline.
+
+### 4.2 Unconditional Writer coupling
+
+Core process entry points still import Writer code eagerly:
+
+- `rka/cli.py` imports `rka.cli_writer` and always registers `rka writer`.
+- `rka/api/app.py` imports and mounts manuscript, manuscript-source, planning,
+  and semantic-patch routes.
+- `rka/api/deps.py` imports Writer-owned services at module import time.
+- `rka/mcp/operation_args.py` imports Writer models into the combined typed
+  dispatch union.
+- `rka/services/worker.py` mixes Core embedding jobs with Writer reference
+  validation.
+- `rka/services/knowledge_pack.py` mixes Core export/import with Writer rows.
+
+Consequently, the present package can run with Writer code included, but a
+physical Core-only package cannot yet import its CLI, API app, or MCP schema
+after simply deleting the Writer modules. These are extraction seams, not
+runtime failures in the current monorepo.
+
+### 4.3 Entry points and web surface
+
+The package publishes two console scripts:
+
+- `rka` (Core target, currently with a Writer subcommand);
+- `rka-writer-tools` (Writer target).
+
+The CLI help smoke check passed and confirmed that `writer` is still exposed
+by the Core command. The FastAPI app similarly remains a combined Core and
+Workbench application. The web application has no frontend unit-test files;
+its current CI gate is a full TypeScript/Vite production build, which was not
+run here because this task excluded rebuilds and focused on the Python Core
+boundary.
+
+## 5. Executed checks and results
+
+All commands ran from the roadmap worktree. Counts below are not additive
+because some focused groups overlap with broader groups.
+
+### 5.1 Source, metadata, and CLI smoke
+
+The application source was parsed with Python's AST, `pyproject.toml` was read
+with `tomllib`, and the Click root command was invoked with `--help`.
+
+Result:
+
+- 182 Python source files parsed successfully;
+- package name and dependency metadata loaded successfully;
+- both console entry points were present;
+- root CLI help exited successfully;
+- the root CLI still advertised the Writer command, confirming the coupling
+  described above.
+
+### 5.2 Temporary database and API startup smoke
+
+The smoke script performed the following entirely in a temporary directory:
+
+1. initialized the schema and all migrations available without `sqlite-vec`;
+2. created two projects;
+3. wrote and read back a journal entry including its summary;
+4. wrote the same search terms in another project;
+5. verified FTS returned only the requested project's entry;
+6. started and stopped the FastAPI lifespan with LLM and embeddings disabled.
+
+Result:
+
+```text
+source_version=2.9.0
+migrations_applied=49 latest=051_scope_tags_primary_key_per_project.sql
+journal_roundtrip=pass fts_project_isolation=pass hits=1
+api_lifespan_no_llm_no_embeddings=pass
+```
+
+The migration count is intentionally reported rather than normalized away:
+it records the missing `sqlite-vec` capability in this base-style runtime.
+
+### 5.3 Core service sweep
+
+First, the service suite was run with the clearly Writer-owned service files
+excluded. This broad pass produced:
+
+```text
+832 passed, 22 skipped, 20 failed
+```
+
+All 20 failures were attributable to the baseline boundary/environment:
+
+- 19 depended on vector tables or embedding metadata unavailable without
+  `sqlite-vec` (backfill, embedding workers, and integrity completeness);
+- one was `test_evaluation_contract.py`, which the ownership inventory assigns
+  to Writer and which also reached the same incomplete-index integrity result.
+
+A second pass additionally excluded the vector-dependent files and the Writer
+evaluation contract:
+
+```text
+794 passed, 16 skipped in 116.85s
+```
+
+This is the clean non-vector Core service baseline for this environment.
+
+### 5.4 Core schema and project-scope tests
+
+A focused set covered Core migrations 017--023, 030--031, multi-project
+foundation, Phase-2 startup behavior, project-scoped tag keys, v2 migration,
+database transactions, and project-scope request models.
+
+```text
+79 passed in 15.33s
+```
+
+All databases were fixture-created temporary files.
+
+### 5.5 Core REST tests
+
+The REST suite was run with the five clearly Writer-owned API files excluded.
+
+```text
+148 passed, 1 failed in 40.88s
+```
+
+The sole failure was `test_integrity_check_clean_db`: the API returned six
+`index_check_incomplete` findings because the isolated runtime lacked
+`sqlite-vec`. The same condition was independently observed during the service
+sweep. No journal, project-scope, claim, decision, graph, hook, experiment, or
+change-tracking REST failure occurred.
+
+### 5.6 Core MCP contract and dispatch tests
+
+A focused MCP set covered claims, evidence status, project scope, context
+currency, dispatch coercion, experiments, hooks, decision compatibility,
+outcomes, report fields, server behavior, and v2.6/v2.7 dispatch contracts.
+
+```text
+378 passed in 7.86s
+```
+
+This validates the current combined server's Core branches. It does not yet
+prove that the Writer branches can be physically removed from the shared
+Pydantic union; that requires the E2 contract split.
+
+## 6. Checks intentionally deferred
+
+The following are not part of this baseline result:
+
+- full `python -m pytest` in a fresh CI-equivalent environment;
+- vector migration, embedding backfill, model-swap, and vector-isolation tests;
+- package/wheel build and installation into a new clean environment;
+- Core import after physically removing Writer modules;
+- Writer or Workbench functional tests;
+- eval-harness replay against live projects;
+- frontend production build;
+- live Docker startup, migration, backup, or restore;
+- any test involving network providers or user credentials.
+
+They should not be represented as passing until their own safe environments
+and gates are available.
+
+## 7. Baseline verdict and immediate E1 actions
+
+The non-vector Core logic has a strong baseline: journal round-trip,
+project-scoped FTS, temporary API startup, 794 non-vector service tests, 79
+schema/scope tests, 148 REST tests, and 378 focused MCP tests passed. However,
+the repository is not yet a Core-only distributable because Writer modules are
+eagerly imported and vector support is bundled with Agentic LLM dependencies.
+
+The smallest next actions are:
+
+1. Split the current `llm` extra into a Core embedding extra and an
+   Agentic-owned provider extra; define whether the Core release installs the
+   embedding extra by default.
+2. Add test ownership markers or checked-in test manifests for `core`,
+   `writer`, `agentic`, and `requires_vec`, then create a Core-only CI job.
+3. Make CLI subcommands, API routers/dependencies, MCP operation unions, worker
+   handlers, and knowledge-pack record families separable without importing
+   Writer modules.
+4. Add a clean package-install smoke gate that proves `rka --help`, API
+   lifespan, Core MCP schema, journal round-trip, and integrity checks with the
+   declared Core dependency profile.
+5. Run the vector-dependent Core tests in a fresh environment containing the
+   new embedding extra before declaring the Core package release-ready.
+
+No production/runtime data was read or changed while producing this baseline.


### PR DESCRIPTION
## Summary

- ratify ADR 0012 and separate RKA Core, RKA Writer, and RKA Agentic ownership
- add the E0 ownership inventory, E0-E6 execution plan, and GitHub tracking slate
- record the Core-only baseline and the independently audited claim-edge remediation
- preserve the existing Workbench roadmap as Writer design history

## Validation

- documentation relative-link check passed
- `git diff --check` passed
- branch was reviewed after push and matches the remote commit

## Scope

This PR freezes boundaries and sequencing only. It does not create GitHub milestones or issues, move code between repositories, modify a live RKA database, or merge the separate claim-edge implementation branch.