### PR TITLE
feat: add RKA Project visual identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to RKA are documented here. Format loosely follows
 
 ### Added
 
+- The RKA Project visual identity now has canonical SVG masters, documented
+  color tokens, and mirrored Web/plugin assets. RKA Core's README and dashboard
+  use the new mark, and the Core startup smoke verifies the deployed icon is
+  actual SVG content rather than a masked SPA fallback.
 - A clean-wheel CI gate now installs the built `rka-core` artifact outside the
   checkout and verifies migrations, SQLite/FTS retrieval, REST health, the
   worker, and the five-tool MCP surface.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# RKA — Research Knowledge Agent
+<p align="center">
+  <img src="https://raw.githubusercontent.com/infinitywings/rka/main/assets/brand/rka-project-plugin-app-icon.svg" alt="RKA Project mark" width="112">
+</p>
+
+# RKA Core — Research Knowledge Agent
 
 [![pytest](https://github.com/infinitywings/rka/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/infinitywings/rka/actions/workflows/pytest.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,42 @@
+# RKA Project visual identity
+
+This directory is the source of truth for the shared visual identity used by
+RKA Core and other RKA Project products. The mark represents a durable research
+record (the vertical spine) branching into structured knowledge and exploration
+(teal) and salient evidence, decisions, or outputs (amber).
+
+## Production masters
+
+| File | Intended use |
+|---|---|
+| `rka-project-mark-color.svg` | General-purpose color mark on light backgrounds. |
+| `rka-project-mark-monochrome.svg` | One-color contexts; set the CSS `color` property when embedding inline. |
+| `rka-project-plugin-app-icon.svg` | Browser, plugin, and app surfaces on either light or dark backgrounds. |
+| `rka-brand-tokens.css` | Shared color values for deterministic exports. |
+
+The Web and Claude-plugin copies of the app icon are release mirrors. Tests
+require them to remain byte-for-byte identical to the master in this directory.
+
+## Reference compositions
+
+`rka-project-wordmark-horizontal.svg` and `rka-project-lockup-dark.svg` preserve
+the approved composition, spacing, and type direction. They currently contain
+live text using a system-font fallback stack, so they are design references—not
+portable production masters. Convert the lettering to vector outlines after the
+final typeface is approved before using either file as a release asset.
+
+## Usage notes
+
+- Keep the product name as real text beside the symbol for accessibility and
+  searchability. In this repository, the visible product name is **RKA Core**;
+  **RKA Project** is the broader ecosystem identity.
+- Use the app icon when the background is unknown. The transparent color mark's
+  navy spine can disappear on dark surfaces.
+- Teal and amber are structural accent colors in the symbol. Do not use them as
+  small body text on white or off-white backgrounds.
+- Do not stretch, rotate, recolor individual branches, or add effects to the
+  masters.
+- Generate raster sizes deterministically from these SVG masters. The original
+  concept PNGs are intentionally not committed as production exports.
+
+These assets are distributed under the repository's [MIT license](../../LICENSE).

--- a/assets/brand/rka-brand-tokens.css
+++ b/assets/brand/rka-brand-tokens.css
@@ -1,0 +1,9 @@
+:root {
+  --rka-navy: #073566;
+  --rka-navy-dark: #061a40;
+  --rka-teal: #0799a3;
+  --rka-teal-on-dark: #16b3bb;
+  --rka-amber: #f2a516;
+  --rka-amber-on-dark: #ffb21a;
+  --rka-off-white: #f7f5ef;
+}

--- a/assets/brand/rka-project-lockup-dark.svg
+++ b/assets/brand/rka-project-lockup-dark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1800 560" role="img" aria-labelledby="title desc">
+  <title id="title">RKA Project dark lockup</title>
+  <desc id="desc">RKA Project mark and wordmark on a deep navy background.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1800" y2="560" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#061A40"/>
+      <stop offset="1" stop-color="#0A3572"/>
+    </linearGradient>
+  </defs>
+  <rect width="1800" height="560" rx="40" fill="url(#background)"/>
+  <g transform="translate(74 20)">
+    <g fill="none" stroke-linecap="round" stroke-width="34">
+      <path d="M140 96V416" stroke="#F7F5EF"/>
+      <path d="M140 256L318 160" stroke="#16B3BB"/>
+      <path d="M140 256L318 352" stroke="#FFB21A"/>
+    </g>
+    <g fill="#F7F5EF">
+      <circle cx="140" cy="96" r="43"/>
+      <circle cx="140" cy="256" r="47"/>
+      <circle cx="140" cy="416" r="43"/>
+    </g>
+    <circle cx="318" cy="160" r="43" fill="#16B3BB"/>
+    <circle cx="318" cy="352" r="43" fill="#FFB21A"/>
+  </g>
+  <text x="510" y="350" fill="#F7F5EF" font-family="Inter, SF Pro Display, Segoe UI, Arial, sans-serif" font-size="220" letter-spacing="-6">
+    <tspan font-weight="700">RKA</tspan><tspan dx="48" font-weight="400">Project</tspan>
+  </text>
+</svg>

--- a/assets/brand/rka-project-mark-color.svg
+++ b/assets/brand/rka-project-mark-color.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">RKA Project mark</title>
+  <desc id="desc">A research spine branching into two connected knowledge paths.</desc>
+  <g fill="none" stroke-linecap="round" stroke-width="44">
+    <path d="M160 88V424" stroke="#073566"/>
+    <path d="M160 256L352 152" stroke="#0799A3"/>
+    <path d="M160 256L352 360" stroke="#F2A516"/>
+  </g>
+  <g fill="#073566">
+    <circle cx="160" cy="88" r="52"/>
+    <circle cx="160" cy="256" r="56"/>
+    <circle cx="160" cy="424" r="52"/>
+  </g>
+  <circle cx="352" cy="152" r="52" fill="#0799A3"/>
+  <circle cx="352" cy="360" r="52" fill="#F2A516"/>
+</svg>

--- a/assets/brand/rka-project-mark-monochrome.svg
+++ b/assets/brand/rka-project-mark-monochrome.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc" color="#073566">
+  <title id="title">RKA Project monochrome mark</title>
+  <desc id="desc">A one-color research spine branching into two connected knowledge paths.</desc>
+  <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="44">
+    <path d="M160 88V424"/>
+    <path d="M160 256L352 152"/>
+    <path d="M160 256L352 360"/>
+  </g>
+  <g fill="currentColor">
+    <circle cx="160" cy="88" r="52"/>
+    <circle cx="160" cy="256" r="56"/>
+    <circle cx="160" cy="424" r="52"/>
+    <circle cx="352" cy="152" r="52"/>
+    <circle cx="352" cy="360" r="52"/>
+  </g>
+</svg>

--- a/assets/brand/rka-project-plugin-app-icon.svg
+++ b/assets/brand/rka-project-plugin-app-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">RKA Project app icon</title>
+  <desc id="desc">RKA Project mark on a deep navy rounded-square background.</desc>
+  <defs>
+    <linearGradient id="background" x1="48" y1="36" x2="464" y2="480" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#071C46"/>
+      <stop offset="1" stop-color="#0B3C80"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="108" fill="url(#background)"/>
+  <g fill="none" stroke-linecap="round" stroke-width="35">
+    <path d="M170 112V400" stroke="#F7F5EF"/>
+    <path d="M170 256L342 166" stroke="#16B3BB"/>
+    <path d="M170 256L342 346" stroke="#FFB21A"/>
+  </g>
+  <g fill="#F7F5EF">
+    <circle cx="170" cy="112" r="43"/>
+    <circle cx="170" cy="256" r="47"/>
+    <circle cx="170" cy="400" r="43"/>
+  </g>
+  <circle cx="342" cy="166" r="43" fill="#16B3BB"/>
+  <circle cx="342" cy="346" r="43" fill="#FFB21A"/>
+</svg>

--- a/assets/brand/rka-project-wordmark-horizontal.svg
+++ b/assets/brand/rka-project-wordmark-horizontal.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1700 520" role="img" aria-labelledby="title desc">
+  <title id="title">RKA Project</title>
+  <desc id="desc">RKA Project color mark and horizontal wordmark.</desc>
+  <g transform="translate(18 4)">
+    <g fill="none" stroke-linecap="round" stroke-width="36">
+      <path d="M140 92V420" stroke="#073566"/>
+      <path d="M140 256L322 158" stroke="#0799A3"/>
+      <path d="M140 256L322 354" stroke="#F2A516"/>
+    </g>
+    <g fill="#073566">
+      <circle cx="140" cy="92" r="44"/>
+      <circle cx="140" cy="256" r="48"/>
+      <circle cx="140" cy="420" r="44"/>
+    </g>
+    <circle cx="322" cy="158" r="44" fill="#0799A3"/>
+    <circle cx="322" cy="354" r="44" fill="#F2A516"/>
+  </g>
+  <text x="440" y="327" fill="#073566" font-family="Inter, SF Pro Display, Segoe UI, Arial, sans-serif" font-size="205" letter-spacing="-5">
+    <tspan font-weight="700">RKA</tspan><tspan dx="44" font-weight="400">Project</tspan>
+  </text>
+</svg>

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/rka-project-plugin-app-icon.svg" alt="RKA Project mark" width="96">
+</p>
+
 # rka — Claude Code plugin for the Research Knowledge Agent
 
 This is the official Claude Code plugin for [RKA](https://github.com/infinitywings/rka). It lives inside the upstream RKA repository at `plugin/`, distributed via the local marketplace at `.claude-plugin/marketplace.json` in the repo root.

--- a/plugin/assets/rka-project-plugin-app-icon.svg
+++ b/plugin/assets/rka-project-plugin-app-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">RKA Project app icon</title>
+  <desc id="desc">RKA Project mark on a deep navy rounded-square background.</desc>
+  <defs>
+    <linearGradient id="background" x1="48" y1="36" x2="464" y2="480" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#071C46"/>
+      <stop offset="1" stop-color="#0B3C80"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="108" fill="url(#background)"/>
+  <g fill="none" stroke-linecap="round" stroke-width="35">
+    <path d="M170 112V400" stroke="#F7F5EF"/>
+    <path d="M170 256L342 166" stroke="#16B3BB"/>
+    <path d="M170 256L342 346" stroke="#FFB21A"/>
+  </g>
+  <g fill="#F7F5EF">
+    <circle cx="170" cy="112" r="43"/>
+    <circle cx="170" cy="256" r="47"/>
+    <circle cx="170" cy="400" r="43"/>
+  </g>
+  <circle cx="342" cy="166" r="43" fill="#16B3BB"/>
+  <circle cx="342" cy="346" r="43" fill="#FFB21A"/>
+</svg>

--- a/scripts/core_startup_smoke.py
+++ b/scripts/core_startup_smoke.py
@@ -261,6 +261,23 @@ def main() -> None:
                             f"web dashboard asset has unexpected content type: {content_type}"
                         )
 
+                    brand_icon = httpx.get(
+                        f"{base_url}/brand/rka-project-plugin-app-icon.svg",
+                        timeout=5,
+                    )
+                    brand_icon.raise_for_status()
+                    brand_content_type = brand_icon.headers.get("content-type", "")
+                    if "image/svg+xml" not in brand_content_type:
+                        raise RuntimeError(
+                            "web brand icon has unexpected content type: "
+                            f"{brand_content_type}"
+                        )
+                    if not brand_icon.text.lstrip().startswith("<svg"):
+                        raise RuntimeError(
+                            "web brand icon did not return SVG content; "
+                            "the SPA fallback may have masked a missing asset"
+                        )
+
                 asyncio.run(
                     asyncio.wait_for(
                         _probe_mcp(runtime_python, runtime_cwd, env, mcp_log),

--- a/tests/test_brand_assets.py
+++ b/tests/test_brand_assets.py
@@ -1,0 +1,73 @@
+"""Regression checks for the RKA Project visual identity contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BRAND_ROOT = ROOT / "assets" / "brand"
+APP_ICON = BRAND_ROOT / "rka-project-plugin-app-icon.svg"
+SVG_ASSETS = (
+    BRAND_ROOT / "rka-project-mark-color.svg",
+    BRAND_ROOT / "rka-project-mark-monochrome.svg",
+    APP_ICON,
+    BRAND_ROOT / "rka-project-wordmark-horizontal.svg",
+    BRAND_ROOT / "rka-project-lockup-dark.svg",
+)
+RUNTIME_ICON_MIRRORS = (
+    ROOT / "web" / "public" / "brand" / "rka-project-plugin-app-icon.svg",
+    ROOT / "plugin" / "assets" / "rka-project-plugin-app-icon.svg",
+)
+FORBIDDEN_SVG_ELEMENTS = {"script", "image", "foreignObject"}
+
+
+def _local_name(value: str) -> str:
+    return value.rsplit("}", 1)[-1]
+
+
+def test_brand_svg_assets_are_self_contained() -> None:
+    for asset in SVG_ASSETS:
+        root = ElementTree.parse(asset).getroot()
+        assert _local_name(root.tag) == "svg"
+        assert root.attrib.get("viewBox")
+
+        for element in root.iter():
+            assert _local_name(element.tag) not in FORBIDDEN_SVG_ELEMENTS
+            for name, value in element.attrib.items():
+                if _local_name(name) == "href":
+                    assert not value.startswith(("http://", "https://", "//"))
+
+
+def test_runtime_icons_match_the_canonical_master() -> None:
+    canonical = APP_ICON.read_bytes()
+    for mirror in RUNTIME_ICON_MIRRORS:
+        assert mirror.read_bytes() == canonical
+
+
+def test_web_identity_uses_the_runtime_icon_and_product_name() -> None:
+    index = (ROOT / "web" / "index.html").read_text(encoding="utf-8")
+    sidebar = (
+        ROOT / "web" / "src" / "components" / "layout" / "Sidebar.tsx"
+    ).read_text(encoding="utf-8")
+
+    icon_path = "/brand/rka-project-plugin-app-icon.svg"
+    assert f'href="{icon_path}"' in index
+    assert "<title>RKA Core — Research Knowledge Agent</title>" in index
+    assert 'name="theme-color" content="#073566"' in index
+    assert f'src="{icon_path}"' in sidebar
+    assert 'alt=""' in sidebar
+
+
+def test_readmes_keep_accessible_text_with_the_mark() -> None:
+    root_readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    plugin_readme = (ROOT / "plugin" / "README.md").read_text(encoding="utf-8")
+
+    assert "# RKA Core — Research Knowledge Agent" in root_readme
+    assert (
+        "https://raw.githubusercontent.com/infinitywings/rka/main/"
+        "assets/brand/rka-project-plugin-app-icon.svg"
+    ) in root_readme
+    assert "# rka — Claude Code plugin for the Research Knowledge Agent" in plugin_readme
+    assert "assets/rka-project-plugin-app-icon.svg" in plugin_readme

--- a/web/index.html
+++ b/web/index.html
@@ -2,9 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/brand/rka-project-plugin-app-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web</title>
+    <meta name="theme-color" content="#073566" />
+    <meta
+      name="description"
+      content="RKA Core is a local-first, provenance-aware research knowledge system."
+    />
+    <title>RKA Core — Research Knowledge Agent</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/brand/rka-project-plugin-app-icon.svg
+++ b/web/public/brand/rka-project-plugin-app-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">RKA Project app icon</title>
+  <desc id="desc">RKA Project mark on a deep navy rounded-square background.</desc>
+  <defs>
+    <linearGradient id="background" x1="48" y1="36" x2="464" y2="480" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#071C46"/>
+      <stop offset="1" stop-color="#0B3C80"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="108" fill="url(#background)"/>
+  <g fill="none" stroke-linecap="round" stroke-width="35">
+    <path d="M170 112V400" stroke="#F7F5EF"/>
+    <path d="M170 256L342 166" stroke="#16B3BB"/>
+    <path d="M170 256L342 346" stroke="#FFB21A"/>
+  </g>
+  <g fill="#F7F5EF">
+    <circle cx="170" cy="112" r="43"/>
+    <circle cx="170" cy="256" r="47"/>
+    <circle cx="170" cy="400" r="43"/>
+  </g>
+  <circle cx="342" cy="166" r="43" fill="#16B3BB"/>
+  <circle cx="342" cy="346" r="43" fill="#FFB21A"/>
+</svg>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -127,9 +127,11 @@ export function Sidebar({
       {/* Logo / Project Name */}
       <div className="border-b px-4 py-3">
         <div className="flex items-center gap-2">
-          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground text-xs font-bold">
-            R
-          </div>
+          <img
+            src="/brand/rka-project-plugin-app-icon.svg"
+            alt=""
+            className="h-7 w-7 shrink-0 rounded-md"
+          />
           <div className="flex min-w-0 flex-col">
             <span className="max-w-[140px] truncate text-sm font-semibold">
               {project?.project_name ?? "RKA"}


### PR DESCRIPTION
## Summary

- add canonical SVG brand masters, shared color tokens, and clear production/reference guidance
- apply the app icon to the Core README, Claude plugin README, Web favicon, and desktop/mobile sidebar
- replace the placeholder browser title and metadata with the RKA Core identity
- verify runtime icon delivery as real SVG so the SPA fallback cannot mask a missing asset
- add regression tests that keep Web/plugin icon mirrors byte-identical to the canonical master

## Product boundary

- visible product name remains **RKA Core**; **RKA Project** is the umbrella identity
- geometry-only SVGs are production masters
- live-text wordmark/lockup SVGs are retained as reference compositions until the type is converted to outlines
- concept PNGs, PWA/native exports, theme recoloring, Writer, and Agentic are out of scope
- Claude manifests remain schema-clean; no unsupported icon field was added

## Validation

- `python -m pytest -q tests/test_brand_assets.py` — 4 passed
- `python -m ruff check scripts/core_startup_smoke.py tests/test_brand_assets.py` — passed
- SVG XML validation — passed
- `npx eslint src/components/layout/Sidebar.tsx` — passed
- `npm run build` — passed
- `claude plugin validate --strict .` — passed
- `claude plugin validate --strict plugin` — passed
- `python scripts/core_startup_smoke.py --require-web --require-vec` — passed
- Core profile — 3051 passed, 294 deselected
- visual QA — desktop light/dark and 375 px mobile drawer passed

## Baseline note

Repository-wide `npm run lint` still reports seven existing errors and two warnings in unchanged files. The modified Sidebar passes ESLint independently. Remote CI remains the merge gate.