### PR TITLE
fix(core): enforce journal and provenance round-trip reliability

### DIFF
--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -269,7 +269,20 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
     # description, fix_action). Severity field is populated by Affordance
     # E so consumers can distinguish critical vs warning without knowing
     # the category list.
+    from rka.services.base import EntityLinkValidationError
     from rka.services.knowledge_pack import KnowledgePackIntegrityError
+
+    @app.exception_handler(EntityLinkValidationError)
+    async def entity_link_validation_handler(
+        request: Request, exc: EntityLinkValidationError,
+    ):
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": "invalid_entity_link",
+                "detail": str(exc),
+            },
+        )
 
     @app.exception_handler(KnowledgePackIntegrityError)
     async def knowledge_pack_integrity_handler(

--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -3915,6 +3915,7 @@ class UpdateNoteArgs(ProjectScopedArgs):
     def _enforce_non_empty_update(self) -> "UpdateNoteArgs":
         mutable_fields = (
             self.content,
+            self.summary,
             self.type,
             self.confidence,
             self.importance,
@@ -3929,7 +3930,7 @@ class UpdateNoteArgs(ProjectScopedArgs):
         if all(f is None for f in mutable_fields):
             raise ValueError(
                 "update_note: at least one mutable field must be non-None "
-                "(content, type, confidence, importance, tags, phase, "
+                "(content, summary, type, confidence, importance, tags, phase, "
                 "verbatim_input, source, related_decisions, related_literature, "
                 "related_mission)."
             )

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -822,6 +822,7 @@ async def rka_add_note(
 async def rka_update_note(
     id: str,
     content: str | None = None,
+    summary: str | None = None,
     type: str | None = None,
     confidence: str | None = None,
     importance: str | None = None,
@@ -841,6 +842,7 @@ async def rka_update_note(
     Args:
         id: The note ID to update (PRIMARY FIELD — required addressing key)
         content: New content (the canonical body field for the update)
+        summary: New short summary
         type: New type — note | log | directive
         confidence: New confidence level — hypothesis | tested | verified | superseded | retracted
         importance: New importance level — critical | high | normal | low
@@ -854,7 +856,8 @@ async def rka_update_note(
     """
     async with _client(project_id) as c:
         body = {
-            "content": content, "type": type, "confidence": confidence,
+            "content": content, "summary": summary, "type": type,
+            "confidence": confidence,
             "importance": importance, "verbatim_input": verbatim_input,
             "related_decisions": related_decisions,
             "related_literature": related_literature,

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -547,6 +547,7 @@ async def dispatch_review(target: str, *, project_id: str, payload: dict[str, An
         return await _legacy("rka_update_note")(
             id=p["id"],
             content=p.get("content"),
+            summary=p.get("summary"),
             type=p.get("type"),
             confidence=p.get("confidence"),
             importance=p.get("importance"),

--- a/rka/services/base.py
+++ b/rka/services/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from rka.constants import DEFAULT_PROJECT_ID
 from rka.infra.database import Database
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 VALID_ACTORS = frozenset({"brain", "executor", "pi", "llm", "web_ui", "system"})
+
+
+class EntityLinkValidationError(ValueError):
+    """Raised when a typed provenance edge names an invalid project endpoint."""
 
 
 def _now() -> str:
@@ -303,25 +307,87 @@ class BaseService:
         created_by: str = "system",
         project_id: str | None = None,
     ) -> None:
-        """Record a typed edge in entity_links (idempotent — skips duplicates)."""
-        link_id = generate_id("link")
+        """Record a project-local typed edge (idempotent — skips duplicates)."""
         resolved_project_id = self._resolve_project_id(project_id)
-        await self.db.execute(
-            """INSERT OR IGNORE INTO entity_links
-               (id, source_type, source_id, link_type, target_type, target_id, created_by, project_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            [link_id, source_type, source_id, link_type, target_type, target_id, created_by, resolved_project_id],
+        async with self.db.transaction():
+            await self._require_link_entity(
+                source_type,
+                source_id,
+                project_id=resolved_project_id,
+            )
+            await self._require_link_entity(
+                target_type,
+                target_id,
+                project_id=resolved_project_id,
+            )
+            await self.db.execute(
+                """INSERT OR IGNORE INTO entity_links
+                   (id, source_type, source_id, link_type, target_type, target_id, created_by, project_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    generate_id("link"),
+                    source_type,
+                    source_id,
+                    link_type,
+                    target_type,
+                    target_id,
+                    created_by,
+                    resolved_project_id,
+                ],
+            )
+
+    _LINK_ENTITY_TABLES: ClassVar[dict[str, str]] = {
+        "artifact": "artifacts",
+        "checkpoint": "checkpoints",
+        "claim": "claims",
+        "cluster": "evidence_clusters",
+        "decision": "decisions",
+        "experiment_observation": "experiment_observations",
+        "figure": "figures",
+        "interpretation_candidate": "interpretation_candidates",
+        "journal": "journal",
+        "literature": "literature",
+        "mission": "missions",
+    }
+
+    async def _require_link_entity(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        project_id: str,
+    ) -> None:
+        """Require a typed edge endpoint to exist in the active project."""
+        table = self._LINK_ENTITY_TABLES.get(entity_type)
+        if table is None:
+            raise EntityLinkValidationError(
+                f"unsupported entity link type {entity_type!r}"
+            )
+        row = await self.db.fetchone(
+            f"SELECT id FROM {table} WHERE id = ? AND project_id = ?",
+            [entity_id, project_id],
         )
-        await self.db.commit()
+        if row is None:
+            raise EntityLinkValidationError(
+                f"{entity_type} {entity_id!r} not found in project {project_id}"
+            )
 
     @staticmethod
-    def _normalized_link_ids(entity_ids: list[str] | None) -> set[str]:
-        """Return a de-duplicated set of non-blank entity IDs."""
-        return {
-            entity_id.strip()
-            for entity_id in (entity_ids or [])
-            if entity_id and entity_id.strip()
-        }
+    def _canonical_link_ids(entity_ids: list[str] | None) -> list[str]:
+        """Trim and de-duplicate entity IDs while retaining caller order."""
+        canonical: list[str] = []
+        seen: set[str] = set()
+        for raw_id in entity_ids or []:
+            entity_id = raw_id.strip() if raw_id else ""
+            if entity_id and entity_id not in seen:
+                canonical.append(entity_id)
+                seen.add(entity_id)
+        return canonical
+
+    @classmethod
+    def _normalized_link_ids(cls, entity_ids: list[str] | None) -> set[str]:
+        """Return the canonical IDs as a set for edge replacement."""
+        return set(cls._canonical_link_ids(entity_ids))
 
     async def _replace_outgoing_links(
         self,
@@ -344,6 +410,17 @@ class BaseService:
         resolved_project_id = self._resolve_project_id(project_id)
         desired = self._normalized_link_ids(target_ids)
         async with self.db.transaction():
+            await self._require_link_entity(
+                source_type,
+                source_id,
+                project_id=resolved_project_id,
+            )
+            for target_id in sorted(desired):
+                await self._require_link_entity(
+                    target_type,
+                    target_id,
+                    project_id=resolved_project_id,
+                )
             rows = await self.db.fetchall(
                 """SELECT target_id
                    FROM entity_links
@@ -400,6 +477,17 @@ class BaseService:
         resolved_project_id = self._resolve_project_id(project_id)
         desired = self._normalized_link_ids(source_ids)
         async with self.db.transaction():
+            await self._require_link_entity(
+                target_type,
+                target_id,
+                project_id=resolved_project_id,
+            )
+            for source_id in sorted(desired):
+                await self._require_link_entity(
+                    source_type,
+                    source_id,
+                    project_id=resolved_project_id,
+                )
             rows = await self.db.fetchall(
                 """SELECT source_id
                    FROM entity_links

--- a/rka/services/decisions.py
+++ b/rka/services/decisions.py
@@ -50,6 +50,21 @@ class DecisionService(BaseService):
         """Create a new decision node."""
         dec_id = generate_id("decision")
         actor_val = actor or data.decided_by
+        related_journal = (
+            None
+            if data.related_journal is None
+            else self._canonical_link_ids(data.related_journal)
+        )
+        related_literature = (
+            None
+            if data.related_literature is None
+            else self._canonical_link_ids(data.related_literature)
+        )
+        related_missions = (
+            None
+            if data.related_missions is None
+            else self._canonical_link_ids(data.related_missions)
+        )
 
         options_json = None
         if data.options:
@@ -72,9 +87,9 @@ class DecisionService(BaseService):
                     data.rationale,
                     data.decided_by,
                     data.status,
-                    self._json_dumps(data.related_missions),
-                    self._json_dumps(data.related_literature),
-                    self._json_dumps(data.related_journal),
+                    self._json_dumps(related_missions),
+                    self._json_dumps(related_literature),
+                    self._json_dumps(related_journal),
                     data.kind,
                     self._json_dumps(data.assumptions),
                     self.project_id,
@@ -89,7 +104,7 @@ class DecisionService(BaseService):
                 source_id=dec_id,
                 link_type="justified_by",
                 target_type="journal",
-                target_ids=data.related_journal,
+                target_ids=related_journal,
                 created_by=actor_val,
             )
             await self._replace_incoming_links(
@@ -97,7 +112,7 @@ class DecisionService(BaseService):
                 target_id=dec_id,
                 link_type="informed_by",
                 source_type="literature",
-                source_ids=data.related_literature,
+                source_ids=related_literature,
                 created_by=actor_val,
             )
             await self._replace_outgoing_links(
@@ -105,7 +120,7 @@ class DecisionService(BaseService):
                 source_id=dec_id,
                 link_type="triggered",
                 target_type="mission",
-                target_ids=data.related_missions,
+                target_ids=related_missions,
                 created_by=actor_val,
             )
             await self._replace_incoming_links(
@@ -191,6 +206,13 @@ class DecisionService(BaseService):
         replace_related_literature = "related_literature" in dump
         replace_related_journal = "related_journal" in dump
         replace_parent = "parent_id" in dump
+        for field in (
+            "related_missions",
+            "related_literature",
+            "related_journal",
+        ):
+            if field in dump:
+                dump[field] = self._canonical_link_ids(dump[field])
 
         updates = {}
         for field, value in dump.items():
@@ -258,7 +280,7 @@ class DecisionService(BaseService):
                     source_id=dec_id,
                     link_type="justified_by",
                     target_type="journal",
-                    target_ids=data.related_journal,
+                    target_ids=dump["related_journal"],
                     created_by=actor,
                 )
             if replace_related_literature:
@@ -267,7 +289,7 @@ class DecisionService(BaseService):
                     target_id=dec_id,
                     link_type="informed_by",
                     source_type="literature",
-                    source_ids=data.related_literature,
+                    source_ids=dump["related_literature"],
                     created_by=actor,
                 )
             if replace_related_missions:
@@ -276,7 +298,7 @@ class DecisionService(BaseService):
                     source_id=dec_id,
                     link_type="triggered",
                     target_type="mission",
-                    target_ids=data.related_missions,
+                    target_ids=dump["related_missions"],
                     created_by=actor,
                 )
             if replace_parent:

--- a/rka/services/literature.py
+++ b/rka/services/literature.py
@@ -40,6 +40,11 @@ class LiteratureService(BaseService):
         """Create a new literature entry."""
         lit_id = generate_id("literature")
         source = actor or data.added_by
+        related_decisions = (
+            None
+            if data.related_decisions is None
+            else self._canonical_link_ids(data.related_decisions)
+        )
 
         async with self.db.transaction():
             await self.db.execute(
@@ -65,7 +70,7 @@ class LiteratureService(BaseService):
                     data.methodology_notes,
                     data.relevance,
                     data.relevance_score,
-                    self._json_dumps(data.related_decisions),
+                    self._json_dumps(related_decisions),
                     data.added_by,
                     data.notes,
                     data.zotero_item_key,
@@ -82,7 +87,7 @@ class LiteratureService(BaseService):
                 source_id=lit_id,
                 link_type="informed_by",
                 target_type="decision",
-                target_ids=data.related_decisions,
+                target_ids=related_decisions,
                 created_by=source,
             )
             await self._sync_fts(
@@ -164,6 +169,10 @@ class LiteratureService(BaseService):
         dump = data.model_dump(exclude_none=True)
         tags = dump.pop("tags", None)
         replace_related_decisions = "related_decisions" in dump
+        if replace_related_decisions:
+            dump["related_decisions"] = self._canonical_link_ids(
+                dump["related_decisions"]
+            )
 
         updates = {}
         for field, value in dump.items():
@@ -211,7 +220,7 @@ class LiteratureService(BaseService):
                     source_id=lit_id,
                     link_type="informed_by",
                     target_type="decision",
-                    target_ids=data.related_decisions,
+                    target_ids=dump["related_decisions"],
                     created_by=actor,
                 )
 

--- a/rka/services/notes.py
+++ b/rka/services/notes.py
@@ -44,6 +44,16 @@ class NoteService(BaseService):
         """Create a new journal entry."""
         entry_id = generate_id("journal")
         source = actor or data.source
+        related_decisions = (
+            None
+            if data.related_decisions is None
+            else self._canonical_link_ids(data.related_decisions)
+        )
+        related_literature = (
+            None
+            if data.related_literature is None
+            else self._canonical_link_ids(data.related_literature)
+        )
 
         async with self.db.transaction():
             await self.db.execute(
@@ -60,8 +70,8 @@ class NoteService(BaseService):
                     source,
                     data.phase,
                     data.verbatim_input,
-                    self._json_dumps(data.related_decisions),
-                    self._json_dumps(data.related_literature),
+                    self._json_dumps(related_decisions),
+                    self._json_dumps(related_literature),
                     data.related_mission,
                     data.supersedes,
                     data.confidence,
@@ -95,7 +105,7 @@ class NoteService(BaseService):
                 source_id=entry_id,
                 link_type="references",
                 target_type="decision",
-                target_ids=data.related_decisions,
+                target_ids=related_decisions,
                 created_by=source or "system",
             )
             await self._replace_outgoing_links(
@@ -103,7 +113,7 @@ class NoteService(BaseService):
                 source_id=entry_id,
                 link_type="cites",
                 target_type="literature",
-                target_ids=data.related_literature,
+                target_ids=related_literature,
                 created_by=source or "system",
             )
             await self._replace_incoming_links(
@@ -250,6 +260,14 @@ class NoteService(BaseService):
         replace_related_decisions = "related_decisions" in dump
         replace_related_literature = "related_literature" in dump
         replace_related_mission = "related_mission" in dump
+        if replace_related_decisions:
+            dump["related_decisions"] = self._canonical_link_ids(
+                dump["related_decisions"]
+            )
+        if replace_related_literature:
+            dump["related_literature"] = self._canonical_link_ids(
+                dump["related_literature"]
+            )
 
         updates = {}
         for field, value in dump.items():
@@ -297,7 +315,7 @@ class NoteService(BaseService):
                     source_id=entry_id,
                     link_type="references",
                     target_type="decision",
-                    target_ids=data.related_decisions,
+                    target_ids=dump["related_decisions"],
                 )
             if replace_related_literature:
                 await self._replace_outgoing_links(
@@ -305,7 +323,7 @@ class NoteService(BaseService):
                     source_id=entry_id,
                     link_type="cites",
                     target_type="literature",
-                    target_ids=data.related_literature,
+                    target_ids=dump["related_literature"],
                 )
             if replace_related_mission:
                 await self._replace_incoming_links(

--- a/tests/test_api/test_core_reliability_project_isolation.py
+++ b/tests/test_api/test_core_reliability_project_isolation.py
@@ -1,0 +1,71 @@
+"""REST project isolation for journal provenance writes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+
+
+@pytest_asyncio.fixture
+async def api_client(tmp_path: Path):
+    app = create_app(
+        RKAConfig(
+            project_dir=tmp_path,
+            db_path=Path("core-reliability-api.db"),
+            llm_enabled=False,
+            embeddings_enabled=False,
+        )
+    )
+    async with app.router.lifespan_context(app), httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_rest_rejects_foreign_provenance_without_partial_write(
+    api_client: httpx.AsyncClient,
+) -> None:
+    created = await api_client.post(
+        "/api/projects",
+        json={"id": "prj_foreign", "name": "Foreign"},
+    )
+    assert created.status_code == 200, created.text
+    foreign_decision = await api_client.post(
+        "/api/decisions",
+        headers={"X-RKA-Project": "prj_foreign"},
+        json={
+            "question": "Foreign decision?",
+            "phase": "design",
+            "decided_by": "brain",
+        },
+    )
+    assert foreign_decision.status_code == 201, foreign_decision.text
+
+    response = await api_client.post(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+        json={
+            "content": "REST write that must roll back.",
+            "related_decisions": [foreign_decision.json()["id"]],
+        },
+    )
+    assert response.status_code == 422, response.text
+    assert "proj_default" in response.json()["detail"]
+
+    listed = await api_client.get(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert listed.status_code == 200
+    assert all(
+        note["content"] != "REST write that must roll back."
+        for note in listed.json()
+    )

--- a/tests/test_mcp/test_core_reliability_journal_roundtrip.py
+++ b/tests/test_mcp/test_core_reliability_journal_roundtrip.py
@@ -1,0 +1,117 @@
+"""Typed MCP -> REST -> service journal reliability contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka.api.app import create_app
+from rka.config import RKAConfig
+from rka.mcp.operation_args import RecordNoteArgs, UpdateNoteArgs
+from rka.mcp.verb_dispatch import dispatch_execute_typed
+
+
+@pytest_asyncio.fixture
+async def mcp_env(tmp_path: Path, monkeypatch):
+    import rka.mcp.server as mcp_server
+
+    app = create_app(
+        RKAConfig(
+            project_dir=tmp_path,
+            db_path=Path("core-reliability-mcp.db"),
+            llm_enabled=False,
+            embeddings_enabled=False,
+        )
+    )
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+
+        def client(project_id: str | None = None) -> httpx.AsyncClient:
+            headers = {"X-RKA-Project": project_id} if project_id else {}
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                headers=headers,
+            )
+
+        monkeypatch.setattr(mcp_server, "_client", client)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as rest:
+            yield rest
+
+
+@pytest.mark.asyncio
+async def test_mcp_summary_only_note_update_round_trip(
+    mcp_env: httpx.AsyncClient,
+) -> None:
+    created = await mcp_env.post(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+        json={"content": "Body stays unchanged.", "summary": "Old summary."},
+    )
+    assert created.status_code == 201, created.text
+    note_id = created.json()["id"]
+
+    result = await dispatch_execute_typed(
+        UpdateNoteArgs(
+            operation="update_note",
+            project_id="proj_default",
+            id=note_id,
+            summary="New summary.",
+        )
+    )
+    assert "Updated" in result
+
+    read_back = await mcp_env.get(
+        f"/api/notes/{note_id}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert read_back.status_code == 200
+    assert read_back.json()["summary"] == "New summary."
+    assert read_back.json()["content"] == "Body stays unchanged."
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_foreign_provenance_without_partial_write(
+    mcp_env: httpx.AsyncClient,
+) -> None:
+    project = await mcp_env.post(
+        "/api/projects",
+        json={"id": "prj_foreign", "name": "Foreign"},
+    )
+    assert project.status_code == 200, project.text
+    decision = await mcp_env.post(
+        "/api/decisions",
+        headers={"X-RKA-Project": "prj_foreign"},
+        json={
+            "question": "Foreign decision?",
+            "phase": "design",
+            "decided_by": "brain",
+        },
+    )
+    assert decision.status_code == 201, decision.text
+
+    with pytest.raises(Exception, match="API error 422.*proj_default"):
+        await dispatch_execute_typed(
+            RecordNoteArgs(
+                operation="record_note",
+                project_id="proj_default",
+                content="MCP write that must roll back.",
+                provenance={"related_decisions": [decision.json()["id"]]},
+            )
+        )
+
+    listed = await mcp_env.get(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert listed.status_code == 200
+    assert all(
+        note["content"] != "MCP write that must roll back."
+        for note in listed.json()
+    )

--- a/tests/test_services/test_core_reliability_roundtrip.py
+++ b/tests/test_services/test_core_reliability_roundtrip.py
@@ -1,0 +1,307 @@
+"""Core journal/provenance reliability contracts from roadmap issue #123."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rka.infra.database import Database
+from rka.models.decision import DecisionCreate, DecisionUpdate
+from rka.models.journal import JournalEntryCreate, JournalEntryUpdate
+from rka.models.literature import LiteratureCreate
+from rka.models.mission import MissionCreate
+from rka.services.artifacts import ArtifactService
+from rka.services.base import BaseService
+from rka.services.decisions import DecisionService
+from rka.services.literature import LiteratureService
+from rka.services.missions import MissionService
+from rka.services.notes import NoteService
+
+
+async def _ensure_project(db: Database, project_id: str) -> None:
+    await db.execute(
+        "INSERT OR IGNORE INTO projects (id, name, description, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        [project_id, project_id, "Core reliability fixture", "system"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_foreign_relation_is_rejected_without_partial_journal_write(
+    db: Database,
+) -> None:
+    await _ensure_project(db, "prj_alpha")
+    await _ensure_project(db, "prj_beta")
+    foreign = await DecisionService(
+        db, project_id="prj_beta"
+    ).create(
+        DecisionCreate(
+            question="Foreign decision?",
+            phase="design",
+            decided_by="brain",
+        )
+    )
+
+    alpha = NoteService(db, project_id="prj_alpha")
+    with pytest.raises(ValueError, match="project prj_alpha"):
+        await alpha.create(
+            JournalEntryCreate(
+                content="This write must roll back.",
+                related_decisions=[foreign.id],
+            )
+        )
+
+    assert await db.fetchone(
+        "SELECT id FROM journal WHERE project_id = ? AND content = ?",
+        ["prj_alpha", "This write must roll back."],
+    ) is None
+    assert await db.fetchone(
+        "SELECT id FROM entity_links WHERE project_id = ? AND target_id = ?",
+        ["prj_alpha", foreign.id],
+    ) is None
+    assert await db.fetchone(
+        "SELECT id FROM events WHERE project_id = ? AND summary LIKE ?",
+        ["prj_alpha", "%This write must roll back.%"],
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_repeated_relation_update_is_idempotent_and_foreign_failure_is_atomic(
+    db: Database,
+) -> None:
+    await _ensure_project(db, "prj_alpha")
+    await _ensure_project(db, "prj_beta")
+    local = await DecisionService(db, project_id="prj_alpha").create(
+        DecisionCreate(
+            question="Local decision?",
+            phase="design",
+            decided_by="brain",
+        )
+    )
+    foreign = await DecisionService(db, project_id="prj_beta").create(
+        DecisionCreate(
+            question="Foreign decision?",
+            phase="design",
+            decided_by="brain",
+        )
+    )
+    notes = NoteService(db, project_id="prj_alpha")
+    note = await notes.create(
+        JournalEntryCreate(content="Stable note.", related_decisions=[local.id])
+    )
+
+    before = await db.fetchone(
+        "SELECT id FROM entity_links WHERE project_id = ? AND source_id = ? "
+        "AND link_type = 'references' AND target_id = ?",
+        ["prj_alpha", note.id, local.id],
+    )
+    assert before is not None
+
+    await notes.update(
+        note.id,
+        JournalEntryUpdate(
+            related_decisions=[f"  {local.id}  ", "", local.id]
+        ),
+    )
+    after_retry = await db.fetchall(
+        "SELECT id FROM entity_links WHERE project_id = ? AND source_id = ? "
+        "AND link_type = 'references'",
+        ["prj_alpha", note.id],
+    )
+    assert after_retry == [before]
+    normalized = await notes.get(note.id)
+    assert normalized is not None
+    assert normalized.related_decisions == [local.id]
+
+    with pytest.raises(ValueError, match="project prj_alpha"):
+        await notes.update(
+            note.id,
+            JournalEntryUpdate(related_decisions=[foreign.id]),
+        )
+
+    after_failure = await notes.get(note.id)
+    assert after_failure is not None
+    assert after_failure.related_decisions == [local.id]
+    assert await db.fetchall(
+        "SELECT id FROM entity_links WHERE project_id = ? AND source_id = ? "
+        "AND link_type = 'references'",
+        ["prj_alpha", note.id],
+    ) == [before]
+
+
+@pytest.mark.asyncio
+async def test_story_and_artifact_links_round_trip_after_database_reopen(
+    tmp_path: Path,
+) -> None:
+    """Round-trip the story and retry operations with existing stable keys.
+
+    Artifact registration is content-addressed; edge assignment has a stable
+    source/type/target identity. Journal/decision/mission/literature creates
+    intentionally remain distinct commands until the public contract defines
+    caller-supplied idempotency keys.
+    """
+    db_path = tmp_path / "roundtrip.db"
+    artifact_path = tmp_path / "experiment.txt"
+    artifact_path.write_text("measured result\n")
+
+    db = Database(str(db_path))
+    await db.connect()
+    await db.initialize_schema()
+    await db.initialize_phase2_schema()
+    await _ensure_project(db, "prj_story")
+
+    notes = NoteService(db, project_id="prj_story")
+    decisions = DecisionService(db, project_id="prj_story")
+    literature = LiteratureService(db, project_id="prj_story")
+    missions = MissionService(db, project_id="prj_story")
+    artifacts = ArtifactService(db, project_id="prj_story")
+
+    pi_note = await notes.create(
+        JournalEntryCreate(
+            content="The PI selected a three-class framing.",
+            summary="Three-class framing",
+            type="directive",
+            source="pi",
+            verbatim_input="Map the nine cases into three classes.",
+            confidence="verified",
+            importance="critical",
+        )
+    )
+    decision = await decisions.create(
+        DecisionCreate(
+            question="How should the nine cases be grouped?",
+            chosen="Three semantic classes",
+            rationale="The grouping preserves the research distinction.",
+            phase="design",
+            decided_by="pi",
+            related_journal=[pi_note.id],
+        )
+    )
+    paper = await literature.create(
+        LiteratureCreate(
+            title="A supporting taxonomy",
+            added_by="brain",
+            related_decisions=[decision.id],
+        )
+    )
+    mission = await missions.create(
+        MissionCreate(
+            phase="evaluation",
+            objective="Evaluate the selected grouping.",
+            motivated_by_decision=decision.id,
+        )
+    )
+    await decisions.update(
+        decision.id,
+        DecisionUpdate(
+            related_literature=[paper.id],
+            related_missions=[mission.id],
+        ),
+    )
+    result_note = await notes.create(
+        JournalEntryCreate(
+            content="The experiment supports the three-class framing.",
+            source="executor",
+            related_decisions=[decision.id],
+            related_literature=[paper.id],
+            related_mission=mission.id,
+            supersedes=pi_note.id,
+            confidence="tested",
+        )
+    )
+    artifact = await artifacts.register(str(artifact_path), created_by="executor")
+    links = BaseService(db, project_id="prj_story")
+    await links.add_link(
+        "journal",
+        result_note.id,
+        "produced",
+        "artifact",
+        artifact["id"],
+        created_by="executor",
+    )
+    await links.add_link(
+        "journal",
+        result_note.id,
+        "produced",
+        "artifact",
+        artifact["id"],
+        created_by="executor",
+    )
+    duplicate = await artifacts.register(str(artifact_path), created_by="executor")
+    assert duplicate == {"id": artifact["id"], "duplicate": True}
+
+    await db.close()
+    reopened = Database(str(db_path))
+    await reopened.connect()
+    try:
+        reopened_notes = NoteService(reopened, project_id="prj_story")
+        old = await reopened_notes.get(pi_note.id)
+        current = await reopened_notes.get(result_note.id)
+        assert old is not None and current is not None
+        assert old.source == "pi"
+        assert old.verbatim_input == "Map the nine cases into three classes."
+        assert old.confidence == "superseded"
+        assert old.status == "superseded"
+        assert old.superseded_by == current.id
+        assert current.related_decisions == [decision.id]
+        assert current.related_literature == [paper.id]
+        assert current.related_mission == mission.id
+
+        edge_rows = await reopened.fetchall(
+            "SELECT source_type, source_id, link_type, target_type, target_id "
+            "FROM entity_links WHERE project_id = ?",
+            ["prj_story"],
+        )
+        produced_artifact_rows = [
+            row
+            for row in edge_rows
+            if (
+                row["source_type"],
+                row["source_id"],
+                row["link_type"],
+                row["target_type"],
+                row["target_id"],
+            )
+            == (
+                "journal",
+                result_note.id,
+                "produced",
+                "artifact",
+                artifact["id"],
+            )
+        ]
+        assert len(produced_artifact_rows) == 1
+        edges = {
+            (
+                row["source_type"],
+                row["source_id"],
+                row["link_type"],
+                row["target_type"],
+                row["target_id"],
+            )
+            for row in edge_rows
+        }
+        assert ("decision", decision.id, "justified_by", "journal", pi_note.id) in edges
+        assert ("literature", paper.id, "informed_by", "decision", decision.id) in edges
+        assert ("decision", decision.id, "motivated", "mission", mission.id) in edges
+        assert ("mission", mission.id, "produced", "journal", result_note.id) in edges
+        assert ("journal", result_note.id, "supersedes", "journal", pi_note.id) in edges
+        assert (
+            "journal",
+            result_note.id,
+            "produced",
+            "artifact",
+            artifact["id"],
+        ) in edges
+        assert await ArtifactService(
+            reopened, project_id="prj_story"
+        ).get(artifact["id"])
+        artifact_count = await reopened.fetchone(
+            "SELECT COUNT(*) AS n FROM artifacts WHERE project_id = ? "
+            "AND content_hash = (SELECT content_hash FROM artifacts WHERE id = ?)",
+            ["prj_story", artifact["id"]],
+        )
+        assert artifact_count == {"n": 1}
+    finally:
+        await reopened.close()

--- a/tests/test_services/test_journal_write_path.py
+++ b/tests/test_services/test_journal_write_path.py
@@ -154,6 +154,15 @@ class TestTheSummaryIsSearchable:
             "record_note could write summary and update_note could not fix it"
         )
 
+    def test_update_note_accepts_summary_only(self):
+        args = UpdateNoteArgs(
+            operation="update_note",
+            project_id="prj_x",
+            id="jrn_x",
+            summary="A corrected summary.",
+        )
+        assert args.summary == "A corrected summary."
+
     def test_the_advertised_schema_agrees(self):
         from rka.mcp.operations_schema import OPERATIONS_SCHEMA
 


### PR DESCRIPTION
## Summary

- validate typed provenance-link endpoints for entity type, existence, and project ownership before mutation
- canonicalize journal, decision, and literature relation IDs so stored fields and graph edges round-trip consistently
- restore summary-only journal updates across the typed MCP, REST, and service path
- add durable service, REST, and MCP regression coverage for PI attribution, verbatim input, supersession, project isolation, database reopen, and duplicate-free stable links

## Reliability boundary

Retry coverage here follows the stable identities already defined by Core: content-addressed artifact registration and source/type/target edge assignment. Create-note, decision, mission, and literature calls remain distinct commands until RKA defines a separate caller-supplied idempotency-key contract.

## Verification

- 102 focused tests passed
- 3264 full Core tests passed
- new regression files pass Ruff
- `git diff --check` passed
- independent implementation audit found no unresolved P0/P1 issues

Closes #123
