### PR TITLE
E2.1: publish Core capability discovery contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to RKA are documented here. Format loosely follows
 
 ### Added
 
+- Versioned Core capability discovery now exposes the package and public
+  contract versions through REST and the existing five-tool MCP dispatch
+  surface. Clients can require a Core contract or runtime capability and
+  receive a structured, actionable compatibility error when it is unavailable.
+- MCP operation discovery now reports explicit deprecation metadata separately
+  from the existing usage-derived stable/preview signal. The disabled
+  `upsert_argument_spine` compatibility operation identifies its supported
+  semantic-proposal replacements.
 - The RKA Project visual identity now has canonical SVG masters, documented
   color tokens, and mirrored Web/plugin assets. RKA Core's README and dashboard
   use the new mark, and the Core startup smoke verifies the deployed icon is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,16 @@ The default MCP interface exposes a compact dispatch surface rather than broadca
 
 Each dispatched operation has a typed argument model with operation-specific required fields and enums. `rka_describe` is the authoritative runtime catalog; this avoids maintaining a brittle duplicate list in the README.
 
+Core publishes an additive, versioned capability manifest at
+`GET /api/capabilities`; the same document is available through the unscoped
+`rka_query(args={"operation": "capabilities"})` dispatch. Product versions and public
+contract versions are separate. MCP reports connector and backend versions
+independently so version drift remains visible, while explicit deprecation
+metadata remains distinct from the historical usage-derived stable/preview
+signal. Capability documents label that signal as `usage-readiness`; only the
+REST and MCP interface contracts are declared stable at this stage.
+`/api/health` remains a liveness endpoint rather than a negotiation contract.
+
 ## Local-first boundary
 
 The core database and dashboard run locally. Embeddings may remain fully local or use a configured compatible backend. MCP stdio also remains local. Remote access must be mediated through an authenticated connector; the raw HTTP MCP port should not be exposed directly.

--- a/docs/TECHNICAL_REFERENCE.md
+++ b/docs/TECHNICAL_REFERENCE.md
@@ -62,9 +62,24 @@ The MCP binary is a thin proxy to the REST API configured by `RKA_API_URL`, whic
 | `rka_load_tools` | Load deferred compatibility tools when required. |
 | `rka_help` | Discovery and help alias. |
 
-Use `rka_describe("")` for the operation index and `rka_describe("<operation>")` for exact required fields, enums, and provenance constraints. This runtime description is authoritative and should be preferred over copied operation lists.
+Use `rka_query(args={"operation": "capabilities"})` to discover the connector and
+Core versions, the supported `rka-core/v1` contract, REST/MCP interface
+contracts, runtime capabilities, and connector/backend compatibility. Optional
+`required_contract` and `required_capabilities` fields fail with structured
+guidance when the current runtime cannot satisfy them.
 
-Project-scoped operations require an explicit `project_id`. `list_projects` and `create_project` are intentionally unscoped.
+Use `rka_describe("")` for the default operation index and
+`rka_describe("<operation>")` for exact required fields, enums, usage-readiness
+maturity, and deprecation guidance. The historical `stable`/`preview` maturity
+axis reflects current production use, not a versioned compatibility promise;
+explicit deprecation is reported separately. Pass `include_preview=true` only
+when intentionally exploring preview or compatibility operations. This runtime
+description is authoritative and should be preferred over copied operation
+lists.
+
+Project-scoped operations require an explicit `project_id`. `list_projects`,
+`capabilities`, `health`, `create_project`, and `reset_session` are intentionally
+unscoped.
 
 ### Transport modes
 
@@ -78,8 +93,16 @@ The HTTP transport does not provide authentication by itself. Bind it to loopbac
 - Base URL: `http://localhost:9712/api`
 - OpenAPI UI: `http://localhost:9712/docs`
 - Health: `http://localhost:9712/api/health`
+- Capability discovery: `http://localhost:9712/api/capabilities`
 
 Most endpoints are project-scoped. Pass the project identifier through the documented header or query parameter. Use the live OpenAPI schema for exact request and response models.
+
+`GET /api/capabilities` is additive and versioned by
+`schema_version=rka.core-capabilities/v1`. It preserves the historical top-level
+`embedding` block and keeps the removed `llm` field absent. Repeat the
+`required_capability` query parameter to require multiple runtime capabilities;
+unsupported contracts or combinations return HTTP 409 with the supported
+contract/capability set and a recovery hint.
 
 Major route families include projects, status, notes, decisions, literature, missions, checkpoints, claims, clusters, research maps, freshness, search, context, graphs, artifacts, workspace ingestion, audit history, and knowledge-pack import/export.
 

--- a/rka/api/routes/project.py
+++ b/rka/api/routes/project.py
@@ -27,6 +27,7 @@ from rka.api.deps import (
     get_knowledge_pack_service,
     require_project,
 )
+from rka.models.capabilities import CapabilityNegotiationError, CoreCapabilities
 from rka.models.knowledge_pack import KnowledgePackImportResult
 from rka.models.project import ProjectCreate, ProjectInfo, ProjectState, ProjectStateUpdate
 # Aliased: this module already defines a route handler called `get_status`
@@ -37,6 +38,10 @@ from rka.services.embedding_backfill import (
     get_status as get_job_status,
     latest_status as latest_job_status,
     register_job,
+)
+from rka.services.capabilities import (
+    build_core_capabilities,
+    validate_capability_requirements,
 )
 from rka.services.knowledge_pack import KnowledgePackService
 from rka.services.project import ProjectService
@@ -98,10 +103,17 @@ async def update_status(
     return await svc.update(data, actor=actor, project_id=project_id)
 
 
-@router.get("/capabilities")
-async def get_capabilities(request: Request):
-    """Return embedding availability so consumers (rka_get_status,
-    rka_search) can adapt their output when the capability is degraded.
+@router.get(
+    "/capabilities",
+    response_model=CoreCapabilities,
+    responses={409: {"model": CapabilityNegotiationError}},
+)
+async def get_capabilities(
+    request: Request,
+    required_contract: str | None = Query(default=None),
+    required_capability: list[str] | None = Query(default=None),
+):
+    """Return Core/interface versions plus runtime capability availability.
 
     Affordance C (Mission B / mis_01KR209WY4M6WQFEXRH79KC2ZF). Pure
     runtime introspection — no DB write, no schema change.
@@ -131,7 +143,18 @@ async def get_capabilities(request: Request):
             "reason_unavailable": "sqlite-vec extension not loaded",
         }
 
-    return {"embedding": emb_block}
+    document = build_core_capabilities(
+        embedding_available=emb_block["available"],
+        embedding_reason=emb_block["reason_unavailable"],
+    )
+    error = validate_capability_requirements(
+        document,
+        required_contract=required_contract,
+        required_capabilities=required_capability,
+    )
+    if error is not None:
+        return JSONResponse(status_code=409, content=error.model_dump(mode="json"))
+    return document
 
 
 @router.delete("/projects/{project_id}")

--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -196,7 +196,8 @@ class ProjectScopedArgs(BaseModel):
 class UnscopedArgs(BaseModel):
     """Base for operations that don't require a project_id.
 
-    Used by ``list_projects``, ``health``, ``create_project``, ``reset_session``.
+    Used by ``list_projects``, ``capabilities``, ``health``, ``create_project``,
+    and ``reset_session``.
     """
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
@@ -1256,7 +1257,7 @@ class QueryWorkspaceScanArgs(ProjectScopedArgs):
 
 
 # ---------------------------------------------------------------------------
-# Unscoped session operations (list_projects / health)
+# Unscoped session operations (list_projects / capabilities / health)
 # ---------------------------------------------------------------------------
 
 
@@ -1264,6 +1265,28 @@ class QueryListProjectsArgs(UnscopedArgs):
     """[ANY] List all available projects (UNSCOPED — does not require project_id)."""
 
     operation: Literal["list_projects"] = "list_projects"
+
+
+class QueryCapabilitiesArgs(UnscopedArgs):
+    """[ANY] Discover Core and interface contracts (UNSCOPED)."""
+
+    operation: Literal["capabilities"] = "capabilities"
+    required_contract: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Optional Core contract required by the caller.",
+        ),
+    ] = None
+    required_capabilities: Annotated[
+        Optional[list[str]],
+        Field(
+            default=None,
+            description=(
+                "Optional runtime capabilities that must be available (rest, mcp, embedding)."
+            ),
+        ),
+    ] = None
 
 
 class QueryHealthArgs(UnscopedArgs):
@@ -1355,6 +1378,7 @@ QueryArgsUnion = Annotated[
         QueryWorkspaceScanArgs,
         # Unscoped session
         QueryListProjectsArgs,
+        QueryCapabilitiesArgs,
         QueryHealthArgs,
     ],
     Field(discriminator="operation"),
@@ -5175,6 +5199,7 @@ __all__ = [
     "QueryWorkspaceTreeArgs",
     "QueryWorkspaceScanArgs",
     "QueryListProjectsArgs",
+    "QueryCapabilitiesArgs",
     "QueryHealthArgs",
     # Union
     "QueryArgsUnion",

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -2004,6 +2004,39 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "related_operations": ["status", "create_project"],
         "notes": "UNSCOPED — does not require project_id.",
     },
+    "capabilities": {
+        "operation": "capabilities",
+        "tool": "rka_query",
+        "category": "session",
+        "role_tag": "ANY",
+        "summary": "Discover Core, REST, MCP, and runtime capability contracts (UNSCOPED).",
+        "signature": (
+            "rka_query(operation='capabilities', required_contract=None, "
+            "required_capabilities=None)"
+        ),
+        "required_fields": [],
+        "optional_fields": ["required_contract", "required_capabilities"],
+        "enums": {},
+        "examples": [
+            {
+                "description": "Discover versions and stable interface contracts.",
+                "call": {"operation": "capabilities"},
+            },
+            {
+                "description": "Require a compatible Core contract and embedding runtime.",
+                "call": {
+                    "operation": "capabilities",
+                    "required_contract": "rka-core/v1",
+                    "required_capabilities": ["embedding"],
+                },
+            },
+        ],
+        "related_operations": ["health", "list_projects"],
+        "notes": (
+            "UNSCOPED. Unsupported contract/capability requirements return "
+            "a structured actionable error without mutating Core state."
+        ),
+    },
     "health": {
         "operation": "health",
         "tool": "rka_query",
@@ -5560,6 +5593,25 @@ PREVIEW_OPERATIONS: frozenset[str] = frozenset({
 })
 
 
+# Explicit operation deprecations are a public compatibility signal, not a
+# proxy for production usage. Keep them separate from ``operation_maturity``:
+# one operation can be both usage-preview and deprecated. Broader frozen
+# Writer/Workbench compatibility classification belongs to E2.4.
+DEPRECATED_OPERATIONS: dict[str, dict[str, Any]] = {
+    "upsert_argument_spine": {
+        "reason": (
+            "Agent-direct argument-spine replacement is disabled; use an "
+            "attributed semantic proposal and separate PI/web apply transition."
+        ),
+        "replacement_operations": [
+            "prepare_semantic_patch_context",
+            "create_semantic_patch_proposal",
+            "apply_semantic_patch_proposal",
+        ],
+    },
+}
+
+
 def operation_maturity(op_name: str) -> str:
     """``'stable'`` or ``'preview'`` for one operation."""
     entry = OPERATIONS_SCHEMA.get(op_name)
@@ -5568,6 +5620,12 @@ def operation_maturity(op_name: str) -> str:
     if op_name in PREVIEW_OPERATIONS or entry.get("category") in PREVIEW_CATEGORIES:
         return "preview"
     return "stable"
+
+
+def operation_deprecation(op_name: str) -> dict[str, Any] | None:
+    """Return explicit compatibility guidance for a deprecated operation."""
+
+    return DEPRECATED_OPERATIONS.get(op_name)
 
 
 def suggest_operations(query: str, *, top_n: int = 5) -> list[str]:
@@ -5598,7 +5656,10 @@ def list_operations_compact(*, include_preview: bool = False) -> dict[str, list[
     """
     out: dict[str, list[str]] = {"rka_query": [], "rka_execute": []}
     for op_name, entry in OPERATIONS_SCHEMA.items():
-        if not include_preview and operation_maturity(op_name) == "preview":
+        if not include_preview and (
+            operation_maturity(op_name) == "preview"
+            or operation_deprecation(op_name) is not None
+        ):
             continue
         tool = entry["tool"]
         out.setdefault(tool, []).append(op_name)
@@ -5638,16 +5699,22 @@ async def dispatch_describe(
                 "rka_describe('<op>') for schema; rka_query/_execute "
                 "inputSchema already carries per-branch enums."
             ),
+            "deprecated_operations": sorted(DEPRECATED_OPERATIONS),
         }
         if not include_preview:
-            hidden = len(OPERATIONS_SCHEMA) - listed
-            payload["preview_hidden"] = hidden
+            preview_hidden = sum(
+                operation_maturity(op_name) == "preview"
+                and operation_deprecation(op_name) is None
+                for op_name in OPERATIONS_SCHEMA
+            )
+            payload["preview_hidden"] = preview_hidden
             payload["preview_hint"] = (
-                f"{hidden} preview operations are omitted — subsystems with no "
+                f"{preview_hidden} preview operations are omitted — subsystems with no "
                 "production data yet (manuscript, planning, experiments, "
                 "semantic-patches, hooks, interpretation staging, claim scope). "
                 "Pass include_preview=True to see them."
             )
+            payload["deprecated_hidden"] = len(DEPRECATED_OPERATIONS)
         return json.dumps(payload, indent=2)
 
     op = operation.strip()
@@ -5666,15 +5733,25 @@ async def dispatch_describe(
             indent=2,
         )
 
-    return json.dumps({**entry, "maturity": operation_maturity(op)}, indent=2)
+    deprecation = operation_deprecation(op)
+    payload = {
+        **entry,
+        "maturity": operation_maturity(op),
+        "deprecated": deprecation is not None,
+    }
+    if deprecation is not None:
+        payload["deprecation"] = deprecation
+    return json.dumps(payload, indent=2)
 
 
 __all__ = [
     "OPERATIONS_SCHEMA",
+    "DEPRECATED_OPERATIONS",
     "PREVIEW_CATEGORIES",
     "PREVIEW_OPERATIONS",
     "dispatch_describe",
     "operation_maturity",
+    "operation_deprecation",
     "get_operation_schema",
     "list_operations_grouped",
     "list_operations_compact",

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -18,6 +18,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 import httpx
 
+from rka import __version__
 from rka.models.mission import MissionTask
 from rka.mcp._enums import (
     ChkTypeLit,
@@ -338,6 +339,11 @@ Then follow the returned guide. Also available:
 """
 
 mcp = FastMCP("Research Knowledge Agent", instructions=RKA_INSTRUCTIONS)
+# FastMCP otherwise leaves this unset and the initialize handshake falls back
+# to the MCP SDK version, which makes a stale connector look like the backend's
+# product version. E2 discovery reports connector/backend versions separately;
+# the handshake should identify this connector build too.
+mcp._mcp_server.version = __version__
 API_URL = os.environ.get("RKA_API_URL", "http://127.0.0.1:9712")
 API_TIMEOUT = httpx.Timeout(connect=30.0, read=120.0, write=120.0, pool=30.0)
 
@@ -7720,14 +7726,14 @@ async def rka_query(args: _QueryArgsUnion) -> str:
     context", "manuscript readiness", "manuscript spine", "changes since",
     "what changed", "manuscript impact", "reference validation status",
     "review queue", "open checkpoints", "pending maintenance",
-    "list projects", "health check".
+    "list projects", "capability discovery", "health check".
 
     Args:
         args: One of the typed ``Query*Args`` models from
               ``rka.mcp.operation_args``. The model's ``operation`` field
               is the discriminator. Project-scoped operations require
-              ``project_id``; the only unscoped reads are
-              ``list_projects`` and ``health``.
+              ``project_id``; the unscoped reads are ``list_projects``,
+              ``capabilities``, and ``health``.
 
     Returns:
         JSON-string payload from the underlying REST endpoint, or a
@@ -9013,13 +9019,13 @@ async def rka_describe(operation: str = "", include_preview: bool = False) -> st
     Modes:
       - operation='<name>'   -> full schema (signature, required/optional
                                 fields, enum value sets, 1-2 examples,
-                                related_operations, role_tag, notes).
+                                related_operations, role_tag, notes, maturity,
+                                and explicit deprecation guidance when present).
       - operation=''         -> operations index grouped by tool
                                 (rka_query / rka_execute); use this when you
-                                want to BROWSE. Preview operations are omitted
-                                by default — subsystems that carry no
-                                production data yet — and the response reports
-                                how many were hidden. Pass
+                                want to BROWSE. Preview and deprecated
+                                operations are omitted by default and reported
+                                separately. Pass
                                 include_preview=True to see the whole surface.
       - unknown operation    -> {error: 'unknown_operation', did_you_mean: [...]}.
 
@@ -9028,16 +9034,16 @@ async def rka_describe(operation: str = "", include_preview: bool = False) -> st
             rka_query(args={"operation": ...}) or
             rka_execute(args={"operation": ...})).
             Pass '' to browse the index.
-        include_preview: include operations whose subsystem has no production
-            data yet. Default False keeps the browse index to what is actually
-            in use.
+        include_preview: include preview and deprecated compatibility
+            operations. Default False keeps the browse index to the default
+            usage-tested surface.
 
     Returns:
         JSON. For a known operation: {operation, tool, category,
         summary, signature, required_fields, optional_fields, enums,
-        examples, related_operations, role_tag, notes}. For an unknown
-        name: {error, operation, did_you_mean, hint}. For empty: the
-        operations index.
+        examples, related_operations, role_tag, notes, maturity, deprecated,
+        deprecation?}. For an unknown name: {error, operation,
+        did_you_mean, hint}. For empty: the operations index.
     """
     return await _dispatch_describe(operation, include_preview=include_preview)
 

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -56,6 +56,8 @@ import json
 import logging
 from typing import Any
 
+import httpx
+
 logger = logging.getLogger(__name__)
 
 
@@ -2962,6 +2964,114 @@ def _coerce_result_to_str(result: Any) -> str:
         return repr(result)
 
 
+async def _dispatch_capabilities_typed(args: "BaseModel") -> str:  # type: ignore[name-defined]  # noqa: F821
+    """Proxy versioned discovery while keeping connector/backend drift visible."""
+
+    from rka import __version__
+    from rka.mcp.server import _client
+    from rka.services.capabilities import CORE_CONTRACT
+
+    required_contract = getattr(args, "required_contract", None)
+    required_capabilities = getattr(args, "required_capabilities", None) or []
+    params: list[tuple[str, str]] = []
+    if required_contract:
+        params.append(("required_contract", required_contract))
+    params.extend(("required_capability", capability) for capability in required_capabilities)
+
+    try:
+        async with _client() as client:
+            response = await client.get(
+                "/api/capabilities",
+                params=params or None,
+            )
+    except httpx.RequestError as exc:
+        detail = str(exc) or f"{type(exc).__name__} (no message)"
+        return _err(
+            "backend_unavailable",
+            "The MCP connector could not reach the RKA Core capability endpoint.",
+            connector_version=__version__,
+            required_contract=required_contract or CORE_CONTRACT,
+            detail=detail,
+            hint=(
+                "Start or rebuild the Core backend, verify RKA_API_URL, and "
+                "keep the local connector and backend installations synchronized."
+            ),
+        )
+
+    try:
+        body = response.json()
+    except Exception:  # noqa: BLE001 - compatibility path may return HTML/text
+        body = None
+
+    if response.status_code in {404, 405}:
+        return _err(
+            "incompatible_backend",
+            "The Core backend does not expose the E2 capability contract.",
+            connector_version=__version__,
+            rest_status_code=response.status_code,
+            required_contract=required_contract or CORE_CONTRACT,
+            hint=(
+                "Upgrade/rebuild the Core backend or reinstall the connector "
+                "so both provide rka-core/v1 discovery."
+            ),
+        )
+
+    backend_version = None
+    supported_contracts: list[str] = []
+    if isinstance(body, dict):
+        backend_version = body.get("core", {}).get("version") or body.get("core_version")
+        supported_contracts = body.get("core", {}).get("supported_contracts") or body.get(
+            "supported_contracts", []
+        )
+    connector = {
+        "name": "rka-mcp",
+        "version": __version__,
+        "backend_version": backend_version,
+        "version_match": backend_version == __version__,
+        "compatible": CORE_CONTRACT in supported_contracts,
+    }
+
+    if not response.is_success:
+        if isinstance(body, dict):
+            body["connector"] = connector
+            return json.dumps(body, indent=2)
+        return _err(
+            "backend_error",
+            "The Core backend rejected capability discovery.",
+            connector=connector,
+            rest_status_code=response.status_code,
+            detail=response.text[:500],
+            hint="Inspect the backend response and synchronize connector/backend versions.",
+        )
+
+    if not isinstance(body, dict) or body.get("schema_version") != "rka.core-capabilities/v1":
+        return _err(
+            "incompatible_backend",
+            "The Core backend returned a pre-E2 or malformed capability document.",
+            connector=connector,
+            required_contract=required_contract or CORE_CONTRACT,
+            observed_payload=body,
+            hint=(
+                "Upgrade/rebuild the Core backend or reinstall the connector "
+                "so both provide rka.core-capabilities/v1."
+            ),
+        )
+
+    compatible = CORE_CONTRACT in supported_contracts
+    connector["compatible"] = compatible
+    body["connector"] = connector
+    if not compatible:
+        return _err(
+            "incompatible_backend",
+            f"The connector requires {CORE_CONTRACT}.",
+            connector=connector,
+            backend_capabilities=body,
+            required_contract=CORE_CONTRACT,
+            hint="Synchronize the connector and Core backend before writes.",
+        )
+    return json.dumps(body, indent=2)
+
+
 async def dispatch_query_typed(args: "BaseModel") -> str:  # type: ignore[name-defined]  # noqa: F821
     """v2.7.0 typed-query dispatch.
 
@@ -2981,9 +3091,11 @@ async def dispatch_query_typed(args: "BaseModel") -> str:  # type: ignore[name-d
     op = args.operation  # type: ignore[attr-defined]
     pid = getattr(args, "project_id", None)
 
-    # Unscoped reads — list_projects + health.
+    # Unscoped reads — list_projects + capabilities + health.
     if op == "list_projects":
         return _coerce_result_to_str(await dispatch_session("list_projects"))
+    if op == "capabilities":
+        return await _dispatch_capabilities_typed(args)
     if op == "health":
         return _coerce_result_to_str(await dispatch_session("health"))
 

--- a/rka/models/capabilities.py
+++ b/rka/models/capabilities.py
@@ -1,0 +1,81 @@
+"""Public models for RKA Core capability and contract discovery."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class EmbeddingCapability(BaseModel):
+    """Runtime availability of the optional embedding backend."""
+
+    available: bool
+    reason_unavailable: str | None = None
+
+
+class CoreContractIdentity(BaseModel):
+    """Product identity and public-contract compatibility information."""
+
+    name: Literal["rka-core"] = "rka-core"
+    version: str
+    contract: str
+    supported_contracts: list[str]
+
+
+class RestInterfaceCapability(BaseModel):
+    """Stable REST discovery entrypoint."""
+
+    status: Literal["stable"] = "stable"
+    contract: str
+    discovery: str = "/openapi.json"
+
+
+class McpInterfaceCapability(BaseModel):
+    """Stable MCP dispatch interface and operation-discovery summary."""
+
+    status: Literal["stable"] = "stable"
+    contract: str
+    discovery: str = "rka_describe"
+    operation_maturity_basis: Literal["usage-readiness"] = "usage-readiness"
+    default_operation_count: int = Field(ge=0)
+    usage_preview_operation_count: int = Field(ge=0)
+    deprecated_operation_count: int = Field(ge=0)
+
+
+class InterfaceCapabilities(BaseModel):
+    rest: RestInterfaceCapability
+    mcp: McpInterfaceCapability
+
+
+class CoreCapabilities(BaseModel):
+    """Versioned, additive discovery document returned by Core."""
+
+    schema_version: Literal["rka.core-capabilities/v1"] = "rka.core-capabilities/v1"
+    core: CoreContractIdentity
+    interfaces: InterfaceCapabilities
+    supported_capabilities: list[str]
+    available_capabilities: list[str]
+    embedding: EmbeddingCapability
+
+
+class CapabilityRequirementIssue(BaseModel):
+    """One unsatisfied capability or contract requirement."""
+
+    requirement: str
+    reason: str
+    status: Literal["unsupported", "unavailable"]
+
+
+class CapabilityNegotiationError(BaseModel):
+    """Actionable response for an unsupported client requirement set."""
+
+    error: Literal["unsupported_core_contract", "unsupported_capability_combination"]
+    message: str
+    core_version: str
+    requested_contract: str | None = None
+    required_capabilities: list[str]
+    supported_contracts: list[str]
+    supported_capabilities: list[str]
+    issues: list[CapabilityRequirementIssue]
+    hint: str

--- a/rka/services/capabilities.py
+++ b/rka/services/capabilities.py
@@ -1,0 +1,153 @@
+"""Build and validate the public RKA Core capability manifest."""
+
+from __future__ import annotations
+
+from rka import __version__
+from rka.mcp.operations_schema import (
+    DEPRECATED_OPERATIONS,
+    OPERATIONS_SCHEMA,
+    operation_maturity,
+)
+from rka.models.capabilities import (
+    CapabilityNegotiationError,
+    CapabilityRequirementIssue,
+    CoreCapabilities,
+    CoreContractIdentity,
+    EmbeddingCapability,
+    InterfaceCapabilities,
+    McpInterfaceCapability,
+    RestInterfaceCapability,
+)
+
+
+CAPABILITY_SCHEMA_VERSION = "rka.core-capabilities/v1"
+CORE_CONTRACT = "rka-core/v1"
+REST_CONTRACT = "rka-rest/v1"
+MCP_CONTRACT = "rka-mcp/v1"
+SUPPORTED_CORE_CONTRACTS = (CORE_CONTRACT,)
+SUPPORTED_CAPABILITIES = ("rest", "mcp", "embedding")
+
+
+def _operation_counts() -> dict[str, int]:
+    """Return mutually exclusive discovery counts.
+
+    ``operation_maturity`` remains the historical usage/readiness signal.
+    Explicit deprecation is an orthogonal contract signal and takes
+    precedence in this summary so the three counts add up to the full
+    operation registry.
+    """
+
+    counts = {"stable": 0, "preview": 0, "deprecated": 0}
+    for operation in OPERATIONS_SCHEMA:
+        if operation in DEPRECATED_OPERATIONS:
+            counts["deprecated"] += 1
+        else:
+            counts[operation_maturity(operation)] += 1
+    return counts
+
+
+def build_core_capabilities(
+    *, embedding_available: bool, embedding_reason: str | None
+) -> CoreCapabilities:
+    """Build the versioned discovery document without touching storage."""
+
+    counts = _operation_counts()
+    embedding = EmbeddingCapability(
+        available=embedding_available,
+        reason_unavailable=embedding_reason,
+    )
+    available = ["rest", "mcp"]
+    if embedding.available:
+        available.append("embedding")
+
+    return CoreCapabilities(
+        schema_version=CAPABILITY_SCHEMA_VERSION,
+        core=CoreContractIdentity(
+            version=__version__,
+            contract=CORE_CONTRACT,
+            supported_contracts=list(SUPPORTED_CORE_CONTRACTS),
+        ),
+        interfaces=InterfaceCapabilities(
+            rest=RestInterfaceCapability(contract=REST_CONTRACT),
+            mcp=McpInterfaceCapability(
+                contract=MCP_CONTRACT,
+                default_operation_count=counts["stable"],
+                usage_preview_operation_count=counts["preview"],
+                deprecated_operation_count=counts["deprecated"],
+            ),
+        ),
+        supported_capabilities=list(SUPPORTED_CAPABILITIES),
+        available_capabilities=available,
+        embedding=embedding,
+    )
+
+
+def validate_capability_requirements(
+    document: CoreCapabilities,
+    *,
+    required_contract: str | None,
+    required_capabilities: list[str] | None,
+) -> CapabilityNegotiationError | None:
+    """Return an actionable error when a client's requirements cannot be met."""
+
+    requirements = list(dict.fromkeys(required_capabilities or []))
+    issues: list[CapabilityRequirementIssue] = []
+
+    if required_contract and required_contract not in document.core.supported_contracts:
+        issues.append(
+            CapabilityRequirementIssue(
+                requirement=required_contract,
+                reason="The requested Core contract is not implemented by this server.",
+                status="unsupported",
+            )
+        )
+
+    supported = set(document.supported_capabilities)
+    available = set(document.available_capabilities)
+    for capability in requirements:
+        if capability not in supported:
+            issues.append(
+                CapabilityRequirementIssue(
+                    requirement=capability,
+                    reason="Unknown capability name for this discovery contract.",
+                    status="unsupported",
+                )
+            )
+        elif capability not in available:
+            reason = (
+                document.embedding.reason_unavailable
+                if capability == "embedding"
+                else "The capability is supported but unavailable in this runtime."
+            )
+            issues.append(
+                CapabilityRequirementIssue(
+                    requirement=capability,
+                    reason=reason or "The capability is unavailable.",
+                    status="unavailable",
+                )
+            )
+
+    if not issues:
+        return None
+
+    capability_issue_requirements = {issue.requirement for issue in issues} & set(
+        requirements
+    )
+    contract_only = bool(required_contract) and not capability_issue_requirements
+    error_code = (
+        "unsupported_core_contract" if contract_only else "unsupported_capability_combination"
+    )
+    return CapabilityNegotiationError(
+        error=error_code,
+        message="This RKA Core runtime cannot satisfy the requested contract/capabilities.",
+        core_version=document.core.version,
+        requested_contract=required_contract,
+        required_capabilities=requirements,
+        supported_contracts=document.core.supported_contracts,
+        supported_capabilities=document.supported_capabilities,
+        issues=issues,
+        hint=(
+            f"Use a client compatible with {CORE_CONTRACT}; remove unsupported "
+            "requirements or enable the unavailable runtime capability, then retry."
+        ),
+    )

--- a/tests/test_api/test_capabilities_route.py
+++ b/tests/test_api/test_capabilities_route.py
@@ -5,10 +5,11 @@ the endpoint. Mission D (v2.4.0 / mis_01KRNYPVB8N3HDMZ9HK9HM3TB0) is a
 BREAKING-IN-MINOR change: the `llm` field is removed entirely per PI
 directive jrn_01KRNZBS50K250HHHHEC58E4GC.
 
-Verified states (post-Mission-D):
-  - Response is exactly {"embedding": {available, reason_unavailable}}
+Verified states (E2.1, additive over Mission D):
+  - The embedding block remains {available, reason_unavailable}
+  - Core/interface versions and contract discovery are explicit
+  - Unsupported requirements return an actionable 409 response
   - `llm` field is ABSENT (not null, not {available: false} — gone)
-  - embedding block shape preserved per Mission B Affordance C
 """
 
 from __future__ import annotations
@@ -20,7 +21,9 @@ import pytest
 import pytest_asyncio
 
 from rka.api.app import create_app
+from rka import __version__
 from rka.config import RKAConfig
+from rka.mcp.operations_schema import DEPRECATED_OPERATIONS, OPERATIONS_SCHEMA
 
 
 @pytest_asyncio.fixture
@@ -49,16 +52,36 @@ async def api_client(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_capabilities_endpoint_returns_only_embedding(api_client: httpx.AsyncClient):
-    """Mission D BREAKING-IN-MINOR regression lock: `llm` is gone."""
+async def test_capabilities_endpoint_is_versioned_and_additive(api_client: httpx.AsyncClient):
     r = await api_client.get("/api/capabilities")
     assert r.status_code == 200
     body = r.json()
-    # Only `embedding` is allowed at the top level.
-    assert set(body.keys()) == {"embedding"}, (
-        f"capabilities response should contain only 'embedding' after Mission D; "
-        f"got keys: {sorted(body.keys())}"
+    assert set(body) >= {
+        "schema_version",
+        "core",
+        "interfaces",
+        "supported_capabilities",
+        "available_capabilities",
+        "embedding",
+    }
+    assert body["schema_version"] == "rka.core-capabilities/v1"
+    assert body["core"] == {
+        "name": "rka-core",
+        "version": __version__,
+        "contract": "rka-core/v1",
+        "supported_contracts": ["rka-core/v1"],
+    }
+    assert body["interfaces"]["rest"]["contract"] == "rka-rest/v1"
+    assert body["interfaces"]["mcp"]["contract"] == "rka-mcp/v1"
+    mcp = body["interfaces"]["mcp"]
+    assert mcp["operation_maturity_basis"] == "usage-readiness"
+    assert (
+        mcp["default_operation_count"]
+        + mcp["usage_preview_operation_count"]
+        + mcp["deprecated_operation_count"]
+        == len(OPERATIONS_SCHEMA)
     )
+    assert mcp["deprecated_operation_count"] == len(DEPRECATED_OPERATIONS)
 
 
 @pytest.mark.asyncio
@@ -98,3 +121,77 @@ async def test_capabilities_embedding_disabled_carries_reason(api_client: httpx.
     emb = body["embedding"]
     assert emb["available"] is False
     assert "disabled" in emb["reason_unavailable"].lower()
+
+
+@pytest.mark.asyncio
+async def test_supported_contract_and_capability_requirements_succeed(
+    api_client: httpx.AsyncClient,
+):
+    r = await api_client.get(
+        "/api/capabilities",
+        params=[
+            ("required_contract", "rka-core/v1"),
+            ("required_capability", "rest"),
+            ("required_capability", "mcp"),
+        ],
+    )
+    assert r.status_code == 200
+    assert r.json()["available_capabilities"] == ["rest", "mcp"]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_contract_is_actionable(api_client: httpx.AsyncClient):
+    r = await api_client.get(
+        "/api/capabilities",
+        params={"required_contract": "rka-core/v99"},
+    )
+    assert r.status_code == 409
+    body = r.json()
+    assert body["error"] == "unsupported_core_contract"
+    assert body["requested_contract"] == "rka-core/v99"
+    assert body["supported_contracts"] == ["rka-core/v1"]
+    assert body["issues"][0]["requirement"] == "rka-core/v99"
+    assert "rka-core/v1" in body["hint"]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_contract_with_satisfied_capability_keeps_contract_error(
+    api_client: httpx.AsyncClient,
+):
+    r = await api_client.get(
+        "/api/capabilities",
+        params=[
+            ("required_contract", "rka-core/v99"),
+            ("required_capability", "rest"),
+        ],
+    )
+    assert r.status_code == 409
+    body = r.json()
+    assert body["error"] == "unsupported_core_contract"
+    assert [issue["requirement"] for issue in body["issues"]] == ["rka-core/v99"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("required_capability", "status", "reason_fragment"),
+    [
+        ("embedding", "unavailable", "disabled"),
+        ("writer", "unsupported", "unknown capability"),
+    ],
+)
+async def test_unsupported_capability_combination_is_actionable(
+    api_client: httpx.AsyncClient,
+    required_capability: str,
+    status: str,
+    reason_fragment: str,
+):
+    r = await api_client.get(
+        "/api/capabilities",
+        params={"required_capability": required_capability},
+    )
+    assert r.status_code == 409
+    body = r.json()
+    assert body["error"] == "unsupported_capability_combination"
+    assert body["required_capabilities"] == [required_capability]
+    assert body["issues"][0]["status"] == status
+    assert reason_fragment in body["issues"][0]["reason"].lower()

--- a/tests/test_infra/test_version_consistency.py
+++ b/tests/test_infra/test_version_consistency.py
@@ -1,0 +1,14 @@
+"""Keep the source package and distribution product versions aligned."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+from rka import __version__
+
+
+def test_pyproject_version_matches_runtime_package() -> None:
+    root = Path(__file__).resolve().parents[2]
+    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert project["project"]["version"] == __version__

--- a/tests/test_mcp/test_capability_discovery.py
+++ b/tests/test_mcp/test_capability_discovery.py
@@ -1,0 +1,249 @@
+"""MCP parity tests for E2.1 Core capability discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rka import __version__
+from rka.api.app import create_app
+from rka.config import RKAConfig
+from rka.mcp.operation_args import QueryCapabilitiesArgs
+
+
+def _capability_document(*, core_version: str) -> dict:
+    return {
+        "schema_version": "rka.core-capabilities/v1",
+        "core": {
+            "name": "rka-core",
+            "version": core_version,
+            "contract": "rka-core/v1",
+            "supported_contracts": ["rka-core/v1"],
+        },
+        "interfaces": {
+            "rest": {
+                "status": "stable",
+                "contract": "rka-rest/v1",
+                "discovery": "/openapi.json",
+            },
+            "mcp": {
+                "status": "stable",
+                "contract": "rka-mcp/v1",
+                "discovery": "rka_describe",
+                "operation_maturity_basis": "usage-readiness",
+                "default_operation_count": 1,
+                "usage_preview_operation_count": 0,
+                "deprecated_operation_count": 0,
+            },
+        },
+        "supported_capabilities": ["rest", "mcp", "embedding"],
+        "available_capabilities": ["rest", "mcp"],
+        "embedding": {"available": False, "reason_unavailable": "disabled"},
+    }
+
+
+@pytest_asyncio.fixture
+async def capability_backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import rka.mcp.server as mcp_server
+
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path("capability_discovery.db"),
+        llm_enabled=False,
+        embeddings_enabled=False,
+    )
+    app = create_app(config)
+    lifespan = app.router.lifespan_context(app)
+    await lifespan.__aenter__()
+    try:
+
+        def fake_client(project_id: str | None = None) -> httpx.AsyncClient:
+            assert project_id is None
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            )
+
+        monkeypatch.setattr(mcp_server, "_client", fake_client)
+        yield mcp_server
+    finally:
+        await lifespan.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_capabilities_query_is_unscoped_and_reports_connector_backend(
+    capability_backend,
+):
+    body = json.loads(await capability_backend.rka_query(QueryCapabilitiesArgs()))
+    assert body["schema_version"] == "rka.core-capabilities/v1"
+    assert body["core"]["version"] == __version__
+    assert body["connector"] == {
+        "name": "rka-mcp",
+        "version": __version__,
+        "backend_version": __version__,
+        "version_match": True,
+        "compatible": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_capabilities_query_preserves_actionable_requirement_error(
+    capability_backend,
+):
+    body = json.loads(
+        await capability_backend.rka_query(QueryCapabilitiesArgs(required_contract="rka-core/v99"))
+    )
+    assert body["error"] == "unsupported_core_contract"
+    assert body["supported_contracts"] == ["rka-core/v1"]
+    assert body["connector"]["version"] == __version__
+    assert "rka-core/v1" in body["hint"]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_query_preserves_capability_requirement_error(
+    capability_backend,
+):
+    body = json.loads(
+        await capability_backend.rka_query(
+            QueryCapabilitiesArgs(required_capabilities=["embedding"])
+        )
+    )
+    assert body["error"] == "unsupported_capability_combination"
+    assert body["issues"][0]["status"] == "unavailable"
+    assert body["connector"]["compatible"] is True
+
+
+@pytest.mark.asyncio
+async def test_pre_e2_backend_returns_incompatible_backend(monkeypatch: pytest.MonkeyPatch):
+    import rka.mcp.server as mcp_server
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/capabilities"
+        return httpx.Response(
+            200,
+            json={
+                "embedding": {
+                    "available": False,
+                    "reason_unavailable": "legacy response",
+                }
+            },
+        )
+
+    def fake_client(project_id: str | None = None) -> httpx.AsyncClient:
+        assert project_id is None
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://legacy",
+        )
+
+    monkeypatch.setattr(mcp_server, "_client", fake_client)
+    body = json.loads(await mcp_server.rka_query(QueryCapabilitiesArgs()))
+    assert body["error"] == "incompatible_backend"
+    assert body["connector"]["version"] == __version__
+    assert body["observed_payload"]["embedding"]["reason_unavailable"] == ("legacy response")
+    assert "upgrade" in body["hint"].lower()
+
+
+@pytest.mark.asyncio
+async def test_version_skew_is_visible_but_contract_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import rka.mcp.server as mcp_server
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_capability_document(core_version="2.9.0"))
+
+    def fake_client(project_id: str | None = None) -> httpx.AsyncClient:
+        assert project_id is None
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://skewed",
+        )
+
+    monkeypatch.setattr(mcp_server, "_client", fake_client)
+    body = json.loads(await mcp_server.rka_query(QueryCapabilitiesArgs()))
+    assert body["connector"]["backend_version"] == "2.9.0"
+    assert body["connector"]["version_match"] is False
+    assert body["connector"]["compatible"] is True
+
+
+@pytest.mark.asyncio
+async def test_valid_manifest_without_required_contract_uses_uniform_error_shape(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import rka.mcp.server as mcp_server
+
+    manifest = _capability_document(core_version="4.0.0")
+    manifest["core"]["contract"] = "rka-core/v2"
+    manifest["core"]["supported_contracts"] = ["rka-core/v2"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=manifest)
+
+    def fake_client(project_id: str | None = None) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://future",
+        )
+
+    monkeypatch.setattr(mcp_server, "_client", fake_client)
+    body = json.loads(await mcp_server.rka_query(QueryCapabilitiesArgs()))
+    assert body["error"] == "incompatible_backend"
+    assert body["required_contract"] == "rka-core/v1"
+    assert body["connector"]["compatible"] is False
+    assert body["backend_capabilities"]["core"]["contract"] == "rka-core/v2"
+    assert "synchronize" in body["hint"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [404, 405])
+async def test_missing_capability_endpoint_is_actionable_incompatibility(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+):
+    import rka.mcp.server as mcp_server
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, text="not available")
+
+    def fake_client(project_id: str | None = None) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://legacy",
+        )
+
+    monkeypatch.setattr(mcp_server, "_client", fake_client)
+    body = json.loads(await mcp_server.rka_query(QueryCapabilitiesArgs()))
+    assert body["error"] == "incompatible_backend"
+    assert body["rest_status_code"] == status_code
+    assert "upgrade" in body["hint"].lower()
+
+
+@pytest.mark.asyncio
+async def test_unreachable_backend_returns_recovery_hint(monkeypatch: pytest.MonkeyPatch):
+    import rka.mcp.server as mcp_server
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    def fake_client(project_id: str | None = None) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://offline",
+        )
+
+    monkeypatch.setattr(mcp_server, "_client", fake_client)
+    body = json.loads(await mcp_server.rka_query(QueryCapabilitiesArgs()))
+    assert body["error"] == "backend_unavailable"
+    assert body["connector_version"] == __version__
+    assert "RKA_API_URL" in body["hint"]
+
+
+def test_mcp_initialize_identifies_the_rka_connector_version():
+    import rka.mcp.server as mcp_server
+
+    assert mcp_server.mcp._mcp_server.version == __version__

--- a/tests/test_mcp/test_v270_model_drift.py
+++ b/tests/test_mcp/test_v270_model_drift.py
@@ -238,7 +238,13 @@ def test_each_literal_field_uses_enums_alias(model: type[BaseModel]) -> None:
 # ----------------------------------------------------------------------
 
 
-_UNSCOPED_OPS = {"list_projects", "health", "create_project", "reset_session"}
+_UNSCOPED_OPS = {
+    "list_projects",
+    "capabilities",
+    "health",
+    "create_project",
+    "reset_session",
+}
 
 
 @pytest.mark.parametrize("model", _union_members(QueryArgsUnion) + _union_members(ExecuteArgsUnion))
@@ -426,7 +432,9 @@ def test_preview_operations_are_hidden_from_the_browse_index():
     full = json.loads(asyncio.run(dispatch_describe("", include_preview=True)))
 
     assert default["listed"] < default["total"]
-    assert default["preview_hidden"] == default["total"] - default["listed"]
+    assert default["preview_hidden"] + default["deprecated_hidden"] == (
+        default["total"] - default["listed"]
+    )
     assert full["listed"] == len(OPERATIONS_SCHEMA)
     # the hidden set must be discoverable, not silently dropped
     assert "include_preview" in default["preview_hint"]
@@ -468,3 +476,38 @@ def test_every_operation_is_classified():
 
     for op in OPERATIONS_SCHEMA:
         assert operation_maturity(op) in {"stable", "preview"}, op
+
+
+def test_explicit_deprecation_is_distinct_from_usage_maturity():
+    """A compatibility deprecation must be machine-readable without
+    pretending the historical usage-derived maturity axis is a contract."""
+    import asyncio
+    import json
+
+    from rka.mcp.operations_schema import (
+        DEPRECATED_OPERATIONS,
+        dispatch_describe,
+        operation_maturity,
+    )
+
+    assert set(DEPRECATED_OPERATIONS) == {"upsert_argument_spine"}
+    assert operation_maturity("upsert_argument_spine") == "preview"
+
+    exact = json.loads(asyncio.run(dispatch_describe("upsert_argument_spine")))
+    assert exact["deprecated"] is True
+    assert exact["deprecation"]["replacement_operations"] == [
+        "prepare_semantic_patch_context",
+        "create_semantic_patch_proposal",
+        "apply_semantic_patch_proposal",
+    ]
+
+    default = json.loads(asyncio.run(dispatch_describe("")))
+    assert "upsert_argument_spine" not in default["rka_execute"].split(", ")
+    assert default["deprecated_operations"] == ["upsert_argument_spine"]
+    assert default["deprecated_hidden"] == 1
+    assert (
+        default["listed"]
+        + default["preview_hidden"]
+        + default["deprecated_hidden"]
+        == default["total"]
+    )


### PR DESCRIPTION
## Summary
- publish an additive, versioned REST capability manifest for Core, REST, MCP, and embedding availability
- add unscoped MCP capability discovery without expanding the five-tool top-level surface
- report connector/backend version drift and uniform actionable incompatibility errors
- keep usage-readiness separate from explicit operation deprecation metadata
- document the public contract and lock package/runtime version consistency

## Verification
- 3,074 Core tests passed; 294 Writer/Agentic tests deselected by the Core gate
- 962 targeted API/MCP contract tests passed
- scoped Ruff and git diff checks passed
- clean wheel includes the capability modules, excludes Writer files, and passes migrations, REST, five-tool MCP, worker startup smoke
- independent audit findings were triaged and resolved

Closes #127