### PR TITLE
docs: establish RKA Project organization

### DIFF
--- a/docs/adr/0012-rka-ecosystem-repository-boundaries.md
+++ b/docs/adr/0012-rka-ecosystem-repository-boundaries.md
@@ -1,7 +1,9 @@
 # ADR 0012: RKA ecosystem repository and authority boundaries
 
 - Status: accepted for E0 boundary freeze; Agentic portions superseded by
-  [ADR 0013](0013-shelve-agentic-and-focus-core-writer.md)
+  [ADR 0013](0013-shelve-agentic-and-focus-core-writer.md); account placement
+  and organization deferral superseded by
+  [ADR 0015](0015-establish-rka-project-github-organization.md)
 - Date: 2026-08-25
 - Decision owner: Chenglong Fu
 - Scope: repository ownership, data authority, integration contracts, migration,
@@ -13,6 +15,11 @@
 > Agentic repository and extraction milestone are shelved. The Agentic text
 > below is retained as the historical decision record, not as an active
 > implementation or installation plan.
+
+> **2026-08-28 amendment:** RKA Project will use the `rka-project` GitHub
+> organization. The personal-account placement and rejected-organization
+> alternative below are retained as historical context; ADR 0015 governs the
+> migration.
 
 ## Context
 

--- a/docs/adr/0015-establish-rka-project-github-organization.md
+++ b/docs/adr/0015-establish-rka-project-github-organization.md
@@ -1,0 +1,100 @@
+# ADR 0015: Establish the RKA Project GitHub organization
+
+- **Status:** Accepted
+- **Date:** 2026-08-28
+- **Decision owner:** Chenglong Fu
+- **Supersedes:** the account-placement and organization deferral in
+  [ADR 0012](0012-rka-ecosystem-repository-boundaries.md)
+- **Execution checklist:**
+  [`../organization-migration-checklist.md`](../organization-migration-checklist.md)
+
+## Context
+
+RKA Core and RKA Writer now have distinct product boundaries and release
+cadences. The active ecosystem also needs a stable public identity, shared
+roadmap, project website, and future home for an install-friendly application.
+Keeping those repositories under a personal namespace makes the project harder
+to present as a coherent open-source effort and leaves ecosystem assets tied to
+one product repository.
+
+ADR 0012 intentionally deferred a GitHub organization while the product
+boundaries were unsettled. Those boundaries are now clear: Core owns durable
+research knowledge and retrieval; Writer is a separate downstream authoring
+product; the future App owns installation and machine integration; Agentic is
+shelved under ADR 0013.
+
+## Decision
+
+1. Create a GitHub organization with handle **`rka-project`** and display name
+   **RKA Project**.
+2. The active repository structure is:
+
+   | Repository | Responsibility |
+   |---|---|
+   | `.github` | Organization profile and shared brand masters |
+   | `rka-core` | Durable research records, provenance, retrieval, integrity, REST, MCP, CLI, and the maintenance UI |
+   | `rka-writer` | Researcher-in-the-loop manuscript workbench and academic-writing workflows |
+   | `rka-project.github.io` | Public project website |
+   | `rka-app` | Future installer, service lifecycle, upgrades, rollback, and AI-client configuration |
+
+3. Transfer the existing Writer repository first as a migration rehearsal.
+   Protect its current uncommitted development work before transfer. Then
+   transfer and rename the current Core repository from `infinitywings/rka` to
+   `rka-project/rka-core`.
+4. Do not create an umbrella `rka` repository. The organization profile,
+   website, and organization-level roadmap provide the ecosystem entry points.
+5. Do not create an Agentic repository. Historical Agentic branches and design
+   records remain preserved but are not presented as an active product.
+6. Move ecosystem brand masters to the organization `.github` repository.
+   Individual products may retain versioned copies required by their packages
+   and interfaces.
+7. Create an organization-level **RKA Ecosystem Roadmap** covering Core,
+   Writer, App, Site, and shelved work. Repository issue trackers remain the
+   authority for implementation details.
+8. Initially use the GitHub Free plan. Keep base repository permission at
+   `None`, restrict repository transfer and deletion to owners, require 2FA,
+   and add a second trusted owner before the project depends on organization
+   infrastructure for releases.
+
+## Migration rules
+
+- Preserve Git history, issues, pull requests, releases, stars, and redirects
+  by using GitHub repository transfer rather than creating replacement repos.
+- Never recreate `infinitywings/rka` after transfer; doing so would break the
+  old repository redirect.
+- Update local remotes and hard-coded namespace references immediately after
+  each transfer.
+- Reverify branch rules, required checks, Actions permissions, environments,
+  secrets, deploy keys, Pages, packages, and release identities after transfer.
+- Treat the website and `.github` repositories as independent products with
+  their own reviewable changes. They do not become Core runtime dependencies.
+- Do not advertise unreleased installation paths or Writer behavior as current
+  Core capability.
+
+## Consequences
+
+### Positive
+
+- RKA has a durable project identity independent of one repository name.
+- Core, Writer, the website, and the future App can evolve independently while
+  sharing a coherent public roadmap and visual language.
+- Repository names now communicate product boundaries directly.
+- Community, security, and contribution material can be maintained once at the
+  organization level where appropriate.
+
+### Costs and risks
+
+- Repository URLs, badges, manifests, installation instructions, OIDC trust,
+  package links, and local remotes require coordinated updates.
+- GitHub Pages URLs do not inherit repository-transfer redirects.
+- A single-owner organization is an availability risk until a second trusted
+  owner is added.
+- Transfer sequencing must protect Writer's current uncommitted work and avoid
+  interrupting Core users.
+
+## Relationship to earlier decisions
+
+ADR 0012 remains authoritative for Core and Writer ownership, authority
+boundaries, public-contract isolation, and non-destructive state migration.
+ADR 0013 continues to shelve Agentic. ADR 0014 continues to place end-user
+installation and machine integration in the future `rka-app` product.

--- a/docs/organization-migration-checklist.md
+++ b/docs/organization-migration-checklist.md
@@ -1,0 +1,57 @@
+# RKA Project organization migration checklist
+
+This checklist moves the active RKA ecosystem from the personal
+`infinitywings` namespace to the `rka-project` GitHub organization without
+losing repository state or local work.
+
+## 1. Establish the organization
+
+- [ ] Create the free `rka-project` organization with display name **RKA Project**.
+- [ ] Set the public description, website, contact email, and organization avatar.
+- [ ] Set base repository permission to `None`.
+- [ ] Restrict repository deletion and transfer to owners.
+- [ ] Require two-factor authentication.
+- [ ] Add a second trusted owner before release automation depends on the organization.
+- [ ] Create `core-maintainers`, `writer-maintainers`, and `site-maintainers` teams when a second contributor needs access.
+
+## 2. Create shared project surfaces
+
+- [ ] Create `.github` and publish `profile/README.md` plus shared brand masters.
+- [ ] Create `rka-project.github.io` and publish the reviewed project homepage.
+- [ ] Create the organization-level **RKA Ecosystem Roadmap**.
+- [ ] Use Product, Horizon, Status, and Release gate fields.
+- [ ] Add Core Reliability, Writer Platform, Distribution, Website & Community, Releases, and Shelved views only as they become useful.
+
+## 3. Protect and transfer Writer
+
+- [ ] Preserve the local `codex/integrate-academic-reviewers` work in reviewable commits and push it before transfer.
+- [ ] Record Writer's default branch, branch rules, Actions settings, secrets, environments, issues, releases, and deploy keys.
+- [ ] Transfer `infinitywings/rka-writer` to `rka-project/rka-writer`.
+- [ ] Update local remotes and every Core/Writer cross-reference.
+- [ ] Verify clone, tests, CI, issues, releases, redirects, and permissions.
+
+## 4. Transfer and rename Core
+
+- [ ] Record Core's default branch, branch rules, Actions settings, secrets, environments, issues, releases, packages, webhooks, and deploy keys.
+- [ ] Transfer and rename `infinitywings/rka` to `rka-project/rka-core`.
+- [ ] Do not recreate `infinitywings/rka`.
+- [ ] Update local remotes and hard-coded `infinitywings/rka` references.
+- [ ] Update plugin manifests, badges, documentation, source links, and install instructions.
+- [ ] Run the complete Core test gate and startup smoke test from the new remote state.
+- [ ] Verify old repository URLs redirect and the new clone URL works.
+
+## 5. Release and package follow-up
+
+- [ ] Rebind future PyPI trusted publishing to `rka-project/rka-core` before the first public package release.
+- [ ] Use `ghcr.io/rka-project/rka-core` for future container publication.
+- [ ] Reassociate GitHub Packages with the transferred repository if needed.
+- [ ] Verify any OIDC subject, environment, or repository-owner conditions after transfer.
+- [ ] Keep repository secrets scoped narrowly until an organization-wide secret is demonstrably needed.
+
+## 6. Close-out
+
+- [ ] Confirm both local checkouts are clean and point to the new remotes.
+- [ ] Confirm the organization profile and website link only to existing or explicitly marked in-development products.
+- [ ] Confirm the roadmap represents Agentic as shelved rather than active.
+- [ ] Record the final organization, repository, website, and roadmap URLs in the RKA development project.
+- [ ] Close or update migration issues only after the corresponding live state is read back and verified.


### PR DESCRIPTION
## Summary

- establish the rka-project GitHub organization as the long-term home for the ecosystem
- define the target repositories and Writer-first migration order
- add a live-state verification checklist for repository transfer, releases, Pages, and package identities
- supersede ADR 0012 only where it deferred an organization; preserve the Core/Writer authority boundary and shelved Agentic decision

## Validation

- git diff --check
- documentation-only change

## Migration safety

This PR does not transfer or rename any repository. Those external changes remain separate, staged operations after the organization exists and Writer's current work is protected.