### PR TITLE
feat(core): deprecate legacy Writer surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to RKA are documented here. Format loosely follows
 
 - The Python distribution is named `rka-core` while retaining the stable
   `rka` import package and CLI.
+- The 43 Writer-owned manuscript, planning, semantic-patch, and historical
+  reference-validation MCP operations are now explicit deprecated
+  compatibility surfaces and are omitted from the default stable tool index.
+  Their 53 REST operations remain callable and are marked deprecated in
+  OpenAPI. New authoring work belongs in `rka-project/rka-writer`; no legacy
+  data, route, typed branch, or response payload is removed by this change.
 - Dockerless state now defaults consistently to `~/.rka/rka.db`, independent
   of the current working directory. The base wheel defaults optional
   embeddings off; the Docker/full profile enables them explicitly.

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ RKA Ecosystem project:
    provide version, capability, and compatibility discovery.
 3. **RKA Writer extraction** — move the Writer skill, manuscript semantics,
    academic-writing tools, and Workbench to `rka-project/rka-writer`.
-4. **Core 3.0 and ecosystem validation** — slim the Core distribution only
-   after legacy-state migration and downstream compatibility tests pass.
+4. **Future Core slimming and ecosystem validation** — slim the Core
+   distribution only in an explicitly approved breaking release, after
+   legacy-state migration and downstream compatibility tests pass.
 
 The earlier Agentic repository/extraction proposal is shelved. Its history is
 preserved, but it is not an active product, dependency, or installation path.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,7 @@ roadmap.
 | **E2** | **Stable external contract** | Freeze supported REST/MCP behavior and provide capability/version discovery plus legacy Writer export. | Public-contract-only clients complete core workflows and legacy Writer export round-trips. |
 | **E3** | **Agentic work shelved** | Preserve the historical branch and design record without creating or operating a separate Agentic product. | Active docs and packaging do not direct users to install Agentic; reactivation requires a new PI decision. |
 | **E4** | **Writer repository extraction** | Establish `rka-project/rka-writer`, migrate Writer state, and move Workbench ownership. | Writer runs independently, imports legacy state, and detects stale Core references. |
-| **E5** | **RKA Core 3.0** | Remove active Writer execution code from Core while preserving compatibility export and migration history. | Core and Writer compatibility suites pass without destructive database changes. |
+| **E5** | **Future Core slimming** | Remove active Writer execution code only in a future explicitly approved breaking release, while preserving compatibility export and migration history. | Core and Writer compatibility suites pass without destructive database changes. |
 | **E6** | **Ecosystem integration** | Maintain Core and Writer releases under one GitHub Project and compatibility matrix. | Core-only and Core+Writer deployments have reproducible smoke tests. |
 
 The detailed deliverables, rollback paths, and decision checkpoints for E0-E6

--- a/docs/TECHNICAL_REFERENCE.md
+++ b/docs/TECHNICAL_REFERENCE.md
@@ -77,6 +77,21 @@ when intentionally exploring preview or compatibility operations. This runtime
 description is authoritative and should be preferred over copied operation
 lists.
 
+### Legacy Writer compatibility
+
+The manuscript, planning, semantic-patch, and historical reference-validation
+operations retained in Core are frozen compatibility surfaces. They remain
+callable so existing projects can read, audit, and migrate legacy Writer state,
+but they are deprecated, omitted from the default stable MCP tool listings,
+and marked `deprecated: true` in OpenAPI. Calls also receive an out-of-band
+notice through MCP logging or the REST `X-RKA-Compatibility-Status`,
+`X-RKA-Removal-Milestone`, and `Link` headers; response bodies are unchanged.
+New manuscript and Workbench development belongs in
+[`rka-project/rka-writer`](https://github.com/rka-project/rka-writer).
+Removal is not part of E2.4: it is gated on E2.3 export verification, downstream
+readiness, the E5 slimming milestone, and a future explicitly approved breaking
+release. No removal version or date is currently scheduled.
+
 Project-scoped operations require an explicit `project_id`. `list_projects`,
 `capabilities`, `health`, `create_project`, and `reset_session` are intentionally
 unscoped.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -575,6 +575,14 @@ The Brain processes up to 10 maintenance items per session, prioritized by impor
 
 # Part V — Reference
 
+> **Legacy Writer compatibility:** Sections 15.3–15.4 describe frozen Core
+> interfaces retained so existing manuscript projects can be inspected and
+> migrated without data loss. They are not the path for new authoring work.
+> Install and develop against
+> [`rka-project/rka-writer`](https://github.com/rka-project/rka-writer) instead.
+> Core will keep these compatibility interfaces through E2; any later removal
+> requires verified export and an explicitly approved breaking release.
+
 ### 15.3 — Reviewing manuscript edit proposals
 
 Workbench edits do not change planning or manuscript state immediately. A
@@ -785,7 +793,7 @@ The web dashboard at `http://localhost:9712` provides a visual interface for bro
 | **Research Map** | `/research-map` | Three-level drill-down: RQs → clusters → claims |
 | **Interpretation Review** | `/interpretations` | Review source-located `icd_` candidates before canonical promotion |
 | **Claim Scope Review** | `/claim-scopes` | Append and audit canonical `csc_` applicability contracts; resolve manuscript scope blockers |
-| **Manuscript Workbench** | `/workbench` | Navigate canonical manuscript evidence and create, fork, select, compare, archive, or resume provisional planning branches |
+| **Manuscript Workbench (legacy compatibility)** | `/workbench` | Inspect and migrate existing Core-hosted manuscript state; use the separate `rka-writer` project for new authoring work |
 | **Notebook** | `/notebook` | (historical) Q&A chat and summary generation — the LLM-backed Q&A/summary features were removed in v2.4.0 |
 | **Audit Log** | `/audit` | System audit trail with action/entity/actor filters |
 | **Context Inspector** | `/context` | Generate and inspect context packages |

--- a/docs/adr/0012-rka-ecosystem-repository-boundaries.md
+++ b/docs/adr/0012-rka-ecosystem-repository-boundaries.md
@@ -165,7 +165,7 @@ The active milestone sequence is:
 3. E2 stable external contracts and legacy Writer export;
 4. E3 Agentic repository extraction;
 5. E4 Writer repository extraction and state migration;
-6. E5 Core 3.0 slimming;
+6. E5 future Core slimming in an explicitly approved breaking release;
 7. E6 ecosystem compatibility and integration validation.
 
 No repository extraction starts before E1 and E2 pass their exit gates.

--- a/docs/superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md
+++ b/docs/superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md
@@ -22,7 +22,7 @@ Recommended Project fields:
 
 | Field | Values |
 |---|---|
-| Ecosystem phase | E0 Boundary; E1 Core reliability; E2 Contract; E3 Agentic extraction; E4 Writer extraction; E5 Core 3.0; E6 Integration |
+| Ecosystem phase | E0 Boundary; E1 Core reliability; E2 Contract; E3 Agentic extraction; E4 Writer extraction; E5 Future Core slimming; E6 Integration |
 | Component | Core; Writer; Agentic; Integration |
 | Status | Backlog; Ready; In progress; Review; Blocked; Done |
 | Release gate | Not started; Partial; Passed |
@@ -57,7 +57,7 @@ Create after the documentation branch is reviewed:
 1. **E0 — Core boundary freeze**
 2. **E1 — Core reliability baseline**
 3. **E2 — Stable external contract**
-4. **E5 — RKA Core 3.0**
+4. **E5 — Future Core slimming**
 
 ### Future `infinitywings/rka-agentic`
 
@@ -283,7 +283,8 @@ Acceptance:
 - manuscript/Workbench operations are hidden from the default stable index;
 - documentation points new development to Writer;
 - existing callers receive a compatibility notice rather than data loss;
-- removal is deferred to E5/Core 3.0.
+- removal is deferred to E5 and a future explicitly approved breaking release;
+  the already-released Core 3.0.0 does not remove these surfaces.
 
 Labels: `roadmap`, `area: core`, `breaking-change`.
 
@@ -308,7 +309,7 @@ Create these in the RKA Ecosystem Project now and move them into
 4. Move Workbench services, UI, source synchronization, and provider adapters.
 5. Pass real-project claim-to-draft and stale-reference tests.
 
-### E5 — RKA Core 3.0
+### E5 — Future Core slimming
 
 #### E5.1 Remove active Writer and Agentic code from Core
 
@@ -333,7 +334,7 @@ Acceptance:
 
 Labels: `roadmap`, `area: integration`, `breaking-change`.
 
-#### E5.3 Publish the Core 3.0 migration and recovery guide
+#### E5.3 Publish the future Core migration and recovery guide
 
 Acceptance:
 

--- a/docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md
+++ b/docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md
@@ -236,7 +236,7 @@ Exit gate:
 Rollback: switch back to the legacy Core Writer surface; do not delete either
 copy until the compatibility window ends.
 
-### E5: Core 3.0 slimming
+### E5: Future Core slimming
 
 Scope:
 
@@ -254,8 +254,9 @@ Exit gate:
 - Writer and Agentic compatibility suites pass against the release candidate;
 - existing databases open without destructive schema changes.
 
-Rollback: remain on the final 2.x compatibility release. Core 3.0 is not
-published until downstream suites pass.
+Rollback: remain on the current compatibility release. No future breaking
+release is scheduled until downstream suites pass and removal is explicitly
+approved.
 
 ### E6: Ecosystem integration and release discipline
 
@@ -281,7 +282,8 @@ Exit gate:
    Writer export.
 2. RKA Agentic 1.0: public-contract-only orchestrator.
 3. RKA Writer 1.0: public-contract-only Writer and verified legacy import.
-4. RKA Core 3.0: active optional-layer code removed after downstream gates.
+4. Future Core breaking release: active optional-layer code removed only after
+   downstream gates and explicit approval.
 
 The releases are independent. Each downstream repository publishes the Core
 major versions it supports.
@@ -325,7 +327,7 @@ Do not start today:
 - remote repository creation;
 - live Writer-state migration;
 - deletion of manuscript tables or routes;
-- Core 3.0 removal work;
+- future Core removal work;
 - installed plugin/runtime replacement;
 - merging unrelated dirty-root changes.
 
@@ -336,5 +338,5 @@ Human confirmation is required before:
 - creating the two new GitHub repositories;
 - switching legacy manuscript authority from Core to Writer;
 - running a long live re-embedding or irreversible data migration;
-- publishing RKA Core 3.0;
+- publishing a future Core breaking release;
 - deleting any legacy branch, table, compatibility code, or remote artifact.

--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -62,6 +62,23 @@ from rka.services.search import SearchService
 
 logger = logging.getLogger(__name__)
 
+_WRITER_COMPATIBILITY_PATH_PREFIXES = (
+    "/api/manuscripts",
+    "/api/manuscript-source-proposals",
+    "/api/planning",
+    "/api/semantic-patches",
+)
+_WRITER_MIGRATION_TARGET = "https://github.com/rka-project/rka-writer"
+
+
+def _is_writer_compatibility_path(path: str) -> bool:
+    """Return whether one REST path belongs to frozen Writer compatibility."""
+
+    return any(
+        path == prefix or path.startswith(f"{prefix}/")
+        for prefix in _WRITER_COMPATIBILITY_PATH_PREFIXES
+    )
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -298,6 +315,19 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
             },
         )
 
+    @app.middleware("http")
+    async def writer_compatibility_notice(request: Request, call_next):
+        """Add an out-of-band notice without changing legacy response bodies."""
+
+        response = await call_next(request)
+        if _is_writer_compatibility_path(request.url.path):
+            response.headers["X-RKA-Compatibility-Status"] = "deprecated"
+            response.headers["X-RKA-Removal-Milestone"] = "E5"
+            response.headers["Link"] = (
+                f"<{_WRITER_MIGRATION_TARGET}>; rel=\"successor-version\""
+            )
+        return response
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=[
@@ -307,6 +337,11 @@ def create_app(config: RKAConfig | None = None) -> FastAPI:
         ],
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=[
+            "X-RKA-Compatibility-Status",
+            "X-RKA-Removal-Milestone",
+            "Link",
+        ],
     )
 
     app.include_router(project_routes.router, prefix="/api", tags=["project"])

--- a/rka/api/routes/changes.py
+++ b/rka/api/routes/changes.py
@@ -35,7 +35,7 @@ async def changes_since(
     return await service.changes_since(cursor, limit=limit)
 
 
-@router.get("/manuscripts/{manuscript_id}/impact")
+@router.get("/manuscripts/{manuscript_id}/impact", deprecated=True)
 async def get_manuscript_impact(
     manuscript_id: str,
     service: Annotated[

--- a/rka/api/routes/manuscript_sources.py
+++ b/rka/api/routes/manuscript_sources.py
@@ -19,7 +19,7 @@ from rka.services.manuscript_source import (
 )
 
 
-router = APIRouter()
+router = APIRouter(deprecated=True)
 
 
 def _require_web_actor(actor: str) -> None:

--- a/rka/api/routes/manuscripts.py
+++ b/rka/api/routes/manuscripts.py
@@ -50,7 +50,7 @@ from rka.services.semantic_patch import (
     SemanticPatchService,
 )
 
-router = APIRouter()
+router = APIRouter(deprecated=True)
 
 
 # Small transport-only request wrappers stay next to the routes; native domain

--- a/rka/api/routes/planning.py
+++ b/rka/api/routes/planning.py
@@ -25,7 +25,7 @@ from rka.services.planning import (
 )
 
 
-router = APIRouter()
+router = APIRouter(deprecated=True)
 
 
 def _raise_planning_error(exc: Exception) -> None:

--- a/rka/api/routes/semantic_patches.py
+++ b/rka/api/routes/semantic_patches.py
@@ -29,7 +29,7 @@ from rka.services.semantic_patch import (
 )
 
 
-router = APIRouter()
+router = APIRouter(deprecated=True)
 
 
 def _raise_error(exc: Exception) -> None:

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -5595,21 +5595,66 @@ PREVIEW_OPERATIONS: frozenset[str] = frozenset({
 
 # Explicit operation deprecations are a public compatibility signal, not a
 # proxy for production usage. Keep them separate from ``operation_maturity``:
-# one operation can be both usage-preview and deprecated. Broader frozen
-# Writer/Workbench compatibility classification belongs to E2.4.
-DEPRECATED_OPERATIONS: dict[str, dict[str, Any]] = {
-    "upsert_argument_spine": {
+# one operation can be both usage-preview and deprecated.
+#
+# E2.4 freezes the still-present Writer/Workbench branches as compatibility
+# adapters. They remain callable so existing projects can read, audit, and
+# migrate legacy state, but new authoring work belongs in the standalone Writer
+# project. Derive the set from the ownership categories so a future operation
+# cannot accidentally look like a supported Core feature merely because a
+# developer forgot to add it to another hand-maintained list. The exact current
+# membership is locked in tests.
+WRITER_COMPATIBILITY_CATEGORIES: frozenset[str] = frozenset({
+    "manuscript",
+    "manuscript_planning",
+    "semantic_patches",
+})
+WRITER_COMPATIBILITY_OPERATIONS: frozenset[str] = frozenset(
+    op_name
+    for op_name, entry in OPERATIONS_SCHEMA.items()
+    if entry.get("category") in WRITER_COMPATIBILITY_CATEGORIES
+    or op_name == "reference_validation_status"
+)
+
+
+def _writer_compatibility_deprecation() -> dict[str, Any]:
+    """Return fresh metadata for one frozen Writer compatibility operation."""
+
+    return {
+        "status": "deprecated_compatibility",
         "reason": (
-            "Agent-direct argument-spine replacement is disabled; use an "
-            "attributed semantic proposal and separate PI/web apply transition."
+            "This manuscript/Workbench operation is retained only for legacy "
+            "RKA Core compatibility, audit, and migration. New authoring "
+            "development belongs in the standalone RKA Writer project."
+        ),
+        "owner": "rka-writer",
+        "migration_target": "https://github.com/rka-project/rka-writer",
+        "migration_issue": "https://github.com/rka-project/rka-core/issues/129",
+        "compatibility": "behavior_preserved",
+        "removal_milestone": "E5",
+        "removal_version": "not_scheduled",
+    }
+
+
+DEPRECATED_OPERATIONS: dict[str, dict[str, Any]] = {
+    op_name: _writer_compatibility_deprecation()
+    for op_name in WRITER_COMPATIBILITY_OPERATIONS
+}
+DEPRECATED_OPERATIONS["upsert_argument_spine"].update(
+    {
+        "reason": (
+            "Agent-direct argument-spine replacement is disabled. Existing "
+            "Core callers may use the attributed semantic-proposal transition "
+            "during the compatibility window; new authoring development "
+            "belongs in the standalone RKA Writer project."
         ),
         "replacement_operations": [
             "prepare_semantic_patch_context",
             "create_semantic_patch_proposal",
             "apply_semantic_patch_proposal",
         ],
-    },
-}
+    }
+)
 
 
 def operation_maturity(op_name: str) -> str:
@@ -5695,11 +5740,13 @@ async def dispatch_describe(
             "rka_execute": ", ".join(compact.get("rka_execute", [])),
             "listed": listed,
             "total": len(OPERATIONS_SCHEMA),
+            # Preserve the pre-E2.4 discovery field for existing callers.
+            # Deprecated names are separate from the stable tool indexes.
+            "deprecated_operations": sorted(DEPRECATED_OPERATIONS),
             "hint": (
                 "rka_describe('<op>') for schema; rka_query/_execute "
                 "inputSchema already carries per-branch enums."
             ),
-            "deprecated_operations": sorted(DEPRECATED_OPERATIONS),
         }
         if not include_preview:
             preview_hidden = sum(
@@ -5709,12 +5756,16 @@ async def dispatch_describe(
             )
             payload["preview_hidden"] = preview_hidden
             payload["preview_hint"] = (
-                f"{preview_hidden} preview operations are omitted — subsystems with no "
-                "production data yet (manuscript, planning, experiments, "
-                "semantic-patches, hooks, interpretation staging, claim scope). "
-                "Pass include_preview=True to see them."
+                f"{preview_hidden} usage-preview operations are omitted "
+                "(experiments, hooks, interpretation staging, claim scope, "
+                "and the summary stub). Pass include_preview=True to see them."
             )
             payload["deprecated_hidden"] = len(DEPRECATED_OPERATIONS)
+            payload["deprecated_hint"] = (
+                f"{len(DEPRECATED_OPERATIONS)} frozen Writer compatibility "
+                "operations are omitted from the stable tool indexes and "
+                "listed separately. Use exact describe for migration guidance."
+            )
         return json.dumps(payload, indent=2)
 
     op = operation.strip()
@@ -5749,6 +5800,8 @@ __all__ = [
     "DEPRECATED_OPERATIONS",
     "PREVIEW_CATEGORIES",
     "PREVIEW_OPERATIONS",
+    "WRITER_COMPATIBILITY_CATEGORIES",
+    "WRITER_COMPATIBILITY_OPERATIONS",
     "dispatch_describe",
     "operation_maturity",
     "operation_deprecation",

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -7708,8 +7708,43 @@ def _timeout_error(exc: httpx.TimeoutException) -> str:
     }, indent=2)
 
 
+async def _warn_if_deprecated_operation(
+    args: object,
+    ctx: _MCPContext | None,
+) -> None:
+    """Send a compatibility notice without changing a tool result payload."""
+
+    if ctx is None:
+        return
+    operation = getattr(args, "operation", None)
+    if not isinstance(operation, str):
+        return
+
+    from rka.mcp.operations_schema import operation_deprecation
+
+    notice = operation_deprecation(operation)
+    if notice is None:
+        return
+    await ctx.warning(json.dumps({
+        "event": "rka.compatibility.deprecated_operation",
+        "message": (
+            f"RKA Core compatibility notice: '{operation}' is deprecated. "
+            "Its current behavior is preserved for legacy audit and migration; "
+            "use the standalone RKA Writer project for new authoring work."
+        ),
+        "operation": operation,
+        "owner": notice.get("owner"),
+        "migration_target": notice.get("migration_target"),
+        "removal_milestone": notice.get("removal_milestone"),
+        "removal_version": notice.get("removal_version"),
+    }, sort_keys=True))
+
+
 @tool(tier=_TIER_ALWAYS_ON, category="dispatch", always_load=True)
-async def rka_query(args: _QueryArgsUnion) -> str:
+async def rka_query(
+    args: _QueryArgsUnion,
+    ctx: _MCPContext = None,  # type: ignore[assignment]
+) -> str:
     """[ANY] READ from the project knowledge base. ALL reads flow through this verb.
 
     v2.7.0 NO-COMPROMISE typed-arg surface. The ``args`` parameter is a
@@ -7722,11 +7757,14 @@ async def rka_query(args: _QueryArgsUnion) -> str:
     Trigger phrases: "what's the status", "what's blocked", "search for",
     "show me decisions", "list literature", "fetch entity", "context",
     "research map", "decision tree", "ego graph", "trace provenance",
-    "multi-hop", "claims", "clusters", "resolve entities", "manuscript
-    context", "manuscript readiness", "manuscript spine", "changes since",
-    "what changed", "manuscript impact", "reference validation status",
-    "review queue", "open checkpoints", "pending maintenance",
+    "multi-hop", "claims", "clusters", "resolve entities", "changes since",
+    "what changed", "review queue", "open checkpoints", "pending maintenance",
     "list projects", "capability discovery", "health check".
+
+    Frozen Writer/Workbench compatibility branches remain callable but are not
+    part of Core's default operation index. Use ``rka_describe('<operation>')``
+    for their migration notice; use the standalone RKA Writer project for new
+    authoring development.
 
     Args:
         args: One of the typed ``Query*Args`` models from
@@ -7744,6 +7782,7 @@ async def rka_query(args: _QueryArgsUnion) -> str:
     of v2.7.0 compromise #3) or ``rka_describe('<op_name>')`` for
     full per-operation schema + examples.
     """
+    await _warn_if_deprecated_operation(args, ctx)
     try:
         return await _dispatch_query_typed(args)
     except httpx.TimeoutException as exc:
@@ -9207,7 +9246,10 @@ ExecuteOpLit = _Literal[tuple(_EXECUTE_OPERATIONS)]  # type: ignore[valid-type]
 
 
 @tool(tier=_TIER_ALWAYS_ON, category="dispatch", always_load=True)
-async def rka_execute(args: _ExecuteArgsUnion) -> str:
+async def rka_execute(
+    args: _ExecuteArgsUnion,
+    ctx: _MCPContext = None,  # type: ignore[assignment]
+) -> str:
     """[BRAIN/EXECUTOR/PI] WRITE / lifecycle operations on RKA. ALL writes flow through this verb.
 
     v2.7.0 NO-COMPROMISE typed-arg surface. The ``args`` parameter is a
@@ -9235,10 +9277,15 @@ async def rka_execute(args: _ExecuteArgsUnion) -> str:
     "extract claims", "create cluster", "merge clusters",
     "resolve contradiction", "flag stale", "evict knowledge",
     "scan workspace", "bootstrap workspace", "create project",
-    "reset session", "register manuscript", "update mission status",
+    "reset session", "update mission status",
     "submit report", "advance RQ", "record PI selection",
     "record outcome", "present decision", "add hook", "enable hook",
     "clear notifications".
+
+    Frozen Writer/Workbench compatibility branches remain callable but are not
+    part of Core's default operation index. Use ``rka_describe('<operation>')``
+    for their migration notice; use the standalone RKA Writer project for new
+    authoring development.
 
     Args:
         args: One of the typed ``*Args`` models from
@@ -9258,6 +9305,7 @@ async def rka_execute(args: _ExecuteArgsUnion) -> str:
     of v2.7.0 compromise #3) or ``rka_describe('<op_name>')`` for
     full per-operation schema + examples.
     """
+    await _warn_if_deprecated_operation(args, ctx)
     try:
         return await _dispatch_execute_typed(args)
     except httpx.TimeoutException as exc:

--- a/tests/test_api/test_writer_compatibility_deprecation.py
+++ b/tests/test_api/test_writer_compatibility_deprecation.py
@@ -1,0 +1,100 @@
+"""E2.4 contract tests for frozen Writer REST compatibility surfaces."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from rka.api.app import create_app
+
+
+HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+WRITER_PATH_PREFIXES = (
+    "/api/manuscripts",
+    "/api/manuscript-source-proposals",
+    "/api/planning",
+    "/api/semantic-patches",
+)
+
+
+def _path_operations(schema: dict, path: str) -> list[dict]:
+    return [
+        operation
+        for method, operation in schema["paths"][path].items()
+        if method in HTTP_METHODS
+    ]
+
+
+def test_writer_routes_are_deprecated_but_remain_in_openapi() -> None:
+    schema = create_app().openapi()
+    writer_operations = [
+        operation
+        for path, path_item in schema["paths"].items()
+        if path.startswith(WRITER_PATH_PREFIXES)
+        for method, operation in path_item.items()
+        if method in HTTP_METHODS
+    ]
+
+    assert len(writer_operations) == 53
+    assert all(operation.get("deprecated") is True for operation in writer_operations)
+
+
+def test_mixed_changes_router_keeps_core_cursor_stable() -> None:
+    schema = create_app().openapi()
+
+    core_changes = _path_operations(schema, "/api/changes")
+    writer_impact = _path_operations(
+        schema,
+        "/api/manuscripts/{manuscript_id}/impact",
+    )
+
+    assert len(core_changes) == 1
+    assert core_changes[0].get("deprecated") is not True
+    assert len(writer_impact) == 1
+    assert writer_impact[0]["deprecated"] is True
+
+
+def test_representative_core_routes_are_not_deprecated() -> None:
+    schema = create_app().openapi()
+
+    for path in ("/api/capabilities", "/api/projects", "/api/claims"):
+        operations = _path_operations(schema, path)
+        assert operations, path
+        assert all(operation.get("deprecated") is not True for operation in operations)
+
+
+@pytest.mark.asyncio
+async def test_writer_call_gets_headers_without_body_wrapping() -> None:
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get(
+            "/api/semantic-patches/schema",
+            headers={"Origin": "http://localhost:5173"},
+        )
+        core_response = await client.get("/openapi.json")
+
+    assert response.status_code == 200
+    assert response.headers["X-RKA-Compatibility-Status"] == "deprecated"
+    assert response.headers["X-RKA-Removal-Milestone"] == "E5"
+    assert "rka-project/rka-writer" in response.headers["Link"]
+    exposed = response.headers["Access-Control-Expose-Headers"].lower()
+    assert "x-rka-compatibility-status" in exposed
+    assert "x-rka-removal-milestone" in exposed
+    assert "link" in exposed
+    assert isinstance(response.json(), dict)
+    assert "compatibility_notice" not in response.json()
+
+    assert core_response.status_code == 200
+    assert "X-RKA-Compatibility-Status" not in core_response.headers
+
+
+def test_writer_path_matching_requires_a_complete_prefix_segment() -> None:
+    from rka.api.app import _is_writer_compatibility_path
+
+    assert _is_writer_compatibility_path("/api/manuscripts") is True
+    assert _is_writer_compatibility_path("/api/manuscripts/man_legacy") is True
+    assert _is_writer_compatibility_path("/api/manuscripts-core") is False

--- a/tests/test_mcp/test_v270_model_drift.py
+++ b/tests/test_mcp/test_v270_model_drift.py
@@ -486,12 +486,36 @@ def test_explicit_deprecation_is_distinct_from_usage_maturity():
 
     from rka.mcp.operations_schema import (
         DEPRECATED_OPERATIONS,
+        OPERATIONS_SCHEMA,
+        WRITER_COMPATIBILITY_CATEGORIES,
+        WRITER_COMPATIBILITY_OPERATIONS,
         dispatch_describe,
         operation_maturity,
     )
 
-    assert set(DEPRECATED_OPERATIONS) == {"upsert_argument_spine"}
+    expected_writer_operations = {
+        op_name
+        for op_name, entry in OPERATIONS_SCHEMA.items()
+        if entry["category"] in WRITER_COMPATIBILITY_CATEGORIES
+        or op_name == "reference_validation_status"
+    }
+    assert WRITER_COMPATIBILITY_OPERATIONS == expected_writer_operations
+    assert len(WRITER_COMPATIBILITY_OPERATIONS) == 43
+    assert set(DEPRECATED_OPERATIONS) == WRITER_COMPATIBILITY_OPERATIONS
+    assert set(DEPRECATED_OPERATIONS) <= set(OPERATIONS_SCHEMA)
     assert operation_maturity("upsert_argument_spine") == "preview"
+    assert operation_maturity("reference_validation_status") == "stable"
+
+    for operation in WRITER_COMPATIBILITY_OPERATIONS:
+        notice = DEPRECATED_OPERATIONS[operation]
+        assert notice["status"] == "deprecated_compatibility"
+        assert notice["owner"] == "rka-writer"
+        assert notice["compatibility"] == "behavior_preserved"
+        assert notice["removal_milestone"] == "E5"
+        assert notice["removal_version"] == "not_scheduled"
+        assert notice["migration_target"] == (
+            "https://github.com/rka-project/rka-writer"
+        )
 
     exact = json.loads(asyncio.run(dispatch_describe("upsert_argument_spine")))
     assert exact["deprecated"] is True
@@ -502,9 +526,24 @@ def test_explicit_deprecation_is_distinct_from_usage_maturity():
     ]
 
     default = json.loads(asyncio.run(dispatch_describe("")))
-    assert "upsert_argument_spine" not in default["rka_execute"].split(", ")
-    assert default["deprecated_operations"] == ["upsert_argument_spine"]
-    assert default["deprecated_hidden"] == 1
+    full = json.loads(asyncio.run(dispatch_describe("", include_preview=True)))
+    default_operations = set(default["rka_query"].split(", ")) | set(
+        default["rka_execute"].split(", ")
+    )
+    full_operations = set(full["rka_query"].split(", ")) | set(
+        full["rka_execute"].split(", ")
+    )
+    assert WRITER_COMPATIBILITY_OPERATIONS.isdisjoint(default_operations)
+    assert WRITER_COMPATIBILITY_OPERATIONS <= full_operations
+    assert default["deprecated_operations"] == sorted(
+        WRITER_COMPATIBILITY_OPERATIONS
+    )
+    assert full["deprecated_operations"] == sorted(
+        WRITER_COMPATIBILITY_OPERATIONS
+    )
+    assert default["deprecated_hidden"] == 43
+    assert "rka-writer" in exact["deprecation"]["migration_target"]
+    assert "Writer compatibility" in default["deprecated_hint"]
     assert (
         default["listed"]
         + default["preview_hidden"]

--- a/tests/test_mcp/test_writer_compatibility_deprecation.py
+++ b/tests/test_mcp/test_writer_compatibility_deprecation.py
@@ -1,0 +1,91 @@
+"""Runtime compatibility notices for frozen Writer MCP operations."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rka.mcp.operation_args import (
+    CreateManuscriptArgs,
+    QueryManuscriptArgs,
+    QueryStatusArgs,
+)
+
+
+class WarningContext:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def warning(self, message: str) -> None:
+        self.calls.append(message)
+
+
+@pytest.mark.asyncio
+async def test_deprecated_query_warns_without_changing_payload(monkeypatch) -> None:
+    import rka.mcp.server as mcp_server
+
+    expected = '[{"id": "man_legacy"}]'
+    dispatch = AsyncMock(return_value=expected)
+    monkeypatch.setattr(mcp_server, "_dispatch_query_typed", dispatch)
+    context = WarningContext()
+
+    result = await mcp_server.rka_query(
+        QueryManuscriptArgs(project_id="prj_test", id="man_legacy"),
+        ctx=context,
+    )
+
+    assert result == expected
+    assert len(context.calls) == 1
+    metadata = json.loads(context.calls[0])
+    assert "deprecated" in metadata["message"]
+    assert metadata["operation"] == "manuscript"
+    assert metadata["owner"] == "rka-writer"
+    assert metadata["removal_version"] == "not_scheduled"
+
+
+@pytest.mark.asyncio
+async def test_deprecated_write_warns_without_changing_payload(monkeypatch) -> None:
+    import rka.mcp.server as mcp_server
+
+    expected = '{"id": "man_new", "revision": 1}'
+    dispatch = AsyncMock(return_value=expected)
+    monkeypatch.setattr(mcp_server, "_dispatch_execute_typed", dispatch)
+    context = WarningContext()
+
+    result = await mcp_server.rka_execute(
+        CreateManuscriptArgs(project_id="prj_test", title="Legacy manuscript"),
+        ctx=context,
+    )
+
+    assert result == expected
+    assert len(context.calls) == 1
+    assert json.loads(context.calls[0])["operation"] == "create_manuscript"
+
+
+@pytest.mark.asyncio
+async def test_core_query_does_not_warn(monkeypatch) -> None:
+    import rka.mcp.server as mcp_server
+
+    dispatch = AsyncMock(return_value='{"phase": "execution"}')
+    monkeypatch.setattr(mcp_server, "_dispatch_query_typed", dispatch)
+    context = WarningContext()
+
+    await mcp_server.rka_query(
+        QueryStatusArgs(project_id="prj_test"),
+        ctx=context,
+    )
+
+    assert context.calls == []
+
+
+def test_context_injection_does_not_expand_public_tool_schema() -> None:
+    import rka.mcp.server as mcp_server
+
+    tools = {tool.name: tool for tool in mcp_server.mcp._tool_manager.list_tools()}
+
+    for name in ("rka_query", "rka_execute"):
+        properties = tools[name].parameters["properties"]
+        assert set(properties) == {"args"}
+        assert "ctx" not in properties


### PR DESCRIPTION
## Summary

- classify all 43 live Writer MCP operations as deprecated compatibility surfaces while retaining callability and the legacy discovery field
- mark all 53 Writer REST operations deprecated in OpenAPI and add out-of-band REST and MCP migration notices without changing response payloads
- direct new authoring work to rka-project/rka-writer and correct the E5 roadmap to an unscheduled future approved breaking release

## Verification

- 3,083 Core tests passed; 294 Writer and Agentic tests intentionally deselected
- 945 focused E2.4 and capability tests passed
- 72 legacy Writer compatibility tests passed
- production web build and Core startup smoke passed
- scoped Ruff and git diff check passed
- three independent read-only audits found no remaining blocker

Closes #130