### PR TITLE
fix(claims): enforce cluster membership integrity

### DIFF
--- a/rka/db/migrations/052_claim_edge_membership_integrity.sql
+++ b/rka/db/migrations/052_claim_edge_membership_integrity.sql
@@ -26,7 +26,7 @@ SET claim_count = (
           AND claim_edges.project_id = evidence_clusters.project_id
     ),
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
-WHERE claim_count != (
+WHERE claim_count IS NOT (
     SELECT COUNT(DISTINCT claim_edges.source_claim_id)
     FROM claim_edges
     WHERE claim_edges.cluster_id = evidence_clusters.id

--- a/rka/db/migrations/052_claim_edge_membership_integrity.sql
+++ b/rka/db/migrations/052_claim_edge_membership_integrity.sql
@@ -1,0 +1,35 @@
+-- Migration 052: make cluster membership a set, not a multiset.
+--
+-- Historical write paths could create the same member_of edge repeatedly.
+-- Keep the first recorded edge for each project/claim/cluster tuple, prevent
+-- recurrence, and repair the cached cluster counts from the unique graph.
+
+DELETE FROM claim_edges
+WHERE relation = 'member_of'
+  AND rowid NOT IN (
+      SELECT MIN(rowid)
+      FROM claim_edges
+      WHERE relation = 'member_of'
+      GROUP BY project_id, source_claim_id, cluster_id, relation
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_claim_edges_member_of
+ON claim_edges(project_id, source_claim_id, cluster_id, relation)
+WHERE relation = 'member_of';
+
+UPDATE evidence_clusters
+SET claim_count = (
+        SELECT COUNT(DISTINCT claim_edges.source_claim_id)
+        FROM claim_edges
+        WHERE claim_edges.cluster_id = evidence_clusters.id
+          AND claim_edges.relation = 'member_of'
+          AND claim_edges.project_id = evidence_clusters.project_id
+    ),
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE claim_count != (
+    SELECT COUNT(DISTINCT claim_edges.source_claim_id)
+    FROM claim_edges
+    WHERE claim_edges.cluster_id = evidence_clusters.id
+      AND claim_edges.relation = 'member_of'
+      AND claim_edges.project_id = evidence_clusters.project_id
+);

--- a/rka/services/claims.py
+++ b/rka/services/claims.py
@@ -459,6 +459,7 @@ class ClaimService(BaseService):
 
     async def create_edge(self, data: ClaimEdgeCreate) -> ClaimEdge:
         edge_id = generate_id("claim_edge")
+        stored_confidence = data.confidence
         async with self.db.transaction():
             if data.relation == "member_of":
                 if data.cluster_id is None or data.target_claim_id is not None:
@@ -494,27 +495,66 @@ class ClaimService(BaseService):
                 )
                 if cluster is None:
                     raise ValueError("cluster is not available in this project")
-            await self.db.execute(
-                """INSERT INTO claim_edges
-                   (id, source_claim_id, target_claim_id, cluster_id, relation,
-                    confidence, project_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                [
-                    edge_id,
-                    data.source_claim_id,
-                    data.target_claim_id,
-                    data.cluster_id,
-                    data.relation,
-                    data.confidence,
-                    self.project_id,
-                ],
-            )
-
             if data.relation == "member_of" and data.cluster_id:
+                existing = await self.db.fetchone(
+                    """SELECT id, confidence FROM claim_edges
+                       WHERE project_id = ? AND source_claim_id = ?
+                         AND cluster_id = ? AND relation = 'member_of'""",
+                    [self.project_id, data.source_claim_id, data.cluster_id],
+                )
+                if existing:
+                    edge_id = existing["id"]
+                    stored_confidence = existing["confidence"]
+                else:
+                    await self.db.execute(
+                        """INSERT INTO claim_edges
+                           (id, source_claim_id, target_claim_id, cluster_id,
+                            relation, confidence, project_id)
+                           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                        [
+                            edge_id,
+                            data.source_claim_id,
+                            data.target_claim_id,
+                            data.cluster_id,
+                            data.relation,
+                            data.confidence,
+                            self.project_id,
+                        ],
+                    )
                 await self.db.execute(
-                    "UPDATE evidence_clusters SET claim_count = claim_count + 1, "
-                    "updated_at = ? WHERE id = ? AND project_id = ?",
-                    [_now(), data.cluster_id, self.project_id],
+                    """UPDATE evidence_clusters
+                       SET claim_count = (
+                               SELECT COUNT(DISTINCT source_claim_id)
+                               FROM claim_edges
+                               WHERE cluster_id = ?
+                                 AND relation = 'member_of'
+                                 AND project_id = ?
+                           ),
+                           updated_at = ?
+                       WHERE id = ? AND project_id = ?""",
+                    [
+                        data.cluster_id,
+                        self.project_id,
+                        _now(),
+                        data.cluster_id,
+                        self.project_id,
+                    ],
+                )
+            else:
+                await self.db.execute(
+                    """INSERT INTO claim_edges
+                       (id, source_claim_id, target_claim_id, cluster_id, relation,
+                        confidence, project_id)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    [
+                        edge_id,
+                        data.source_claim_id,
+                        data.target_claim_id,
+                        data.cluster_id,
+                        data.relation,
+                        data.confidence,
+                        self.project_id,
+                    ],
                 )
             if data.relation == "contradicts":
                 affected_claims = [
@@ -547,7 +587,7 @@ class ClaimService(BaseService):
             target_claim_id=data.target_claim_id,
             cluster_id=data.cluster_id,
             relation=data.relation,
-            confidence=data.confidence,
+            confidence=stored_confidence,
             project_id=self.project_id,
         )
 

--- a/rka/services/claims.py
+++ b/rka/services/claims.py
@@ -489,7 +489,7 @@ class ClaimService(BaseService):
                     raise ValueError("target claim is not available in this project")
             if data.cluster_id is not None:
                 cluster = await self.db.fetchone(
-                    """SELECT 1 FROM evidence_clusters
+                    """SELECT claim_count FROM evidence_clusters
                        WHERE id = ? AND project_id = ?""",
                     [data.cluster_id, self.project_id],
                 )
@@ -521,25 +521,31 @@ class ClaimService(BaseService):
                             self.project_id,
                         ],
                     )
-                await self.db.execute(
-                    """UPDATE evidence_clusters
-                       SET claim_count = (
-                               SELECT COUNT(DISTINCT source_claim_id)
-                               FROM claim_edges
-                               WHERE cluster_id = ?
-                                 AND relation = 'member_of'
-                                 AND project_id = ?
-                           ),
-                           updated_at = ?
-                       WHERE id = ? AND project_id = ?""",
-                    [
-                        data.cluster_id,
-                        self.project_id,
-                        _now(),
-                        data.cluster_id,
-                        self.project_id,
-                    ],
+                count_row = await self.db.fetchone(
+                    """SELECT COUNT(DISTINCT source_claim_id) AS claim_count
+                       FROM claim_edges
+                       WHERE cluster_id = ? AND relation = 'member_of'
+                         AND project_id = ?""",
+                    [data.cluster_id, self.project_id],
                 )
+                actual_count = count_row["claim_count"] if count_row else 0
+                # A retry that finds the same membership must be a true no-op:
+                # updating the parent cluster would otherwise append a false
+                # semantic change to the immutable change-events ledger.  A
+                # stale cached count is still repaired on either a create or a
+                # retry, including the nullable legacy state.
+                if cluster["claim_count"] != actual_count:
+                    await self.db.execute(
+                        """UPDATE evidence_clusters
+                           SET claim_count = ?, updated_at = ?
+                           WHERE id = ? AND project_id = ?""",
+                        [
+                            actual_count,
+                            _now(),
+                            data.cluster_id,
+                            self.project_id,
+                        ],
+                    )
             else:
                 await self.db.execute(
                     """INSERT INTO claim_edges

--- a/rka/services/clusters.py
+++ b/rka/services/clusters.py
@@ -284,7 +284,7 @@ class ClusterService(BaseService):
 
             # Recompute the count defensively after all edge writes.
             count_row = await self.db.fetchone(
-                """SELECT COUNT(*) AS cnt FROM claim_edges
+                """SELECT COUNT(DISTINCT source_claim_id) AS cnt FROM claim_edges
                    WHERE cluster_id = ? AND relation = 'member_of'
                      AND project_id = ?""",
                 [cluster_id, self.project_id],

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -1926,6 +1926,26 @@ class KnowledgePackService(BaseService):
             for row in prepared:
                 if "scope_revision" in row:
                     row["scope_revision"] = 0
+        if table == "claim_edges":
+            # Packs exported before migration 052 may contain repeated
+            # cluster memberships. Preserve the first edge, matching the
+            # migration's repair rule, so old packs remain importable under
+            # the new unique membership invariant.
+            seen_memberships: set[tuple[str, str, str, str]] = set()
+            unique_rows: list[dict[str, Any]] = []
+            for row in prepared:
+                if row.get("relation") == "member_of":
+                    membership = (
+                        str(row.get("project_id") or ""),
+                        str(row.get("source_claim_id") or ""),
+                        str(row.get("cluster_id") or ""),
+                        "member_of",
+                    )
+                    if membership in seen_memberships:
+                        continue
+                    seen_memberships.add(membership)
+                unique_rows.append(row)
+            prepared = unique_rows
         return prepared
 
     def _rewrite_project_scope(
@@ -2229,7 +2249,7 @@ class KnowledgePackService(BaseService):
         await self.db.execute(
             """UPDATE evidence_clusters
                SET claim_count = (
-                   SELECT COUNT(*) FROM claim_edges
+                   SELECT COUNT(DISTINCT source_claim_id) FROM claim_edges
                    WHERE claim_edges.cluster_id = evidence_clusters.id
                      AND claim_edges.relation = 'member_of'
                      AND claim_edges.project_id = evidence_clusters.project_id
@@ -2573,13 +2593,13 @@ class KnowledgePackService(BaseService):
         # 6. evidence_clusters.claim_count mismatch
         mismatched = await self.db.fetchall(
             """SELECT ec.id, ec.claim_count,
-                      (SELECT COUNT(*) FROM claim_edges ce
+                      (SELECT COUNT(DISTINCT ce.source_claim_id) FROM claim_edges ce
                        WHERE ce.cluster_id = ec.id
                          AND ce.project_id = ec.project_id
                          AND ce.relation = 'member_of') as actual
                FROM evidence_clusters ec
                WHERE ec.project_id = ?
-               AND ec.claim_count != (SELECT COUNT(*) FROM claim_edges ce
+               AND ec.claim_count != (SELECT COUNT(DISTINCT ce.source_claim_id) FROM claim_edges ce
                                       WHERE ce.cluster_id = ec.id
                                         AND ce.project_id = ec.project_id
                                         AND ce.relation = 'member_of')

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -2599,10 +2599,12 @@ class KnowledgePackService(BaseService):
                          AND ce.relation = 'member_of') as actual
                FROM evidence_clusters ec
                WHERE ec.project_id = ?
-               AND ec.claim_count != (SELECT COUNT(DISTINCT ce.source_claim_id) FROM claim_edges ce
-                                      WHERE ce.cluster_id = ec.id
-                                        AND ce.project_id = ec.project_id
-                                        AND ce.relation = 'member_of')
+               AND ec.claim_count IS NOT (
+                   SELECT COUNT(DISTINCT ce.source_claim_id) FROM claim_edges ce
+                   WHERE ce.cluster_id = ec.id
+                     AND ce.project_id = ec.project_id
+                     AND ce.relation = 'member_of'
+               )
                LIMIT 50""",
             [pid],
         )
@@ -2615,7 +2617,7 @@ class KnowledgePackService(BaseService):
                     "count": len(mismatched),
                     "ids": [r["id"] for r in mismatched[:10]],
                     "description": "evidence_clusters with claim_count != actual claim_edges count",
-                    "fix_action": "Run migration 016 to recompute claim counts",
+                    "fix_action": "Recompute cluster claim counts from unique memberships",
                 }
             )
 

--- a/rka/services/researcher_tools.py
+++ b/rka/services/researcher_tools.py
@@ -346,6 +346,15 @@ class ResearcherToolsService(BaseService):
                 "cluster", cluster_id,
                 {"label": spec["label"], "synthesis": ""},
             )
+            if rq_id:
+                await self._replace_outgoing_links(
+                    source_type="cluster",
+                    source_id=cluster_id,
+                    link_type="answers",
+                    target_type="decision",
+                    target_ids=[rq_id],
+                    project_id=self.project_id,
+                )
 
             claim_ids = spec.get("claim_ids", [])
             for claim_id in claim_ids:
@@ -393,7 +402,7 @@ class ResearcherToolsService(BaseService):
 
         # Update source cluster claim_count
         remaining = await self.db.fetchone(
-            """SELECT COUNT(*) as cnt FROM claim_edges
+            """SELECT COUNT(DISTINCT source_claim_id) as cnt FROM claim_edges
                WHERE cluster_id = ? AND relation = 'member_of'
                  AND project_id = ?""",
             [source_id, self.project_id],
@@ -497,33 +506,40 @@ class ResearcherToolsService(BaseService):
             "cluster", target_id,
             {"label": target_label, "synthesis": target_synthesis or ""},
         )
-
-        total_moved = 0
-        for sid in normalized_source_ids:
-            # Get all claims in source
-            edges = await self.db.fetchall(
-                """SELECT source_claim_id FROM claim_edges
-                   WHERE cluster_id = ? AND relation = 'member_of'
-                     AND project_id = ?""",
-                [sid, self.project_id],
+        if research_question_id:
+            await self._replace_outgoing_links(
+                source_type="cluster",
+                source_id=target_id,
+                link_type="answers",
+                target_type="decision",
+                target_ids=[research_question_id],
+                project_id=self.project_id,
             )
-            for edge in edges:
-                claim_id = edge["source_claim_id"]
-                await self.db.execute(
-                    """DELETE FROM claim_edges
-                       WHERE source_claim_id = ? AND cluster_id = ?
-                         AND relation = 'member_of' AND project_id = ?""",
-                    [claim_id, sid, self.project_id],
-                )
-                edge_id = generate_id("claim_edge")
-                await self.db.execute(
-                    """INSERT OR IGNORE INTO claim_edges
-                       (id, source_claim_id, cluster_id, relation, confidence, project_id, created_at)
-                       VALUES (?, ?, ?, 'member_of', 1.0, ?, ?)""",
-                    [edge_id, claim_id, target_id, self.project_id, _now()],
-                )
-                total_moved += 1
 
+        source_memberships = await self.db.fetchall(
+            f"""SELECT DISTINCT source_claim_id FROM claim_edges
+                WHERE cluster_id IN ({placeholders})
+                  AND relation = 'member_of' AND project_id = ?""",
+            [*normalized_source_ids, self.project_id],
+        )
+        await self.db.execute(
+            f"""DELETE FROM claim_edges
+                WHERE cluster_id IN ({placeholders})
+                  AND relation = 'member_of' AND project_id = ?""",
+            [*normalized_source_ids, self.project_id],
+        )
+        for edge in source_memberships:
+            edge_id = generate_id("claim_edge")
+            await self.db.execute(
+                """INSERT OR IGNORE INTO claim_edges
+                   (id, source_claim_id, cluster_id, relation, confidence,
+                    project_id, created_at)
+                   VALUES (?, ?, ?, 'member_of', 1.0, ?, ?)""",
+                [edge_id, edge["source_claim_id"], target_id, self.project_id, _now()],
+            )
+
+        total_moved = len(source_memberships)
+        for sid in normalized_source_ids:
             # Zero out source cluster
             await self.db.execute(
                 """UPDATE evidence_clusters
@@ -918,13 +934,13 @@ class ResearcherToolsService(BaseService):
             cid = row["cluster_id"]
             # Check if >50% of claims in this cluster are stale
             total = await self.db.fetchone(
-                """SELECT COUNT(*) as cnt FROM claim_edges
+                """SELECT COUNT(DISTINCT source_claim_id) as cnt FROM claim_edges
                    WHERE cluster_id = ? AND relation = 'member_of'
                      AND project_id = ?""",
                 [cid, self.project_id],
             )
             stale = await self.db.fetchone(
-                """SELECT COUNT(*) as cnt FROM claim_edges ce
+                """SELECT COUNT(DISTINCT ce.source_claim_id) as cnt FROM claim_edges ce
                    JOIN claims c ON c.id = ce.source_claim_id
                                 AND c.project_id = ce.project_id
                    WHERE ce.cluster_id = ? AND ce.relation = 'member_of'

--- a/rka/services/researcher_tools.py
+++ b/rka/services/researcher_tools.py
@@ -18,6 +18,24 @@ _EMBED_JOB = {
 class ResearcherToolsService(BaseService):
     """Lightweight tools that compose existing data — no new tables, no LLM, no background jobs."""
 
+    async def _validate_research_question(self, research_question_id: str) -> None:
+        """Require a same-project decision whose semantic kind is RQ."""
+        rq = await self.db.fetchone(
+            """SELECT kind FROM decisions
+               WHERE id = ? AND project_id = ?""",
+            [research_question_id, self.project_id],
+        )
+        if rq is None:
+            raise ValueError(
+                "research question is not available in this project: "
+                f"{research_question_id}"
+            )
+        if rq["kind"] != "research_question":
+            raise ValueError(
+                f"Decision {research_question_id} is not a research_question "
+                f"(kind={rq['kind']})"
+            )
+
     async def _index_new_row(
         self, entity_type: str, entity_id: str, fts_data: dict,
     ) -> None:
@@ -325,16 +343,7 @@ class ResearcherToolsService(BaseService):
             cluster_id = generate_id("cluster")
             rq_id = spec.get("research_question_id") or source.get("research_question_id")
             if rq_id is not None:
-                rq = await self.db.fetchone(
-                    """SELECT 1 FROM decisions
-                       WHERE id = ? AND project_id = ?""",
-                    [rq_id, self.project_id],
-                )
-                if rq is None:
-                    raise ValueError(
-                        "split cluster research question is not available "
-                        "in this project"
-                    )
+                await self._validate_research_question(rq_id)
             await self.db.execute(
                 """INSERT INTO evidence_clusters
                    (id, research_question_id, label, confidence, claim_count,
@@ -473,25 +482,22 @@ class ResearcherToolsService(BaseService):
                 "every source cluster must be available in this project"
             )
 
-        # Resolve research_question_id from first source if not provided
+        # Resolve a shared parent automatically. If the sources span multiple
+        # RQs, require the caller to make the semantic reassignment explicit.
         if not research_question_id:
-            source_by_id = {row["id"]: row for row in source_rows}
-            for source_id in normalized_source_ids:
-                candidate = source_by_id[source_id].get("research_question_id")
-                if candidate:
-                    research_question_id = candidate
-                    break
-        if research_question_id is not None:
-            rq = await self.db.fetchone(
-                """SELECT 1 FROM decisions
-                   WHERE id = ? AND project_id = ?""",
-                [research_question_id, self.project_id],
-            )
-            if rq is None:
+            source_rq_ids = {
+                row["research_question_id"]
+                for row in source_rows
+                if row.get("research_question_id")
+            }
+            if len(source_rq_ids) > 1:
                 raise ValueError(
-                    "merge cluster research question is not available "
-                    "in this project"
+                    "source clusters span multiple research questions; "
+                    "provide research_question_id explicitly"
                 )
+            research_question_id = next(iter(source_rq_ids), None)
+        if research_question_id is not None:
+            await self._validate_research_question(research_question_id)
 
         target_id = generate_id("cluster")
         await self.db.execute(

--- a/tests/test_db/test_migration_052.py
+++ b/tests/test_db/test_migration_052.py
@@ -26,7 +26,7 @@ def test_migration_052_deduplicates_membership_and_repairs_counts(
             """
             CREATE TABLE evidence_clusters (
                 id TEXT PRIMARY KEY,
-                claim_count INTEGER NOT NULL DEFAULT 0,
+                claim_count INTEGER DEFAULT 0,
                 updated_at TEXT,
                 project_id TEXT NOT NULL
             );
@@ -42,6 +42,8 @@ def test_migration_052_deduplicates_membership_and_repairs_counts(
             );
             INSERT INTO evidence_clusters
             VALUES ('ecl_one', 9, NULL, 'prj_one');
+            INSERT INTO evidence_clusters
+            VALUES ('ecl_null_count', NULL, NULL, 'prj_one');
             INSERT INTO claim_edges VALUES
               ('ced_oldest', 'clm_one', NULL, 'ecl_one', 'member_of',
                1.0, 'prj_one', '2026-01-01T00:00:00Z'),
@@ -59,6 +61,10 @@ def test_migration_052_deduplicates_membership_and_repairs_counts(
         assert connection.execute(
             "SELECT claim_count FROM evidence_clusters WHERE id = 'ecl_one'"
         ).fetchone() == (1,)
+        assert connection.execute(
+            """SELECT claim_count FROM evidence_clusters
+               WHERE id = 'ecl_null_count'"""
+        ).fetchone() == (0,)
         with pytest.raises(sqlite3.IntegrityError):
             connection.execute(
                 """INSERT INTO claim_edges

--- a/tests/test_db/test_migration_052.py
+++ b/tests/test_db/test_migration_052.py
@@ -1,0 +1,79 @@
+"""Migration 052 claim-membership uniqueness and count repair."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+MIGRATION_052 = (
+    Path(__file__).parents[2]
+    / "rka"
+    / "db"
+    / "migrations"
+    / "052_claim_edge_membership_integrity.sql"
+)
+
+
+def test_migration_052_deduplicates_membership_and_repairs_counts(
+    tmp_path: Path,
+) -> None:
+    connection = sqlite3.connect(tmp_path / "late-052.db")
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE evidence_clusters (
+                id TEXT PRIMARY KEY,
+                claim_count INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT,
+                project_id TEXT NOT NULL
+            );
+            CREATE TABLE claim_edges (
+                id TEXT PRIMARY KEY,
+                source_claim_id TEXT NOT NULL,
+                target_claim_id TEXT,
+                cluster_id TEXT,
+                relation TEXT NOT NULL,
+                confidence REAL,
+                project_id TEXT NOT NULL,
+                created_at TEXT
+            );
+            INSERT INTO evidence_clusters
+            VALUES ('ecl_one', 9, NULL, 'prj_one');
+            INSERT INTO claim_edges VALUES
+              ('ced_oldest', 'clm_one', NULL, 'ecl_one', 'member_of',
+               1.0, 'prj_one', '2026-01-01T00:00:00Z'),
+              ('ced_duplicate', 'clm_one', NULL, 'ecl_one', 'member_of',
+               0.5, 'prj_one', '2026-01-02T00:00:00Z');
+            """
+        )
+
+        connection.executescript(MIGRATION_052.read_text())
+
+        assert connection.execute(
+            """SELECT id FROM claim_edges
+               WHERE relation = 'member_of'"""
+        ).fetchall() == [("ced_oldest",)]
+        assert connection.execute(
+            "SELECT claim_count FROM evidence_clusters WHERE id = 'ecl_one'"
+        ).fetchone() == (1,)
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                """INSERT INTO claim_edges
+                   (id, source_claim_id, cluster_id, relation, project_id)
+                   VALUES ('ced_again', 'clm_one', 'ecl_one', 'member_of',
+                           'prj_one')"""
+            )
+    finally:
+        connection.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_052_is_registered_and_restart_safe(db_with_project) -> None:
+    assert await db_with_project.fetchone(
+        "SELECT 1 FROM schema_migrations WHERE filename = ?",
+        [MIGRATION_052.name],
+    ) == {"1": 1}
+    assert await db_with_project.run_migrations() == 0

--- a/tests/test_services/test_knowledge_pack.py
+++ b/tests/test_services/test_knowledge_pack.py
@@ -38,6 +38,43 @@ async def _make_db(path: Path) -> Database:
 
 
 @pytest.mark.asyncio
+async def test_prepare_claim_edges_deduplicates_legacy_memberships(db) -> None:
+    service = KnowledgePackService(db)
+    rows = [
+        {
+            "id": "ced_first",
+            "project_id": "prj_source",
+            "source_claim_id": "clm_one",
+            "cluster_id": "ecl_one",
+            "relation": "member_of",
+        },
+        {
+            "id": "ced_duplicate",
+            "project_id": "prj_source",
+            "source_claim_id": "clm_one",
+            "cluster_id": "ecl_one",
+            "relation": "member_of",
+        },
+        {
+            "id": "ced_supports",
+            "project_id": "prj_source",
+            "source_claim_id": "clm_one",
+            "target_claim_id": "clm_two",
+            "relation": "supports",
+        },
+    ]
+
+    prepared = service._prepare_rows_for_insert(
+        "claim_edges",
+        rows,
+        "prj_target",
+    )
+
+    assert [row["id"] for row in prepared] == ["ced_first", "ced_supports"]
+    assert {row["project_id"] for row in prepared} == {"prj_target"}
+
+
+@pytest.mark.asyncio
 async def test_knowledge_pack_round_trip_imports_into_same_db_with_remapped_ids_and_artifacts(tmp_path: Path):
     db = await _make_db(tmp_path / "round-trip.db")
     artifact_path = tmp_path / "reference.txt"

--- a/tests/test_services/test_knowledge_pack.py
+++ b/tests/test_services/test_knowledge_pack.py
@@ -75,6 +75,26 @@ async def test_prepare_claim_edges_deduplicates_legacy_memberships(db) -> None:
 
 
 @pytest.mark.asyncio
+async def test_check_integrity_reports_null_cluster_claim_count(db) -> None:
+    await db.execute(
+        """INSERT INTO evidence_clusters
+           (id, label, claim_count, project_id)
+           VALUES ('ecl_null_count', 'nullable legacy count', NULL,
+                   'proj_default')"""
+    )
+    await db.commit()
+
+    issues = await KnowledgePackService(db).check_integrity("proj_default")
+
+    mismatch = next(
+        issue for issue in issues
+        if issue["category"] == "claim_count_mismatch"
+    )
+    assert mismatch["ids"] == ["ecl_null_count"]
+    assert mismatch["severity"] == "warning"
+
+
+@pytest.mark.asyncio
 async def test_knowledge_pack_round_trip_imports_into_same_db_with_remapped_ids_and_artifacts(tmp_path: Path):
     db = await _make_db(tmp_path / "round-trip.db")
     artifact_path = tmp_path / "reference.txt"
@@ -636,6 +656,92 @@ def _write_synthetic_pack(
     }
     with zipfile.ZipFile(pack_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+
+
+@pytest.mark.asyncio
+async def test_import_deduplicates_legacy_memberships_and_repairs_count(
+    tmp_path: Path,
+) -> None:
+    pack_path = tmp_path / "legacy-memberships.rka-pack.zip"
+    source_project_id = "proj_legacy_memberships_src"
+    _write_synthetic_pack(
+        pack_path,
+        source_project_id=source_project_id,
+        source_project_name="Legacy Membership Source",
+        tables={
+            "journal": [
+                {
+                    "id": "jrn_legacy_membership",
+                    "type": "finding",
+                    "content": "Legacy source evidence.",
+                    "source": "executor",
+                    "project_id": source_project_id,
+                }
+            ],
+            "claims": [
+                {
+                    "id": "clm_legacy_membership",
+                    "source_entry_id": "jrn_legacy_membership",
+                    "claim_type": "evidence",
+                    "content": "One claim was assigned twice.",
+                    "project_id": source_project_id,
+                }
+            ],
+            "evidence_clusters": [
+                {
+                    "id": "ecl_legacy_membership",
+                    "label": "Legacy membership cluster",
+                    "claim_count": 2,
+                    "project_id": source_project_id,
+                }
+            ],
+            "claim_edges": [
+                {
+                    "id": "ced_legacy_first",
+                    "source_claim_id": "clm_legacy_membership",
+                    "cluster_id": "ecl_legacy_membership",
+                    "relation": "member_of",
+                    "confidence": 0.25,
+                    "project_id": source_project_id,
+                },
+                {
+                    "id": "ced_legacy_duplicate",
+                    "source_claim_id": "clm_legacy_membership",
+                    "cluster_id": "ecl_legacy_membership",
+                    "relation": "member_of",
+                    "confidence": 0.75,
+                    "project_id": source_project_id,
+                },
+            ],
+        },
+    )
+    db = await _make_db(tmp_path / "legacy-memberships.db")
+    try:
+        with pack_path.open("rb") as pack_file:
+            result = await KnowledgePackService(db).import_pack(
+                pack_file,
+                project_id="proj_legacy_memberships_dst",
+                project_name="Legacy Membership Destination",
+                defer_indexing=True,
+            )
+
+        assert result.imported_counts["claim_edges"] == 1
+        assert any(
+            issue["category"] == "claim_count_mismatch"
+            for issue in result.integrity_issues
+        )
+        assert await db.fetchone(
+            """SELECT COUNT(*) AS edges, MIN(confidence) AS confidence
+               FROM claim_edges
+               WHERE project_id = 'proj_legacy_memberships_dst'
+                 AND relation = 'member_of'"""
+        ) == {"edges": 1, "confidence": 0.25}
+        assert await db.fetchone(
+            """SELECT claim_count FROM evidence_clusters
+               WHERE project_id = 'proj_legacy_memberships_dst'"""
+        ) == {"claim_count": 1}
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_researcher_tools_transactions.py
+++ b/tests/test_services/test_researcher_tools_transactions.py
@@ -4,10 +4,20 @@ from __future__ import annotations
 
 import pytest
 
+from rka.models.claim import ClaimEdgeCreate
+from rka.services.claims import ClaimService
 from rka.services.researcher_tools import ResearcherToolsService
 
 
 async def _seed_cluster_graph(db) -> None:
+    await db.execute(
+        """INSERT INTO decisions
+           (id, phase, question, chosen, rationale, decided_by, kind, project_id)
+           VALUES ('dec_cluster_atomic_rq', 'core_hardening',
+                   'Atomic RQ?', 'Investigate.',
+                   'Test research question.', 'pi', 'research_question',
+                   'proj_default')"""
+    )
     await db.execute(
         """INSERT INTO journal
            (id, type, content, source, confidence, importance, project_id)
@@ -24,8 +34,8 @@ async def _seed_cluster_graph(db) -> None:
         )
         await db.execute(
             """INSERT INTO evidence_clusters
-               (id, label, claim_count, project_id)
-               VALUES (?, ?, 1, 'proj_default')""",
+               (id, research_question_id, label, claim_count, project_id)
+               VALUES (?, 'dec_cluster_atomic_rq', ?, 1, 'proj_default')""",
             [f"ecl_cluster_atomic_{suffix}", f"atomic cluster {suffix}"],
         )
         await db.execute(
@@ -147,6 +157,10 @@ async def test_split_cluster_failure_rolls_back_new_cluster_and_membership(
              AND project_id = 'proj_default'"""
     )
     assert membership == {"cluster_id": "ecl_cluster_atomic_one"}
+    assert await db.fetchall(
+        """SELECT source_id FROM entity_links
+           WHERE project_id = 'proj_default' AND link_type = 'answers'"""
+    ) == []
 
 
 @pytest.mark.asyncio
@@ -195,3 +209,108 @@ async def test_merge_cluster_failure_rolls_back_target_and_source_edges(
             "cluster_id": "ecl_cluster_atomic_two",
         },
     ]
+    assert await db.fetchall(
+        """SELECT source_id FROM entity_links
+           WHERE project_id = 'proj_default' AND link_type = 'answers'"""
+    ) == []
+
+
+@pytest.mark.asyncio
+async def test_member_of_edge_creation_is_idempotent_and_count_is_distinct(db) -> None:
+    await _seed_cluster_graph(db)
+    service = ClaimService(db, project_id="proj_default")
+    membership = ClaimEdgeCreate(
+        source_claim_id="clm_cluster_atomic_one",
+        cluster_id="ecl_cluster_atomic_one",
+        relation="member_of",
+        confidence=1.0,
+    )
+
+    first = await service.create_edge(membership)
+    second = await service.create_edge(membership)
+
+    assert first.id == second.id
+    assert await db.fetchone(
+        """SELECT COUNT(DISTINCT source_claim_id) AS distinct_claims,
+                  COUNT(*) AS edges
+           FROM claim_edges
+           WHERE project_id = 'proj_default'
+             AND cluster_id = 'ecl_cluster_atomic_one'
+             AND relation = 'member_of'"""
+    ) == {"distinct_claims": 1, "edges": 1}
+    assert await db.fetchone(
+        """SELECT claim_count FROM evidence_clusters
+           WHERE id = 'ecl_cluster_atomic_one'
+             AND project_id = 'proj_default'"""
+    ) == {"claim_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_merge_clusters_counts_unique_union_and_links_target_to_rq(db) -> None:
+    await _seed_cluster_graph(db)
+    await db.execute(
+        """INSERT INTO claim_edges
+           (id, source_claim_id, cluster_id, relation, confidence, project_id)
+           VALUES ('ced_cluster_overlap', 'clm_cluster_atomic_one',
+                   'ecl_cluster_atomic_two', 'member_of', 1.0,
+                   'proj_default')"""
+    )
+    await db.execute(
+        """UPDATE evidence_clusters SET claim_count = 2
+           WHERE id = 'ecl_cluster_atomic_two'"""
+    )
+    await db.commit()
+    service = ResearcherToolsService(db, project_id="proj_default")
+
+    result = await service.merge_clusters(
+        ["ecl_cluster_atomic_one", "ecl_cluster_atomic_two"],
+        "merged target",
+    )
+
+    assert result["total_claims_moved"] == 2
+    assert await db.fetchone(
+        """SELECT claim_count, research_question_id
+           FROM evidence_clusters WHERE id = ?""",
+        [result["target_id"]],
+    ) == {
+        "claim_count": 2,
+        "research_question_id": "dec_cluster_atomic_rq",
+    }
+    assert await db.fetchone(
+        """SELECT COUNT(*) AS edges,
+                  COUNT(DISTINCT source_claim_id) AS distinct_claims
+           FROM claim_edges
+           WHERE project_id = 'proj_default' AND cluster_id = ?
+             AND relation = 'member_of'""",
+        [result["target_id"]],
+    ) == {"edges": 2, "distinct_claims": 2}
+    assert await db.fetchone(
+        """SELECT target_id FROM entity_links
+           WHERE project_id = 'proj_default'
+             AND source_type = 'cluster' AND source_id = ?
+             AND link_type = 'answers' AND target_type = 'decision'""",
+        [result["target_id"]],
+    ) == {"target_id": "dec_cluster_atomic_rq"}
+
+
+@pytest.mark.asyncio
+async def test_split_cluster_links_each_new_cluster_to_its_rq(db) -> None:
+    await _seed_cluster_graph(db)
+    service = ResearcherToolsService(db, project_id="proj_default")
+
+    result = await service.split_cluster(
+        "ecl_cluster_atomic_one",
+        [{
+            "label": "new split",
+            "claim_ids": ["clm_cluster_atomic_one"],
+        }],
+    )
+    new_cluster_id = result["new_clusters"][0]["id"]
+
+    assert await db.fetchone(
+        """SELECT target_id FROM entity_links
+           WHERE project_id = 'proj_default'
+             AND source_type = 'cluster' AND source_id = ?
+             AND link_type = 'answers' AND target_type = 'decision'""",
+        [new_cluster_id],
+    ) == {"target_id": "dec_cluster_atomic_rq"}

--- a/tests/test_services/test_researcher_tools_transactions.py
+++ b/tests/test_services/test_researcher_tools_transactions.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from rka.infra.database import Database
 from rka.models.claim import ClaimEdgeCreate
 from rka.services.claims import ClaimService
 from rka.services.researcher_tools import ResearcherToolsService
@@ -226,10 +229,30 @@ async def test_member_of_edge_creation_is_idempotent_and_count_is_distinct(db) -
         confidence=1.0,
     )
 
+    events_before = await db.fetchone(
+        """SELECT COUNT(*) AS count FROM change_events
+           WHERE project_id = 'proj_default'"""
+    )
+    cluster_before = await db.fetchone(
+        """SELECT updated_at FROM evidence_clusters
+           WHERE id = 'ecl_cluster_atomic_one'
+             AND project_id = 'proj_default'"""
+    )
     first = await service.create_edge(membership)
     second = await service.create_edge(membership)
+    events_after = await db.fetchone(
+        """SELECT COUNT(*) AS count FROM change_events
+           WHERE project_id = 'proj_default'"""
+    )
+    cluster_after = await db.fetchone(
+        """SELECT updated_at FROM evidence_clusters
+           WHERE id = 'ecl_cluster_atomic_one'
+             AND project_id = 'proj_default'"""
+    )
 
     assert first.id == second.id
+    assert events_after == events_before
+    assert cluster_after == cluster_before
     assert await db.fetchone(
         """SELECT COUNT(DISTINCT source_claim_id) AS distinct_claims,
                   COUNT(*) AS edges
@@ -243,6 +266,73 @@ async def test_member_of_edge_creation_is_idempotent_and_count_is_distinct(db) -
            WHERE id = 'ecl_cluster_atomic_one'
              AND project_id = 'proj_default'"""
     ) == {"claim_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_member_of_creation_converges_without_duplicate_events(db) -> None:
+    await db.execute(
+        """INSERT INTO journal
+           (id, type, content, source, confidence, importance, project_id)
+           VALUES ('jrn_cluster_concurrent', 'observation', 'source observation',
+                   'executor', 'tested', 'normal', 'proj_default')"""
+    )
+    await db.execute(
+        """INSERT INTO claims
+           (id, source_entry_id, claim_type, content, confidence, project_id)
+           VALUES ('clm_cluster_concurrent', 'jrn_cluster_concurrent',
+                   'evidence', 'concurrent claim', 0.8, 'proj_default')"""
+    )
+    await db.execute(
+        """INSERT INTO evidence_clusters
+           (id, label, claim_count, project_id)
+           VALUES ('ecl_cluster_concurrent', 'concurrent cluster', 0,
+                   'proj_default')"""
+    )
+    await db.commit()
+
+    second_db = Database(db.db_path)
+    await second_db.connect()
+    try:
+        first_service = ClaimService(db, project_id="proj_default")
+        second_service = ClaimService(second_db, project_id="proj_default")
+        membership = ClaimEdgeCreate(
+            source_claim_id="clm_cluster_concurrent",
+            cluster_id="ecl_cluster_concurrent",
+            relation="member_of",
+            confidence=1.0,
+        )
+        events_before = await db.fetchone(
+            """SELECT COUNT(*) AS count FROM change_events
+               WHERE project_id = 'proj_default'"""
+        )
+
+        first, second = await asyncio.gather(
+            first_service.create_edge(membership),
+            second_service.create_edge(membership),
+        )
+
+        assert first.id == second.id
+        assert await db.fetchone(
+            """SELECT COUNT(*) AS edges FROM claim_edges
+               WHERE source_claim_id = 'clm_cluster_concurrent'
+                 AND cluster_id = 'ecl_cluster_concurrent'
+                 AND relation = 'member_of'
+                 AND project_id = 'proj_default'"""
+        ) == {"edges": 1}
+        assert await db.fetchone(
+            """SELECT claim_count FROM evidence_clusters
+               WHERE id = 'ecl_cluster_concurrent'
+                 AND project_id = 'proj_default'"""
+        ) == {"claim_count": 1}
+        events_after = await db.fetchone(
+            """SELECT COUNT(*) AS count FROM change_events
+               WHERE project_id = 'proj_default'"""
+        )
+        # One claim-edge insert and one real cluster-count update. The losing
+        # retry observes both and appends no additional semantic event.
+        assert events_after["count"] - events_before["count"] == 2
+    finally:
+        await second_db.close()
 
 
 @pytest.mark.asyncio
@@ -314,3 +404,92 @@ async def test_split_cluster_links_each_new_cluster_to_its_rq(db) -> None:
              AND link_type = 'answers' AND target_type = 'decision'""",
         [new_cluster_id],
     ) == {"target_id": "dec_cluster_atomic_rq"}
+
+
+@pytest.mark.asyncio
+async def test_split_cluster_rejects_non_rq_parent(db) -> None:
+    await _seed_cluster_graph(db)
+    await db.execute(
+        """INSERT INTO decisions
+           (id, phase, question, decided_by, kind, project_id)
+           VALUES ('dec_cluster_design', 'core_hardening', 'Design choice?',
+                   'pi', 'design_choice', 'proj_default')"""
+    )
+    await db.commit()
+    service = ResearcherToolsService(db, project_id="proj_default")
+
+    with pytest.raises(ValueError, match="is not a research_question"):
+        await service.split_cluster(
+            "ecl_cluster_atomic_one",
+            [{
+                "label": "invalid split",
+                "research_question_id": "dec_cluster_design",
+                "claim_ids": ["clm_cluster_atomic_one"],
+            }],
+        )
+
+    assert await db.fetchone(
+        """SELECT COUNT(*) AS count FROM evidence_clusters
+           WHERE project_id = 'proj_default'"""
+    ) == {"count": 2}
+
+
+@pytest.mark.asyncio
+async def test_merge_clusters_rejects_non_rq_parent(db) -> None:
+    await _seed_cluster_graph(db)
+    await db.execute(
+        """INSERT INTO decisions
+           (id, phase, question, decided_by, kind, project_id)
+           VALUES ('dec_cluster_design', 'core_hardening', 'Design choice?',
+                   'pi', 'design_choice', 'proj_default')"""
+    )
+    await db.commit()
+    service = ResearcherToolsService(db, project_id="proj_default")
+
+    with pytest.raises(ValueError, match="is not a research_question"):
+        await service.merge_clusters(
+            ["ecl_cluster_atomic_one", "ecl_cluster_atomic_two"],
+            "invalid merge",
+            research_question_id="dec_cluster_design",
+        )
+
+    assert await db.fetchone(
+        """SELECT COUNT(*) AS count FROM evidence_clusters
+           WHERE project_id = 'proj_default'"""
+    ) == {"count": 2}
+
+
+@pytest.mark.asyncio
+async def test_merge_clusters_requires_explicit_parent_for_mixed_rqs(db) -> None:
+    await _seed_cluster_graph(db)
+    await db.execute(
+        """INSERT INTO decisions
+           (id, phase, question, decided_by, kind, project_id)
+           VALUES ('dec_cluster_second_rq', 'core_hardening', 'Second RQ?',
+                   'pi', 'research_question', 'proj_default')"""
+    )
+    await db.execute(
+        """UPDATE evidence_clusters
+           SET research_question_id = 'dec_cluster_second_rq'
+           WHERE id = 'ecl_cluster_atomic_two'
+             AND project_id = 'proj_default'"""
+    )
+    await db.commit()
+    service = ResearcherToolsService(db, project_id="proj_default")
+
+    with pytest.raises(ValueError, match="span multiple research questions"):
+        await service.merge_clusters(
+            ["ecl_cluster_atomic_one", "ecl_cluster_atomic_two"],
+            "ambiguous merge",
+        )
+
+    result = await service.merge_clusters(
+        ["ecl_cluster_atomic_one", "ecl_cluster_atomic_two"],
+        "explicit merge",
+        research_question_id="dec_cluster_second_rq",
+    )
+    assert await db.fetchone(
+        """SELECT research_question_id FROM evidence_clusters
+           WHERE id = ? AND project_id = 'proj_default'""",
+        [result["target_id"]],
+    ) == {"research_question_id": "dec_cluster_second_rq"}


### PR DESCRIPTION
## Summary

- migrate `member_of` cluster membership from multiset behavior to a unique project-scoped set
- make membership retries semantic no-ops while repairing stale cached counts
- normalize duplicate legacy knowledge-pack memberships and use NULL-safe integrity checks
- validate split and merge parents as research questions and require an explicit target for mixed-RQ merges
- add migration, import, transaction, retry, and two-connection concurrency regressions

## Validation

- 35 focused claim-edge and knowledge-pack tests passed
- complete Core gate passed: 2,804 tests
- Ruff critical syntax and undefined-name checks passed
- `git diff --check` passed
- temporary real-database copy: 971 membership rows became 967 unique rows, duplicate memberships fell from 4 to 0, and count mismatches fell from 3 to 0

## Residual scope

This bounded fix preserves the first legacy duplicate in input order. Empty source-cluster lifecycle after merge and database-level relation-shape constraints remain separate design decisions.