### PR TITLE
docs: update links after RKA Project migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to RKA are documented here. Format loosely follows
   durable journal, literature, decision, mission, claim, evidence, provenance,
   lifecycle, and retrieval contracts. Manuscript drafting and revision are
   provided by the separately installed
-  [`rka-writer`](https://github.com/infinitywings/rka-writer) project.
+  [`rka-writer`](https://github.com/rka-project/rka-writer) project.
 - **Historical reference-validation state remains readable.** Existing,
   project-scoped validation jobs and attestations remain available for audit.
   Core no longer initiates or executes new validation runs; external Writer or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ When working here you are modifying the tool itself, not using it for research.
 - RKA Core owns durable research records, provenance, integrity, retrieval,
   migrations, and public REST/MCP contracts.
 - New manuscript, Writer, or Workbench behavior belongs in
-  [`infinitywings/rka-writer`](https://github.com/infinitywings/rka-writer), not
+  [`rka-project/rka-writer`](https://github.com/rka-project/rka-writer), not
   this repository. Legacy manuscript/Workbench surfaces in Core are frozen;
   change them only for correctness, security, migration, or compatibility.
 - Agentic orchestration is shelved and unsupported. Do not add new Agentic

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ You are running on a machine that already has Docker and a coding agent. Your jo
 |---|---|
 | **RKA backend** | FastAPI + worker + SQLite + FTS5 + sqlite-vec running in Docker on `localhost:9712`. Web dashboard at the same URL. |
 | **Claude Code (Executor)** | Core plugin: 3 role skills (`rka:rka-brain`, `rka:rka-executor`, `rka:rka-pi`), the credential setup utility, 5 slash commands (`/rka-status`, `/rka-search`, `/rka-pending`, `/rka-set-project`, `/rka-setup-claude-desktop`), a SessionStart backend check, and the typed MCP dispatch surface. |
-| **Writer (optional, separate)** | Install the explicit-only [`rka-writer`](https://github.com/infinitywings/rka-writer) plugin only when manuscript drafting or revision is wanted. It is not included in or activated by RKA Core. |
+| **Writer (optional, separate)** | Install the explicit-only [`rka-writer`](https://github.com/rka-project/rka-writer) plugin only when manuscript drafting or revision is wanted. It is not included in or activated by RKA Core. |
 | **Claude Desktop (Brain)** | Typed RKA tool surface via the `mcpServers.rka` entry in `claude_desktop_config.json`. Wrapper-based config gives version checking; every scoped operation still requires an explicit project id. Skills and slash commands are Claude Code only (Claude Desktop's plugin format is separate). |
 | **ChatGPT (optional remote connector)** | RKA reachable from ChatGPT as a custom MCP connector over an OAuth-protected ngrok tunnel — an 8-tool surface (5 dispatch + 3 skill tools). Opt-in; set up in **Step 6** (§3). The web UI is never exposed. |
 
@@ -104,7 +104,7 @@ Everyone runs **Step 1** (the backend). Then run only the steps their chosen sur
 
 **Pre-check**: Docker Desktop must be running before `docker compose up -d` will work. Confirm with `docker info` (non-zero exit means Docker isn't running — launch Docker Desktop and wait until the whale icon says "running", then retry).
 
-**🟡 Precondition (clone location)**: ask the user where they want the repo cloned (default: `~/Code` on macOS/Linux, `%USERPROFILE%\Code` on Windows). `cd` into that parent, so the repo lands at `<parent>/rka`. **Record the absolute `<parent>/rka` path** — Step 2 needs it as the marketplace path. Don't clone into an unstated cwd; if the user has no preference, state the default you're using and proceed.
+**🟡 Precondition (clone location)**: ask the user where they want the repo cloned (default: `~/Code` on macOS/Linux, `%USERPROFILE%\Code` on Windows). `cd` into that parent, so the repo lands at `<parent>/rka-core`. **Record the absolute `<parent>/rka-core` path** — Step 2 needs it as the marketplace path. Don't clone into an unstated cwd; if the user has no preference, state the default you're using and proceed.
 
 > **⚠️ Windows: do not clone into a OneDrive-synced folder.** On most Windows installs `Desktop` and `Documents` are backed up by OneDrive. OneDrive's Files On-Demand will silently dehydrate untouched repo files into cloud placeholders, and Docker BuildKit then refuses to send them in the build context — a later `docker compose up -d --build` fails with `invalid file request <path>`. The clone works fine; the breakage appears weeks later on the first rebuild. `%USERPROFILE%\Code` (the default above) is outside OneDrive and is the safe choice. If the repo is already in a synced folder, see [§9 Windows: rebuilding and updating](#windows-rebuilding-and-updating-an-existing-install) for the recovery procedure.
 
@@ -113,8 +113,8 @@ Everyone runs **Step 1** (the backend). Then run only the steps their chosen sur
 mkdir -p ~/Code && cd ~/Code              # macOS/Linux
 # Windows (PowerShell): New-Item -ItemType Directory -Force "$env:USERPROFILE\Code" | Set-Location
 
-git clone https://github.com/infinitywings/rka.git
-cd rka
+git clone https://github.com/rka-project/rka-core.git
+cd rka-core
 docker compose up -d
 ```
 
@@ -171,10 +171,10 @@ The marketplace lives inside the cloned RKA repo (at `.claude-plugin/marketplace
 In any Claude Code chat window (in VSCode), run:
 
 ```
-/plugin marketplace add /absolute/path/to/your/cloned/rka
+/plugin marketplace add /absolute/path/to/your/cloned/rka-core
 ```
 
-Replace `/absolute/path/to/your/cloned/rka` with the actual path where you cloned the repo in Step 1 (e.g., `/Users/<you>/Code/rka` on macOS, `C:\Users\<you>\Code\rka` on Windows). Use the absolute path, not `~`.
+Replace `/absolute/path/to/your/cloned/rka-core` with the actual path where you cloned the repo in Step 1 (e.g., `/Users/<you>/Code/rka-core` on macOS, `C:\Users\<you>\Code\rka-core` on Windows). Use the absolute path, not `~`.
 
 **Success signal**: Claude Code prints "Marketplace 'rka' added" (or equivalent confirmation).
 
@@ -217,7 +217,7 @@ If anything fails at any step, the original config is restored from the backup a
 ### Step 4.5 (optional) — Install the standalone Writer plugin
 
 Manuscript drafting is intentionally outside this repository. If it is wanted,
-install [`rka-writer`](https://github.com/infinitywings/rka-writer) by following
+install [`rka-writer`](https://github.com/rka-project/rka-writer) by following
 that repository's README. Writer is explicit-only and may use this Core MCP as
 an evidence source, but Core does not install Writer tools, commands, hooks, or
 dependencies.
@@ -689,8 +689,8 @@ Use this path if:
 ### 8.1 — Install the RKA stdio binary
 
 ```bash
-git clone https://github.com/infinitywings/rka.git
-cd rka
+git clone https://github.com/rka-project/rka-core.git
+cd rka-core
 UV_CACHE_DIR=/tmp/uv-cache uv tool install --force --reinstall .
 # Binary lands at ~/.local/bin/rka (macOS/Linux) or %USERPROFILE%\.local\bin\rka.exe (Windows)
 ```
@@ -913,7 +913,7 @@ Install the orchestrator if you want to:
 ### Step 11.1 — Switch to the agentic branch
 
 ```bash
-cd <your-clone-dir>/rka
+cd <your-clone-dir>/rka-core
 git checkout agentic
 ```
 
@@ -985,7 +985,7 @@ The file holds a long-lived OAuth token and (optionally) API keys — it must no
 The Compose overlay adds a third container (`rka-orchestrator`) alongside `rka-server` and `rka-worker` without modifying the root `docker-compose.yml`:
 
 ```bash
-cd <your-clone-dir>/rka
+cd <your-clone-dir>/rka-core
 docker compose -f docker-compose.yml \
                -f orchestrator/docker-compose.yml up -d --build
 ```
@@ -1061,7 +1061,7 @@ See [`USAGE_GUIDE.md`](USAGE_GUIDE.md#agentic-distribution--orchestrator-workflo
 
 ### Workspace bind mount — `HOST_WORKSPACE_ROOT`
 
-For non-`$HOME` workspace roots (external drives, `/Volumes/...`, etc.), set `HOST_WORKSPACE_ROOT` in the **repo-root `.env`** (i.e., `<your-clone-dir>/rka/.env`), **NOT** in `orchestrator/.env`. Docker Compose reads `.env` from the directory of the first `-f` file (the repo root) for YAML `${VAR}` interpolation; the `env_file:` directive only populates env vars inside the running container and does not feed interpolation.
+For non-`$HOME` workspace roots (external drives, `/Volumes/...`, etc.), set `HOST_WORKSPACE_ROOT` in the **repo-root `.env`** (i.e., `<your-clone-dir>/rka-core/.env`), **NOT** in `orchestrator/.env`. Docker Compose reads `.env` from the directory of the first `-f` file (the repo root) for YAML `${VAR}` interpolation; the `env_file:` directive only populates env vars inside the running container and does not feed interpolation.
 
 If you put `HOST_WORKSPACE_ROOT` in `orchestrator/.env`, the bind mount falls back to `${HOME}` and the workspace appears empty inside the container — a silent failure.
 
@@ -1071,7 +1071,7 @@ If you put `HOST_WORKSPACE_ROOT` in `orchestrator/.env`, the bind mount falls ba
 |---|---|
 | Docker volume `orchestrator-data` | `/data/orchestrator.db` (parked-interrupt queue + workflow_runs) + `/data/orchestrator-saver.db` (LangGraph checkpointer) |
 | `orchestrator/.env` (gitignored, mode 0600) | `CLAUDE_CODE_OAUTH_TOKEN`, optional API keys, and `RKA_LEGACY_TOOLS=1` propagated to the subprocess |
-| `<your-clone-dir>/rka/.env` (gitignored, repo-root) | `HOST_WORKSPACE_ROOT` for non-`$HOME` workspace roots — fed to Compose YAML `${VAR}` interpolation for the workspace bind mount |
+| `<your-clone-dir>/rka-core/.env` (gitignored, repo-root) | `HOST_WORKSPACE_ROOT` for non-`$HOME` workspace roots — fed to Compose YAML `${VAR}` interpolation for the workspace bind mount |
 | `~/.claude.json` (mounted read-only) | Host's Claude CLI global config |
 | `~/rka-projects/{project_id}/` (Phase D MVP convention) | Per-project `tools.json` + `.env` template after onboarding |
 
@@ -1090,15 +1090,15 @@ docker compose -f docker-compose.yml -f orchestrator/docker-compose.yml down
 
 | Location | What |
 |---|---|
-| `<your-clone-dir>/rka/` | The cloned RKA source repo (only docker-compose.yml is needed at runtime; rest is for development) |
+| `<your-clone-dir>/rka-core/` | The cloned RKA Core source repo (only docker-compose.yml is needed at runtime; rest is for development) |
 | Docker volume `rka-data` (managed by Docker Desktop) | The SQLite database `/data/rka.db` and any project artifacts |
 | `~/.claude/plugins/cache/rka/rka/<version>/` (macOS/Linux) or `%USERPROFILE%\.claude\plugins\cache\rka\rka\<version>\` (Windows) | The installed plugin: skills, commands, hooks, wrapper script |
 | `~/Library/Application Support/RKA/integration.json` (macOS) or `%APPDATA%\RKA\integration.json` (Windows) | Plugin-written config telling the wrapper which RKA backend to bridge to |
 | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows) | Claude Desktop's MCP config with the `rka` entry; backups of any prior version live alongside it as `*.backup-YYYYMMDD-HHMMSS` |
 | `~/.claude/plugins/installed_plugins.json` | Claude Code's registry of installed plugins (includes `rka@rka` entry after install) |
-| `~/.claude/plugins/known_marketplaces.json` | Claude Code's registry of marketplace sources (includes the `infinitywings/rka` GitHub source after `/plugin marketplace add`) |
+| `~/.claude/plugins/known_marketplaces.json` | Claude Code's registry of marketplace sources (includes the `rka-project/rka-core` GitHub source after `/plugin marketplace add`) |
 | Docker volume `orchestrator-data` *(agentic only)* | `/data/orchestrator.db` (parked-interrupt queue + workflow_runs) and `/data/orchestrator-saver.db` (LangGraph checkpointer) |
-| `<your-clone-dir>/rka/orchestrator/.env` *(agentic only, mode 0600)* | `CLAUDE_CODE_OAUTH_TOKEN`, `RKA_LEGACY_TOOLS=1`, and optional API keys |
-| `<your-clone-dir>/rka/.env` *(agentic only, optional)* | `HOST_WORKSPACE_ROOT` for non-`$HOME` workspace bind mount (see §11 Workspace bind mount) |
+| `<your-clone-dir>/rka-core/orchestrator/.env` *(agentic only, mode 0600)* | `CLAUDE_CODE_OAUTH_TOKEN`, `RKA_LEGACY_TOOLS=1`, and optional API keys |
+| `<your-clone-dir>/rka-core/.env` *(agentic only, optional)* | `HOST_WORKSPACE_ROOT` for non-`$HOME` workspace bind mount (see §11 Workspace bind mount) |
 | `~/.claude.json` *(agentic only, mounted read-only into container)* | Host's Claude CLI global config consumed by the orchestrator daemon's SDK subprocess |
 | [`docs/v2.6.x-v2.7.0-tool-surface-arc.md`](docs/v2.6.x-v2.7.0-tool-surface-arc.md) | Canonical narrative of the v2.6 → v2.7.0 tool-surface migration (project_id discipline → dispatch + 91 typed Pydantic operations) |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/infinitywings/rka/main/assets/brand/rka-project-plugin-app-icon.svg" alt="RKA Project mark" width="112">
+  <img src="https://raw.githubusercontent.com/rka-project/rka-core/main/assets/brand/rka-project-plugin-app-icon.svg" alt="RKA Project mark" width="112">
 </p>
 
 # RKA Core — Research Knowledge Agent
 
-[![pytest](https://github.com/infinitywings/rka/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/infinitywings/rka/actions/workflows/pytest.yml)
+[![pytest](https://github.com/rka-project/rka-core/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/rka-project/rka-core/actions/workflows/pytest.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **A local-first research operating system for turning day-to-day research activity into durable, auditable knowledge.**
@@ -160,8 +160,8 @@ The intended integration is an explicit, testable crosswalk—not a lossy text e
 Prerequisite: [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
 ```bash
-git clone https://github.com/infinitywings/rka.git
-cd rka
+git clone https://github.com/rka-project/rka-core.git
+cd rka-core
 docker compose up -d
 ```
 
@@ -192,7 +192,7 @@ For a complete first-project walkthrough, see [USAGE_GUIDE.md](USAGE_GUIDE.md).
 | **CLI** | Starting services, status, backup, credentials, and workspace bootstrap | [Technical Reference](docs/TECHNICAL_REFERENCE.md) |
 | **REST API** | Custom integrations and application development | [Technical Reference](docs/TECHNICAL_REFERENCE.md), live `/docs` |
 | **ChatGPT connector** | Authenticated access from ChatGPT to a local RKA instance | [Connector Guide](docs/CHATGPT_CONNECTOR.md) |
-| **Writer (separate project)** | Explicitly invoked manuscript assistance using RKA's public contract | [`infinitywings/rka-writer`](https://github.com/infinitywings/rka-writer) |
+| **Writer (separate project)** | Explicitly invoked manuscript assistance using RKA's public contract | [`rka-project/rka-writer`](https://github.com/rka-project/rka-writer) |
 
 ## Architecture
 
@@ -211,7 +211,7 @@ RKA Ecosystem project:
 2. **Stable integration contract** — freeze the supported REST/MCP surface and
    provide version, capability, and compatibility discovery.
 3. **RKA Writer extraction** — move the Writer skill, manuscript semantics,
-   academic-writing tools, and Workbench to `infinitywings/rka-writer`.
+   academic-writing tools, and Workbench to `rka-project/rka-writer`.
 4. **Core 3.0 and ecosystem validation** — slim the Core distribution only
    after legacy-state migration and downstream compatibility tests pass.
 
@@ -222,7 +222,7 @@ The Workbench, ARA interoperability, and dual-output evaluation remain planned
 Writer/ecosystem work; they are not the immediate Core implementation target.
 
 The dependency-ordered plan lives in the repository [Roadmap](ROADMAP.md), with
-active work tracked through [GitHub milestones](https://github.com/infinitywings/rka/milestones).
+active work tracked through [GitHub milestones](https://github.com/rka-project/rka-core/milestones).
 Roadmap items describe direction and should not be interpreted as released
 features.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap prioritizes a reliable, independently usable RKA research-
 knowledge core. Writer/Workbench is the only active downstream product and is
-released separately as `infinitywings/rka-writer`. Agentic orchestration is
+released separately as `rka-project/rka-writer`. Agentic orchestration is
 shelved: its existing history is preserved, but no `rka-agentic` repository or
 runtime extraction is planned unless the PI explicitly reactivates it.
 
@@ -68,7 +68,7 @@ roadmap.
 | **E1** | **Core reliability baseline** | Harden journal, provenance, project isolation, retrieval, claim edges, migrations, export/import, and recovery. | Core-only install/tests pass; no cross-project leakage; real backup upgrade and integrity pass. |
 | **E2** | **Stable external contract** | Freeze supported REST/MCP behavior and provide capability/version discovery plus legacy Writer export. | Public-contract-only clients complete core workflows and legacy Writer export round-trips. |
 | **E3** | **Agentic work shelved** | Preserve the historical branch and design record without creating or operating a separate Agentic product. | Active docs and packaging do not direct users to install Agentic; reactivation requires a new PI decision. |
-| **E4** | **Writer repository extraction** | Create `infinitywings/rka-writer`, migrate Writer state, and move Workbench ownership. | Writer runs independently, imports legacy state, and detects stale Core references. |
+| **E4** | **Writer repository extraction** | Establish `rka-project/rka-writer`, migrate Writer state, and move Workbench ownership. | Writer runs independently, imports legacy state, and detects stale Core references. |
 | **E5** | **RKA Core 3.0** | Remove active Writer execution code from Core while preserving compatibility export and migration history. | Core and Writer compatibility suites pass without destructive database changes. |
 | **E6** | **Ecosystem integration** | Maintain Core and Writer releases under one GitHub Project and compatibility matrix. | Core-only and Core+Writer deployments have reproducible smoke tests. |
 

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -134,8 +134,8 @@ Both should print version numbers without errors.
 ### Step 2. Clone and start RKA
 
 ```bash
-git clone https://github.com/infinitywings/rka.git
-cd rka
+git clone https://github.com/rka-project/rka-core.git
+cd rka-core
 docker compose up -d
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,7 +83,7 @@ RKA separates the durable activity record from interpretations built over it.
 
 ### Downstream publication layer (separate project)
 
-The standalone [`rka-writer`](https://github.com/infinitywings/rka-writer)
+The standalone [`rka-writer`](https://github.com/rka-project/rka-writer)
 project can use claims, clusters, research questions, literature, decisions,
 and evidence through Core's public contract to construct a claim spine and
 draft. Its manuscript workbench is a separately installed editing and audit

--- a/docs/CHATGPT_CONNECTOR.md
+++ b/docs/CHATGPT_CONNECTOR.md
@@ -53,7 +53,7 @@ local stdio clients keep, so local access is unaffected either way.
 
 The Core connector intentionally exposes only the `pi`, `brain`, and
 `executor` roles. Manuscript assistance is not a hidden connector role: install
-and invoke [`rka-writer`](https://github.com/infinitywings/rka-writer)
+and invoke [`rka-writer`](https://github.com/rka-project/rka-writer)
 separately when writing support is wanted.
 
 ## Prerequisites

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -251,8 +251,8 @@ Docker is the simplest way to run RKA. It requires no Python environment, no Nod
 **Prerequisites:** Docker Desktop ([docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/))
 
 ```bash
-git clone https://github.com/infinitywings/rka.git
-cd rka
+git clone https://github.com/rka-project/rka-core.git
+cd rka-core
 docker compose up -d
 ```
 
@@ -965,4 +965,4 @@ Click the trash icon next to the project selector in the sidebar. A confirmation
 
 *RKA v2.3.2 — Research Knowledge Agent*
 *UNC Charlotte, CS / IoT / CPS Security Research*
-*https://github.com/infinitywings/rka*
+*https://github.com/rka-project/rka-core*

--- a/docs/chatgpt-rka-connector-handoff.md
+++ b/docs/chatgpt-rka-connector-handoff.md
@@ -8,7 +8,7 @@ This document summarizes the conversation, decisions, implementation work, curre
 > deployment handoff. Current RKA Core packages only the `brain`, `executor`,
 > and `pi` role skills plus `mcp-credentials`. Writer guidance, reference
 > validation, and manuscript tooling moved to the separately installed
-> [`rka-writer`](https://github.com/infinitywings/rka-writer) project. The Core
+> [`rka-writer`](https://github.com/rka-project/rka-writer) project. The Core
 > connector does not expose or auto-activate a `writer` role.
 
 > **2026-07-06 continuation — deployment completed + always-on skill surface.**
@@ -253,7 +253,7 @@ rka_start_session(role="pi", project_id="prj_...")
 ```
 
 For manuscript guidance, install and invoke the separate
-[`rka-writer`](https://github.com/infinitywings/rka-writer) plugin. A Core call
+[`rka-writer`](https://github.com/rka-project/rka-writer) plugin. A Core call
 such as `rka_read_skill(name="writer")` is intentionally unsupported after the
 3.0 split.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Chenglong Fu",
     "email": "cfu6@charlotte.edu"
   },
-  "homepage": "https://github.com/infinitywings/rka",
-  "repository": "https://github.com/infinitywings/rka",
+  "homepage": "https://github.com/rka-project/rka-core",
+  "repository": "https://github.com/rka-project/rka-core",
   "license": "MIT",
   "keywords": [
     "research",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@
 
 # rka — Claude Code plugin for the Research Knowledge Agent
 
-This is the official Claude Code plugin for [RKA](https://github.com/infinitywings/rka). It lives inside the upstream RKA repository at `plugin/`, distributed via the local marketplace at `.claude-plugin/marketplace.json` in the repo root.
+This is the official Claude Code plugin for [RKA](https://github.com/rka-project/rka-core). It lives inside the upstream RKA Core repository at `plugin/`, distributed via the local marketplace at `.claude-plugin/marketplace.json` in the repo root.
 
 > **Quick install** — see [INSTALL.md at the repo root](../INSTALL.md). The TL;DR: clone the rka repo, `docker compose up -d`, then in Claude Code: `/plugin marketplace add /path/to/cloned/rka` followed by `/plugin install rka@rka`.
 
@@ -102,4 +102,4 @@ For Claude Desktop, the wrapper picks up changes automatically (no install step)
 
 This plugin was scaffolded as part of the empirical-verification probe for plugin architecture (mission `mis_01KQNN8YZG7A4ZAGDCQ8ZVA97Z`, decision `dec_01KQNPC7A683HK0KRX1PAGNNED` — Option B: wrapper exec's local stdio binary, no HTTP MCP bridge). The probe's findings shape the v1.0 design; future v2.4 RKA.app will automate the setup currently handled by `/rka-setup-claude-desktop`. Both ids are RKA knowledge-base entities; query them via any RKA tool (e.g., `mcp__plugin_rka_rka__rka_get(id="dec_01KQNPC7A683HK0KRX1PAGNNED")` from a Claude session, or visit the corresponding entity in the web dashboard at `http://localhost:9712`).
 
-Upstream RKA: [github.com/infinitywings/rka](https://github.com/infinitywings/rka)
+Upstream RKA Core: [github.com/rka-project/rka-core](https://github.com/rka-project/rka-core)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ dependencies = [
     "python-ulid>=3.0.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/rka-project/rka-core"
+Repository = "https://github.com/rka-project/rka-core"
+Issues = "https://github.com/rka-project/rka-core/issues"
+Changelog = "https://github.com/rka-project/rka-core/blob/main/CHANGELOG.md"
+
 [project.optional-dependencies]
 # Core retrieval dependencies. Kept separate from legacy provider clients so
 # the supported Core runtime never needs an LLM SDK.

--- a/tests/test_brand_assets.py
+++ b/tests/test_brand_assets.py
@@ -66,7 +66,7 @@ def test_readmes_keep_accessible_text_with_the_mark() -> None:
 
     assert "# RKA Core — Research Knowledge Agent" in root_readme
     assert (
-        "https://raw.githubusercontent.com/infinitywings/rka/main/"
+        "https://raw.githubusercontent.com/rka-project/rka-core/main/"
         "assets/brand/rka-project-plugin-app-icon.svg"
     ) in root_readme
     assert "# rka — Claude Code plugin for the Research Knowledge Agent" in plugin_readme

--- a/wiki/Deployment-Main.md
+++ b/wiki/Deployment-Main.md
@@ -184,17 +184,17 @@ echo $PATH | tr ':' '\n' | grep -q "$HOME/.local/bin" && echo "OK" || \
 
 ### 1.5 AppleDouble pre-check (skip if cloning under `~/`)
 
-If you clone into `~/Code/rka` or `~/Documents/rka` on the boot APFS volume, skip this. If you clone onto **`/Volumes/*`**, OneDrive, Dropbox, iCloud, or an SMB/AFP mount, macOS will create `._*` AppleDouble files that break both `docker compose build` (`failed to xattr ... operation not permitted`) and `uv tool install` (`No such file or directory: '._requires.txt'`).
+If you clone into `~/Code/rka-core` or `~/Documents/rka-core` on the boot APFS volume, skip this. If you clone onto **`/Volumes/*`**, OneDrive, Dropbox, iCloud, or an SMB/AFP mount, macOS will create `._*` AppleDouble files that break both `docker compose build` (`failed to xattr ... operation not permitted`) and `uv tool install` (`No such file or directory: '._requires.txt'`).
 
-**Recommendation:** clone into `~/Code/rka`. If you must use an external volume, see [§ 7.4 AppleDouble fix](#74-appledouble-blocks-docker-build--uv-tool-install).
+**Recommendation:** clone into `~/Code/rka-core`. If you must use an external volume, see [§ 7.4 AppleDouble fix](#74-appledouble-blocks-docker-build--uv-tool-install).
 
 ---
 
 ## 2. Clone the repo + pin a reference
 
 ```bash
-git clone https://github.com/infinitywings/rka.git
-cd rka
+git clone https://github.com/rka-project/rka-core.git
+cd rka-core
 git branch --show-current
 ```
 
@@ -601,7 +601,7 @@ D1–D3 (host binary install) are **optional** smoke-test rows — the docker-ex
 | **A2** | `xcode-select -p && git --version` | Non-empty path + `git version 2.x` | `xcode-select --install` |
 | **A3** | `python3 --version` | `Python 3.9.x` or higher | `brew install python` (only needed if stock `/usr/bin/python3` is missing) |
 | **A4** | `uv --version` (only required if running D1–D3) | `uv 0.x` or newer | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
-| **B1** | `git clone https://github.com/infinitywings/rka.git && cd rka && git branch --show-current` | Prints `main` | `git fetch origin main && git checkout main` |
+| **B1** | `git clone https://github.com/rka-project/rka-core.git && cd rka-core && git branch --show-current` | Prints `main` | `git fetch origin main && git checkout main` |
 | **B1a** | `git rev-parse HEAD > .deployed-sha; cat .deployed-sha` | 40-char SHA recorded | Capture for deployment log; or `git checkout v2.5.12` for a pinned reference |
 | **B2** | `find . -name '._*' -not -path './.git/*' -not -path './.venv/*' -not -path './node_modules/*' \| wc -l` | Prints `0` | Re-run with `-delete` |
 | **C1** | `docker compose up -d --build` | Exits 0; ends with `Started` lines | See [§ 7](#7-troubleshooting) by error class |


### PR DESCRIPTION
## Summary

- update active Core links, badges, clone commands, and plugin metadata to `rka-project/rka-core`
- update current Writer cross-references to `rka-project/rka-writer`
- add canonical project URLs to `pyproject.toml`
- keep historical ADR, audit, PR, issue, and shelved Agentic provenance unchanged

## Validation

- `python -m pytest -q --tb=short --strict-markers -m "not writer and not agentic"` — 3051 passed, 294 deselected
- `python scripts/core_startup_smoke.py --require-web --require-vec` — passed after rebuilding the web bundle
- TOML and plugin JSON parsing — passed
- `git diff --check` — passed
- live new repository and raw brand asset URLs — verified

## Migration context

This is the minimal active-reference update after transferring and renaming `infinitywings/rka` to `rka-project/rka-core`. GitHub redirects preserve historical links, so provenance records were not rewritten.