### PR TITLE
fix(core): validate real backup and recovery

### DIFF
--- a/docs/CORE_PROFILE.md
+++ b/docs/CORE_PROFILE.md
@@ -78,6 +78,16 @@ The `rka migrate` command initializes both the base and Phase-2 schemas, so FTS
 and vector tables are established consistently with normal REST and worker
 startup.
 
+## Recovery smoke gate
+
+Use [`scripts/core_recovery_smoke.py`](../scripts/core_recovery_smoke.py) only
+against a real source through its read-only online-backup boundary. The script
+upgrades temporary copies, checks table/ID/link/revision digests, validates
+selected knowledge packs under intentional ID re-keying, and restores an exact
+rollback copy. The separate pinned-previous-image step remains manual and is
+documented in [CORE_RECOVERY.md](CORE_RECOVERY.md); no live migration or
+container replacement is implied by this gate.
+
 ## CI contract
 
 The `pytest` workflow installs no LLM-provider SDK. Its Core job restores the

--- a/docs/CORE_RECOVERY.md
+++ b/docs/CORE_RECOVERY.md
@@ -1,0 +1,103 @@
+# RKA Core Backup and Recovery
+
+This runbook validates recovery without modifying the live RKA database or
+replacing a running container. It deliberately uses temporary directories and
+an exact previous image ID. Do not use the stock Compose file for a parallel
+drill: its fixed container names and port collide with the live deployment.
+
+## Create a consistent backup
+
+`rka backup` uses SQLite's online-backup API. It includes committed WAL pages,
+writes an integrity-checked temporary database, and atomically publishes the
+destination as a portable single-file DELETE-journal snapshot. A foreign-key
+warning describes findings already present in the source; it does not silently
+repair or omit them.
+
+```bash
+rka backup --output /private/tmp/rka-recovery/source.db
+```
+
+When RKA runs in Docker, create the snapshot inside the mounted data volume and
+then copy only that completed snapshot out of the container:
+
+```bash
+docker exec rka-server rka backup --output /data/recovery-source.db
+docker cp rka-server:/data/recovery-source.db /private/tmp/rka-recovery/source.db
+```
+
+## Run the disposable validation
+
+Select one or more real projects that cover the desired Core records. The
+script makes another online snapshot, upgrades only temporary copies, compares
+all shared data-table counts and digests, validates portable Core pack state
+under intentional ID re-keying, and restores an exact rollback copy. It rejects
+a report path that aliases the database or its runtime files. Its persisted JSON
+contains counts, schema names, and hashes rather than research content, paths,
+exception messages, or raw entity IDs.
+
+```bash
+python scripts/core_recovery_smoke.py \
+  --source-db /private/tmp/rka-recovery/source.db \
+  --project-id prj_FIRST \
+  --project-id prj_SECOND \
+  --report /private/tmp/rka-recovery/report.json
+```
+
+This smoke is a current-schema compatibility and idempotence gate. Shared
+canonical rows, IDs, links, revisions, and both migration ledgers must remain
+exact. Test an older database as a separate reviewed migration case with an
+explicitly documented set of expected migrations; this command does not
+silently allow ledger or data changes.
+
+Knowledge-pack import is a clone operation: entity IDs intentionally change.
+The smoke reads canonical Core rows independently from the source database,
+compares them with the manifest, then independently maps the source manifest
+forward into the target namespace by the captured one-to-one ID map. It
+compares that expectation with raw imported rows plus project metadata/state,
+links, revisions, scope hashes, artifact bytes, counts, and final integrity.
+The equality gate intentionally excludes FTS/vector indexes and rebuildable
+derived views such as review queues, topics, context snapshots, keynodes, and
+graph views; their behavior has separate focused tests. It does not redefine
+the separate Writer compatibility export planned for E2.
+
+## Prove rollback with the previous runtime
+
+Before building or replacing any image, record the exact image ID used by the
+running server. A mutable tag such as `latest` is not rollback evidence.
+
+```bash
+docker inspect --format '{{.Image}}' rka-server
+docker image inspect --format '{{.Id}}' IMAGE_ID_FROM_PREVIOUS_COMMAND
+```
+
+Copy the untouched backup into a third temporary directory, remove any stale
+sidecars in that directory, and let the pinned old image run its normal
+base-plus-Phase-2 startup path against only that copy:
+
+```bash
+mkdir -p /private/tmp/rka-recovery/old-runtime
+cp /private/tmp/rka-recovery/source.db /private/tmp/rka-recovery/old-runtime/rka.db
+rm -f /private/tmp/rka-recovery/old-runtime/rka.db-wal \
+  /private/tmp/rka-recovery/old-runtime/rka.db-shm \
+  /private/tmp/rka-recovery/old-runtime/rka.db-journal \
+  /private/tmp/rka-recovery/old-runtime/rka.db.phase2.lock
+docker run --rm --name rka-recovery-old \
+  -v /private/tmp/rka-recovery/old-runtime:/data \
+  IMAGE_ID_FROM_PREVIOUS_COMMAND rka migrate
+```
+
+Record the image ID, `rka --version`, migration/runtime ledgers, SQLite
+integrity, foreign-key findings, and the restored snapshot comparison in the
+private recovery evidence. Never point the old image at the upgraded copy or
+the live `rka-data` volume.
+
+## Recovery gate
+
+Do not replace live state unless all of the following are true:
+
+- the online backup passes SQLite integrity and its SHA-256 is recorded;
+- the disposable upgrade is idempotent and reports no unexplained row, ID,
+  link, or revision change;
+- selected packs preserve canonical Core state and final integrity;
+- the exact backup is restored and the pinned previous runtime opens it;
+- the live migration/replacement has separate PI authorization.

--- a/docs/TECHNICAL_REFERENCE.md
+++ b/docs/TECHNICAL_REFERENCE.md
@@ -33,13 +33,15 @@ docker compose up -d --build
 | `rka mcp` | Start the default stdio MCP adapter. |
 | `rka mcp --transport http --host 127.0.0.1 --port 9713` | Start local Streamable HTTP MCP. |
 | `rka status` | Show current project status. |
-| `rka backup` | Create a database backup. |
+| `rka backup` | Create an online, integrity-checked SQLite backup. |
 | `rka migrate` | Run pending migrations. |
 | `rka bootstrap scan <folder>` | Inspect a workspace before ingestion. |
 | `rka bootstrap ingest <folder>` | Ingest an approved workspace scan. |
 | `rka cred ...` | Initialize, inspect, and propagate the credential vault. |
 
 Use `rka --help` and `rka <command> --help` for the installed version's complete option set.
+See [CORE_RECOVERY.md](CORE_RECOVERY.md) for the disposable upgrade,
+knowledge-pack, and pinned-runtime rollback procedure.
 
 ## MCP
 

--- a/docs/superpowers/specs/2026-08-28-e1-real-backup-recovery-evidence.md
+++ b/docs/superpowers/specs/2026-08-28-e1-real-backup-recovery-evidence.md
@@ -1,0 +1,130 @@
+# E1.5 Real-Backup Upgrade and Recovery Evidence
+
+- Date: 2026-08-28
+- Issue: [#125](https://github.com/infinitywings/rka/issues/125)
+- Candidate base: `6485d81` plus the bounded #125 implementation
+- Live runtime observed read-only: RKA `3.0.0`, image
+  `sha256:27121e4e687d8c09e9b057daee7637cabea69d71638056b45c746361499689bc`
+- Previous runtime: RKA `2.9.0`, image
+  `sha256:9de17a8f96b992ff312693d23f3ddb00645571836f97ceb3eb2b7617713bdf49`
+
+## Safety boundary
+
+The live database and containers were not migrated, restarted, replaced, or
+re-embedded. A read-only SQLite online backup was written to container `/tmp`,
+normalized to a portable single-file DELETE-journal database, copied to
+`/private/tmp`, and then removed from the container. Every subsequent write
+used a disposable database or temporary bind mount.
+
+The source snapshot:
+
+- SHA-256: `acc7f225e2cb59792f08bee82947db355921dddba69faf055b6c7ca41c2d5f8c`
+- size: 200,622,080 bytes;
+- SQLite `integrity_check`: `ok`;
+- foreign-key violations: 0;
+- projects: 20;
+- SQL migrations: 53;
+- runtime schema upgrades: 1.
+
+The committed report must not contain the snapshot, record text, raw entity-ID
+sets, artifact files, or project paths. The final private JSON report is
+`/private/tmp/rka-e1-125-report-v4.json`.
+
+## Upgrade and idempotence result
+
+`scripts/core_recovery_smoke.py` took another online snapshot and ran the
+normal base-plus-Phase-2 initialization path against only a temporary copy.
+
+| Check | Result |
+|---|---|
+| SQLite integrity after candidate startup | pass |
+| Foreign-key findings before/after | 0 / 0 |
+| Shared non-index data tables | 78 / 78 |
+| Changed row digests | none |
+| Changed ID sets | none |
+| Changed link tables | none |
+| Changed revision tables | none |
+| SQL migrations before/after | 53 / 53 |
+| Runtime upgrades before/after | 1 / 1 |
+| Second migration pass | 0 applied |
+
+This was a schema-53 compatibility/idempotence case. It therefore required
+exact preservation and did not invoke the older migration-052 repair allowance.
+
+## Knowledge-pack result
+
+Two complementary real projects were selected without committing their raw IDs
+or content:
+
+| Project role | Project fingerprint | Re-keyed entity count | Canonical mismatch | Critical target issue |
+|---|---|---:|---:|---:|
+| Experiment plan/run/observation/locator chain | `8bd3f780b15ec013` | 227 | 0 | 0 |
+| Claim, cluster, edge, decision, and journal graph | `71f1fdf364e13da1` | 726 | 0 | 0 |
+
+For each pack, the harness captured the importer's in-memory ID bijection and
+independently compared source-database rows with the manifest, then
+mapped the source manifest forward into the target namespace without calling
+the production remap helpers. Project metadata/state, portable Core rows,
+links, revisions, ID-map
+coverage/uniqueness, manifest counts, imported counts, and final semantic
+integrity all matched. These two real packs contained no claim-scope versions
+or artifacts, so those checks were not represented as non-vacuous real-data
+evidence. FTS/vector rows and rebuildable derived views were also not
+represented as exact live-database preservation evidence.
+
+Focused provider-free regressions separately proved that both inline pack
+import and background `index_project()` rebuild artifact and figure vector
+rows with the target `project_id` and correct `entity_type`, and that both are
+searchable after import. The recovery regression used a non-empty bundled
+artifact and verified its imported bytes. Another regression proved that
+re-keying an entity ID embedded in claim prose updates a previously current
+claim-scope hash while an already stale scope remains stale.
+
+## Exact rollback and previous-runtime result
+
+The harness restored the untouched backup byte-for-byte into a third temporary
+path and reproduced the complete pre-upgrade logical snapshot. The pinned RKA
+2.9.0 image then ran its normal migration command against only that restored
+copy:
+
+```text
+rka, version 2.9.0
+Applied 0 migration(s).
+```
+
+Post-open verification under the previous runtime found:
+
+- SQLite integrity: pass;
+- foreign-key violations: 0;
+- SQL migrations: 53;
+- runtime upgrades: 1;
+- changed rows, IDs, links, or revisions: none.
+
+This proves that the preserved backup and exact previous image form a usable
+rollback pair. It does not authorize replacement of the live deployment.
+
+## Pre-existing installation findings
+
+The source-wide semantic check also reported installation-local warnings while
+validating each selected project: incomplete index inspection, orphaned FTS
+rows, orphaned vector rows, and stranded entities. Existing integrity queries
+collect capped samples across several index families, so their reported counts
+are **sample counts, not exact totals**. These findings were neither caused nor
+repaired by #125. They require a separate, explicitly authorized maintenance
+investigation before any deletion, reindex, or re-homing action.
+
+## Automated verification
+
+The final candidate passed the following independent gates:
+
+| Gate | Result |
+|---|---|
+| Focused backup, pack, vector partition/search, migration, and recovery regressions | 82 passed |
+| Core suite (`not writer and not agentic`) | 3,021 passed |
+| Retained Writer/Agentic compatibility suite | 294 passed |
+| Core startup smoke | migrations, REST, MCP, worker, and sqlite-vec passed |
+| Compose validation | `docker compose config --quiet` passed |
+| Patch hygiene | selected Ruff checks and `git diff --check` passed |
+
+The startup smoke used a temporary loopback port and disposable database. No
+test in this final gate changed the live RKA database or container state.

--- a/rka/cli.py
+++ b/rka/cli.py
@@ -243,9 +243,11 @@ def status():
 @main.command()
 @click.option("--output", "-o", default=None, help="Output file path")
 def backup(output: str | None):
-    """Backup the database to a file."""
-    import shutil
+    """Create a consistent, integrity-checked database backup."""
+    import sqlite3
+
     from rka.config import RKAConfig
+    from rka.infra.sqlite_backup import backup_sqlite_database
 
     config = RKAConfig()
     src = Path(config.database_url)
@@ -256,8 +258,17 @@ def backup(output: str | None):
     from datetime import datetime
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     dst = Path(output) if output else src.parent / f"rka_backup_{timestamp}.db"
-    shutil.copy2(src, dst)
-    click.echo(f"✅ Backed up to {dst}")
+    try:
+        result = backup_sqlite_database(src, dst)
+    except (OSError, sqlite3.DatabaseError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"✅ Backed up to {result.path}")
+    click.echo(f"   SHA-256: {result.sha256}")
+    if result.foreign_key_violations:
+        click.echo(
+            "⚠️  Backup preserved "
+            f"{result.foreign_key_violations} pre-existing foreign-key violation(s)."
+        )
 
 
 @main.command()

--- a/rka/infra/sqlite_backup.py
+++ b/rka/infra/sqlite_backup.py
@@ -1,0 +1,162 @@
+"""Consistent, atomic backups for live SQLite databases."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SQLiteBackupResult:
+    """Metadata that can be recorded without exposing database contents."""
+
+    path: Path
+    sha256: str
+    size_bytes: int
+    page_count: int
+    foreign_key_violations: int
+
+
+def protected_sqlite_runtime_paths(source: str | Path) -> frozenset[Path]:
+    """Paths a backup/report must never replace for this SQLite database."""
+
+    source_path = Path(source).expanduser().resolve()
+    candidates = {
+        source_path,
+        Path(f"{source_path}-wal"),
+        Path(f"{source_path}-shm"),
+        Path(f"{source_path}-journal"),
+        Path(f"{source_path}.phase2.lock"),
+    }
+    protected = set(candidates)
+    protected.update(candidate.resolve() for candidate in candidates)
+    return frozenset(protected)
+
+
+def backup_sqlite_database(
+    source: str | Path,
+    destination: str | Path,
+) -> SQLiteBackupResult:
+    """Create an integrity-checked snapshot with SQLite's online backup API.
+
+    The source connection is query-only, so this operation can safely snapshot
+    a live WAL database without checkpointing or otherwise mutating it. The
+    destination is written beside its final path and atomically published only
+    after ``PRAGMA integrity_check`` succeeds.
+    """
+
+    source_path = Path(source).expanduser().resolve()
+    destination_input = Path(destination).expanduser()
+    if destination_input.is_symlink():
+        raise ValueError("Backup destination must not be a symbolic link")
+    destination_path = destination_input.resolve()
+
+    if not source_path.is_file():
+        raise FileNotFoundError(f"SQLite database not found: {source_path}")
+    if destination_path in protected_sqlite_runtime_paths(source_path):
+        raise ValueError(
+            "Backup destination must not replace the source database or its runtime files"
+        )
+
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination_path.name}.",
+        suffix=".tmp",
+        dir=destination_path.parent,
+    )
+    os.close(fd)
+    temporary_path = Path(temporary_name)
+
+    try:
+        source_uri = f"{source_path.as_uri()}?mode=ro"
+        with (
+            sqlite3.connect(source_uri, uri=True, timeout=30) as source_connection,
+            sqlite3.connect(temporary_path) as destination_connection,
+        ):
+            source_connection.execute("PRAGMA query_only = ON")
+            source_connection.backup(destination_connection)
+            # A backup inherits the source's persistent WAL journal mode. A
+            # standalone copy without its own -wal/-shm sidecars may then be
+            # impossible to open read-only. No writer can race on this private
+            # temporary destination, so normalize it to a portable single-file
+            # DELETE-journal database before validation and publication.
+            journal_mode = str(
+                destination_connection.execute("PRAGMA journal_mode = DELETE").fetchone()[0]
+            ).casefold()
+            if journal_mode != "delete":
+                raise sqlite3.DatabaseError(
+                    f"Backup could not enter portable DELETE journal mode: {journal_mode}"
+                )
+            integrity_rows = [
+                str(row[0])
+                for row in destination_connection.execute("PRAGMA integrity_check")
+            ]
+            if integrity_rows != ["ok"]:
+                details = "; ".join(integrity_rows[:5])
+                raise sqlite3.DatabaseError(
+                    f"Backup failed SQLite integrity_check: {details}"
+                )
+            foreign_key_violations = sum(
+                1 for _row in destination_connection.execute("PRAGMA foreign_key_check")
+            )
+            page_count = int(
+                destination_connection.execute("PRAGMA page_count").fetchone()[0]
+            )
+
+        os.chmod(temporary_path, 0o600)
+        with temporary_path.open("rb") as backup_file:
+            os.fsync(backup_file.fileno())
+        digest = _sha256(temporary_path)
+        size_bytes = temporary_path.stat().st_size
+        os.replace(temporary_path, destination_path)
+        fsync_directory(destination_path.parent)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return SQLiteBackupResult(
+        path=destination_path,
+        sha256=digest,
+        size_bytes=size_bytes,
+        page_count=page_count,
+        foreign_key_violations=foreign_key_violations,
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fsync_directory(directory: Path) -> None:
+    """Persist the atomic rename where directory fsync is supported."""
+
+    try:
+        descriptor = os.open(directory, os.O_RDONLY)
+    except OSError as exc:
+        if exc.errno in _UNSUPPORTED_DIRECTORY_FSYNC_ERRNOS:
+            return
+        raise
+    try:
+        os.fsync(descriptor)
+    except OSError as exc:
+        if exc.errno not in _UNSUPPORTED_DIRECTORY_FSYNC_ERRNOS:
+            raise
+    finally:
+        os.close(descriptor)
+
+
+_UNSUPPORTED_DIRECTORY_FSYNC_ERRNOS = {
+    errno.EBADF,
+    errno.EINVAL,
+    getattr(errno, "ENOTSUP", errno.EINVAL),
+    getattr(errno, "EOPNOTSUPP", errno.EINVAL),
+}

--- a/rka/services/artifacts.py
+++ b/rka/services/artifacts.py
@@ -40,7 +40,12 @@ def build_artifact_text(
         parts.append(f"mime: {mime}")
     if metadata:
         if isinstance(metadata, str):
-            metadata_text = metadata
+            try:
+                parsed_metadata = json.loads(metadata)
+            except (json.JSONDecodeError, TypeError):
+                metadata_text = metadata
+            else:
+                metadata_text = json.dumps(parsed_metadata, sort_keys=True)
         else:
             metadata_text = json.dumps(metadata, sort_keys=True)
         parts.append(f"metadata: {metadata_text}")
@@ -425,7 +430,7 @@ class ArtifactService(BaseService):
                 project_id=self.project_id,
             )
         except Exception as exc:
-            logger.debug("Embedding sync failed for artifact %s: %s", artifact_id, exc)
+            logger.warning("Embedding sync failed for artifact %s: %s", artifact_id, exc)
 
     async def _embed_figure(
         self,
@@ -448,4 +453,4 @@ class ArtifactService(BaseService):
                 project_id=self.project_id,
             )
         except Exception as exc:
-            logger.debug("Embedding sync failed for figure %s: %s", figure_id, exc)
+            logger.warning("Embedding sync failed for figure %s: %s", figure_id, exc)

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -18,6 +18,7 @@ from rka.infra.ids import generate_id
 from rka.models.knowledge_pack import KnowledgePackImportResult
 from rka.models.planning import validate_planning_payload
 from rka.models.semantic_patch import SemanticPatchProposalCreate
+from rka.services.artifacts import ArtifactService
 from rka.services.base import BaseService, _now
 from rka.services.outline_integrity import validate_unit_hierarchy
 
@@ -700,7 +701,14 @@ _EMBEDDED_ID_RE = re.compile(r"\b[a-z][a-z_]{1,30}_[0-9A-HJKMNP-TV-Z]{16,32}\b")
 _PROSE_TEXT_COLUMNS: dict[str, tuple[str, ...]] = {
     "journal": ("content", "summary", "verbatim_input"),
     "decisions": ("question", "rationale", "chosen", "abandonment_reason", "options"),
-    "missions": ("objective", "context", "tasks", "acceptance_criteria"),
+    "missions": (
+        "objective",
+        "context",
+        "tasks",
+        "acceptance_criteria",
+        "checkpoint_triggers",
+        "report",
+    ),
     "literature": ("abstract", "notes"),
     "claims": ("content", "staleness_resolution"),
     "claim_scope_versions": (
@@ -1472,14 +1480,72 @@ class KnowledgePackService(BaseService):
             raise ValueError("Knowledge pack is missing manifest.json") from exc
         try:
             manifest = json.loads(raw_manifest.decode("utf-8"))
-        except json.JSONDecodeError as exc:
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise ValueError("Knowledge pack manifest is not valid JSON") from exc
+        if not isinstance(manifest, dict):
+            raise ValueError("Knowledge pack manifest must be an object")
 
-        pack_format = manifest.get("pack_format_version") or manifest.get("schema_version")
-        if pack_format not in range(1, PACK_SCHEMA_VERSION + 1):
+        pack_format = (
+            manifest["pack_format_version"]
+            if "pack_format_version" in manifest
+            else manifest.get("schema_version")
+        )
+        if (
+            isinstance(pack_format, bool)
+            or not isinstance(pack_format, int)
+            or pack_format not in range(1, PACK_SCHEMA_VERSION + 1)
+        ):
             raise ValueError(f"Unsupported knowledge pack format version: {pack_format}")
-        if not manifest.get("project"):
+        project = manifest.get("project")
+        if not isinstance(project, dict) or not project:
             raise ValueError("Knowledge pack manifest is missing project metadata")
+        if not isinstance(project.get("id"), str) or not project["id"].strip():
+            raise ValueError("Knowledge pack project metadata requires a non-empty ID")
+        if manifest.get("project_state") is not None and not isinstance(
+            manifest["project_state"],
+            dict,
+        ):
+            raise ValueError("Knowledge pack project_state must be an object or null")
+        tables = manifest.get("tables")
+        if not isinstance(tables, dict):
+            raise ValueError("Knowledge pack manifest tables must be an object")
+        for table, rows in tables.items():
+            if not isinstance(table, str) or not isinstance(rows, list):
+                raise ValueError(
+                    "Knowledge pack manifest table payloads must be arrays"
+                )
+            for index, row in enumerate(rows):
+                if not isinstance(row, dict):
+                    raise ValueError(
+                        f"Knowledge pack {table}[{index}] must be an object"
+                    )
+        table_counts = manifest.get("table_counts")
+        if pack_format == PACK_SCHEMA_VERSION and table_counts is None:
+            raise ValueError(
+                f"Knowledge pack format {PACK_SCHEMA_VERSION} requires table_counts"
+            )
+        if table_counts is not None:
+            if not isinstance(table_counts, dict):
+                raise ValueError("Knowledge pack table_counts must be an object")
+            if set(table_counts) != set(tables):
+                raise ValueError(
+                    "Knowledge pack table_counts keys must match tables exactly"
+                )
+            for table, expected_count in table_counts.items():
+                if (
+                    isinstance(expected_count, bool)
+                    or not isinstance(expected_count, int)
+                    or expected_count < 0
+                ):
+                    raise ValueError(
+                        f"Knowledge pack table_counts[{table!r}] must be a non-negative integer"
+                    )
+                actual_count = len(tables.get(table, []))
+                if actual_count != expected_count:
+                    raise ValueError(
+                        f"Knowledge pack table count mismatch for {table!r}: "
+                        f"manifest={expected_count}, payload={actual_count}"
+                    )
         return manifest
 
     async def _assert_target_project_available(self, project_id: str, project_name: str) -> None:
@@ -1608,7 +1674,49 @@ class KnowledgePackService(BaseService):
                 )
                 for row in tables.get(table, [])
             ]
+        self._refresh_remapped_claim_scope_hashes(tables, remapped)
         return remapped
+
+    @staticmethod
+    def _refresh_remapped_claim_scope_hashes(
+        source_tables: dict[str, list[dict[str, Any]]],
+        remapped_tables: dict[str, list[dict[str, Any]]],
+    ) -> None:
+        """Keep current scope contracts current when claim prose is re-keyed.
+
+        Entity IDs embedded in claim prose are intentionally rewritten during
+        import. Recompute a scope hash only when it matched the source claim;
+        an intentionally stale historical scope must remain stale.
+        """
+
+        source_claims = {
+            str(row["id"]): row
+            for row in source_tables.get("claims", [])
+            if row.get("id")
+        }
+        remapped_claims = {
+            str(row["id"]): row
+            for row in remapped_tables.get("claims", [])
+            if row.get("id")
+        }
+        source_scopes = source_tables.get("claim_scope_versions", [])
+        remapped_scopes = remapped_tables.get("claim_scope_versions", [])
+        for source_scope, remapped_scope in zip(source_scopes, remapped_scopes, strict=True):
+            source_claim = source_claims.get(str(source_scope.get("claim_id") or ""))
+            remapped_claim = remapped_claims.get(str(remapped_scope.get("claim_id") or ""))
+            if source_claim is None or remapped_claim is None:
+                continue
+            source_hash = KnowledgePackService._claim_scope_content_hash(source_claim)
+            if source_scope.get("claim_content_hash") != source_hash:
+                continue
+            remapped_scope["claim_content_hash"] = (
+                KnowledgePackService._claim_scope_content_hash(remapped_claim)
+            )
+
+    @staticmethod
+    def _claim_scope_content_hash(claim: dict[str, Any]) -> str:
+        material = f"{claim.get('claim_type', '')}\0{claim.get('content', '')}".encode()
+        return hashlib.sha256(material).hexdigest()
 
     def _build_id_map(self, tables: dict[str, list[dict[str, Any]]]) -> dict[str, str]:
         id_map: dict[str, str] = {}
@@ -1679,7 +1787,12 @@ class KnowledgePackService(BaseService):
             value = remapped.get(column)
             if isinstance(value, str) and value:
                 remapped[column] = _EMBEDDED_ID_RE.sub(
-                    lambda m: id_map.get(m.group(0), m.group(0)), value
+                    lambda match: (
+                        target_project_id
+                        if match.group(0) == source_project_id
+                        else id_map.get(match.group(0), match.group(0))
+                    ),
+                    value,
                 )
 
         if table == "manuscript_checkpoints" and remapped.get("dependency_snapshot"):
@@ -2128,6 +2241,11 @@ class KnowledgePackService(BaseService):
         "mission": ("missions", ["id", "objective", "context"]),
         "claim": ("claims", ["id", "content"]),
         "cluster": ("evidence_clusters", ["id", "label", "synthesis"]),
+        "artifact": (
+            "artifacts",
+            ["id", "filename", "filetype", "mime", "metadata"],
+        ),
+        "figure": ("figures", ["id", "caption", "summary", "claims"]),
     }
 
     async def count_indexable(self, project_id: str) -> int:
@@ -2163,6 +2281,11 @@ class KnowledgePackService(BaseService):
         unembeddable row should not strand the remaining thousands.
         """
         indexer = BaseService(self.db, embeddings=self.embeddings, project_id=project_id)
+        artifact_indexer = ArtifactService(
+            self.db,
+            embeddings=self.embeddings,
+            project_id=project_id,
+        )
         done = 0
         for etype, (table, cols) in self._INDEXABLE.items():
             rows = await self.db.fetchall(
@@ -2171,7 +2294,12 @@ class KnowledgePackService(BaseService):
             )
             for row in rows:
                 try:
-                    await indexer._sync_indexes(etype, row["id"], dict(row))
+                    await self._sync_indexable_row(
+                        indexer,
+                        artifact_indexer,
+                        etype,
+                        dict(row),
+                    )
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "index_project: %s %s failed (skipped): %s",
@@ -2196,23 +2324,47 @@ class KnowledgePackService(BaseService):
             embeddings=self.embeddings,
             project_id=target_project_id,
         )
-        for row in tables.get("journal", []):
-            await scoped_indexer._sync_indexes("journal", row["id"], row)
-        for row in tables.get("decisions", []):
-            await scoped_indexer._sync_indexes("decision", row["id"], row)
-        for row in tables.get("literature", []):
-            await scoped_indexer._sync_indexes("literature", row["id"], row)
-        for row in tables.get("missions", []):
-            await scoped_indexer._sync_indexes("mission", row["id"], row)
-        # Defect 3 (mis_01KR1Z28QW9WYXG4VV8PGYWD8G T5): pre-v2.3.4 the iteration
-        # stopped at missions, so imported claims and clusters were invisible
-        # to FTS / vec search until a manual reindex. _sync_indexes routes via
-        # _FTS_CONFIG (claim + cluster present) and _EMBED_TEXT_MAP (claim
-        # present; cluster vectors parked).
-        for row in tables.get("claims", []):
-            await scoped_indexer._sync_indexes("claim", row["id"], row)
-        for row in tables.get("evidence_clusters", []):
-            await scoped_indexer._sync_indexes("cluster", row["id"], row)
+        artifact_indexer = ArtifactService(
+            self.db,
+            embeddings=self.embeddings,
+            project_id=target_project_id,
+        )
+        for entity_type, (table, _columns) in self._INDEXABLE.items():
+            for row in tables.get(table, []):
+                await self._sync_indexable_row(
+                    scoped_indexer,
+                    artifact_indexer,
+                    entity_type,
+                    row,
+                )
+
+    @staticmethod
+    async def _sync_indexable_row(
+        indexer: BaseService,
+        artifact_indexer: ArtifactService,
+        entity_type: str,
+        row: dict[str, Any],
+    ) -> None:
+        """Rebuild one imported entity with its canonical indexing text."""
+
+        if entity_type == "artifact":
+            await artifact_indexer._embed_artifact(
+                artifact_id=row["id"],
+                filename=row["filename"],
+                filetype=row.get("filetype"),
+                mime=row.get("mime"),
+                metadata=row.get("metadata"),
+            )
+            return
+        if entity_type == "figure":
+            await artifact_indexer._embed_figure(
+                figure_id=row["id"],
+                caption=row.get("caption"),
+                summary=row.get("summary"),
+                claims=row.get("claims"),
+            )
+            return
+        await indexer._sync_indexes(entity_type, row["id"], row)
 
     @staticmethod
     def _copy_and_hash(src: BinaryIO, dst: BinaryIO) -> str:

--- a/scripts/core_recovery_smoke.py
+++ b/scripts/core_recovery_smoke.py
@@ -1,0 +1,913 @@
+#!/usr/bin/env python3
+"""Validate an RKA backup, upgrade, pack round trip, and offline rollback.
+
+The source database is opened only by SQLite's online-backup API. All schema
+initialization, imports, and recovery writes happen under a temporary directory.
+The JSON report contains counts and hashes, never research text or raw IDs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rka.infra.database import Database  # noqa: E402
+from rka.infra.sqlite_backup import (  # noqa: E402
+    backup_sqlite_database,
+    fsync_directory,
+    protected_sqlite_runtime_paths,
+)
+from rka.services.knowledge_pack import (  # noqa: E402
+    _INSERT_ORDER,
+    KnowledgePackService,
+)
+
+
+REPORT_SCHEMA = "rka-core-recovery/v1"
+LEDGER_TABLES = ("schema_migrations", "runtime_schema_upgrades")
+INDEX_PREFIXES = ("fts_", "vec_")
+LINK_TABLES = {
+    "claim_edges",
+    "claim_evidence_relations",
+    "entity_links",
+    "entity_topics",
+    "evidence_locators",
+    "interpretation_promotions",
+    "tags",
+}
+INSTALLATION_LOCAL_INTEGRITY_CATEGORIES = {
+    "index_check_incomplete",
+    "orphaned_fts_rows",
+    "orphaned_vector_rows",
+    "stranded_entities",
+}
+
+# Portable Core semantics in the current pack contract. Writer compatibility
+# rows are still imported and preserved, but their extraction contract belongs
+# to E2 and is deliberately not redefined by this E1 recovery smoke.
+PORTABLE_CORE_TABLES = {
+    "literature",
+    "decisions",
+    "decision_options",
+    "missions",
+    "journal",
+    "checkpoints",
+    "interpretation_candidates",
+    "interpretation_candidate_hints",
+    "interpretation_review_events",
+    "interpretation_promotions",
+    "experiments",
+    "experiment_plan_versions",
+    "experiment_runs",
+    "experiment_run_events",
+    "experiment_observations",
+    "evidence_locators",
+    "claims",
+    "claim_scope_versions",
+    "claim_evidence_relations",
+    "evidence_clusters",
+    "claim_edges",
+    "entity_links",
+    "tags",
+    "calibration_outcomes",
+    "hooks",
+    "artifacts",
+    "figures",
+}
+
+IMPORT_IGNORED_COLUMNS: dict[str, set[str]] = {
+    # Imported files live below the target project's managed artifact root.
+    "artifacts": {"filepath", "pack_file"},
+    # This hash is intentionally refreshed when a fresh claim is re-keyed and
+    # is checked independently by _claim_scope_hashes_preserved.
+    "claim_scope_versions": {"claim_content_hash"},
+}
+
+
+class CapturingKnowledgePackService(KnowledgePackService):
+    """Expose the importer-created bijection only to this validation script."""
+
+    imported_id_map: dict[str, str]
+
+    def _build_id_map(self, tables: dict[str, list[dict[str, Any]]]) -> dict[str, str]:
+        mapping = super()._build_id_map(tables)
+        self.imported_id_map = dict(mapping)
+        return mapping
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _value_bytes(value: Any) -> bytes:
+    if value is None:
+        payload = b""
+        marker = b"N"
+    elif isinstance(value, bytes):
+        payload = value
+        marker = b"B"
+    elif isinstance(value, float):
+        payload = value.hex().encode()
+        marker = b"F"
+    elif isinstance(value, int):
+        payload = str(value).encode()
+        marker = b"I"
+    else:
+        payload = str(value).encode("utf-8", errors="surrogatepass")
+        marker = b"T"
+    return marker + len(payload).to_bytes(8, "big") + payload
+
+
+def _row_digest(row: dict[str, Any], *, ignored: set[str] | None = None) -> str:
+    ignored = ignored or set()
+    digest = hashlib.sha256()
+    for column in sorted(set(row) - ignored):
+        digest.update(_value_bytes(column))
+        digest.update(_value_bytes(row[column]))
+    return digest.hexdigest()
+
+
+def _rows_digest(
+    rows: list[dict[str, Any]],
+    *,
+    ignored: set[str] | None = None,
+) -> str:
+    digest = hashlib.sha256()
+    for row_hash in sorted(_row_digest(row, ignored=ignored) for row in rows):
+        digest.update(row_hash.encode())
+    return digest.hexdigest()
+
+
+def _list_user_tables(connection: sqlite3.Connection) -> list[str]:
+    rows = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+    ).fetchall()
+    return [
+        str(row[0])
+        for row in rows
+        if not str(row[0]).startswith("sqlite_")
+        and not str(row[0]).startswith(INDEX_PREFIXES)
+        and str(row[0]) not in LEDGER_TABLES
+    ]
+
+
+def _ledger(connection: sqlite3.Connection, table: str, column: str) -> dict[str, Any]:
+    exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        [table],
+    ).fetchone()
+    if exists is None:
+        return {"count": 0, "entries": [], "digest": _rows_digest([])}
+    entries = [
+        str(row[0])
+        for row in connection.execute(
+            f"SELECT {_quote_identifier(column)} FROM {_quote_identifier(table)} "
+            f"ORDER BY {_quote_identifier(column)}"
+        ).fetchall()
+    ]
+    return {
+        "count": len(entries),
+        "entries": entries,
+        "digest": hashlib.sha256("\n".join(entries).encode()).hexdigest(),
+    }
+
+
+def _database_snapshot(path: Path) -> dict[str, Any]:
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as connection:
+        connection.row_factory = sqlite3.Row
+        integrity = [str(row[0]) for row in connection.execute("PRAGMA integrity_check")]
+        foreign_keys = [dict(row) for row in connection.execute("PRAGMA foreign_key_check")]
+        tables: dict[str, Any] = {}
+        for table in _list_user_tables(connection):
+            quoted = _quote_identifier(table)
+            columns = [
+                str(row[1])
+                for row in connection.execute(f"PRAGMA table_info({quoted})").fetchall()
+            ]
+            rows = [dict(row) for row in connection.execute(f"SELECT * FROM {quoted}")]
+            ids = sorted(str(row["id"]) for row in rows if "id" in row)
+            tables[table] = {
+                "count": len(rows),
+                "columns": columns,
+                "row_digest": _rows_digest(rows),
+                "id_count": len(ids),
+                "id_digest": hashlib.sha256("\n".join(ids).encode()).hexdigest(),
+                "has_revision": "revision" in columns or table.endswith("_versions"),
+            }
+        return {
+            "sqlite_integrity_ok": integrity == ["ok"],
+            "sqlite_integrity_finding_count": 0 if integrity == ["ok"] else len(integrity),
+            "sqlite_integrity_digest": hashlib.sha256("\n".join(integrity).encode()).hexdigest(),
+            "foreign_key_violation_count": len(foreign_keys),
+            "foreign_key_digest": _rows_digest(foreign_keys),
+            "schema_migrations": _ledger(connection, "schema_migrations", "filename"),
+            "runtime_schema_upgrades": _ledger(
+                connection,
+                "runtime_schema_upgrades",
+                "name",
+            ),
+            "tables": tables,
+        }
+
+
+def _compare_upgrade(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    before_tables = before["tables"]
+    after_tables = after["tables"]
+    shared = sorted(set(before_tables) & set(after_tables))
+    changed = [table for table in shared if before_tables[table] != after_tables[table]]
+    changed_ids = [
+        table
+        for table in shared
+        if before_tables[table]["id_digest"] != after_tables[table]["id_digest"]
+    ]
+    changed_links = [table for table in changed if table in LINK_TABLES]
+    changed_revisions = [
+        table
+        for table in changed
+        if before_tables[table]["has_revision"] or after_tables[table]["has_revision"]
+    ]
+    foreign_keys_equal = (
+        before["foreign_key_violation_count"] == after["foreign_key_violation_count"]
+        and before["foreign_key_digest"] == after["foreign_key_digest"]
+    )
+    schema_ledger_equal = before["schema_migrations"] == after["schema_migrations"]
+    runtime_ledger_equal = (
+        before["runtime_schema_upgrades"] == after["runtime_schema_upgrades"]
+    )
+    removed = sorted(set(before_tables) - set(after_tables))
+    return {
+        "passed": not changed
+        and not removed
+        and not changed_ids
+        and foreign_keys_equal
+        and schema_ledger_equal
+        and runtime_ledger_equal
+        and after["sqlite_integrity_ok"],
+        "changed_tables": changed,
+        "changed_id_sets": changed_ids,
+        "changed_link_tables": changed_links,
+        "changed_revision_tables": changed_revisions,
+        "new_tables": sorted(set(after_tables) - set(before_tables)),
+        "removed_tables": removed,
+        "foreign_keys_equal": foreign_keys_equal,
+        "schema_migration_ledger_equal": schema_ledger_equal,
+        "runtime_upgrade_ledger_equal": runtime_ledger_equal,
+        "schema_migrations_added": sorted(
+            set(after["schema_migrations"]["entries"])
+            - set(before["schema_migrations"]["entries"])
+        ),
+        "runtime_upgrades_added": sorted(
+            set(after["runtime_schema_upgrades"]["entries"])
+            - set(before["runtime_schema_upgrades"]["entries"])
+        ),
+    }
+
+
+async def _upgrade_database(path: Path) -> int:
+    database = Database(str(path))
+    await database.connect()
+    try:
+        await database.initialize_schema()
+        await database.initialize_phase2_schema()
+        await database.run_migrations()
+        return await database.run_migrations()
+    finally:
+        await database.close()
+
+
+async def _read_project_tables(
+    database: Database,
+    project_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Read the portable Core contract directly from the source database."""
+
+    tables: dict[str, list[dict[str, Any]]] = {}
+    for table in sorted(PORTABLE_CORE_TABLES):
+        columns = await database.fetchall(f"PRAGMA table_info({_quote_identifier(table)})")
+        names = {str(column["name"]) for column in columns}
+        if "project_id" not in names:
+            raise RuntimeError(f"Portable Core table lacks project_id: {table}")
+        tables[table] = await database.fetchall(
+            f"SELECT * FROM {_quote_identifier(table)} WHERE project_id = ?",
+            [project_id],
+        )
+    return tables
+
+
+def _source_manifest_comparison(
+    source_database_tables: dict[str, list[dict[str, Any]]],
+    manifest_tables: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Compare exporter output with an independently read source snapshot."""
+
+    missing_tables = sorted(PORTABLE_CORE_TABLES - set(manifest_tables))
+    table_results: dict[str, Any] = {}
+    for table in sorted(PORTABLE_CORE_TABLES):
+        source_rows = [dict(row) for row in source_database_tables.get(table, [])]
+        manifest_rows = [dict(row) for row in manifest_tables.get(table, [])]
+        ignored = {"pack_file"} if table == "artifacts" else set()
+        source_digest = _rows_digest(source_rows, ignored=ignored)
+        manifest_digest = _rows_digest(manifest_rows, ignored=ignored)
+        table_results[table] = {
+            "database_count": len(source_rows),
+            "manifest_count": len(manifest_rows),
+            "database_digest": source_digest,
+            "manifest_digest": manifest_digest,
+            "matched": source_digest == manifest_digest,
+        }
+    mismatched = [
+        table for table, details in table_results.items() if not details["matched"]
+    ]
+    return {
+        "passed": not missing_tables and not mismatched,
+        "missing_tables": missing_tables,
+        "mismatched_tables": mismatched,
+        "tables": table_results,
+    }
+
+
+def _forward_rekey_value(
+    value: Any,
+    *,
+    id_map: dict[str, str],
+    source_project_id: str,
+    target_project_id: str,
+) -> Any:
+    """Build an independent source-to-target expectation for imported strings."""
+
+    if not isinstance(value, str):
+        return value
+    normalized = value.replace(source_project_id, target_project_id)
+    for source_id, target_id in sorted(
+        id_map.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
+        normalized = normalized.replace(source_id, target_id)
+    return _canonicalize_json_text(normalized)
+
+
+def _canonicalize_json_text(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return value
+    if not isinstance(parsed, (dict, list)):
+        return value
+    return json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_expected_target_row(
+    table: str,
+    row: dict[str, Any],
+    *,
+    id_map: dict[str, str],
+    source_project_id: str,
+    target_project_id: str,
+) -> dict[str, Any]:
+    ignored = IMPORT_IGNORED_COLUMNS.get(table, set())
+    return {
+        column: _forward_rekey_value(
+            value,
+            id_map=id_map,
+            source_project_id=source_project_id,
+            target_project_id=target_project_id,
+        )
+        for column, value in row.items()
+        if column not in ignored and column != "pack_file"
+    }
+
+
+def _normalize_target_row(table: str, row: dict[str, Any]) -> dict[str, Any]:
+    ignored = IMPORT_IGNORED_COLUMNS.get(table, set())
+    return {
+        column: _canonicalize_json_text(value)
+        for column, value in row.items()
+        if column not in ignored
+    }
+
+
+def _normalize_manifest_row(table: str, row: dict[str, Any]) -> dict[str, Any]:
+    ignored = IMPORT_IGNORED_COLUMNS.get(table, set())
+    return {
+        column: _canonicalize_json_text(value)
+        for column, value in row.items()
+        if column not in ignored and column != "pack_file"
+    }
+
+
+def _mismatched_columns(
+    expected_rows: list[dict[str, Any]],
+    actual_rows: list[dict[str, Any]],
+) -> list[str]:
+    columns = set().union(
+        *(set(row) for row in expected_rows),
+        *(set(row) for row in actual_rows),
+    )
+    return sorted(
+        column
+        for column in columns
+        if _rows_digest([{"value": row.get(column)} for row in expected_rows])
+        != _rows_digest([{"value": row.get(column)} for row in actual_rows])
+    )
+
+
+def _claim_scope_hashes_preserved(
+    source_tables: dict[str, list[dict[str, Any]]],
+    imported_tables: dict[str, list[dict[str, Any]]],
+    *,
+    inverse_id_map: dict[str, str],
+) -> bool:
+    """Verify that fresh scope hashes refresh and stale hashes stay stale."""
+
+    source_claims = {
+        str(row["id"]): row for row in source_tables.get("claims", []) if row.get("id")
+    }
+    imported_claims = {
+        inverse_id_map.get(str(row.get("id")), str(row.get("id"))): row
+        for row in imported_tables.get("claims", [])
+        if row.get("id")
+    }
+    imported_scopes = {
+        inverse_id_map.get(str(row.get("id")), str(row.get("id"))): row
+        for row in imported_tables.get("claim_scope_versions", [])
+        if row.get("id")
+    }
+    for source_scope in source_tables.get("claim_scope_versions", []):
+        source_scope_id = str(source_scope.get("id") or "")
+        source_claim_id = str(source_scope.get("claim_id") or "")
+        source_claim = source_claims.get(source_claim_id)
+        imported_scope = imported_scopes.get(source_scope_id)
+        imported_claim = imported_claims.get(source_claim_id)
+        if source_claim is None or imported_scope is None or imported_claim is None:
+            return False
+        source_hash = hashlib.sha256(
+            f"{source_claim.get('claim_type', '')}\0{source_claim.get('content', '')}".encode()
+        ).hexdigest()
+        imported_hash = hashlib.sha256(
+            f"{imported_claim.get('claim_type', '')}\0{imported_claim.get('content', '')}".encode()
+        ).hexdigest()
+        expected_hash = (
+            imported_hash
+            if source_scope.get("claim_content_hash") == source_hash
+            else source_scope.get("claim_content_hash")
+        )
+        if imported_scope.get("claim_content_hash") != expected_hash:
+            return False
+    return True
+
+
+def _artifact_bytes_preserved(
+    source_tables: dict[str, list[dict[str, Any]]],
+    imported_tables: dict[str, list[dict[str, Any]]],
+    *,
+    inverse_id_map: dict[str, str],
+) -> bool:
+    source_hashes = {
+        str(row["id"]): str(row.get("content_hash") or "")
+        for row in source_tables.get("artifacts", [])
+        if row.get("id")
+    }
+    imported = imported_tables.get("artifacts", [])
+    if len(imported) != len(source_hashes):
+        return False
+    for row in imported:
+        source_id = inverse_id_map.get(str(row.get("id") or ""))
+        expected_hash = source_hashes.get(str(source_id or ""))
+        filepath = row.get("filepath")
+        if not expected_hash or not isinstance(filepath, str):
+            return False
+        path = Path(filepath)
+        if not path.is_file() or _sha256_file(path) != expected_hash:
+            return False
+    return True
+
+
+def _normalized_integrity(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        [
+            {
+                "category": issue.get("category"),
+                "severity": issue.get("severity"),
+                "sample_count": issue.get("count"),
+            }
+            for issue in issues
+            if issue.get("category") not in INSTALLATION_LOCAL_INTEGRITY_CATEGORIES
+        ],
+        key=lambda issue: (
+            str(issue["category"]),
+            str(issue["severity"]),
+            int(issue["sample_count"] or 0),
+        ),
+    )
+
+
+def _installation_integrity_summary(
+    issues: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return sorted(
+        [
+            {
+                "category": issue.get("category"),
+                "severity": issue.get("severity"),
+                "sample_count": issue.get("count"),
+            }
+            for issue in issues
+            if issue.get("category") in INSTALLATION_LOCAL_INTEGRITY_CATEGORIES
+        ],
+        key=lambda issue: str(issue["category"]),
+    )
+
+
+def _integrity_signature(issues: list[dict[str, Any]]) -> str:
+    return _rows_digest(_normalized_integrity(issues))
+
+
+async def _validate_pack_round_trip(
+    source_path: Path,
+    project_id: str,
+    work_dir: Path,
+    ordinal: int,
+) -> dict[str, Any]:
+    source_db = Database(str(source_path))
+    await source_db.connect()
+    target_db = Database(str(work_dir / f"pack-target-{ordinal}.db"))
+    await target_db.connect()
+    await target_db.initialize_schema()
+    await target_db.initialize_phase2_schema()
+    pack_path: Path | None = None
+    try:
+        source_service = KnowledgePackService(source_db, project_id=project_id)
+        source_issues = await source_service.check_integrity(project_id)
+        source_database_tables = await _read_project_tables(source_db, project_id)
+        source_project = await source_db.fetchone(
+            "SELECT * FROM projects WHERE id = ?",
+            [project_id],
+        )
+        source_state = await source_db.fetchone(
+            "SELECT * FROM project_states WHERE project_id = ?",
+            [project_id],
+        )
+        pack_name, _filename = await source_service.export_pack(project_id)
+        pack_path = Path(pack_name)
+        with zipfile.ZipFile(pack_path) as archive:
+            manifest = json.loads(archive.read("manifest.json"))
+
+        source_tables = manifest.get("tables", {})
+        source_manifest = _source_manifest_comparison(
+            source_database_tables,
+            source_tables,
+        )
+        project_manifest_matches = (
+            source_project is not None
+            and _rows_digest([dict(source_project)])
+            == _rows_digest([dict(manifest.get("project") or {})])
+        )
+        state_manifest_matches = (
+            (source_state is None and manifest.get("project_state") is None)
+            or (
+                source_state is not None
+                and _rows_digest([dict(source_state)])
+                == _rows_digest([dict(manifest.get("project_state") or {})])
+            )
+        )
+
+        target_project_id = f"recovery_pack_{ordinal:03d}"
+        target_project_name = f"Recovery Pack {ordinal:03d}"
+        importer = CapturingKnowledgePackService(target_db)
+        with pack_path.open("rb") as pack_file:
+            result = await importer.import_pack(
+                pack_file,
+                project_id=target_project_id,
+                project_name=target_project_name,
+                defer_indexing=True,
+            )
+
+        inverse_id_map = {
+            target_id: source_id
+            for source_id, target_id in importer.imported_id_map.items()
+        }
+        table_results: dict[str, Any] = {}
+        imported_tables: dict[str, list[dict[str, Any]]] = {}
+        source_ids: set[str] = set()
+        for table in sorted(PORTABLE_CORE_TABLES):
+            actual = await target_db.fetchall(
+                f"SELECT * FROM {_quote_identifier(table)} WHERE project_id = ?",
+                [target_project_id],
+            )
+            imported_tables[table] = [dict(row) for row in actual]
+            expected_rows = [
+                _normalize_expected_target_row(
+                    table,
+                    dict(row),
+                    id_map=importer.imported_id_map,
+                    source_project_id=project_id,
+                    target_project_id=target_project_id,
+                )
+                for row in source_tables.get(table, [])
+            ]
+            normalized_actual = [
+                _normalize_target_row(table, dict(row))
+                for row in actual
+            ]
+            source_ids.update(
+                str(row["id"])
+                for row in source_tables.get(table, [])
+                if row.get("id")
+            )
+            expected_digest = _rows_digest(expected_rows)
+            actual_digest = _rows_digest(normalized_actual)
+            table_results[table] = {
+                "source_count": len(source_tables.get(table, [])),
+                "imported_count": len(actual),
+                "expected_digest": expected_digest,
+                "actual_digest": actual_digest,
+                "matched": expected_digest == actual_digest,
+                "mismatched_columns": _mismatched_columns(
+                    expected_rows,
+                    normalized_actual,
+                ),
+            }
+
+        target_project = await target_db.fetchone(
+            "SELECT * FROM projects WHERE id = ?",
+            [target_project_id],
+        )
+        expected_target_project = dict(manifest["project"])
+        expected_target_project["id"] = target_project_id
+        expected_target_project["name"] = target_project_name
+        target_project_matches = (
+            target_project is not None
+            and _rows_digest([dict(target_project)])
+            == _rows_digest([expected_target_project])
+        )
+        target_state = await target_db.fetchone(
+            "SELECT * FROM project_states WHERE project_id = ?",
+            [target_project_id],
+        )
+        source_manifest_state = manifest.get("project_state") or {}
+        expected_target_state = {
+            "project_id": target_project_id,
+            "project_name": target_project_name,
+            "project_description": manifest["project"].get("description"),
+            "current_phase": source_manifest_state.get("current_phase"),
+            "phases_config": source_manifest_state.get("phases_config"),
+            "summary": source_manifest_state.get("summary"),
+            "blockers": source_manifest_state.get("blockers"),
+            "metrics": source_manifest_state.get("metrics"),
+            "created_at": source_manifest_state.get("created_at")
+            or manifest["project"].get("created_at"),
+            "updated_at": source_manifest_state.get("updated_at")
+            or manifest["project"].get("updated_at"),
+        }
+        target_state_matches = (
+            target_state is not None
+            and expected_target_state["phases_config"] is not None
+            and _rows_digest([dict(target_state)])
+            == _rows_digest([expected_target_state])
+        )
+        id_map_complete = source_ids.issubset(importer.imported_id_map)
+        id_map_values_unique = len(importer.imported_id_map.values()) == len(
+            set(importer.imported_id_map.values())
+        )
+        scope_hashes_preserved = _claim_scope_hashes_preserved(
+            source_tables,
+            imported_tables,
+            inverse_id_map=inverse_id_map,
+        )
+        artifact_bytes_preserved = _artifact_bytes_preserved(
+            source_tables,
+            imported_tables,
+            inverse_id_map=inverse_id_map,
+        )
+
+        target_issues = await importer.check_integrity(target_project_id)
+        critical = [issue for issue in target_issues if issue.get("severity") == "critical"]
+        count_matches = all(
+            result.imported_counts.get(table, 0) == len(rows)
+            for table, rows in source_tables.items()
+            if table in _INSERT_ORDER
+        )
+        mismatched_tables = [
+            table for table, details in table_results.items() if not details["matched"]
+        ]
+        source_signature = _integrity_signature(source_issues)
+        target_signature = _integrity_signature(target_issues)
+        manifest_counts_match = (
+            set(manifest.get("table_counts", {})) == set(source_tables)
+            and all(
+                manifest.get("table_counts", {}).get(table) == len(rows)
+                for table, rows in source_tables.items()
+            )
+        )
+        return {
+            "project_fingerprint": hashlib.sha256(project_id.encode()).hexdigest()[:16],
+            "passed": source_manifest["passed"]
+            and project_manifest_matches
+            and state_manifest_matches
+            and target_project_matches
+            and target_state_matches
+            and id_map_complete
+            and id_map_values_unique
+            and scope_hashes_preserved
+            and artifact_bytes_preserved
+            and manifest_counts_match
+            and not mismatched_tables
+            and count_matches
+            and not critical
+            and source_signature == target_signature,
+            "id_map_size": len(importer.imported_id_map),
+            "id_map_complete": id_map_complete,
+            "id_map_values_unique": id_map_values_unique,
+            "source_manifest": source_manifest,
+            "project_manifest_matches_database": project_manifest_matches,
+            "state_manifest_matches_database": state_manifest_matches,
+            "target_project_matches_manifest": target_project_matches,
+            "target_state_matches_manifest": target_state_matches,
+            "claim_scope_hashes_preserved": scope_hashes_preserved,
+            "artifact_bytes_preserved": artifact_bytes_preserved,
+            "manifest_counts_match_payload": manifest_counts_match,
+            "imported_counts_match": count_matches,
+            "mismatched_tables": mismatched_tables,
+            "source_integrity_signature": source_signature,
+            "target_integrity_signature": target_signature,
+            "source_integrity_summary": _normalized_integrity(source_issues),
+            "target_integrity_summary": _normalized_integrity(target_issues),
+            "source_installation_findings": _installation_integrity_summary(source_issues),
+            "target_installation_findings": _installation_integrity_summary(target_issues),
+            "target_critical_issue_count": len(critical),
+            "tables": table_results,
+        }
+    finally:
+        if pack_path is not None:
+            pack_path.unlink(missing_ok=True)
+        await target_db.close()
+        await source_db.close()
+
+
+def _restore_exact(backup: Path, destination: Path) -> None:
+    temporary = destination.with_name(f".{destination.name}.restore.tmp")
+    shutil.copyfile(backup, temporary)
+    os.chmod(temporary, 0o600)
+    with temporary.open("rb") as restored:
+        os.fsync(restored.fileno())
+    for suffix in ("-wal", "-shm", "-journal", ".phase2.lock"):
+        Path(f"{destination}{suffix}").unlink(missing_ok=True)
+    os.replace(temporary, destination)
+    fsync_directory(destination.parent)
+
+
+def _write_report_atomic(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(report, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    source = args.source_db.expanduser().resolve()
+    source_before = {
+        "size_bytes": source.stat().st_size,
+        "mtime_ns": source.stat().st_mtime_ns,
+    }
+    with tempfile.TemporaryDirectory(prefix="rka-core-recovery-") as temporary:
+        work_dir = Path(temporary)
+        baseline = work_dir / "baseline.db"
+        upgrade = work_dir / "upgrade.db"
+        rollback = work_dir / "rollback.db"
+
+        backup = backup_sqlite_database(source, baseline)
+        backup_sqlite_database(baseline, upgrade)
+        before = _database_snapshot(upgrade)
+        second_pass_migrations = await _upgrade_database(upgrade)
+        after = _database_snapshot(upgrade)
+        upgrade_comparison = _compare_upgrade(before, after)
+
+        pack_results = [
+            await _validate_pack_round_trip(upgrade, project_id, work_dir, ordinal)
+            for ordinal, project_id in enumerate(args.project_id, start=1)
+        ]
+
+        _restore_exact(baseline, rollback)
+        rollback_snapshot = _database_snapshot(rollback)
+        rollback_exact = _sha256_file(rollback) == _sha256_file(baseline)
+        rollback_logical = rollback_snapshot == _database_snapshot(baseline)
+        source_after = {
+            "size_bytes": source.stat().st_size,
+            "mtime_ns": source.stat().st_mtime_ns,
+        }
+
+        passed = (
+            upgrade_comparison["passed"]
+            and second_pass_migrations == 0
+            and bool(pack_results)
+            and all(result["passed"] for result in pack_results)
+            and rollback_exact
+            and rollback_logical
+        )
+        return {
+            "schema": REPORT_SCHEMA,
+            "passed": passed,
+            "source_observation": {
+                "before": source_before,
+                "after": source_after,
+                "note": (
+                    "Metadata equality is informational for a live source; concurrent RKA "
+                    "writers may change it while online backup remains read-only."
+                ),
+            },
+            "backup": {
+                "sha256": backup.sha256,
+                "size_bytes": backup.size_bytes,
+                "page_count": backup.page_count,
+                "foreign_key_violations": backup.foreign_key_violations,
+            },
+            "upgrade": {
+                "second_idempotence_pass_applied": second_pass_migrations,
+                "before": before,
+                "after": after,
+                "comparison": upgrade_comparison,
+            },
+            "knowledge_packs": pack_results,
+            "rollback": {
+                "exact_backup_bytes_restored": rollback_exact,
+                "logical_snapshot_restored": rollback_logical,
+                "previous_runtime": "requires isolated pinned-image runbook step",
+            },
+        }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-db", type=Path, required=True)
+    parser.add_argument("--project-id", action="append", default=[])
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+
+    source_path = args.source_db.expanduser().resolve()
+    report_input = args.report.expanduser()
+    if report_input.is_symlink():
+        parser.error("--report must not be a symbolic link")
+    report_path = report_input.resolve()
+    if report_path in protected_sqlite_runtime_paths(source_path):
+        parser.error("--report must not replace the source database or its runtime files")
+    try:
+        report = asyncio.run(_run(args))
+    except Exception as exc:
+        print(
+            f"Recovery validation failed ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        report = {
+            "schema": REPORT_SCHEMA,
+            "passed": False,
+            "stage": "recovery_validation",
+            "error_type": type(exc).__name__,
+        }
+    _write_report_atomic(report_path, report)
+    print(f"Recovery report: {report_path}")
+    if not report.get("passed"):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli/test_core_backup.py
+++ b/tests/test_cli/test_core_backup.py
@@ -1,0 +1,57 @@
+"""Core backup-command regressions."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+import rka.config as config_module
+from rka.cli import main
+
+
+def test_backup_command_uses_consistent_snapshot(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    destination = tmp_path / "nested" / "backup.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+        connection.execute("INSERT INTO records DEFAULT VALUES")
+
+    monkeypatch.setattr(
+        config_module,
+        "RKAConfig",
+        lambda: SimpleNamespace(database_url=str(source)),
+    )
+
+    result = CliRunner().invoke(main, ["backup", "--output", str(destination)])
+
+    assert result.exit_code == 0, result.output
+    assert f"Backed up to {destination.resolve()}" in result.output
+    assert "SHA-256:" in result.output
+    with sqlite3.connect(destination) as restored:
+        assert restored.execute("SELECT COUNT(*) FROM records").fetchone()[0] == 1
+
+
+def test_backup_command_fails_without_replacing_destination(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "corrupt.db"
+    destination = tmp_path / "backup.db"
+    source.write_bytes(b"corrupt")
+    destination.write_bytes(b"keep me")
+    monkeypatch.setattr(
+        config_module,
+        "RKAConfig",
+        lambda: SimpleNamespace(database_url=str(source)),
+    )
+
+    result = CliRunner().invoke(main, ["backup", "--output", str(destination)])
+
+    assert result.exit_code != 0
+    assert destination.read_bytes() == b"keep me"

--- a/tests/test_core_recovery_smoke.py
+++ b/tests/test_core_recovery_smoke.py
@@ -1,0 +1,273 @@
+"""End-to-end regression for the disposable Core recovery smoke."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sqlite3
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.core_recovery_smoke as recovery_smoke
+from rka.infra.database import Database
+from rka.models.journal import JournalEntryCreate
+from rka.models.project import ProjectCreate
+from rka.services.artifacts import ArtifactService
+from rka.services.notes import NoteService
+from rka.services.project import ProjectService
+from scripts.core_recovery_smoke import (
+    PORTABLE_CORE_TABLES,
+    _compare_upgrade,
+    _database_snapshot,
+    _normalize_expected_target_row,
+    _normalize_target_row,
+    _restore_exact,
+    _run,
+    _source_manifest_comparison,
+    main,
+)
+
+
+def test_source_manifest_oracle_detects_an_omitted_core_table() -> None:
+    source_tables = {table: [] for table in PORTABLE_CORE_TABLES}
+    source_tables["journal"] = [
+        {"id": "jrn_source", "project_id": "proj_source", "content": "kept"}
+    ]
+    manifest_tables = dict(source_tables)
+    manifest_tables.pop("journal")
+
+    comparison = _source_manifest_comparison(source_tables, manifest_tables)
+
+    assert comparison["passed"] is False
+    assert comparison["missing_tables"] == ["journal"]
+    assert comparison["mismatched_tables"] == ["journal"]
+
+
+def test_forward_oracle_detects_an_unmapped_source_reference() -> None:
+    source_row = {
+        "id": "lnk_source",
+        "project_id": "proj_source",
+        "source_id": "jrn_source",
+        "target_id": "dec_source",
+    }
+    id_map = {
+        "lnk_source": "lnk_target",
+        "jrn_source": "jrn_target",
+        "dec_source": "dec_target",
+    }
+    expected = _normalize_expected_target_row(
+        "entity_links",
+        source_row,
+        id_map=id_map,
+        source_project_id="proj_source",
+        target_project_id="proj_target",
+    )
+    bad_import = {
+        "id": "lnk_target",
+        "project_id": "proj_target",
+        "source_id": "jrn_target",
+        "target_id": "dec_source",
+    }
+
+    assert _normalize_target_row("entity_links", bad_import) != expected
+
+
+def test_upgrade_comparison_rejects_ledger_rewrite(tmp_path: Path) -> None:
+    source = tmp_path / "ledger.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations (filename TEXT PRIMARY KEY)"
+        )
+        connection.execute(
+            "CREATE TABLE runtime_schema_upgrades (name TEXT PRIMARY KEY)"
+        )
+        connection.execute("INSERT INTO schema_migrations VALUES ('001.sql')")
+        connection.execute("INSERT INTO runtime_schema_upgrades VALUES ('phase2')")
+    before = _database_snapshot(source)
+    after = copy.deepcopy(before)
+    after["schema_migrations"]["entries"] = []
+    after["schema_migrations"]["count"] = 0
+
+    comparison = _compare_upgrade(before, after)
+
+    assert comparison["passed"] is False
+    assert comparison["schema_migration_ledger_equal"] is False
+
+
+def test_offline_restore_replaces_target_and_removes_stale_sidecars(
+    tmp_path: Path,
+) -> None:
+    backup = tmp_path / "backup.db"
+    target = tmp_path / "target.db"
+    backup.write_bytes(b"known-good-backup")
+    target.write_bytes(b"upgraded-target")
+    sidecars = [
+        Path(f"{target}{suffix}")
+        for suffix in ("-wal", "-shm", "-journal", ".phase2.lock")
+    ]
+    for sidecar in sidecars:
+        sidecar.write_bytes(b"stale-runtime-state")
+
+    _restore_exact(backup, target)
+
+    assert target.read_bytes() == backup.read_bytes()
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert all(not sidecar.exists() for sidecar in sidecars)
+
+
+@pytest.mark.parametrize("suffix", ["", "-wal", "-shm", "-journal", ".phase2.lock"])
+def test_recovery_report_cannot_replace_database_runtime_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str,
+) -> None:
+    source = tmp_path / "source.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+    report = Path(f"{source}{suffix}")
+    if report != source:
+        report.write_bytes(b"runtime-state")
+    before = report.read_bytes()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "core_recovery_smoke.py",
+            "--source-db",
+            str(source),
+            "--project-id",
+            "proj_unused",
+            "--report",
+            str(report),
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert report.read_bytes() == before
+
+
+@pytest.mark.parametrize("use_alias_path", [False, True])
+def test_recovery_report_rejects_runtime_symlink_and_its_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    use_alias_path: bool,
+) -> None:
+    source = tmp_path / "source.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+    victim = tmp_path / "victim.bin"
+    victim.write_bytes(b"do-not-replace")
+    sidecar_alias = Path(f"{source}.phase2.lock")
+    sidecar_alias.symlink_to(victim)
+    report = sidecar_alias if use_alias_path else victim
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "core_recovery_smoke.py",
+            "--source-db",
+            str(source),
+            "--project-id",
+            "proj_unused",
+            "--report",
+            str(report),
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert victim.read_bytes() == b"do-not-replace"
+    assert sidecar_alias.is_symlink()
+
+
+def test_failure_report_omits_exception_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.db"
+    source.write_bytes(b"not-opened-by-this-test")
+    report = tmp_path / "report.json"
+
+    async def fail(_args) -> dict:
+        raise RuntimeError("/sensitive/path prj_sensitive")
+
+    monkeypatch.setattr(recovery_smoke, "_run", fail)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "core_recovery_smoke.py",
+            "--source-db",
+            str(source),
+            "--project-id",
+            "proj_unused",
+            "--report",
+            str(report),
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    persisted = json.loads(report.read_text())
+    assert persisted == {
+        "schema": "rka-core-recovery/v1",
+        "passed": False,
+        "stage": "recovery_validation",
+        "error_type": "RuntimeError",
+    }
+    assert "sensitive" not in report.read_text()
+
+
+@pytest.mark.asyncio
+async def test_recovery_smoke_preserves_upgrade_pack_and_rollback(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.db"
+    database = Database(str(source_path))
+    await database.connect()
+    await database.initialize_schema()
+    await database.initialize_phase2_schema()
+    try:
+        await ProjectService(database).create_project(
+            ProjectCreate(id="proj_recovery_source", name="Recovery Source"),
+            actor="system",
+        )
+        await NoteService(database, project_id="proj_recovery_source").create(
+            JournalEntryCreate(
+                content="The recovery smoke preserves this canonical journal entry.",
+                type="finding",
+                source="executor",
+                confidence="tested",
+            ),
+            actor="executor",
+        )
+        artifact_path = tmp_path / "recovery-evidence.txt"
+        artifact_path.write_bytes(b"portable recovery evidence")
+        await ArtifactService(database, project_id="proj_recovery_source").register(
+            filepath=str(artifact_path),
+            created_by="system",
+            metadata={"kind": "recovery", "ordinal": 1},
+        )
+    finally:
+        await database.close()
+
+    report = await _run(
+        SimpleNamespace(
+            source_db=source_path,
+            project_id=["proj_recovery_source"],
+        )
+    )
+
+    assert report["passed"] is True
+    assert report["upgrade"]["comparison"]["changed_tables"] == []
+    assert report["upgrade"]["second_idempotence_pass_applied"] == 0
+    assert report["knowledge_packs"][0]["passed"] is True
+    assert report["knowledge_packs"][0]["artifact_bytes_preserved"] is True
+    assert report["rollback"]["exact_backup_bytes_restored"] is True
+    assert report["rollback"]["logical_snapshot_restored"] is True

--- a/tests/test_infra/test_sqlite_backup.py
+++ b/tests/test_infra/test_sqlite_backup.py
@@ -1,0 +1,100 @@
+"""Regression tests for consistent SQLite backups."""
+
+from __future__ import annotations
+
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from rka.infra.sqlite_backup import backup_sqlite_database
+
+
+def test_backup_includes_committed_rows_still_in_wal(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    destination = tmp_path / "backup.db"
+
+    with sqlite3.connect(source) as writer:
+        assert writer.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT)")
+        writer.commit()
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        writer.execute("INSERT INTO records(value) VALUES ('committed-in-wal')")
+        writer.commit()
+
+        wal_path = Path(f"{source}-wal")
+        assert wal_path.stat().st_size > 0
+        result = backup_sqlite_database(source, destination)
+
+    with sqlite3.connect(destination) as restored:
+        assert restored.execute("SELECT value FROM records").fetchall() == [
+            ("committed-in-wal",)
+        ]
+        assert restored.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert restored.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+
+    assert result.path == destination.resolve()
+    assert result.size_bytes == destination.stat().st_size
+    assert len(result.sha256) == 64
+    assert result.page_count > 0
+    assert result.foreign_key_violations == 0
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+
+
+def test_backup_rejects_source_as_destination(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+
+    with pytest.raises(ValueError, match="must not replace"):
+        backup_sqlite_database(source, source)
+
+
+@pytest.mark.parametrize("suffix", ["-wal", "-shm", "-journal", ".phase2.lock"])
+def test_backup_rejects_sqlite_runtime_paths(tmp_path: Path, suffix: str) -> None:
+    source = tmp_path / "source.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+    protected = Path(f"{source}{suffix}")
+    protected.write_bytes(b"runtime-state")
+
+    with pytest.raises(ValueError, match="runtime files"):
+        backup_sqlite_database(source, protected)
+
+    assert protected.read_bytes() == b"runtime-state"
+
+
+@pytest.mark.parametrize("use_alias_path", [False, True])
+def test_backup_rejects_runtime_symlink_and_its_target(
+    tmp_path: Path,
+    use_alias_path: bool,
+) -> None:
+    source = tmp_path / "source.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+    victim = tmp_path / "victim.bin"
+    victim.write_bytes(b"do-not-replace")
+    sidecar_alias = Path(f"{source}-shm")
+    sidecar_alias.symlink_to(victim)
+    destination = sidecar_alias if use_alias_path else victim
+
+    with pytest.raises(ValueError):
+        backup_sqlite_database(source, destination)
+
+    assert victim.read_bytes() == b"do-not-replace"
+    assert sidecar_alias.is_symlink()
+
+
+def test_failed_backup_preserves_existing_destination(tmp_path: Path) -> None:
+    source = tmp_path / "corrupt.db"
+    destination = tmp_path / "existing.db"
+    source.write_bytes(b"not a sqlite database")
+    destination.write_bytes(b"known-good-destination")
+
+    with pytest.raises(sqlite3.DatabaseError):
+        backup_sqlite_database(source, destination)
+
+    assert destination.read_bytes() == b"known-good-destination"
+    assert list(tmp_path.glob(".existing.db.*.tmp")) == []

--- a/tests/test_services/test_artifacts.py
+++ b/tests/test_services/test_artifacts.py
@@ -6,7 +6,16 @@ from pathlib import Path
 
 import pytest
 
-from rka.services.artifacts import ArtifactService
+from rka.services.artifacts import ArtifactService, build_artifact_text
+
+
+def test_artifact_embedding_text_canonicalizes_stored_json_metadata() -> None:
+    metadata = {"z": 1, "a": 2}
+
+    assert build_artifact_text("result.json", metadata=metadata) == build_artifact_text(
+        "result.json",
+        metadata='{"z": 1, "a": 2}',
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_knowledge_pack.py
+++ b/tests/test_services/test_knowledge_pack.py
@@ -12,6 +12,8 @@ import pytest
 
 from rka import __version__
 from rka.infra.database import Database
+from rka.infra.embeddings import EmbeddingService
+from rka.models.claim import ClaimCreate, ClaimScopeCondition, ClaimScopeWrite
 from rka.models.decision import DecisionCreate, DecisionOption
 from rka.models.journal import JournalEntryCreate
 from rka.models.interpretation import InterpretationCandidateCreate, InterpretationTriage
@@ -27,6 +29,25 @@ from rka.services.missions import MissionService
 from rka.services.notes import NoteService
 from rka.services.interpretation import InterpretationService
 from rka.services.project import ProjectService
+from rka.services.search import SearchService
+
+
+class DeterministicEmbeddings(EmbeddingService):
+    """Local embedding stub that never downloads or calls a provider."""
+
+    def __init__(self, db: Database):
+        super().__init__(model_name="knowledge-pack-test", db=db)
+
+    @staticmethod
+    def _vector(text: str) -> list[float]:
+        digest = hashlib.sha256(text.encode()).digest()
+        return [digest[index % len(digest)] / 255.0 for index in range(768)]
+
+    async def embed(self, text: str) -> list[float]:
+        return self._vector(text)
+
+    async def embed_document(self, text: str) -> list[float]:
+        return self._vector(text)
 
 
 async def _make_db(path: Path) -> Database:
@@ -72,6 +93,233 @@ async def test_prepare_claim_edges_deduplicates_legacy_memberships(db) -> None:
 
     assert [row["id"] for row in prepared] == ["ced_first", "ced_supports"]
     assert {row["project_id"] for row in prepared} == {"prj_target"}
+
+
+def test_load_manifest_rejects_table_count_mismatch(tmp_path: Path) -> None:
+    pack_path = tmp_path / "bad-count.rka-pack.zip"
+    manifest = {
+        "pack_format_version": PACK_SCHEMA_VERSION,
+        "schema_version": 53,
+        "project": {"id": "proj_source", "name": "Source"},
+        "tables": {"journal": []},
+        "table_counts": {"journal": 1},
+    }
+    with zipfile.ZipFile(pack_path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+
+    with zipfile.ZipFile(pack_path) as archive:
+        with pytest.raises(ValueError, match="table count mismatch.*journal"):
+            service = KnowledgePackService.__new__(KnowledgePackService)
+            service._load_manifest(archive)
+
+
+@pytest.mark.parametrize(
+    ("tables", "table_counts", "message"),
+    [
+        ({"journal": 1}, {"journal": 0}, "table payloads must be arrays"),
+        ({"journal": [1]}, {"journal": 1}, r"journal\[0\] must be an object"),
+        ({"journal": []}, {"journal": True}, "non-negative integer"),
+        ({"journal": []}, {}, "keys must match tables exactly"),
+    ],
+)
+def test_load_manifest_rejects_invalid_table_count_contract(
+    tmp_path: Path,
+    tables: dict,
+    table_counts: dict,
+    message: str,
+) -> None:
+    pack_path = tmp_path / "bad-table-contract.rka-pack.zip"
+    manifest = {
+        "pack_format_version": PACK_SCHEMA_VERSION,
+        "schema_version": 53,
+        "project": {"id": "proj_source", "name": "Source"},
+        "tables": tables,
+        "table_counts": table_counts,
+    }
+    with zipfile.ZipFile(pack_path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+
+    with zipfile.ZipFile(pack_path) as archive:
+        with pytest.raises(ValueError, match=message):
+            service = KnowledgePackService.__new__(KnowledgePackService)
+            service._load_manifest(archive)
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"project": "proj_source"}, "missing project metadata"),
+        ({"project": {"name": "Source"}}, "requires a non-empty ID"),
+        ({"project_state": []}, "project_state must be an object or null"),
+        ({"table_counts": None}, "format 7 requires table_counts"),
+    ],
+)
+def test_load_manifest_rejects_invalid_project_contract(
+    tmp_path: Path,
+    override: dict,
+    message: str,
+) -> None:
+    pack_path = tmp_path / "bad-project-contract.rka-pack.zip"
+    manifest = {
+        "pack_format_version": PACK_SCHEMA_VERSION,
+        "schema_version": 53,
+        "project": {"id": "proj_source", "name": "Source"},
+        "project_state": None,
+        "tables": {},
+        "table_counts": {},
+        **override,
+    }
+    with zipfile.ZipFile(pack_path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+
+    with zipfile.ZipFile(pack_path) as archive:
+        with pytest.raises(ValueError, match=message):
+            service = KnowledgePackService.__new__(KnowledgePackService)
+            service._load_manifest(archive)
+
+
+@pytest.mark.parametrize(
+    ("manifest", "message"),
+    [
+        ([], "manifest must be an object"),
+        (
+            {
+                "pack_format_version": True,
+                "project": {"id": "proj_source", "name": "Source"},
+                "tables": {},
+            },
+            "Unsupported knowledge pack format version",
+        ),
+        (
+            {
+                "pack_format_version": 1.0,
+                "project": {"id": "proj_source", "name": "Source"},
+                "tables": {},
+            },
+            "Unsupported knowledge pack format version",
+        ),
+        (
+            {
+                "pack_format_version": False,
+                "schema_version": 7,
+                "project": {"id": "proj_source", "name": "Source"},
+                "tables": {},
+            },
+            "Unsupported knowledge pack format version",
+        ),
+        (
+            {
+                "pack_format_version": 0,
+                "schema_version": 7,
+                "project": {"id": "proj_source", "name": "Source"},
+                "tables": {},
+            },
+            "Unsupported knowledge pack format version",
+        ),
+        (
+            {
+                "pack_format_version": "",
+                "schema_version": 7,
+                "project": {"id": "proj_source", "name": "Source"},
+                "tables": {},
+            },
+            "Unsupported knowledge pack format version",
+        ),
+    ],
+)
+def test_load_manifest_rejects_invalid_top_level_contract(
+    tmp_path: Path,
+    manifest: object,
+    message: str,
+) -> None:
+    pack_path = tmp_path / "bad-top-level-contract.rka-pack.zip"
+    with zipfile.ZipFile(pack_path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+
+    with zipfile.ZipFile(pack_path) as archive:
+        with pytest.raises(ValueError, match=message):
+            service = KnowledgePackService.__new__(KnowledgePackService)
+            service._load_manifest(archive)
+
+
+def test_load_manifest_rejects_non_utf8_payload(tmp_path: Path) -> None:
+    pack_path = tmp_path / "non-utf8.rka-pack.zip"
+    with zipfile.ZipFile(pack_path, "w") as archive:
+        archive.writestr("manifest.json", b"\xff\xfe")
+
+    with zipfile.ZipFile(pack_path) as archive:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            service = KnowledgePackService.__new__(KnowledgePackService)
+            service._load_manifest(archive)
+
+
+def test_scope_hash_remap_preserves_intentionally_stale_scope() -> None:
+    stale_hash = "0" * 64
+    source = {
+        "claims": [
+            {"id": "clm_source", "claim_type": "result", "content": "current content"}
+        ],
+        "claim_scope_versions": [
+            {
+                "id": "csc_source",
+                "claim_id": "clm_source",
+                "claim_content_hash": stale_hash,
+            }
+        ],
+    }
+    remapped = {
+        "claims": [
+            {"id": "clm_target", "claim_type": "result", "content": "rewritten content"}
+        ],
+        "claim_scope_versions": [
+            {
+                "id": "csc_target",
+                "claim_id": "clm_target",
+                "claim_content_hash": stale_hash,
+            }
+        ],
+    }
+
+    KnowledgePackService._refresh_remapped_claim_scope_hashes(source, remapped)
+
+    assert remapped["claim_scope_versions"][0]["claim_content_hash"] == stale_hash
+
+
+def test_remap_rekeys_project_and_entity_ids_in_core_provenance_text() -> None:
+    service = KnowledgePackService.__new__(KnowledgePackService)
+    source_project = "prj_01M100GW2EVPA8T6Q4CSZ5GPFA"
+    target_project = "recovery_pack_001"
+    source_journal = "jrn_01M147SEKP7F5RQ3351PG3SKD9"
+    target_journal = "jrn_01M20000000000000000000000"
+    id_map = {source_journal: target_journal}
+
+    mission = service._remap_row(
+        "missions",
+        {
+            "project_id": source_project,
+            "checkpoint_triggers": f"Review {source_project}",
+            "report": f"Evidence is recorded in {source_journal}",
+        },
+        id_map=id_map,
+        source_project_id=source_project,
+        target_project_id=target_project,
+    )
+    journal = service._remap_row(
+        "journal",
+        {
+            "project_id": source_project,
+            "verbatim_input": f"Inspect {source_project} and {source_journal}",
+        },
+        id_map=id_map,
+        source_project_id=source_project,
+        target_project_id=target_project,
+    )
+
+    assert mission["checkpoint_triggers"] == f"Review {target_project}"
+    assert mission["report"] == f"Evidence is recorded in {target_journal}"
+    assert journal["verbatim_input"] == (
+        f"Inspect {target_project} and {target_journal}"
+    )
 
 
 @pytest.mark.asyncio
@@ -338,6 +586,97 @@ async def test_knowledge_pack_round_trip_preserves_interpretation_promotion_line
         assert imported_scope.current.conditions[0].value == "configured workload"
         assert imported_scope.current.falsifier_status == "applicable"
         assert await db.fetchall("PRAGMA foreign_key_check") == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_pack_rekey_keeps_current_claim_scope_hash_current(tmp_path: Path) -> None:
+    db = await _make_db(tmp_path / "scope-hash-rekey.db")
+    try:
+        await ProjectService(db).create_project(
+            ProjectCreate(id="proj_scope_source", name="Scope Source"),
+            actor="system",
+        )
+        note = await NoteService(db, project_id="proj_scope_source").create(
+            JournalEntryCreate(
+                content="Measured the effect in the isolated test environment.",
+                type="finding",
+                source="executor",
+                confidence="tested",
+            ),
+            actor="executor",
+        )
+        claims = ClaimService(db, project_id="proj_scope_source")
+        claim = await claims.create(
+            ClaimCreate(
+                source_entry_id=note.id,
+                claim_type="result",
+                content=f"The result recorded in {note.id} holds in the isolated test.",
+                confidence=0.8,
+                verified=True,
+            ),
+            actor="executor",
+        )
+        source_scope = await claims.append_scope(
+            claim.id,
+            ClaimScopeWrite(
+                expected_revision=0,
+                actor="brain",
+                reason="Reviewed against the source entry.",
+                conditions=[
+                    ClaimScopeCondition(
+                        kind="environment",
+                        key="test_environment",
+                        operator="equals",
+                        value="isolated",
+                    )
+                ],
+                uncertainty="low",
+                extension_policy="exact_only",
+                prohibited_extensions=["production deployment"],
+                falsifier_status="applicable",
+                falsifier="A repeated isolated test does not reproduce the result.",
+                review_status="reviewed",
+            ),
+        )
+        assert source_scope.scope_readiness == "ready"
+
+        pack_path, _ = await KnowledgePackService(
+            db,
+            project_id="proj_scope_source",
+        ).export_pack()
+        with Path(pack_path).open("rb") as pack_file:
+            await KnowledgePackService(db).import_pack(
+                pack_file,
+                project_id="proj_scope_target",
+                project_name="Scope Target",
+                defer_indexing=True,
+            )
+
+        imported_claim_row = await db.fetchone(
+            "SELECT id, content FROM claims WHERE project_id = ?",
+            ["proj_scope_target"],
+        )
+        imported_note_row = await db.fetchone(
+            "SELECT id FROM journal WHERE project_id = ?",
+            ["proj_scope_target"],
+        )
+        assert imported_claim_row is not None
+        assert imported_note_row is not None
+        assert note.id not in imported_claim_row["content"]
+        assert imported_note_row["id"] in imported_claim_row["content"]
+
+        imported_scope = await ClaimService(
+            db,
+            project_id="proj_scope_target",
+        ).get_scope_history(imported_claim_row["id"])
+        assert imported_scope is not None
+        assert imported_scope.scope_readiness == "ready"
+        assert all(
+            finding.code != "CLAIM_SCOPE_STALE"
+            for finding in imported_scope.findings
+        )
     finally:
         await db.close()
 
@@ -812,6 +1151,114 @@ async def test_import_embedding_sync_uses_explicit_target_project_scope(
         )
         assert imported is not None
         assert embeddings.calls[0]["entity_id"] == imported["id"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("defer_indexing", [False, True], ids=["inline", "background"])
+async def test_pack_import_rebuilds_searchable_artifact_and_figure_vectors(
+    tmp_path: Path,
+    defer_indexing: bool,
+) -> None:
+    db = await _make_db(tmp_path / "artifact-figure-indexes.db")
+    artifact_path = tmp_path / "packet-loss.png"
+    artifact_path.write_bytes(b"deterministic image fixture")
+    try:
+        await ProjectService(db).create_project(
+            ProjectCreate(id="proj_media_source", name="Media Source"),
+            actor="system",
+        )
+        source_artifacts = ArtifactService(db, project_id="proj_media_source")
+        artifact = await source_artifacts.register(
+            filepath=str(artifact_path),
+            created_by="system",
+            metadata={"topic": "packet loss"},
+        )
+        figure = await source_artifacts._store_figure(
+            artifact_id=artifact["id"],
+            page=1,
+            caption="Packet loss over time",
+            caption_confidence=0.95,
+            summary="Packet loss decreases after tuning.",
+            claims=[{"claim": "Tuning reduces packet loss", "confidence": 0.9}],
+        )
+        embeddings = DeterministicEmbeddings(db)
+        background_indexer = KnowledgePackService(db, embeddings=embeddings)
+        assert await background_indexer.count_indexable("proj_media_source") == 2
+        assert await background_indexer.index_project("proj_media_source") == 2
+        pack_path, _ = await KnowledgePackService(
+            db,
+            project_id="proj_media_source",
+        ).export_pack()
+
+        importer = KnowledgePackService(db, embeddings=embeddings)
+        with Path(pack_path).open("rb") as pack_file:
+            await importer.import_pack(
+                pack_file,
+                project_id="proj_media_target",
+                project_name="Media Target",
+                defer_indexing=defer_indexing,
+            )
+
+        if defer_indexing:
+            assert await db.fetchall(
+                "SELECT id FROM vec_artifacts WHERE project_id = ?",
+                ["proj_media_target"],
+            ) == []
+            assert await importer.index_project("proj_media_target") == 2
+
+        imported_artifact = await db.fetchone(
+            "SELECT id FROM artifacts WHERE project_id = ?",
+            ["proj_media_target"],
+        )
+        imported_figure = await db.fetchone(
+            "SELECT id FROM figures WHERE project_id = ?",
+            ["proj_media_target"],
+        )
+        assert imported_artifact is not None
+        assert imported_figure is not None
+        assert imported_artifact["id"] != artifact["id"]
+        assert imported_figure["id"] != figure["id"]
+
+        assert await importer.count_indexable("proj_media_target") == 2
+        vector_rows = await db.fetchall(
+            """SELECT id, project_id, entity_type
+               FROM vec_artifacts
+               WHERE project_id = ?
+               ORDER BY entity_type""",
+            ["proj_media_target"],
+        )
+        assert vector_rows == [
+            {
+                "id": imported_artifact["id"],
+                "project_id": "proj_media_target",
+                "entity_type": "artifact",
+            },
+            {
+                "id": imported_figure["id"],
+                "project_id": "proj_media_target",
+                "entity_type": "figure",
+            },
+        ]
+
+        search = SearchService(
+            db,
+            embeddings=embeddings,
+            project_id="proj_media_target",
+        )
+        artifact_hits = await search.search(
+            "packet-loss.png",
+            entity_types=["artifact"],
+            limit=5,
+        )
+        figure_hits = await search.search(
+            "packet loss after tuning",
+            entity_types=["figure"],
+            limit=5,
+        )
+        assert [hit.entity_id for hit in artifact_hits] == [imported_artifact["id"]]
+        assert [hit.entity_id for hit in figure_hits] == [imported_figure["id"]]
     finally:
         await db.close()
 

--- a/tests/test_services/test_knowledge_pack_native.py
+++ b/tests/test_services/test_knowledge_pack_native.py
@@ -1013,6 +1013,9 @@ def _rewrite_pack_manifest(source: str, destination: Path, mutate) -> None:
         entries = {name: archive.read(name) for name in archive.namelist()}
     manifest = json.loads(entries["manifest.json"])
     mutate(manifest["tables"])
+    manifest["table_counts"] = {
+        table: len(rows) for table, rows in manifest["tables"].items()
+    }
     entries["manifest.json"] = json.dumps(manifest, indent=2, sort_keys=True).encode()
     with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for name, payload in entries.items():


### PR DESCRIPTION
## Summary

- replace file-copy backup with an online, integrity-checked SQLite backup that includes committed WAL state and publishes atomically
- add one disposable recovery smoke that verifies current-schema startup/idempotence, canonical rows/IDs/links/revisions, knowledge-pack clone semantics, artifact bytes, and exact rollback
- harden knowledge-pack manifest validation and preserve current claim-scope hashes during ID re-keying
- rebuild artifact and figure indexes under the imported target project for both inline and background import paths
- document the bounded recovery procedure and the real-backup evidence

## Verification

- focused backup/pack/recovery regressions: 82 passed
- Core suite (`not writer and not agentic`): 3,021 passed
- retained Writer/Agentic compatibility suite: 294 passed
- `python scripts/core_startup_smoke.py`
- `docker compose config --quiet`
- selected Ruff checks and `git diff --check`

## Real-backup drill

- operated on a read-only online snapshot of the current RKA 3.0.0 database; the live database and containers were not migrated, restarted, replaced, or re-indexed
- upgrade/idempotence comparison found no row, ID, link, revision, or migration-ledger drift
- two complementary real project packs imported with zero canonical mismatches and zero critical target issues
- exact rollback restored both bytes and the logical snapshot; pinned RKA 2.9.0 opened the restored copy with zero migrations
- source-global index/sample warnings were recorded as pre-existing and are intentionally out of scope for this PR

Closes #125
