### PR TITLE
feat(embeddings): enforce portable vector-space contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,23 @@ release boundaries are recorded in
 The roadmap is ordered by dependency, not by invented delivery dates. Every
 milestone must satisfy its exit gate before dependent work is treated as ready.
 
+Portable installation and managed model lifecycle belong to the separate
+future `rka-app`, not to a Core branch. Core's provider and vector-space side of
+that boundary is recorded in
+[ADR 0017](docs/adr/0017-portable-embedding-runtime-boundary.md). The Qwen
+standard-profile candidate remains gated by retrieval quality and real 16 GB
+Mac/Windows measurements; it is not yet a Core or App release default.
+The immediate external follow-up is a small `rka-app` sidecar prototype plus a
+frozen two-machine retrieval/hardware evaluation; those tasks consume Core's
+contract but do not extend the E0-E6 Core milestone hierarchy.
+
+One bounded Core follow-up remains separate from the portable-runtime work:
+make explicit/manual embedding repair compare canonical content hashes and
+vector presence, rather than repairing only missing current-model metadata.
+Until then, failed edit embeddings remain owned by the durable worker retry
+path; the backfill endpoint must not be described as a general stale-index
+scrubber.
+
 ## Current strategic priority
 
 RKA Core reliability comes first. No new Writer/Workbench or autonomous

--- a/contracts/rka-rest-v1.openapi.json
+++ b/contracts/rka-rest-v1.openapi.json
@@ -2646,6 +2646,14 @@
                 "type": "null"
               }
             ]
+          },
+          "search_mode": {
+            "default": "lexical",
+            "enum": [
+              "hybrid",
+              "lexical"
+            ],
+            "type": "string"
           }
         },
         "required": [

--- a/docs/adr/0017-portable-embedding-runtime-boundary.md
+++ b/docs/adr/0017-portable-embedding-runtime-boundary.md
@@ -1,0 +1,152 @@
+# ADR 0017: Portable embedding runtime and vector-space boundary
+
+Status: Accepted for staged implementation
+
+## Context
+
+RKA needs useful semantic retrieval on an ordinary research computer without
+requiring LM Studio, Docker, a discrete GPU, or manual MCP configuration. The
+minimum product target is a 16 GB Apple M1 Mac or a 16 GB Windows machine with
+an Intel Core Ultra 7 155H-class processor. Core must remain usable when the
+embedding runtime is unavailable.
+
+RKA already supports OpenAI-compatible embedding endpoints, flexible
+sqlite-vec dimensions, full backfill, and lexical retrieval. It does not need a
+model-specific backend. It did need two missing contracts: query/document input
+adaptation and an identity that prevents incompatible vectors from sharing an
+index.
+
+## Decision
+
+### Ownership
+
+`rka-core` owns the embedding provider contract, vector-space identity,
+sqlite-vec index, re-index behavior, and lexical degradation. It does not
+download models, bundle inference binaries, select a GPU, or supervise a model
+process.
+
+The separate future `rka-app` owns the portable runtime: downloading and
+hash-verifying a pinned model, installing a pinned `llama-server`, selecting a
+tested Metal/Vulkan/CPU path, lifecycle and readiness, loopback ports, logs,
+upgrades, and rollback. This follows ADR 0014; there is no permanent App branch
+inside Core.
+
+### Standard-profile candidate
+
+The standard App profile candidate is the official
+[`Qwen3-Embedding-0.6B` Q8_0 GGUF](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF):
+
+- 1024 output dimensions;
+- a 639 MB Q8_0 artifact;
+- a pinned `llama-server` started with embedding mode, last-token pooling,
+  and L2 normalization (`--pooling last --embd-normalize 2`);
+- an operational input cap of 4096 tokens for the first release;
+- one concurrent embedding slot and small ingestion batches initially;
+- CPU as the baseline path to validate on both target machines; Metal or
+  Windows acceleration is enabled only after a startup smoke test.
+
+The model is a **candidate**, not yet the released default. It becomes the App
+default only after the A/B and two-machine gates below pass. Core's existing
+first-run FastEmbed configuration remains unchanged, and existing installations
+are never silently migrated.
+
+### Core configuration contract
+
+The App configures Core through the existing `openai_compat` backend:
+
+```json
+{
+  "backend": "openai_compat",
+  "config": {
+    "base_url": "http://127.0.0.1:9714",
+    "model": "rka-qwen3-embedding-0.6b-q8_0",
+    "dim": 1024,
+    "embedding_space_id": "rka-space-v1:sha256=<gguf-sha256>;quant=q8_0;tokenizer=<config-sha256>;eos=<policy>;pool=last;norm=l2;truncate=4096;doc=raw-v1;dim=1024;runtime=<llama-revision>",
+    "query_template": "Instruct: Given a research-memory query, retrieve records needed to reconstruct the relevant evidence, decisions, and research context.\nQuery: {text}",
+    "document_template": "{text}"
+  }
+}
+```
+
+`model` is the transport alias sent to `/v1/embeddings`.
+`embedding_space_id` is an opaque, App-generated identity stored in embedding
+metadata. It must change when model bytes, quantization, dimensions, pooling,
+normalization, tokenizer/config revision, EOS behavior, truncation/context cap,
+document encoding/template revision, or pinned runtime revision changes. Core
+does not guess an artifact hash or interpret the fields inside this ID.
+
+Embedding configuration mutation has one active API-writer process. The App
+must not run rolling multi-process PUTs against the same config file. Core
+serializes updates within that process, compensates the file if the database
+commit fails or is cancelled, and reconciles file/database identity again at
+startup; a distributed configuration transaction is outside this boundary.
+
+Templates contain exactly one literal `{text}` placeholder. Core uses literal
+replacement rather than general string formatting. Query and document
+templates are applied separately. A query-only template change refreshes the
+live backend but does not rebuild stored document vectors. A document-template
+or `embedding_space_id` change forces a clean rebuild even when dimensions are
+unchanged, so one vec table never contains mixed embedding spaces.
+
+### Dimension transitions
+
+A same-dimension embedding-space change can rebuild online. The active
+generation is marked `reindexing`, vector reads are withheld, and retrieval
+stays lexical until coverage and consistency checks mark the new generation
+ready.
+
+A populated sqlite-vec index cannot change dimension while API or worker peers
+may still hold the old virtual-table schema. Core therefore returns
+`409 embedding_offline_reindex_required`. The App must stop API and worker
+processes, perform the supervised resize and full re-index, and then restart
+them. An empty first-run index may be resized directly.
+
+### Failure behavior
+
+Hardware fallback may change the execution device while using the exact same
+model artifact and embedding contract. Model-to-model fallback is never
+transparent because it would produce incompatible vectors.
+
+If the configured runtime is unavailable, RKA continues through FTS, tags,
+graph relations, and other non-vector retrieval. It must report this as a
+degraded lexical mode rather than silently switching models. Switching to a
+different model is an explicit profile change followed by a complete re-index.
+
+The current explicit backfill endpoint repairs rows that lack current
+model/dimension metadata. It is not a general content-hash scrubber. A failed
+edit embedding remains on the durable worker/retry path until the separately
+tracked hash-aware repair scan is implemented.
+
+## Promotion evaluation
+
+The existing embedding-disabled Core retrieval baseline remains unchanged.
+Before running the promotion decision, freeze a reproducible comparison of
+lexical-only, current Nomic, and the Qwen candidate from identical
+provider-free database copies. The comparison must name its corpus versions,
+query set, metric tolerances, repetitions, and hardware protocol.
+
+Before Qwen becomes the App default:
+
+1. all project-isolation and currentness gates remain perfect;
+2. every eligible record is represented by exactly one current-space vector
+   and metadata row, with no mixed model identities;
+3. direct Hit@10 and macro MRR meet the frozen non-regression tolerance against
+   Nomic, and Qwen succeeds on hard semantic or cross-language queries that
+   lexical retrieval misses;
+4. the frozen TraceGuard causal-story contract and at least one independent
+   project story reconstruct their required roles, edges, facts, and current
+   decisions within a predeclared noise budget;
+5. peak RSS, warm-query latency, readiness time, and full-backfill failures are
+   measured on both target machines and meet thresholds frozen before the run;
+6. Q8 ranking parity against the official model implementation is measured
+   using a pinned sample and tolerance.
+
+No numeric performance threshold is release-authoritative until the protocol
+and both target-machine measurements are checked into the evaluation record.
+
+## Non-goals
+
+This decision does not add a llama.cpp backend to Core, ship model artifacts in
+the Core wheel, auto-detect GPUs in Core, build dual vector indexes, introduce a
+background health daemon, or make a one-request model failover. It also does not
+change the default model before the evidence gates pass.

--- a/docs/embedding_backends.md
+++ b/docs/embedding_backends.md
@@ -33,11 +33,9 @@ shape.
 - **FastEmbed** — first run, no external services, fully offline. 768-dim
   vectors are fast and accurate for general English text. Best for "I
   want it to work without doing anything."
-- **OpenAI-compat → LM Studio (qwen3-8b)** — when you've already loaded
-  a high-quality embedding model in LM Studio. 4096-dim vectors with
-  the eval-harness-measured +9 % NDCG@10 improvement on
-  semantic-hybrid search. Best for "I want better retrieval quality and
-  I'm already running LM Studio."
+- **OpenAI-compat → a managed local sidecar or LM Studio** — when a local
+  service exposes `/v1/embeddings`. Models that distinguish query and
+  document inputs can use the optional templates described below.
 - **Ollama** — when Ollama is your local model server of choice. Pull
   any embedding model with `ollama pull nomic-embed-text`, then point
   the UI at `http://host.docker.internal:11434`.
@@ -57,7 +55,9 @@ shape.
     "base_url": "http://host.docker.internal:1234",
     "model": "text-embedding-qwen3-embedding-8b",
     "api_key": "sk-...",
-    "dim": 4096
+    "dim": 4096,
+    "query_template": "{text}",
+    "document_template": "{text}"
   },
   "updated_at": "2026-05-15T16:00:00Z",
   "updated_by": "pi"
@@ -65,10 +65,18 @@ shape.
 ```
 
 The `backend` field is one of `"fastembed" | "openai_compat" | "ollama"`.
-The `config` subobject's required keys vary by backend (see matrix
-above). Schema validation is strict (`extra="forbid"` on the Pydantic
-model) — typos in keys surface as a 422 immediately, rather than being
-silently dropped.
+The outer object rejects unknown fields. The backend-specific `config`
+subobject is intentionally extensible; recognized fields are validated when
+the backend is constructed, while consumers should not assume that every
+unknown nested key is rejected.
+
+For a pinned local runtime, `embedding_space_id` may carry the immutable
+artifact/runtime identity used for embedding metadata. It must change when
+model bytes, quantization, pooling, normalization, dimensions, or document
+encoding change. `query_template` and `document_template` each contain exactly
+one literal `{text}` placeholder. Query-only instruction changes do not require
+document re-indexing; changes to the document template or embedding space do.
+See [ADR 0017](adr/0017-portable-embedding-runtime-boundary.md).
 
 ## Switching backends
 
@@ -79,29 +87,30 @@ silently dropped.
 4. Click **Test connection**. The result panel shows `ok`, detected
    `dim`, and `latency_ms`. A failed test is non-destructive; the
    previous config stays active.
-5. Click **Save & re-embed**. A confirmation modal estimates the
-   re-embed wall-clock (~7–14 min for the current 827-claim corpus on
-   qwen3-8b) and warns that existing vectors will be discarded.
+5. Click **Save & re-embed**. A confirmation modal explains whether the
+   change requires missing-row repair, a same-dimension rebuild, or supervised
+   offline maintenance.
 6. Confirm → backfill starts in the background; a progress bar in the
    Settings page polls every ~1.5 s until the job reaches `complete`
-   or `failed`. FTS continues working during the re-embed; semantic
-   search returns empty results for in-flight claims.
+   or `failed`. During a generation rebuild, vector retrieval is withheld and
+   the whole search path remains lexical until coverage and consistency checks
+   mark the new generation ready.
 
 ## Cost of switching
 
-Re-embedding triggers automatically when `(backend, model, dim)` change.
-Changing `api_key` alone does not trigger a re-embed; PUT returns 200
-with the updated (redacted) config.
+Re-embedding triggers automatically when the stored embedding-space identity,
+document template, dimensions, backend, or endpoint model changes. A changed
+embedding space forces a clean rebuild even at the same dimension. Repointing
+an endpoint backfills missing rows without discarding compatible vectors.
+Changing credentials does not invalidate compatible vectors, but it may
+schedule a missing-only repair and return 202 so records created during an
+authentication outage are not stranded. Existing compatible rows are kept.
+This repair does not rescan same-model metadata for changed content; failed
+edit jobs remain visible in the durable job queue and must be retried.
 
-| Backend        | Empirical latency per claim | 827-claim re-embed wall-clock |
-|----------------|-----------------------------|-------------------------------|
-| FastEmbed nomic-768 | ~50–100 ms                | ~1–2 min                      |
-| LM Studio qwen3-8b  | ~0.5–1 s                  | ~7–14 min                     |
-| Ollama nomic-embed-text | ~100–200 ms             | ~2–3 min                      |
-| OpenAI text-embedding-3-small | ~30–60 ms (network-bound) | ~1 min                |
-
-Numbers are reference points from internal testing — your hardware,
-local model server, and network will vary.
+A populated index cannot change vector dimension online. Core returns
+`409 embedding_offline_reindex_required`; a supervisor must stop API and
+worker peers, perform the resize/full re-index, and restart them.
 
 ## Troubleshooting
 
@@ -153,10 +162,9 @@ sane.
 
 Q&A and summary generation that used to live in the web UI were removed
 in v2.4.0 per the LLM-capability-removal directive
-(`jrn_01KRNZBS50K250HHHHEC58E4GC`). Server-side LLM code is preserved
-(`rka/infra/llm.py`, `rka/api/routes/llm.py`, the `rka_ask` /
-`rka_generate_summary` MCP tools) and will be re-wired through the
-orchestrator's Claude Code SDK in a follow-up release.
+(`jrn_01KRNZBS50K250HHHHEC58E4GC`). Server-side legacy LLM code remains
+outside the embedding and Core retrieval contract. Any future generation
+product requires its own explicit boundary decision.
 
 `/api/capabilities` no longer returns the `llm` field (BREAKING change
 at v2.4.0). Consumers of the `embedding` half of the response are

--- a/rka/api/app.py
+++ b/rka/api/app.py
@@ -142,42 +142,68 @@ async def lifespan(app: FastAPI):
     app.state.llm = llm
 
     embeddings: EmbeddingService | None = None
+    app.state.embedding_unavailable_reason = None
     if config.embeddings_enabled:
         # Mission D first-run hook: persist DEFAULT_CONFIG to
         # /data/embedding_config.json on first boot if it doesn't exist,
         # then load whatever's on disk through the pluggable factory.
-        # Falls back to legacy FastEmbed if the config file is corrupt or
-        # the data_dir isn't writable (e.g. test fixtures with default
-        # `/data`, read-only volume mounts).
+        # A missing file uses the documented first-run default. A corrupt
+        # existing file never selects another model implicitly: the API stays
+        # healthy in lexical mode until the operator repairs the configuration.
         from rka.services.embedding_config import (
             DEFAULT_CONFIG,
             EmbeddingConfigError,
             EmbeddingConfigService,
         )
-        from rka.services.embedding_reshape import reshape_all_vec_tables_if_needed
+        from rka.services.embedding_index import (
+            EmbeddingDimensionTransitionRequired,
+            embedding_space_signature,
+            legacy_index_adoption_safe,
+            reconcile_embedding_index,
+        )
 
         cfg_svc = EmbeddingConfigService(config_dir=config.data_dir)
         try:
-            if not cfg_svc.config_path.exists():
+            config_missing = not cfg_svc.config_path.exists()
+            if config_missing:
+                embedding_cfg = DEFAULT_CONFIG.model_copy()
                 try:
-                    cfg_svc.save_config(DEFAULT_CONFIG.model_copy(), actor="system-default")
+                    embedding_cfg = cfg_svc.save_config(
+                        embedding_cfg,
+                        actor="system-default",
+                    )
                     logger.info(
                         "first-run: persisted DEFAULT embedding config to %s",
                         cfg_svc.config_path,
                     )
                 except (OSError, EmbeddingConfigError) as exc:
-                    # data_dir not writable (e.g. read-only test fixture).
-                    # Silent fall-through to legacy FastEmbed below.
+                    # Use the exact same in-memory default; do not silently
+                    # change models because persistence is unavailable.
                     logger.warning(
                         "could not persist DEFAULT embedding config to %s: %s; "
                         "continuing with in-memory default",
                         cfg_svc.config_path,
                         exc,
                     )
+            else:
+                embedding_cfg = cfg_svc.load_config()
+
+            if not (embedding_cfg.config or {}).get("dim"):
+                probe = await cfg_svc.test_config(embedding_cfg)
+                if not probe.ok or not probe.detected_dim:
                     raise EmbeddingConfigError(
-                        "data_dir not writable; using legacy fastembed", hint=""
+                        "embedding dimension is missing and the backend probe failed",
+                        hint="repair the backend, then save the embedding configuration again",
                     )
-            embedding_cfg = cfg_svc.load_config()
+                normalized = dict(embedding_cfg.config or {})
+                normalized["dim"] = int(probe.detected_dim)
+                embedding_cfg = embedding_cfg.model_copy(update={"config": normalized})
+                if not config_missing:
+                    embedding_cfg = cfg_svc.save_config(
+                        embedding_cfg,
+                        actor="system-dimension-detect",
+                    )
+
             embeddings = EmbeddingService.from_config(embedding_cfg.model_dump(), db=db)
             logger.info(
                 "Embedding service enabled (backend=%s, dim=%d)",
@@ -185,33 +211,56 @@ async def lifespan(app: FastAPI):
                 embeddings.dim,
             )
 
-            # v2.5.5 startup-hook (mis_01KS1RFNM2T1HTB077G507T1FR): reshape
-            # every vec_* table whose dim no longer matches the configured
-            # embedding dim. The v2.4 path covered vec_claims only; the
-            # other five hardcoded float[768] tables were stuck at the old
-            # dim and their embedding_metadata kept the stale model_name.
-            target_dim = int(embedding_cfg.config.get("dim") or embeddings.dim or 768)
-            reshape_results = await reshape_all_vec_tables_if_needed(db, dim=target_dim)
-            reshaped = [(t, p) for t, (did, p) in reshape_results.items() if did]
-            if reshaped:
-                logger.info(
-                    "vec tables reshaped at startup (dim=%d): %s",
-                    target_dim,
-                    ", ".join(f"{t} pending={p}" for t, p in reshaped),
-                )
-        except EmbeddingConfigError as exc:
-            # Corrupt config OR unwritable data_dir: fall back to legacy
-            # FastEmbed so the API still starts. The Settings page renders
-            # the 422 hint on next GET.
-            logger.warning(
-                "embedding config error at startup: %s; falling back to legacy FastEmbed",
-                exc.detail,
+            target_dim = int(embedding_cfg.config.get("dim") or embeddings.dim)
+            reconciliation = await reconcile_embedding_index(
+                db,
+                space_signature=embedding_space_signature(
+                    embedding_cfg,
+                    dimensions=target_dim,
+                ),
+                model_name=embeddings.model_name,
+                dim=target_dim,
+                allow_legacy_adoption=legacy_index_adoption_safe(embedding_cfg),
             )
-            embeddings = EmbeddingService(model_name=config.embedding_model, db=db)
+            embeddings.bind_index_generation(
+                reconciliation.state.generation,
+                space_signature=reconciliation.state.space_signature,
+            )
+            if reconciliation.transitioned or reconciliation.resumed:
+                logger.info(
+                    "embedding generation %d will resume at startup (dim=%d)",
+                    reconciliation.state.generation,
+                    target_dim,
+                )
+        except (EmbeddingConfigError, EmbeddingDimensionTransitionRequired, ValueError) as exc:
+            detail = getattr(exc, "detail", str(exc))
+            logger.warning(
+                "embedding startup unavailable: %s; search will use lexical retrieval",
+                detail,
+            )
+            app.state.embedding_unavailable_reason = detail
+            embeddings = None
+    else:
+        app.state.embedding_unavailable_reason = (
+            "embeddings disabled (RKA_EMBEDDINGS_ENABLED=false)"
+        )
     app.state.embeddings = embeddings
 
     search = SearchService(db=db, embeddings=embeddings)
     app.state.search = search
+
+    if embeddings is not None:
+        # Missing-only reconciliation is cheap when the index is complete and
+        # is the restart path for an interrupted generation transition.
+        from rka.services.embedding_backfill import BackfillService, register_job
+
+        status_obj = register_job()
+        startup_backfill = BackfillService(db=db, embeddings=embeddings)
+        background_tasks.append(
+            asyncio.create_task(
+                config_routes._run_backfill_safely(startup_backfill, status_obj)
+            )
+        )
 
     context = ContextEngine(
         db=db,

--- a/rka/api/routes/config.py
+++ b/rka/api/routes/config.py
@@ -4,8 +4,8 @@ Four routes:
 
   - GET  /api/config/embedding              — current config (api_key redacted)
   - PUT  /api/config/embedding              — validate + test + persist;
-                                              202 if backfill kicked off,
-                                              200 if only api_key changed
+                                              202 if reconciliation runs,
+                                              200 if no repair is needed
   - POST /api/config/embedding/test         — probe without persisting
   - GET  /api/config/embedding/backfill/status[?job_id=…]
                                             — polling endpoint for the UI
@@ -17,14 +17,16 @@ Error mapping (Affordance G):
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
-from rka.api.deps import get_db, get_embeddings
 from rka.config import RKAConfig
 from rka.infra.embedding_backends import EmbeddingConfigError
 from rka.infra.embeddings import EmbeddingService
@@ -39,13 +41,25 @@ from rka.services.embedding_config import (
     EmbeddingConfig,
     EmbeddingConfigService,
 )
-from rka.services.embedding_reshape import reshape_all_vec_tables_if_needed
+from rka.services.embedding_index import (
+    EmbeddingDimensionTransitionRequired,
+    EmbeddingGenerationMismatch,
+    assert_online_dimension_compatible,
+    embedding_space_signature,
+    finish_embedding_transition,
+    get_embedding_index_state,
+    legacy_index_adoption_safe,
+    reconcile_embedding_index,
+    resume_embedding_transition,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 REDACTED_API_KEY = "***"
+_CONFIG_UPDATE_LOCK = asyncio.Lock()
+_BACKFILL_LOCK = asyncio.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +88,82 @@ def _redact(config: EmbeddingConfig) -> dict[str, Any]:
     return payload
 
 
+def _restore_saved_secret(
+    svc: EmbeddingConfigService,
+    body: EmbeddingConfig,
+) -> EmbeddingConfig:
+    """Replace an omitted/redacted API key with the saved value for probing."""
+
+    try:
+        prior = svc.load_config()
+    except EmbeddingConfigError:
+        return body
+    submitted = dict(body.config or {})
+    if (
+        prior.backend == body.backend
+        and (
+            "api_key" not in submitted
+            or submitted.get("api_key") == REDACTED_API_KEY
+        )
+    ):
+        saved_secret = (prior.config or {}).get("api_key")
+        if saved_secret:
+            submitted["api_key"] = saved_secret
+            return body.model_copy(update={"config": submitted})
+    return body
+
+
+def _snapshot_config_file(svc: EmbeddingConfigService) -> tuple[bytes | None, int | None]:
+    """Capture the exact live config so a later DB commit failure can undo save."""
+
+    try:
+        data = svc.config_path.read_bytes()
+        mode = svc.config_path.stat().st_mode & 0o777
+        return data, mode
+    except FileNotFoundError:
+        return None, None
+    except OSError as exc:
+        raise EmbeddingConfigError(
+            f"failed to snapshot embedding config at {svc.config_path}: {exc!s}",
+            hint="verify the embedding config directory is readable",
+        ) from exc
+
+
+def _restore_config_file(
+    svc: EmbeddingConfigService,
+    snapshot: tuple[bytes | None, int | None],
+) -> None:
+    """Atomically restore the exact pre-update config, including absence."""
+
+    data, mode = snapshot
+    try:
+        if data is None:
+            svc.config_path.unlink(missing_ok=True)
+            return
+        svc.config_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".embedding_config.restore.",
+            suffix=".tmp",
+            dir=str(svc.config_dir),
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+            os.chmod(tmp_path, mode or 0o600)
+            os.replace(tmp_path, svc.config_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        raise EmbeddingConfigError(
+            f"failed to restore embedding config at {svc.config_path}: {exc!s}",
+            hint="restore embedding_config.backup.json before retrying",
+        ) from exc
+
+
 def _422(error: str, detail: str, hint: str = "") -> JSONResponse:
     return JSONResponse(
         status_code=422,
@@ -81,8 +171,28 @@ def _422(error: str, detail: str, hint: str = "") -> JSONResponse:
     )
 
 
-def _backend_signature(config: EmbeddingConfig) -> tuple[str, str, int, str]:
-    """Identity tuple used to decide whether backfill needs to fire on PUT.
+def _space_signature(config: EmbeddingConfig) -> str:
+    """Fields that determine the stored embedding space.
+
+    A change here requires a clean rebuild even when dimensions match. Mixing
+    vectors from two models or two input contracts in one sqlite-vec table
+    makes rankings undefined.
+    """
+    return embedding_space_signature(config)
+
+
+def _transport_signature(config: EmbeddingConfig) -> tuple[str, str, str]:
+    """Fields that can affect reachability without changing stored vectors."""
+    sub = config.config or {}
+    base_url = str(sub.get("base_url") or sub.get("host") or "")
+    model = str(sub.get("model") or sub.get("model_name") or "")
+    return (config.backend, base_url, model)
+
+
+def _backend_signature(
+    config: EmbeddingConfig,
+) -> tuple[str, tuple[str, str, str]]:
+    """Compatibility wrapper for the complete reconciliation identity.
 
     Includes `base_url` because repointing a dead backend at a reachable host
     is exactly the recovery action, and it is the one that most needs
@@ -94,13 +204,11 @@ def _backend_signature(config: EmbeddingConfig) -> tuple[str, str, int, str]:
     Same dim ⇒ `reshape_all_vec_tables_if_needed` is a no-op, so a base_url
     change costs a backfill of the genuinely-missing rows and nothing else —
     existing vectors are never discarded.
+
+    `api_key` and timeouts are deliberately absent: they may require a client
+    refresh, but they do not define a vector space or require re-embedding.
     """
-    backend = config.backend
-    sub = config.config or {}
-    model = sub.get("model") or sub.get("model_name") or ""
-    dim = int(sub.get("dim") or 0)
-    base_url = str(sub.get("base_url") or sub.get("host") or "")
-    return (backend, model, dim, base_url)
+    return (_space_signature(config), _transport_signature(config))
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +232,30 @@ async def put_embedding_config(
     background_tasks: BackgroundTasks,
     actor: str = Query(default="pi"),
 ) -> Any:
+    async with _CONFIG_UPDATE_LOCK:
+        return await _put_embedding_config_locked(
+            request,
+            body,
+            background_tasks,
+            actor,
+        )
+
+
+async def _put_embedding_config_locked(
+    request: Request,
+    body: EmbeddingConfig,
+    background_tasks: BackgroundTasks,
+    actor: str,
+) -> Any:
     svc = _config_service(request)
+    try:
+        config_snapshot = _snapshot_config_file(svc)
+    except EmbeddingConfigError as exc:
+        return _422("embedding_config_invalid", exc.detail, exc.hint)
+
+    # Settings never receives the saved secret. Omission (or the GET redaction
+    # marker) means preserve the prior key; an explicit empty string removes it.
+    body = _restore_saved_secret(svc, body)
 
     # Step 1: probe the requested config before persisting.
     test_result = await svc.test_config(body)
@@ -135,6 +266,13 @@ async def put_embedding_config(
             "verify base_url + model + api_key in Settings → Embeddings",
         )
 
+    # Persist the observed dimension. A dimless configuration otherwise writes
+    # metadata with dimension 0 and cannot be reconstructed safely at restart.
+    normalized_sub = dict(body.config or {})
+    if not normalized_sub.get("dim") and test_result.detected_dim:
+        normalized_sub["dim"] = int(test_result.detected_dim)
+        body = body.model_copy(update={"config": normalized_sub})
+
     # Step 2: load prior config to determine if backfill is needed.
     try:
         prior = svc.load_config()
@@ -142,45 +280,98 @@ async def put_embedding_config(
         # Treat a corrupt prior as "different" so backfill fires.
         prior = None
 
-    needs_backfill = (
-        prior is None or _backend_signature(prior) != _backend_signature(body)
-    )
+    space_changed = prior is None or _space_signature(prior) != _space_signature(body)
+    transport_changed = prior is None or _transport_signature(prior) != _transport_signature(body)
+    prior_key = (prior.config or {}).get("api_key") if prior is not None else None
+    credential_changed = prior is None or prior_key != (body.config or {}).get("api_key")
+    needs_backfill = space_changed or transport_changed or credential_changed
 
-    # Step 3: persist.
+    db = request.app.state.db
+    target_dim = int((body.config or {}).get("dim") or 0)
     try:
-        saved = svc.save_config(body, actor=actor)
+        await assert_online_dimension_compatible(db, dim=target_dim)
+    except EmbeddingDimensionTransitionRequired as exc:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "embedding_offline_reindex_required",
+                "detail": str(exc),
+                "hint": "stop RKA API and worker, then run the supervised embedding reindex",
+            },
+        )
+
+    new_embeddings = EmbeddingService.from_config(body.model_dump(), db=db)
+
+    # Step 3: reconcile and persist under one DB writer lock. The final
+    # dimension check is authoritative; a racing old-space write cannot land
+    # between it and the sqlite-vec transition. Saving last also means a file
+    # error rolls the DB transition back.
+    config_saved = False
+    try:
+        async with db.transaction(migration_lock=True):
+            await assert_online_dimension_compatible(db, dim=target_dim)
+            reconciliation = await reconcile_embedding_index(
+                db,
+                space_signature=_space_signature(body),
+                model_name=new_embeddings.model_name,
+                dim=target_dim,
+                allow_legacy_adoption=legacy_index_adoption_safe(body),
+            )
+            saved = svc.save_config(body, actor=actor)
+            config_saved = True
+    except EmbeddingDimensionTransitionRequired as exc:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "embedding_offline_reindex_required",
+                "detail": str(exc),
+                "hint": "stop RKA API and worker, then run the supervised embedding reindex",
+            },
+        )
     except EmbeddingConfigError as exc:
         return _422("embedding_config_invalid", exc.detail, exc.hint)
-
-    if not needs_backfill:
-        # api_key (or only-provenance) change — no re-embed, but the search
-        # path holds a provider client built at startup, so it must still be
-        # swapped or every subsequent query keeps using the old credentials
-        # while GET and /test both report the new ones.
-        request.app.state.embeddings = EmbeddingService.from_config(
-            saved.model_dump(), db=request.app.state.db
+    except BaseException as exc:  # cancellation must also restore the file
+        restore_error = None
+        if config_saved:
+            try:
+                _restore_config_file(svc, config_snapshot)
+            except EmbeddingConfigError as restore_exc:
+                restore_error = restore_exc.detail
+        if not isinstance(exc, Exception):
+            raise
+        logger.exception("embedding config update failed before commit")
+        detail = f"embedding configuration was not committed: {exc!s}"
+        if restore_error:
+            detail = f"{detail}; rollback also failed: {restore_error}"
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "embedding_config_update_failed",
+                "detail": detail,
+                "hint": "retry after checking the RKA database and config volume",
+            },
         )
+
+    new_embeddings.bind_index_generation(
+        reconciliation.state.generation,
+        space_signature=reconciliation.state.space_signature,
+    )
+
+    # Swap only after the durable generation transition has committed. Search
+    # observes reindexing and stays lexical until the backfill is complete.
+    request.app.state.embeddings = new_embeddings
+    request.app.state.search.embeddings = new_embeddings
+    request.app.state.embedding_unavailable_reason = None
+
+    needs_backfill = (
+        needs_backfill
+        or reconciliation.transitioned
+        or reconciliation.resumed
+    )
+    if not needs_backfill:
         return JSONResponse(status_code=200, content=_redact(saved))
 
-    # Step 4: kick off backfill in the background and return 202 + job ref.
-    db = request.app.state.db
-    new_embeddings = EmbeddingService.from_config(saved.model_dump(), db=db)
-    # Swap the app-level embeddings handle so subsequent requests use it.
-    request.app.state.embeddings = new_embeddings
-
-    # v2.5.5 (mis_01KS1RFNM2T1HTB077G507T1FR): reshape EVERY vec_* table
-    # before backfill starts. The v2.4 path reshaped vec_claims only;
-    # this version covers vec_journal/decisions/literature/missions/
-    # artifacts too, plus invalidates their stale metadata so backfill
-    # picks them up.
-    target_dim = int(
-        (saved.config or {}).get("dim")
-        or test_result.detected_dim
-        or new_embeddings.dim
-        or 768
-    )
-    reshape_results = await reshape_all_vec_tables_if_needed(db, dim=target_dim)
-
+    # Step 4: kick off missing-only/full backfill and return a job reference.
     status_obj = register_job()
     backfill_svc = BackfillService(db=db, embeddings=new_embeddings)
     background_tasks.add_task(_run_backfill_safely, backfill_svc, status_obj)
@@ -193,7 +384,7 @@ async def put_embedding_config(
             "status_url": f"/api/config/embedding/backfill/status?job_id={status_obj.job_id}",
             "reshape": {
                 table: {"did_reshape": did, "pending": pending}
-                for table, (did, pending) in reshape_results.items()
+                for table, (did, pending) in reconciliation.reshape.items()
             },
         },
     )
@@ -202,6 +393,7 @@ async def put_embedding_config(
 @router.post("/api/config/embedding/test")
 async def test_embedding_config(request: Request, body: EmbeddingConfig) -> Any:
     svc = _config_service(request)
+    body = _restore_saved_secret(svc, body)
     try:
         result = await svc.test_config(body)
     except EmbeddingConfigError as exc:
@@ -239,6 +431,24 @@ async def start_embedding_backfill(
             "no embedding backend is configured",
             "set one in Settings → Embeddings first",
         )
+    try:
+        await resume_embedding_transition(
+            db,
+            generation=getattr(embeddings, "index_generation", None),
+            space_signature=embeddings.space_signature,
+            model_name=embeddings.model_name,
+            dim=embeddings.dim,
+        )
+    except EmbeddingGenerationMismatch as exc:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "embedding_generation_changed",
+                "detail": str(exc),
+                "hint": "restart this RKA process, then retry the backfill",
+            },
+        )
+
     types = tuple(t.strip() for t in entity_types.split(",")) if entity_types else None
     status_obj = register_job()
     svc = BackfillService(db=db, embeddings=embeddings)
@@ -283,10 +493,47 @@ async def _run_backfill_safely(
     entity_types: tuple[str, ...] | None = None,
 ) -> None:
     """Wraps BackfillService.run_backfill so unhandled exceptions land in
-    the status snapshot rather than the background-task logger."""
-    try:
-        await svc.run_backfill(status, entity_types=entity_types)
-    except Exception as exc:  # noqa: BLE001
-        status.state = "failed"
-        status.error = str(exc)
-        logger.exception("backfill job %s failed", status.job_id)
+    the status snapshot rather than the background-task logger.
+
+    The API is one writer process under ADR 0017, so a process-local lock is
+    the ownership boundary for background backfills.  Revalidate and resume
+    the bound generation only after acquiring it: a queued healthy run can
+    recover a same-generation failure, while a stale run never touches a
+    newer generation.
+    """
+    async with _BACKFILL_LOCK:
+        generation = getattr(svc._embeddings, "index_generation", None)
+        try:
+            if generation is not None:
+                await resume_embedding_transition(
+                    svc._db,
+                    generation=generation,
+                    space_signature=svc._embeddings.space_signature,
+                    model_name=svc._embeddings.model_name,
+                    dim=svc._embeddings.dim,
+                )
+            await svc.run_backfill(status, entity_types=entity_types)
+        except Exception as exc:  # noqa: BLE001
+            status.state = "failed"
+            status.error = str(exc)
+            logger.exception("backfill job %s failed", status.job_id)
+        finally:
+            if generation is not None:
+                await finish_embedding_transition(
+                    svc._db,
+                    generation=generation,
+                    success=status.state == "complete",
+                    error=status.error,
+                )
+                current = await get_embedding_index_state(svc._db)
+                if (
+                    status.state == "complete"
+                    and current is not None
+                    and current.generation == generation
+                    and current.status == "failed"
+                ):
+                    status.state = "failed"
+                    status.error = (
+                        current.last_error
+                        or "embedding index consistency check failed"
+                    )

--- a/rka/api/routes/project.py
+++ b/rka/api/routes/project.py
@@ -129,13 +129,34 @@ async def get_capabilities(
     db = getattr(state, "db", None)
 
     embeddings = getattr(state, "embeddings", None)
-    embeddings_available = bool(embeddings) and bool(getattr(db, "vec_available", False))
-    if embeddings_available:
-        emb_block = {"available": True, "reason_unavailable": None}
+    if embeddings and getattr(db, "vec_available", False):
+        if getattr(embeddings, "runtime_available", None) is False:
+            emb_block = {
+                "available": False,
+                "reason_unavailable": (
+                    "configured embedding backend temporarily unavailable; "
+                    "search is using lexical retrieval"
+                ),
+            }
+        elif (
+            getattr(embeddings, "index_search_ready", None) is not None
+            and not await embeddings.index_search_ready()
+        ):
+            emb_block = {
+                "available": False,
+                "reason_unavailable": (
+                    "embedding index is rebuilding or requires repair; "
+                    "search is using lexical retrieval"
+                ),
+            }
+        else:
+            emb_block = {"available": True, "reason_unavailable": None}
     elif not embeddings:
+        reason = getattr(state, "embedding_unavailable_reason", None)
         emb_block = {
             "available": False,
-            "reason_unavailable": "embeddings disabled (RKA_EMBEDDINGS_ENABLED=false)",
+            "reason_unavailable": reason
+            or "embeddings disabled (RKA_EMBEDDINGS_ENABLED=false)",
         }
     else:
         emb_block = {

--- a/rka/db/migrations/055_add_embedding_index_state.sql
+++ b/rka/db/migrations/055_add_embedding_index_state.sql
@@ -1,0 +1,18 @@
+-- Migration 055: durable identity and lifecycle for the derived embedding index.
+-- requires-table: embedding_metadata
+
+-- Canonical research records remain authoritative.  This singleton only
+-- coordinates the rebuildable vector index across the API and worker
+-- processes so an interrupted model/input-space transition can resume safely.
+CREATE TABLE embedding_index_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    generation INTEGER NOT NULL CHECK (generation >= 1),
+    space_signature TEXT NOT NULL CHECK (length(trim(space_signature)) > 0),
+    model_name TEXT NOT NULL CHECK (length(trim(model_name)) > 0),
+    dimensions INTEGER NOT NULL CHECK (dimensions > 0),
+    status TEXT NOT NULL
+        CHECK (status IN ('ready', 'reindexing', 'failed')),
+    last_error TEXT,
+    updated_at TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);

--- a/rka/infra/embedding_backends/__init__.py
+++ b/rka/infra/embedding_backends/__init__.py
@@ -68,6 +68,10 @@ def make_backend(config: dict[str, Any]) -> EmbeddingBackend:
             model=sub.get("model") or "",
             api_key=sub.get("api_key"),
             dim=sub.get("dim"),
+            timeout_seconds=float(sub.get("timeout_seconds", 600.0)),
+            query_template=sub.get("query_template", "{text}"),
+            document_template=sub.get("document_template", "{text}"),
+            embedding_space_id=sub.get("embedding_space_id"),
         )
     if backend_kind == "ollama":
         from rka.infra.embedding_backends.ollama import OllamaBackend
@@ -76,6 +80,7 @@ def make_backend(config: dict[str, Any]) -> EmbeddingBackend:
             base_url=sub.get("base_url") or "http://host.docker.internal:11434",
             model=sub.get("model") or "",
             dim=sub.get("dim"),
+            timeout_seconds=float(sub.get("timeout_seconds", 600.0)),
         )
     raise ValueError(
         f"unknown embedding backend: {backend_kind!r} "

--- a/rka/infra/embedding_backends/fastembed.py
+++ b/rka/infra/embedding_backends/fastembed.py
@@ -5,7 +5,8 @@ Preserves the prior production semantics exactly:
 
   - `nomic-ai/nomic-embed-text-v1.5` default model (768-dim)
   - `search_query: ` / `search_document: ` prefixes on Nomic-family models
-  - first-use download (~130 MB) is performed lazily inside the model
+  - first-use download (~520 MB for the non-quantized default) is performed
+    lazily inside the model
     accessor; the FastEmbed library handles caching
 """
 
@@ -19,7 +20,6 @@ from typing import Any
 
 from rka.infra.embedding_backends.base import (
     ConnectionTestResult,
-    EmbeddingConfigError,
     reconcile_dim,
 )
 
@@ -69,7 +69,7 @@ class FastEmbedBackend:
         self._threads = max(1, threads)
         # v2.7.0.1: persistent model cache. When unset, fastembed defaults to
         # ~/.cache/fastembed which doesn't survive container recreate, causing
-        # repeated 130MB downloads (and HF rate-limiting under load). Setting
+        # repeated model downloads (and HF rate-limiting under load). Setting
         # cache_dir to a volume-mounted path eliminates this.
         if cache_dir is None:
             cache_dir = os.getenv("RKA_EMBEDDING_CACHE_DIR") or None
@@ -96,7 +96,7 @@ class FastEmbedBackend:
 
             logger.info(
                 "Loading FastEmbed model: %s (threads=%d, cache_dir=%s; "
-                "first uncached load downloads ~130MB)",
+                "first uncached load downloads ~520MB for the default model)",
                 self._model_name,
                 self._threads,
                 self._cache_dir or "<fastembed default>",

--- a/rka/infra/embedding_backends/openai_compat.py
+++ b/rka/infra/embedding_backends/openai_compat.py
@@ -29,13 +29,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any
 
 import httpx
 
 from rka.infra.embedding_backends.base import (
     ConnectionTestResult,
-    EmbeddingConfigError,
     reconcile_dim,
 )
 
@@ -55,6 +53,9 @@ class OpenAICompatBackend:
         api_key: str | None = None,
         dim: int | None = None,
         timeout_seconds: float = 600.0,
+        query_template: str = "{text}",
+        document_template: str = "{text}",
+        embedding_space_id: str | None = None,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         if not base_url:
@@ -68,6 +69,11 @@ class OpenAICompatBackend:
         # first real call detects a different length.
         self._dim: int = dim or 0
         self._timeout = timeout_seconds
+        self._query_template = self._validate_template("query_template", query_template)
+        self._document_template = self._validate_template("document_template", document_template)
+        if embedding_space_id is not None and not isinstance(embedding_space_id, str):
+            raise ValueError("embedding_space_id must be a string")
+        self._embedding_space_id = (embedding_space_id or "").strip() or None
         self._http = http_client
 
     @property
@@ -76,7 +82,25 @@ class OpenAICompatBackend:
 
     @property
     def model_name(self) -> str:
-        return self._model
+        # The transport model is what the HTTP server accepts. An explicit
+        # embedding-space id is what RKA stores in embedding metadata so App
+        # can include artifact hash, pooling, normalization, and document
+        # encoding without teaching Core about any one model runtime.
+        return self._embedding_space_id or self._model
+
+    @staticmethod
+    def _validate_template(name: str, value: str) -> str:
+        if not isinstance(value, str):
+            raise ValueError(f"{name} must be a string")
+        if value.count("{text}") != 1:
+            raise ValueError(f"{name} must contain exactly one {{text}} placeholder")
+        return value
+
+    def _prepare(self, text: str, *, is_query: bool) -> str:
+        template = self._query_template if is_query else self._document_template
+        # Literal replacement is intentional. This is not a general-purpose
+        # Python format string, so record text cannot be interpreted as syntax.
+        return template.replace("{text}", text)
 
     def _client(self) -> httpx.AsyncClient:
         if self._http is None:
@@ -123,28 +147,49 @@ class OpenAICompatBackend:
             resp.raise_for_status()
             payload = resp.json()
             data = payload.get("data") or []
-            vecs = [item["embedding"] for item in data]
-            if vecs:
-                # T2.5 calibration: drift-check rather than silent mutate.
-                # `reconcile_dim` returns the new self._dim (or raises on
-                # drift when self._dim was already non-zero).
-                self._dim = reconcile_dim(self._dim, len(vecs[0]))
-            return vecs
+            if len(data) != len(inputs):
+                raise ValueError(
+                    "openai_compat returned "
+                    f"{len(data)} embeddings for {len(inputs)} inputs"
+                )
+            indexed: dict[int, list[float]] = {}
+            for item in data:
+                index = item.get("index")
+                if (
+                    not isinstance(index, int)
+                    or isinstance(index, bool)
+                    or index < 0
+                    or index >= len(inputs)
+                    or index in indexed
+                ):
+                    raise ValueError(
+                        f"openai_compat returned invalid embedding index: {index!r}"
+                    )
+                vector = item.get("embedding")
+                if not isinstance(vector, list) or not vector:
+                    raise ValueError(
+                        f"openai_compat returned no vector for input index {index}"
+                    )
+                # T2.5 calibration: drift-check every vector, not only the
+                # first item in a batch.
+                self._dim = reconcile_dim(self._dim, len(vector))
+                indexed[index] = vector
+            return [indexed[index] for index in range(len(inputs))]
         # unreachable — every loop branch either returns or raises
         if last_exc:
             raise last_exc
         raise RuntimeError("openai_compat embed: exhausted retries")
 
-    async def embed(self, text: str, *, is_query: bool = False) -> list[float]:  # noqa: ARG002
-        out = await self._post_embeddings([text])
+    async def embed(self, text: str, *, is_query: bool = False) -> list[float]:
+        out = await self._post_embeddings([self._prepare(text, is_query=is_query)])
         return out[0]
 
-    async def embed_batch(
-        self, texts: list[str], *, is_query: bool = False  # noqa: ARG002
-    ) -> list[list[float]]:
+    async def embed_batch(self, texts: list[str], *, is_query: bool = False) -> list[list[float]]:
         if not texts:
             return []
-        return await self._post_embeddings(list(texts))
+        return await self._post_embeddings(
+            [self._prepare(text, is_query=is_query) for text in texts]
+        )
 
     async def test_connection(self) -> ConnectionTestResult:
         t0 = time.perf_counter()

--- a/rka/infra/embeddings.py
+++ b/rka/infra/embeddings.py
@@ -46,6 +46,9 @@ class EmbeddingService:
         backend: EmbeddingBackend | None = None,
     ) -> None:
         self.db = db
+        self.index_generation: int | None = None
+        self.runtime_available: bool | None = None
+        self.runtime_error_code: str | None = None
         if backend is not None:
             self._backend: EmbeddingBackend = backend
             self.model_name = backend.model_name
@@ -54,6 +57,15 @@ class EmbeddingService:
                 {"backend": "fastembed", "config": {"model_name": model_name}}
             )
             self.model_name = model_name
+        from rka.services.embedding_index import embedding_space_signature
+
+        self.space_signature = embedding_space_signature(
+            {
+                "backend": "fastembed",
+                "config": {"model_name": self.model_name, "dim": self._backend.dim},
+            },
+            dimensions=self._backend.dim,
+        )
 
     # ------------------------------------------------------------------
     # Construction helpers
@@ -65,7 +77,26 @@ class EmbeddingService:
     ) -> "EmbeddingService":
         """Build a service from a `/data/embedding_config.json`-shaped dict."""
         backend = make_backend(config)
-        return cls(model_name=backend.model_name, db=db, backend=backend)
+        service = cls(model_name=backend.model_name, db=db, backend=backend)
+        from rka.services.embedding_index import embedding_space_signature
+
+        service.space_signature = embedding_space_signature(
+            config,
+            dimensions=backend.dim,
+        )
+        return service
+
+    def bind_index_generation(
+        self,
+        generation: int,
+        *,
+        space_signature: str | None = None,
+    ) -> None:
+        """Bind this process-local backend to a durable index generation."""
+
+        self.index_generation = int(generation)
+        if space_signature is not None:
+            self.space_signature = space_signature
 
     # ------------------------------------------------------------------
     # Public surface — preserved from the pre-T1 EmbeddingService
@@ -81,17 +112,69 @@ class EmbeddingService:
 
     async def embed(self, text: str) -> list[float]:
         """Embed a query string."""
-        return await self._backend.embed(text, is_query=True)
+        try:
+            result = await self._backend.embed(text, is_query=True)
+        except Exception:
+            self.runtime_available = False
+            self.runtime_error_code = "embedding_backend_unavailable"
+            raise
+        self.runtime_available = True
+        self.runtime_error_code = None
+        return result
 
     async def embed_document(self, text: str) -> list[float]:
         """Embed a document for storage."""
-        return await self._backend.embed(text, is_query=False)
+        try:
+            result = await self._backend.embed(text, is_query=False)
+        except Exception:
+            self.runtime_available = False
+            self.runtime_error_code = "embedding_backend_unavailable"
+            raise
+        self.runtime_available = True
+        self.runtime_error_code = None
+        return result
 
     async def embed_batch(
         self, texts: list[str], is_query: bool = False
     ) -> list[list[float]]:
         """Batch embed multiple texts."""
-        return await self._backend.embed_batch(texts, is_query=is_query)
+        try:
+            result = await self._backend.embed_batch(texts, is_query=is_query)
+        except Exception:
+            self.runtime_available = False
+            self.runtime_error_code = "embedding_backend_unavailable"
+            raise
+        self.runtime_available = True
+        self.runtime_error_code = None
+        return result
+
+    async def assert_current_generation(self) -> None:
+        """Reject writes produced by an outdated API or worker process."""
+
+        if self.db is None:
+            return
+        from rka.services.embedding_index import assert_embedding_generation
+
+        await assert_embedding_generation(
+            self.db,
+            generation=self.index_generation,
+            space_signature=self.space_signature,
+            dim=self._backend.dim,
+        )
+
+    async def index_search_ready(self) -> bool:
+        """Return whether this backend may query the durable vector index."""
+
+        if self.db is None:
+            return True
+        from rka.services.embedding_index import embedding_index_search_ready
+
+        return await embedding_index_search_ready(
+            self.db,
+            generation=self.index_generation,
+            space_signature=self.space_signature,
+            dim=self._backend.dim,
+        )
 
     @staticmethod
     def content_hash(content: str | bytes) -> str:
@@ -190,6 +273,7 @@ class EmbeddingService:
             # metadata row, so a failed INSERT cannot leave the entity with no
             # vector at all — which would be worse than a stale one.
             async with self.db.transaction():
+                await self.assert_current_generation()
                 await self.db.execute(
                     f"DELETE FROM {table} WHERE id = ?",
                     [entity_id],

--- a/rka/models/capabilities.py
+++ b/rka/models/capabilities.py
@@ -12,6 +12,7 @@ class EmbeddingCapability(BaseModel):
 
     available: bool
     reason_unavailable: str | None = None
+    search_mode: Literal["hybrid", "lexical"] = "lexical"
 
 
 class CoreContractIdentity(BaseModel):

--- a/rka/services/capabilities.py
+++ b/rka/services/capabilities.py
@@ -83,6 +83,7 @@ def build_core_capabilities(
     embedding = EmbeddingCapability(
         available=embedding_available,
         reason_unavailable=embedding_reason,
+        search_mode="hybrid" if embedding_available else "lexical",
     )
     available = ["rest", "mcp"]
     if embedding.available:

--- a/rka/services/embedding_backfill.py
+++ b/rka/services/embedding_backfill.py
@@ -387,6 +387,42 @@ _ENTITY_BACKFILL_CONFIGS: dict[str, _EntityBackfillConfig] = {
 _DEFAULT_ENTITY_TYPES: tuple[str, ...] = tuple(_ENTITY_BACKFILL_CONFIGS.keys())
 
 
+async def stored_metadata_hashes_match(
+    db: Any,
+    *,
+    model_name: str,
+    dimensions: int,
+) -> bool:
+    """Verify legacy metadata hashes against the current canonical text.
+
+    This bounded seven-query scan is used only while adopting a pre-generation
+    index. It avoids either trusting stale vectors or needlessly discarding a
+    healthy existing installation.
+    """
+
+    from rka.infra.embeddings import EmbeddingService
+
+    for entity_type, cfg in _ENTITY_BACKFILL_CONFIGS.items():
+        rows = await db.fetchall(
+            f"""SELECT s.*, m.content_hash AS _embedding_content_hash
+                FROM {cfg.source_table} s
+                JOIN embedding_metadata m
+                  ON m.project_id = s.project_id
+                 AND m.entity_type = ?
+                 AND m.entity_id = s.{cfg.id_column}
+                WHERE m.model_name = ? AND m.dimensions = ?""",
+            [entity_type, model_name, dimensions],
+        )
+        for row in rows:
+            try:
+                text = cfg.compose_text(row)
+            except Exception:  # noqa: BLE001
+                return False
+            if row["_embedding_content_hash"] != EmbeddingService.content_hash(text):
+                return False
+    return True
+
+
 # ---------------------------------------------------------------------------
 # BackfillService
 # ---------------------------------------------------------------------------
@@ -442,6 +478,12 @@ class BackfillService:
         five entity types so the upper-bound batch is somewhat larger.
         """
         status.state = "running"
+
+        if not bool(getattr(self._db, "vec_available", False)):
+            status.state = "failed"
+            status.error = "sqlite-vec is unavailable; embedding backfill was not run"
+            await _emit_progress(progress_callback, status)
+            return status
 
         if entity_types is None:
             types = _DEFAULT_ENTITY_TYPES
@@ -522,6 +564,7 @@ class BackfillService:
         embed_dim: int = int(getattr(self._embeddings, "dim", 0) or 0)
 
         last_id = ""
+        write_errors: list[str] = []
         while True:
             rows = await self._db.fetchall(
                 cfg.pending_cursor_sql,
@@ -561,6 +604,11 @@ class BackfillService:
                     f"(cursor at {last_id}): "
                     f"{type(exc).__name__}: {exc!s}"
                 ) from exc
+            if len(vectors) != len(work):
+                raise _BackfillBatchError(
+                    f"(cursor at {last_id}): backend returned "
+                    f"{len(vectors)} vectors for {len(work)} inputs"
+                )
 
             # Per-row: write vec_* + embedding_metadata + post_embed.
             #
@@ -591,6 +639,13 @@ class BackfillService:
                     if vec_available:
                         vec_blob = struct.pack(f"{len(vec)}f", *vec)
                         async with self._db.transaction():
+                            generation_guard = getattr(
+                                self._embeddings,
+                                "assert_current_generation",
+                                None,
+                            )
+                            if generation_guard is not None:
+                                await generation_guard()
                             # sqlite-vec's vec0 tables do not honour the
                             # REPLACE conflict clause — re-embedding an entity
                             # that already has a vector raises "UNIQUE
@@ -654,8 +709,15 @@ class BackfillService:
                         "%s %s vec-write failed (leaving pending for retry): %s",
                         cfg.entity_type, entity_id, exc,
                     )
+                    write_errors.append(f"{entity_id}: {type(exc).__name__}: {exc!s}")
 
             await _emit_progress(progress_callback, status)
+
+        if write_errors:
+            sample = "; ".join(write_errors[:3])
+            if len(write_errors) > 3:
+                sample += f"; and {len(write_errors) - 3} more"
+            raise _BackfillBatchError(f"vector writes failed: {sample}")
 
 
 async def _emit_progress(

--- a/rka/services/embedding_config.py
+++ b/rka/services/embedding_config.py
@@ -140,9 +140,21 @@ class EmbeddingConfigService:
         # current file, this is a no-op (first-ever save).
         if self.config_path.exists():
             try:
-                shutil.copy2(self.config_path, self.backup_path)
-                # The backup gets the same restrictive mode as the live file.
-                os.chmod(self.backup_path, 0o600)
+                current = EmbeddingConfig.model_validate_json(
+                    self.config_path.read_text()
+                )
+                if current:
+                    shutil.copy2(self.config_path, self.backup_path)
+                    # The backup gets the same restrictive mode as the live file.
+                    os.chmod(self.backup_path, 0o600)
+            except ValueError as exc:
+                # A repair must not overwrite a known-good backup with corrupt
+                # live bytes. The validated replacement is still written
+                # atomically below.
+                logger.warning(
+                    "embedding config is invalid; preserving existing backup: %s",
+                    exc,
+                )
             except OSError as exc:
                 raise EmbeddingConfigError(
                     f"failed to write pre-flight backup to {self.backup_path}: {exc!s}",

--- a/rka/services/embedding_index.py
+++ b/rka/services/embedding_index.py
@@ -1,0 +1,622 @@
+"""Durable lifecycle guard for RKA's rebuildable embedding index.
+
+The canonical research records never depend on this state.  The singleton
+coordinates API and worker processes while a document embedding space is
+being replaced, preventing an old process from writing vectors after a newer
+configuration has become active.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from rka.services.embedding_reshape import (
+    current_vec_table_dim,
+    reshape_all_vec_tables_if_needed,
+)
+
+
+_VEC_TABLE_NAMES = (
+    "vec_claims",
+    "vec_journal",
+    "vec_decisions",
+    "vec_literature",
+    "vec_missions",
+    "vec_artifacts",
+)
+
+
+class EmbeddingGenerationMismatch(RuntimeError):
+    """Raised when a stale process attempts to write an embedding."""
+
+
+class EmbeddingDimensionTransitionRequired(RuntimeError):
+    """Raised when a vec0 dimension change needs supervised maintenance."""
+
+
+@dataclass(frozen=True)
+class EmbeddingIndexState:
+    generation: int
+    space_signature: str
+    model_name: str
+    dimensions: int
+    status: str
+    last_error: str | None = None
+
+
+@dataclass(frozen=True)
+class EmbeddingIndexReconciliation:
+    state: EmbeddingIndexState
+    transitioned: bool
+    resumed: bool
+    reshape: dict[str, tuple[bool, int]]
+
+
+def _config_payload(config: Any) -> tuple[str, Mapping[str, Any]]:
+    if hasattr(config, "model_dump"):
+        payload = config.model_dump()
+    else:
+        payload = dict(config)
+    return str(payload.get("backend") or ""), payload.get("config") or {}
+
+
+def embedding_space_model_name(config: Any) -> str:
+    """Return the identity stored in legacy ``model_name`` metadata.
+
+    App-managed runtimes provide a complete ``embedding_space_id``.  Existing
+    configurations retain their model identifier for backward compatibility.
+    """
+
+    _backend, sub = _config_payload(config)
+    model = str(sub.get("model") or sub.get("model_name") or "").strip()
+    explicit = str(sub.get("embedding_space_id") or "").strip()
+    return explicit or model
+
+
+def embedding_space_signature(config: Any, *, dimensions: int | None = None) -> str:
+    """Return a stable fingerprint of the stored *document* vector space.
+
+    Query-only formatting is intentionally excluded because it does not alter
+    stored vectors.  App profiles should place tokenizer, artifact hash,
+    pooling, normalization, truncation, and runtime revision in the explicit
+    ``embedding_space_id``.
+    """
+
+    backend, sub = _config_payload(config)
+    dim = int(dimensions or sub.get("dim") or 0)
+    payload = {
+        "version": 1,
+        "backend": backend,
+        "space": embedding_space_model_name(config),
+        "dimensions": dim,
+        "document_template": str(sub.get("document_template") or "{text}"),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def legacy_index_adoption_safe(config: Any) -> bool:
+    """Return whether pre-generation metadata fully describes this space.
+
+    Legacy metadata recorded only model name and dimension. It cannot prove a
+    custom document template or an App-managed artifact/runtime identity, so
+    those configurations require one clean transition when migration 055 is
+    first encountered.
+    """
+
+    _backend, sub = _config_payload(config)
+    return bool(
+        not str(sub.get("embedding_space_id") or "").strip()
+        and str(sub.get("document_template") or "{text}") == "{text}"
+    )
+
+
+def _state_from_row(row: Mapping[str, Any]) -> EmbeddingIndexState:
+    return EmbeddingIndexState(
+        generation=int(row["generation"]),
+        space_signature=str(row["space_signature"]),
+        model_name=str(row["model_name"]),
+        dimensions=int(row["dimensions"]),
+        status=str(row["status"]),
+        last_error=row.get("last_error"),
+    )
+
+
+async def get_embedding_index_state(db: Any) -> EmbeddingIndexState | None:
+    row = await db.fetchone(
+        """SELECT generation, space_signature, model_name, dimensions,
+                  status, last_error
+           FROM embedding_index_state WHERE singleton = 1"""
+    )
+    return _state_from_row(row) if row else None
+
+
+async def _stored_index_adoption_status(
+    db: Any,
+    *,
+    model_name: str,
+    dim: int,
+) -> str | None:
+    if not getattr(db, "vec_available", False):
+        return None
+    for table_name in _VEC_TABLE_NAMES:
+        if await current_vec_table_dim(db, table_name) != dim:
+            return None
+    state = EmbeddingIndexState(
+        generation=1,
+        space_signature="legacy-adoption-check",
+        model_name=model_name,
+        dimensions=dim,
+        status="ready",
+    )
+    if not await _active_index_rows_are_coherent(db, state):
+        return None
+    # Legacy metadata predates a durable generation marker. Prove that its
+    # stored content hashes still match canonical text before adopting it;
+    # healthy existing installs keep their vectors, while stale rows trigger a
+    # one-time clean rebuild.
+    from rka.services.embedding_backfill import stored_metadata_hashes_match
+
+    if not await stored_metadata_hashes_match(
+        db,
+        model_name=model_name,
+        dimensions=dim,
+    ):
+        return None
+    return "ready" if await _active_index_has_full_coverage(db, state) else "reindexing"
+
+
+async def assert_online_dimension_compatible(db: Any, *, dim: int) -> None:
+    """Reject online vec0 schema changes while peer processes may be loaded.
+
+    Same-dimension space changes are safe because they clear rows without
+    replacing the virtual tables.  A dimension change requires the future App
+    supervisor (or an offline maintenance command) to stop API and worker
+    peers before rebuilding sqlite-vec schemas.
+    """
+
+    if not getattr(db, "vec_available", False):
+        return
+    observed = {
+        table_name: await current_vec_table_dim(db, table_name)
+        for table_name in _VEC_TABLE_NAMES
+    }
+    mismatched = {
+        table_name: table_dim
+        for table_name, table_dim in observed.items()
+        if table_dim is not None and table_dim != dim
+    }
+    if mismatched:
+        has_metadata = await db.fetchone(
+            "SELECT 1 AS present FROM embedding_metadata LIMIT 1"
+        )
+        has_vectors = False
+        for table_name in _VEC_TABLE_NAMES:
+            row = await db.fetchone(f"SELECT 1 AS present FROM {table_name} LIMIT 1")
+            if row:
+                has_vectors = True
+                break
+        if not has_metadata and not has_vectors:
+            # First-time setup has no index to protect.  Reshaping the empty
+            # schema is safe and avoids requiring maintenance before a user
+            # has stored any research records.
+            return
+        details = ", ".join(
+            f"{table}={table_dim}" for table, table_dim in sorted(mismatched.items())
+        )
+        raise EmbeddingDimensionTransitionRequired(
+            "embedding dimension change requires controlled offline reindex "
+            f"(target={dim}; current {details})"
+        )
+
+
+async def reconcile_embedding_index(
+    db: Any,
+    *,
+    space_signature: str,
+    model_name: str,
+    dim: int,
+    allow_legacy_adoption: bool = True,
+) -> EmbeddingIndexReconciliation:
+    """Make ``space_signature`` the one active, restart-safe generation.
+
+    A matching interrupted/failed generation is resumed without clearing
+    already rebuilt rows.  A genuinely different space increments the
+    generation and clears all derived vectors plus metadata atomically.
+    """
+
+    if dim <= 0:
+        raise ValueError(f"embedding index dimension must be positive (got {dim})")
+    if not space_signature or not model_name:
+        raise ValueError("embedding index identity must not be empty")
+
+    reshape: dict[str, tuple[bool, int]] = {}
+    transitioned = False
+    resumed = False
+
+    async with db.transaction(migration_lock=True):
+        # The preflight check used by the API is only advisory. Recheck after
+        # BEGIN IMMEDIATE so another process cannot populate an old-dimension
+        # table between validation and DROP/CREATE.
+        await assert_online_dimension_compatible(db, dim=dim)
+        current = await get_embedding_index_state(db)
+        matches = bool(
+            current
+            and current.space_signature == space_signature
+            and current.model_name == model_name
+            and current.dimensions == dim
+        )
+
+        if matches:
+            # The durable generation can be created while sqlite-vec is
+            # unavailable.  When the extension later returns, the physical
+            # tables may still have their bootstrap dimension even though the
+            # singleton already names the target space.  Repair empty schemas
+            # before returning from the matching-generation fast path.
+            if getattr(db, "vec_available", False):
+                reshape = await reshape_all_vec_tables_if_needed(
+                    db,
+                    dim=dim,
+                    force=False,
+                )
+            schema_repaired = any(did for did, _pending in reshape.values())
+            if current.status in {"reindexing", "failed"} or schema_repaired:
+                resumed = True
+                await db.execute(
+                    """UPDATE embedding_index_state
+                       SET status = 'reindexing', last_error = NULL,
+                           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                       WHERE singleton = 1"""
+                )
+                current = EmbeddingIndexState(
+                    generation=current.generation,
+                    space_signature=current.space_signature,
+                    model_name=current.model_name,
+                    dimensions=current.dimensions,
+                    status="reindexing",
+                )
+            return EmbeddingIndexReconciliation(
+                state=current,
+                transitioned=False,
+                resumed=resumed,
+                reshape=reshape,
+            )
+
+        legacy_status = None
+        if current is None and allow_legacy_adoption:
+            legacy_status = await _stored_index_adoption_status(
+                db,
+                model_name=model_name,
+                dim=dim,
+            )
+        if legacy_status is not None:
+            await db.execute(
+                """INSERT INTO embedding_index_state
+                   (singleton, generation, space_signature, model_name,
+                    dimensions, status)
+                   VALUES (1, 1, ?, ?, ?, ?)""",
+                [space_signature, model_name, dim, legacy_status],
+            )
+            state = EmbeddingIndexState(
+                generation=1,
+                space_signature=space_signature,
+                model_name=model_name,
+                dimensions=dim,
+                status=legacy_status,
+            )
+            return EmbeddingIndexReconciliation(
+                state=state,
+                transitioned=False,
+                resumed=legacy_status == "reindexing",
+                reshape=reshape,
+            )
+
+        generation = (current.generation + 1) if current else 1
+        await db.execute(
+            """INSERT INTO embedding_index_state
+               (singleton, generation, space_signature, model_name,
+                dimensions, status, last_error, updated_at)
+               VALUES (1, ?, ?, ?, ?, 'reindexing', NULL,
+                       strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+               ON CONFLICT(singleton) DO UPDATE SET
+                   generation = excluded.generation,
+                   space_signature = excluded.space_signature,
+                   model_name = excluded.model_name,
+                   dimensions = excluded.dimensions,
+                   status = 'reindexing',
+                   last_error = NULL,
+                   updated_at = excluded.updated_at""",
+            [generation, space_signature, model_name, dim],
+        )
+        reshape = await reshape_all_vec_tables_if_needed(db, dim=dim, force=True)
+        transitioned = True
+        state = EmbeddingIndexState(
+            generation=generation,
+            space_signature=space_signature,
+            model_name=model_name,
+            dimensions=dim,
+            status="reindexing",
+        )
+
+    return EmbeddingIndexReconciliation(
+        state=state,
+        transitioned=transitioned,
+        resumed=False,
+        reshape=reshape,
+    )
+
+
+async def resume_embedding_transition(
+    db: Any,
+    *,
+    generation: int | None,
+    space_signature: str,
+    model_name: str,
+    dim: int,
+) -> EmbeddingIndexState:
+    """Resume only the generation already bound to this process.
+
+    Unlike full reconciliation, this operation can never move the durable
+    index to the caller's identity. A stale API process therefore receives a
+    generation mismatch instead of clearing vectors created by a newer one.
+    """
+
+    async with db.transaction():
+        current = await get_embedding_index_state(db)
+        if (
+            current is None
+            or generation is None
+            or current.generation != generation
+            or current.space_signature != space_signature
+            or current.model_name != model_name
+            or current.dimensions != dim
+        ):
+            raise EmbeddingGenerationMismatch(
+                "embedding generation changed; reload the configured backend and retry"
+            )
+        if current.status == "failed":
+            await db.execute(
+                """UPDATE embedding_index_state
+                   SET status = 'reindexing', last_error = NULL,
+                       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                   WHERE singleton = 1 AND generation = ? AND status = 'failed'""",
+                [generation],
+            )
+            current = EmbeddingIndexState(
+                generation=current.generation,
+                space_signature=current.space_signature,
+                model_name=current.model_name,
+                dimensions=current.dimensions,
+                status="reindexing",
+            )
+        return current
+
+
+async def assert_embedding_generation(
+    db: Any,
+    *,
+    generation: int | None,
+    space_signature: str,
+    dim: int,
+) -> None:
+    """Fail closed when a process is not bound to the active generation."""
+
+    current = await get_embedding_index_state(db)
+    if current is None:
+        # Backward-compatible for tests and databases not yet migrated through
+        # normal startup.  Once the singleton exists, every writer is guarded.
+        return
+    if (
+        generation is None
+        or current.generation != generation
+        or current.space_signature != space_signature
+        or current.dimensions != dim
+        or current.status not in {"ready", "reindexing"}
+    ):
+        raise EmbeddingGenerationMismatch(
+            "embedding generation changed; reload the configured backend and retry"
+        )
+
+
+async def embedding_index_search_ready(
+    db: Any,
+    *,
+    generation: int | None,
+    space_signature: str,
+    dim: int,
+) -> bool:
+    current = await get_embedding_index_state(db)
+    if current is None:
+        return True
+    return bool(
+        generation is not None
+        and current.generation == generation
+        and current.space_signature == space_signature
+        and current.dimensions == dim
+        and current.status == "ready"
+    )
+
+
+async def finish_embedding_transition(
+    db: Any,
+    *,
+    generation: int,
+    success: bool,
+    error: str | None = None,
+) -> bool:
+    """Finish only the still-current generation; stale jobs are ignored."""
+
+    status = "ready" if success else "failed"
+    async with db.transaction():
+        current = await get_embedding_index_state(db)
+        if (
+            current is None
+            or current.generation != generation
+            or current.status != "reindexing"
+        ):
+            return False
+        if success and not await _active_index_rows_are_consistent(db, current):
+            success = False
+            status = "failed"
+            error = "embedding backfill left inconsistent vector metadata"
+        await db.execute(
+            """UPDATE embedding_index_state
+               SET status = ?, last_error = ?,
+                   updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+               WHERE singleton = 1 AND generation = ?""",
+            [status, None if success else (error or "embedding backfill failed"), generation],
+        )
+    return True
+
+
+async def _active_index_rows_are_consistent(
+    db: Any,
+    state: EmbeddingIndexState,
+) -> bool:
+    """Verify that every stored vector and metadata row agree on the space.
+
+    Entities with genuinely empty text may have neither row and do not block a
+    usable index.  The transition invariant is that no stored row is stale or
+    orphaned, not that every canonical record must be embeddable.
+    """
+
+    return bool(
+        await _active_index_rows_are_coherent(db, state)
+        and await _active_index_has_full_coverage(db, state)
+    )
+
+
+async def _active_index_rows_are_coherent(
+    db: Any,
+    state: EmbeddingIndexState,
+) -> bool:
+    """Return whether every stored row belongs to one usable vector space."""
+
+    mismatch = await db.fetchone(
+        """SELECT 1 AS mismatch FROM embedding_metadata
+           WHERE model_name <> ? OR dimensions <> ? LIMIT 1""",
+        [state.model_name, state.dimensions],
+    )
+    if mismatch:
+        return False
+
+    table_entities = {
+        "vec_claims": (("claim", "claims"),),
+        "vec_journal": (("journal", "journal"),),
+        "vec_decisions": (("decision", "decisions"),),
+        "vec_literature": (("literature", "literature"),),
+        "vec_missions": (("mission", "missions"),),
+        "vec_artifacts": (("artifact", "artifacts"), ("figure", "figures")),
+    }
+    for table_name, entities in table_entities.items():
+        for entity_type, source_table in entities:
+            missing_source = await db.fetchone(
+                f"""SELECT 1 AS mismatch FROM embedding_metadata m
+                    WHERE m.entity_type = ?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM {source_table} s
+                          WHERE s.id = m.entity_id
+                            AND s.project_id = m.project_id
+                      )
+                    LIMIT 1""",
+                [entity_type],
+            )
+            if missing_source:
+                return False
+
+            vector_filter = (
+                " AND v.entity_type = m.entity_type"
+                if table_name == "vec_artifacts"
+                else ""
+            )
+            missing_vector = await db.fetchone(
+                f"""SELECT 1 AS mismatch FROM embedding_metadata m
+                    WHERE m.entity_type = ?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM {table_name} v
+                          WHERE v.id = m.entity_id
+                            AND v.project_id = m.project_id{vector_filter}
+                      )
+                    LIMIT 1""",
+                [entity_type],
+            )
+            if missing_vector:
+                return False
+
+            metadata_filter = (
+                " AND m.entity_type = v.entity_type"
+                if table_name == "vec_artifacts"
+                else ""
+            )
+            orphan_vector = await db.fetchone(
+                f"""SELECT 1 AS mismatch FROM {table_name} v
+                    WHERE {"v.entity_type = ? AND " if table_name == "vec_artifacts" else ""}
+                      NOT EXISTS (
+                          SELECT 1 FROM embedding_metadata m
+                          WHERE m.entity_id = v.id
+                            AND m.project_id = v.project_id{metadata_filter}
+                            AND m.model_name = ? AND m.dimensions = ?
+                      )
+                    LIMIT 1""",
+                (
+                    [entity_type, state.model_name, state.dimensions]
+                    if table_name == "vec_artifacts"
+                    else [state.model_name, state.dimensions]
+                ),
+            )
+            if orphan_vector:
+                return False
+    return True
+
+
+async def _active_index_has_full_coverage(
+    db: Any,
+    state: EmbeddingIndexState,
+) -> bool:
+    """Return whether every eligible canonical record has current metadata."""
+
+    eligible_sources = {
+        "claim": ("claims", "length(trim(coalesce(content, ''))) > 0"),
+        "journal": (
+            "journal",
+            "length(trim(coalesce(content, '') || ' ' || coalesce(summary, ''))) > 0",
+        ),
+        "decision": (
+            "decisions",
+            "length(trim(coalesce(question, '') || ' ' || coalesce(rationale, ''))) > 0",
+        ),
+        "literature": (
+            "literature",
+            "length(trim(coalesce(title, '') || ' ' || coalesce(abstract, ''))) > 0",
+        ),
+        "mission": (
+            "missions",
+            "length(trim(coalesce(objective, '') || ' ' || coalesce(context, ''))) > 0",
+        ),
+        "artifact": ("artifacts", "length(trim(coalesce(filename, ''))) > 0"),
+        "figure": (
+            "figures",
+            "length(trim(coalesce(caption, '') || ' ' || coalesce(summary, '') "
+            "|| ' ' || coalesce(claims, ''))) > 0",
+        ),
+    }
+    for entity_type, (source_table, eligible_sql) in eligible_sources.items():
+        pending = await db.fetchone(
+            f"""SELECT 1 AS pending FROM {source_table} s
+                WHERE {eligible_sql}
+                  AND NOT EXISTS (
+                      SELECT 1 FROM embedding_metadata m
+                      WHERE m.project_id = s.project_id
+                        AND m.entity_type = ? AND m.entity_id = s.id
+                        AND m.model_name = ? AND m.dimensions = ?
+                  )
+                LIMIT 1""",
+            [entity_type, state.model_name, state.dimensions],
+        )
+        if pending:
+            return False
+    return True

--- a/rka/services/embedding_reshape.py
+++ b/rka/services/embedding_reshape.py
@@ -323,14 +323,47 @@ async def ensure_vec_table_partitions(db: Any) -> dict[str, bool]:
 # ---------------------------------------------------------------------------
 
 
-async def reshape_vec_table(db: Any, table_name: str, *, dim: int) -> int:
+async def embedding_space_mismatch(
+    db: Any,
+    *,
+    model_name: str,
+    dim: int,
+) -> bool:
+    """Return whether stored metadata belongs to a different vector space.
+
+    This is the restart-safe half of config migration. A process can stop after
+    the new config is atomically saved but before PUT rebuilds the tables. On
+    the next boot, dimensions alone are insufficient because two models can
+    share a dimension. Any old metadata therefore forces one clean rebuild.
+    """
+    if not getattr(db, "vec_available", False):
+        return False
+    row = await db.fetchone(
+        """SELECT 1 AS mismatch
+           FROM embedding_metadata
+           WHERE model_name <> ? OR dimensions <> ?
+           LIMIT 1""",
+        [model_name, dim],
+    )
+    return row is not None
+
+
+async def reshape_vec_table(
+    db: Any,
+    table_name: str,
+    *,
+    dim: int,
+    force: bool = False,
+) -> int:
     """Drop + recreate `table_name` at `dim`; mark its entities pending.
 
     Returns the count of entities in the corresponding entity table
     (claims for vec_claims, journal for vec_journal, etc.) — the same
     number that `needs_reembed` will report True for until backfill
     repopulates them. Safe to call when the table is already at `dim`
-    (idempotent fast-path: skip drop, return current pending count).
+    (idempotent fast-path: skip drop, return current pending count), unless
+    `force=True`. A forced rebuild is used when model/input-space identity
+    changes without a dimension change, preventing mixed-space vectors.
 
     Pending-signal logic per entity type:
       - `vec_claims`: `UPDATE claims SET embedding_pending = 1`
@@ -359,11 +392,25 @@ async def reshape_vec_table(db: Any, table_name: str, *, dim: int) -> int:
         return await _count_entity_rows(db, entities)
 
     existing_dim = await current_vec_table_dim(db, table_name)
-    if existing_dim == dim:
+    if existing_dim == dim and not force:
         logger.info(
             "reshape_vec_table: %s already at dim=%d; no-op", table_name, dim
         )
         return await _count_pending(db, table_name, entities)
+
+    if existing_dim == dim and force:
+        # A document-space change at the same dimension only needs an index
+        # reset.  Preserve the vec0 schema so already-running API/worker
+        # connections never observe a DROP/CREATE invalidation.
+        logger.info(
+            "reshape_vec_table: clearing %s at unchanged dim=%d",
+            table_name,
+            dim,
+        )
+        async with db.transaction():
+            await db.execute(f"DELETE FROM {table_name}")
+            await _mark_pending(db, table_name, entities)
+        return await _count_entity_rows(db, entities)
 
     logger.info(
         "reshape_vec_table: dropping %s (was dim=%s) and recreating at dim=%d",
@@ -383,7 +430,10 @@ async def reshape_vec_table(db: Any, table_name: str, *, dim: int) -> int:
 
 
 async def reshape_all_vec_tables_if_needed(
-    db: Any, *, dim: int
+    db: Any,
+    *,
+    dim: int,
+    force: bool = False,
 ) -> dict[str, tuple[bool, int]]:
     """Iterate every known vec_* table; reshape-if-needed; return per-table outcome.
 
@@ -395,11 +445,11 @@ async def reshape_all_vec_tables_if_needed(
     for tbl in _VEC_TABLE_NAMES:
         entities = _TABLE_TO_ENTITIES[tbl]
         existing_dim = await current_vec_table_dim(db, tbl)
-        if existing_dim == dim:
+        if existing_dim == dim and not force:
             pending = await _count_pending(db, tbl, entities)
             out[tbl] = (False, pending)
         else:
-            pending = await reshape_vec_table(db, tbl, dim=dim)
+            pending = await reshape_vec_table(db, tbl, dim=dim, force=force)
             out[tbl] = (True, pending)
     return out
 
@@ -441,13 +491,18 @@ async def _mark_pending(
 ) -> None:
     """Flip the pending signal for every entity of this type.
 
-    `vec_claims` keeps the v2.4 `embedding_pending` flag pattern (the
-    BackfillService cursor reads it directly); the other six use
-    metadata-absence as the signal.
+    `vec_claims` keeps the legacy `embedding_pending` flag for readers that
+    still inspect it. Every entity type, including claims, also deletes
+    embedding metadata because metadata absence is the authoritative pending
+    signal used by the current backfill cursor.
     """
     if table_name == "vec_claims":
-        _entity_type, entity_table = entities[0]
+        entity_type, entity_table = entities[0]
         await db.execute(f"UPDATE {entity_table} SET embedding_pending = 1")
+        await db.execute(
+            "DELETE FROM embedding_metadata WHERE entity_type = ?",
+            [entity_type],
+        )
     else:
         for entity_type, _entity_table in entities:
             await db.execute(

--- a/rka/services/knowledge_pack.py
+++ b/rka/services/knowledge_pack.py
@@ -215,6 +215,7 @@ _TABLE_CATEGORIES: dict[str, list[str]] = {
         "project_deletion_authorizations",
         "kv_store",
         "embedding_metadata",
+        "embedding_index_state",
     ],
     "indexes": [
         # SKIP — rebuilt automatically (vec_*, fts_* detected by prefix)

--- a/rka/services/search.py
+++ b/rka/services/search.py
@@ -141,6 +141,14 @@ class SearchService:
     def with_project(self, project_id: str) -> "SearchService":
         return SearchService(db=self.db, embeddings=self.embeddings, project_id=project_id)
 
+    async def _embedding_index_ready(self) -> bool:
+        if self.embeddings is None:
+            return False
+        check = getattr(self.embeddings, "index_search_ready", None)
+        if check is None:
+            return True
+        return bool(await check())
+
     # Query-understanding patterns (eval-v3 theme E follow-up; Eval-v1
     # Finding: temporal language and actor anchors fell back to literal FTS
     # tokens and missed — "today" matched nothing, "PI directives" ignored
@@ -414,8 +422,19 @@ class SearchService:
         vec_results: list[SearchHit] = []
         if self.embeddings and self.db.vec_available:
             try:
-                query_vec = await self.embeddings.embed(query)
-                vec_results = await self._vector_search(query_vec, types, limit * 2)
+                if await self._embedding_index_ready():
+                    query_vec = await self.embeddings.embed(query)
+                    # Hold one read snapshot from the final generation check
+                    # through KNN. A concurrent transition either waits or is
+                    # observed here, so query and document vectors always come
+                    # from the same generation.
+                    async with self.db.transaction(write=False):
+                        if await self._embedding_index_ready():
+                            vec_results = await self._vector_search(
+                                query_vec,
+                                types,
+                                limit * 2,
+                            )
             except Exception as exc:
                 logger.warning("Vector search failed, using keyword only: %s", exc)
 

--- a/rka/services/worker.py
+++ b/rka/services/worker.py
@@ -17,6 +17,7 @@ corpus refresh mis_01KS0QEW21N2NG4EJTKJ3JTWTE).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import socket
@@ -27,6 +28,14 @@ from rka.infra.database import Database
 from rka.services.jobs import JobLeaseLost, JobQueue
 
 logger = logging.getLogger(__name__)
+
+_EMBEDDING_JOB_TYPES = {
+    "mission_embed",
+    "note_embed",
+    "claim_embed",
+    "decision_embed",
+    "literature_embed",
+}
 
 
 class EnrichmentWorker:
@@ -41,12 +50,20 @@ class EnrichmentWorker:
         lease_seconds: int = 300,
         max_attempts: int = 5,
         worker_id: str | None = None,
+        data_dir: Path | str | None = None,
+        embeddings_enabled: bool = True,
+        env_fallback_model: str = "nomic-ai/nomic-embed-text-v1.5",
     ):
         self.db = db
         self.embeddings = embeddings
         self.poll_interval = poll_interval
         self.queue = JobQueue(db, lease_seconds=lease_seconds, default_max_attempts=max_attempts)
         self.worker_id = worker_id or f"{socket.gethostname()}:{os.getpid()}"
+        self._embedding_data_dir = Path(data_dir) if data_dir is not None else None
+        self._embeddings_enabled = embeddings_enabled
+        self._env_fallback_model = env_fallback_model
+        self._embedding_config_fingerprint: str | None = None
+        self._embedding_generation: int | None = None
 
     # ------------------------------------------------------------------
     # v2.5.8 boot path (Bug 2 fix per dec_01KS3E1FGSK530N8HM04BNMCEW)
@@ -74,10 +91,8 @@ class EnrichmentWorker:
         2. Otherwise, attempt to read `<data_dir>/embedding_config.json`
            via `EmbeddingConfigService.load_config()` and construct an
            `EmbeddingService.from_config(...)`.
-        3. On any failure (file missing, corrupt, EmbeddingService
-           construction error), fall back to the legacy env-driven
-           constructor (`EmbeddingService(model_name=env_fallback_model)`)
-           and log WARNING.
+        3. A missing file retains the legacy first-run default. An existing
+           invalid file fails closed instead of selecting another model.
 
         Log lines explicitly indicate which path was taken so operators
         can correlate worker boot logs with config-changed-via-webui events.
@@ -95,6 +110,9 @@ class EnrichmentWorker:
             lease_seconds=lease_seconds,
             max_attempts=max_attempts,
             worker_id=worker_id,
+            data_dir=data_dir,
+            embeddings_enabled=embeddings_enabled,
+            env_fallback_model=env_fallback_model,
         )
 
     @staticmethod
@@ -105,61 +123,118 @@ class EnrichmentWorker:
         embeddings_enabled: bool,
         env_fallback_model: str,
     ):
-        """Load EmbeddingService from persisted config or fall back to env.
-
-        Isolated as a staticmethod so unit tests can exercise the resolution
-        logic without instantiating a full worker. Logs are informative-only
-        (no exceptions raised on fallback).
-        """
+        """Load EmbeddingService, failing closed on an invalid saved config."""
         if not embeddings_enabled:
             logger.info(
                 "worker boot: embeddings_enabled=False; running without EmbeddingService"
             )
             return None
 
-        # Lazy imports keep the worker.py top-level import surface small
-        # (embedding_config + embedding_backends pull in optional deps).
-        try:
-            from rka.infra.embeddings import EmbeddingService
-            from rka.services.embedding_config import EmbeddingConfigService
+        # Lazy imports keep the worker.py top-level import surface small.
+        from rka.infra.embeddings import EmbeddingService
+        from rka.services.embedding_config import EmbeddingConfigService
 
-            cfg_svc = EmbeddingConfigService(config_dir=data_dir)
-            if not cfg_svc.config_path.exists():
-                logger.info(
-                    "worker boot: falling back to env defaults; persisted config "
-                    "not found at %s",
-                    cfg_svc.config_path,
-                )
-                return EmbeddingService(model_name=env_fallback_model, db=db)
-
-            embedding_cfg = cfg_svc.load_config()
-            embeddings = EmbeddingService.from_config(
-                embedding_cfg.model_dump(), db=db
-            )
+        cfg_svc = EmbeddingConfigService(config_dir=data_dir)
+        if not cfg_svc.config_path.exists():
             logger.info(
-                "worker boot: reading config from %s (backend=%s, dim=%d)",
+                "worker boot: falling back to env defaults; persisted config "
+                "not found at %s",
                 cfg_svc.config_path,
-                embedding_cfg.backend,
-                embeddings.dim,
             )
-            return embeddings
-        except Exception as exc:
-            logger.warning(
-                "worker boot: failed to load persisted config (%s); falling back "
-                "to env defaults (model=%s)",
-                exc,
-                env_fallback_model,
+            return EmbeddingService(model_name=env_fallback_model, db=db)
+
+        embedding_cfg = cfg_svc.load_config()
+        if not (embedding_cfg.config or {}).get("dim"):
+            raise ValueError(
+                "persisted embedding config has no detected dimension; save it through the API"
             )
-            try:
-                from rka.infra.embeddings import EmbeddingService
-                return EmbeddingService(model_name=env_fallback_model, db=db)
-            except Exception as inner_exc:
-                logger.error(
-                    "worker boot: env-fallback EmbeddingService construction also "
-                    "failed (%s); running without embeddings",
-                    inner_exc,
+        embeddings = EmbeddingService.from_config(embedding_cfg.model_dump(), db=db)
+        logger.info(
+            "worker boot: reading config from %s (backend=%s, dim=%d)",
+            cfg_svc.config_path,
+            embedding_cfg.backend,
+            embeddings.dim,
+        )
+        return embeddings
+
+    def _config_fingerprint(self) -> str:
+        if self._embedding_data_dir is None:
+            return "unmanaged"
+        path = self._embedding_data_dir / "embedding_config.json"
+        if not path.exists():
+            return "missing"
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    async def _refresh_embeddings_before_job(self) -> None:
+        """Reload config/generation before an embedding job when needed."""
+
+        if not self._embeddings_enabled or self._embedding_data_dir is None:
+            return
+
+        from rka.infra.embeddings import EmbeddingService
+        from rka.services.embedding_config import EmbeddingConfigService
+        from rka.services.embedding_index import (
+            EmbeddingGenerationMismatch,
+            embedding_space_signature,
+            get_embedding_index_state,
+        )
+
+        fingerprint = self._config_fingerprint()
+        state = await get_embedding_index_state(self.db)
+        generation = state.generation if state is not None else None
+        if (
+            self.embeddings is not None
+            and fingerprint == self._embedding_config_fingerprint
+            and generation == self._embedding_generation
+        ):
+            return
+
+        cfg_svc = EmbeddingConfigService(config_dir=self._embedding_data_dir)
+        if not cfg_svc.config_path.exists():
+            if state is not None:
+                raise EmbeddingGenerationMismatch(
+                    "persisted embedding config is missing for the active generation"
                 )
-                return None
+            embeddings = EmbeddingService(
+                model_name=self._env_fallback_model,
+                db=self.db,
+            )
+        else:
+            embedding_cfg = cfg_svc.load_config()
+            if not (embedding_cfg.config or {}).get("dim"):
+                raise ValueError(
+                    "persisted embedding config has no detected dimension; "
+                    "save it through the API"
+                )
+            embeddings = EmbeddingService.from_config(
+                embedding_cfg.model_dump(),
+                db=self.db,
+            )
+            if state is not None:
+                signature = embedding_space_signature(
+                    embedding_cfg,
+                    dimensions=embeddings.dim,
+                )
+                if (
+                    signature != state.space_signature
+                    or embeddings.model_name != state.model_name
+                    or embeddings.dim != state.dimensions
+                ):
+                    raise EmbeddingGenerationMismatch(
+                        "embedding config and active index generation do not match"
+                    )
+                embeddings.bind_index_generation(
+                    state.generation,
+                    space_signature=state.space_signature,
+                )
+
+        self.embeddings = embeddings
+        self._embedding_config_fingerprint = fingerprint
+        self._embedding_generation = generation
+        logger.info(
+            "worker refreshed embedding configuration (generation=%s)",
+            generation if generation is not None else "legacy",
+        )
 
     async def run_once(self) -> bool:
         """Process one job if available."""
@@ -168,7 +243,7 @@ class EnrichmentWorker:
             return False
 
         try:
-            result = await self._process_job(job)
+            result = await self._process_job_with_generation_retry(job)
         except Exception as exc:  # pragma: no cover - failure path tested via queue state
             logger.exception("Worker job %s failed", job["id"])
             durable_error = str(exc)
@@ -190,6 +265,37 @@ class EnrichmentWorker:
             )
         return True
 
+    async def _process_job_with_generation_retry(
+        self,
+        job: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Retry one managed embedding job after losing a generation race.
+
+        The queue attempt already owns a live lease.  Reloading the durable
+        config and retrying once in that lease avoids terminalizing a
+        max-attempts=1 edit merely because its first vector write crossed a
+        configuration transition.  Persistent config/backend failures still
+        flow through the normal durable queue failure policy.
+        """
+        try:
+            return await self._process_job(job)
+        except Exception as exc:
+            from rka.services.embedding_index import EmbeddingGenerationMismatch
+
+            if (
+                not isinstance(exc, EmbeddingGenerationMismatch)
+                or job["job_type"] not in _EMBEDDING_JOB_TYPES
+                or self._embedding_data_dir is None
+            ):
+                raise
+            logger.info(
+                "Worker job %s lost embedding generation; reloading config and retrying",
+                job["id"],
+            )
+            self._embedding_config_fingerprint = None
+            self._embedding_generation = None
+            return await self._process_job(job)
+
     async def run_forever(self, stop_event: asyncio.Event | None = None) -> None:
         """Process jobs until cancelled or stop_event is set."""
         while True:
@@ -204,6 +310,9 @@ class EnrichmentWorker:
         job_type = job["job_type"]
         project_id = job["project_id"]
         entity_id = job.get("entity_id")
+
+        if job_type in _EMBEDDING_JOB_TYPES:
+            await self._refresh_embeddings_before_job()
 
         # ── Embedding-only jobs ──────────────────────────────────
 

--- a/tests/test_api/test_capabilities_route.py
+++ b/tests/test_api/test_capabilities_route.py
@@ -6,7 +6,7 @@ BREAKING-IN-MINOR change: the `llm` field is removed entirely per PI
 directive jrn_01KRNZBS50K250HHHHEC58E4GC.
 
 Verified states (E2.1, additive over Mission D):
-  - The embedding block remains {available, reason_unavailable}
+  - The embedding block reports availability, reason, and active search mode
   - Core/interface versions and contract discovery are explicit
   - Unsupported requirements return an actionable 409 response
   - `llm` field is ABSENT (not null, not {available: false} — gone)
@@ -107,17 +107,18 @@ async def test_capabilities_llm_field_is_absent(api_client: httpx.AsyncClient):
 
 @pytest.mark.asyncio
 async def test_capabilities_embedding_block_shape_preserved(api_client: httpx.AsyncClient):
-    """The embedding block's shape is unchanged from Mission B Affordance C."""
+    """The embedding block keeps old fields and adds an explicit search mode."""
     r = await api_client.get("/api/capabilities")
     body = r.json()
     emb = body["embedding"]
-    assert set(emb.keys()) >= {"available", "reason_unavailable"}
+    assert set(emb.keys()) >= {"available", "reason_unavailable", "search_mode"}
     assert isinstance(emb["available"], bool)
     if emb["available"]:
         assert emb["reason_unavailable"] is None
     else:
         assert isinstance(emb["reason_unavailable"], str)
         assert len(emb["reason_unavailable"]) > 0
+        assert emb["search_mode"] == "lexical"
 
 
 @pytest.mark.asyncio
@@ -130,6 +131,44 @@ async def test_capabilities_embedding_disabled_carries_reason(api_client: httpx.
     emb = body["embedding"]
     assert emb["available"] is False
     assert "disabled" in emb["reason_unavailable"].lower()
+    assert emb["search_mode"] == "lexical"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_tracks_runtime_and_generation_degradation(
+    api_client: httpx.AsyncClient,
+):
+    class _Embeddings:
+        runtime_available = False
+        ready = True
+
+        async def index_search_ready(self) -> bool:
+            return self.ready
+
+    app = api_client._transport.app
+    assert app.state.db.vec_available is True
+    embeddings = _Embeddings()
+    app.state.embeddings = embeddings
+
+    failed = (await api_client.get("/api/capabilities")).json()
+    assert failed["embedding"]["available"] is False
+    assert failed["embedding"]["search_mode"] == "lexical"
+    assert "embedding" not in failed["available_capabilities"]
+
+    embeddings.runtime_available = True
+    embeddings.ready = False
+    rebuilding = (await api_client.get("/api/capabilities")).json()
+    assert rebuilding["embedding"]["available"] is False
+    assert rebuilding["embedding"]["search_mode"] == "lexical"
+
+    embeddings.ready = True
+    recovered = (await api_client.get("/api/capabilities")).json()
+    assert recovered["embedding"] == {
+        "available": True,
+        "reason_unavailable": None,
+        "search_mode": "hybrid",
+    }
+    assert "embedding" in recovered["available_capabilities"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_api/test_config_routes.py
+++ b/tests/test_api/test_config_routes.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import time
+import struct
 from pathlib import Path
-from typing import Any
 
 import httpx
 import pytest
@@ -14,7 +12,13 @@ import pytest_asyncio
 
 from rka.api.app import create_app
 from rka.config import RKAConfig
-from rka.services.embedding_backfill import clear_registry
+from rka.infra.embedding_backends import ConnectionTestResult
+from rka.services.embedding_backfill import (
+    BackfillService,
+    clear_registry,
+    latest_status,
+    register_job,
+)
 from rka.services.embedding_config import EmbeddingConfig, EmbeddingConfigService
 
 
@@ -129,6 +133,42 @@ async def test_test_endpoint_returns_connection_test_result_shape(api_client):
 
 
 @pytest.mark.asyncio
+async def test_test_endpoint_uses_saved_secret_when_client_omits_it(
+    api_client, monkeypatch
+):
+    client, data_dir = api_client
+    svc = EmbeddingConfigService(config_dir=data_dir)
+    svc.save_config(
+        EmbeddingConfig(
+            backend="openai_compat",
+            config={
+                "base_url": "http://x",
+                "model": "m",
+                "api_key": "sk-saved",
+                "dim": 768,
+            },
+        ),
+        actor="pi",
+    )
+
+    async def _capture(self, config):  # noqa: ARG001
+        assert config.config["api_key"] == "sk-saved"
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=768)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _capture)
+    response = await client.post(
+        "/api/config/embedding/test",
+        json={
+            "backend": "openai_compat",
+            "config": {"base_url": "http://x", "model": "m", "dim": 768},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+@pytest.mark.asyncio
 async def test_test_endpoint_422_on_invalid_body(api_client):
     client, _ = api_client
     r = await client.post(
@@ -196,6 +236,288 @@ async def test_put_returns_422_on_connection_failure(api_client):
     assert body["error"] == "embedding_config_invalid"
     assert "connection test failed" in body["detail"]
     assert "Settings" in body["hint"]  # actionable next step
+
+
+@pytest.mark.asyncio
+async def test_put_refreshes_search_backend_without_reindex(api_client, monkeypatch):
+    """A query-template/key edit must update the live search path immediately."""
+    client, data_dir = api_client
+    svc = EmbeddingConfigService(config_dir=data_dir)
+    svc.save_config(
+        EmbeddingConfig(
+            backend="openai_compat",
+            config={
+                "base_url": "http://x",
+                "model": "m",
+                "api_key": "old",
+                "dim": 4,
+                "query_template": "Query: {text}",
+            },
+        ),
+        actor="pi",
+    )
+
+    async def _passing_test(self, config):  # noqa: ARG001
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=4)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _passing_test)
+    app = client._transport.app
+    previous = app.state.search.embeddings
+
+    response = await client.put(
+        "/api/config/embedding",
+        json={
+            "backend": "openai_compat",
+            "config": {
+                "base_url": "http://x",
+                "model": "m",
+                "api_key": "new",
+                "dim": 4,
+                "query_template": "Instruct: retrieve.\nQuery: {text}",
+            },
+        },
+    )
+
+    # Credential repair schedules a missing-only reconciliation so records
+    # created during an authentication outage are not stranded. It does not
+    # force a document-space rebuild when the generation already matches.
+    assert response.status_code == 202
+    assert app.state.search.embeddings is app.state.embeddings
+    assert app.state.search.embeddings is not previous
+
+
+@pytest.mark.asyncio
+async def test_put_preserves_secret_and_advanced_fields(api_client, monkeypatch):
+    client, data_dir = api_client
+    svc = EmbeddingConfigService(config_dir=data_dir)
+    advanced = {
+        "base_url": "http://x",
+        "model": "transport-model",
+        "api_key": "sk-preserve",
+        "dim": 768,
+        "timeout_seconds": 45,
+        "embedding_space_id": "space-v1",
+        "query_template": "Query: {text}",
+        "document_template": "{text}",
+    }
+    svc.save_config(
+        EmbeddingConfig(backend="openai_compat", config=advanced),
+        actor="pi",
+    )
+
+    async def _passing_test(self, config):  # noqa: ARG001
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=768)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _passing_test)
+    submitted = {key: value for key, value in advanced.items() if key != "api_key"}
+    response = await client.put(
+        "/api/config/embedding",
+        json={"backend": "openai_compat", "config": submitted},
+    )
+
+    assert response.status_code == 202
+    persisted = svc.load_config()
+    assert persisted.config["api_key"] == "sk-preserve"
+    for key, value in submitted.items():
+        assert persisted.config[key] == value
+    fetched = await client.get("/api/config/embedding")
+    assert fetched.json()["config"]["api_key"] == "***"
+
+
+@pytest.mark.asyncio
+async def test_populated_cross_dimension_put_is_non_destructive(api_client, monkeypatch):
+    client, data_dir = api_client
+    app = client._transport.app
+    db = app.state.db
+    blob = struct.pack("768f", *([0.0] * 768))
+    await db.execute(
+        "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+        ["clm_existing", "proj_default", blob],
+    )
+    await db.execute(
+        """INSERT INTO embedding_metadata
+           (project_id, entity_type, entity_id, content_hash, model_name, dimensions)
+           VALUES ('proj_default', 'claim', 'clm_existing', 'hash', 'old', 768)"""
+    )
+
+    async def _passing_test(self, config):  # noqa: ARG001
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=1024)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _passing_test)
+    previous_embeddings = app.state.embeddings
+    previous_search_embeddings = app.state.search.embeddings
+
+    response = await client.put(
+        "/api/config/embedding",
+        json={
+            "backend": "openai_compat",
+            "config": {"base_url": "http://x", "model": "new", "dim": 1024},
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"] == "embedding_offline_reindex_required"
+    assert not (data_dir / "embedding_config.json").exists()
+    assert app.state.embeddings is previous_embeddings
+    assert app.state.search.embeddings is previous_search_embeddings
+    assert latest_status() is None
+    assert await db.fetchone(
+        "SELECT id FROM vec_claims WHERE id = 'clm_existing'"
+    ) == {"id": "clm_existing"}
+
+
+@pytest.mark.asyncio
+async def test_cross_dimension_put_rechecks_after_writer_lock(api_client, monkeypatch):
+    """A late old-space write must make the authoritative check fail closed."""
+    client, data_dir = api_client
+    app = client._transport.app
+    db = app.state.db
+
+    async def _passing_test(self, config):  # noqa: ARG001
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=1024)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _passing_test)
+
+    from rka.api.routes import config as config_routes
+    from rka.services.embedding_index import (
+        assert_online_dimension_compatible as real_dimension_check,
+    )
+
+    calls = 0
+
+    async def _inject_late_write(database, *, dim):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            blob = struct.pack("768f", *([0.0] * 768))
+            await database.execute(
+                "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+                ["clm_late", "proj_default", blob],
+            )
+        await real_dimension_check(database, dim=dim)
+
+    monkeypatch.setattr(
+        config_routes,
+        "assert_online_dimension_compatible",
+        _inject_late_write,
+    )
+
+    response = await client.put(
+        "/api/config/embedding",
+        json={
+            "backend": "openai_compat",
+            "config": {"base_url": "http://x", "model": "new", "dim": 1024},
+        },
+    )
+
+    assert calls == 2
+    assert response.status_code == 409
+    assert response.json()["error"] == "embedding_offline_reindex_required"
+    assert not (data_dir / "embedding_config.json").exists()
+    assert await db.fetchone(
+        "SELECT id FROM vec_claims WHERE id = 'clm_late'"
+    ) is None
+    assert latest_status() is None
+
+
+@pytest.mark.asyncio
+async def test_put_commit_failure_restores_exact_config_and_runtime(api_client, monkeypatch):
+    client, data_dir = api_client
+    app = client._transport.app
+    db = app.state.db
+    svc = EmbeddingConfigService(config_dir=data_dir)
+    svc.save_config(
+        EmbeddingConfig(
+            backend="openai_compat",
+            config={"base_url": "http://old", "model": "old", "dim": 768},
+        ),
+        actor="pi",
+    )
+    before = svc.config_path.read_bytes()
+    previous_embeddings = app.state.embeddings
+    previous_search_embeddings = app.state.search.embeddings
+
+    async def _passing_test(self, config):  # noqa: ARG001
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=768)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _passing_test)
+    connection_type = type(db.conn)
+    real_commit = connection_type.commit
+    fail_once = True
+
+    async def _commit_with_one_failure(connection):
+        nonlocal fail_once
+        if fail_once:
+            fail_once = False
+            raise RuntimeError("injected commit failure")
+        return await real_commit(connection)
+
+    monkeypatch.setattr(connection_type, "commit", _commit_with_one_failure)
+
+    response = await client.put(
+        "/api/config/embedding",
+        json={
+            "backend": "openai_compat",
+            "config": {"base_url": "http://new", "model": "new", "dim": 768},
+        },
+    )
+
+    assert response.status_code == 500
+    assert response.json()["error"] == "embedding_config_update_failed"
+    assert svc.config_path.read_bytes() == before
+    assert await db.fetchone(
+        "SELECT generation FROM embedding_index_state WHERE singleton = 1"
+    ) is None
+    assert app.state.embeddings is previous_embeddings
+    assert app.state.search.embeddings is previous_search_embeddings
+    assert latest_status() is None
+
+
+@pytest.mark.asyncio
+async def test_put_cancellation_restores_newly_created_config(api_client, monkeypatch):
+    client, data_dir = api_client
+    app = client._transport.app
+    db = app.state.db
+    previous_embeddings = app.state.embeddings
+
+    async def _passing_test(self, config):  # noqa: ARG001
+        return ConnectionTestResult(ok=True, detail="ok", detected_dim=768)
+
+    monkeypatch.setattr(EmbeddingConfigService, "test_config", _passing_test)
+    connection_type = type(db.conn)
+    real_commit = connection_type.commit
+    cancel_once = True
+
+    async def _commit_with_one_cancellation(connection):
+        nonlocal cancel_once
+        if cancel_once:
+            cancel_once = False
+            raise asyncio.CancelledError
+        return await real_commit(connection)
+
+    monkeypatch.setattr(connection_type, "commit", _commit_with_one_cancellation)
+
+    # Starlette's BaseHTTPMiddleware converts a cancelled handler into this
+    # transport-level error after the endpoint has re-raised cancellation.
+    with pytest.raises(RuntimeError, match="No response returned"):
+        await client.put(
+            "/api/config/embedding",
+            json={
+                "backend": "openai_compat",
+                "config": {
+                    "base_url": "http://new",
+                    "model": "new",
+                    "dim": 768,
+                },
+            },
+        )
+
+    assert not (data_dir / "embedding_config.json").exists()
+    assert await db.fetchone(
+        "SELECT generation FROM embedding_index_state WHERE singleton = 1"
+    ) is None
+    assert app.state.embeddings is previous_embeddings
+    assert latest_status() is None
 
 
 # ---------------------------------------------------------------------------
@@ -308,6 +630,73 @@ def test_backend_signature_ignores_api_key():
     assert _backend_signature(a) == _backend_signature(b)
 
 
+def test_space_signature_distinguishes_embedding_space_id():
+    """Same-dimension model changes cannot share one sqlite-vec index."""
+    from rka.api.routes.config import _space_signature
+
+    a = EmbeddingConfig(
+        backend="openai_compat",
+        config={
+            "base_url": "http://x",
+            "model": "transport-model",
+            "dim": 1024,
+            "embedding_space_id": "qwen-q8-sha-a",
+        },
+    )
+    b = EmbeddingConfig(
+        backend="openai_compat",
+        config={
+            "base_url": "http://x",
+            "model": "transport-model",
+            "dim": 1024,
+            "embedding_space_id": "qwen-q8-sha-b",
+        },
+    )
+    assert _space_signature(a) != _space_signature(b)
+
+
+def test_query_template_change_does_not_change_document_space():
+    """A query-only instruction update does not require re-indexing documents."""
+    from rka.api.routes.config import _space_signature
+
+    base = {
+        "base_url": "http://x",
+        "model": "transport-model",
+        "dim": 1024,
+        "embedding_space_id": "qwen-q8-sha-a",
+        "document_template": "{text}",
+    }
+    a = EmbeddingConfig(
+        backend="openai_compat",
+        config={**base, "query_template": "Query: {text}"},
+    )
+    b = EmbeddingConfig(
+        backend="openai_compat",
+        config={**base, "query_template": "Instruct: retrieve.\nQuery: {text}"},
+    )
+    assert _space_signature(a) == _space_signature(b)
+
+
+def test_document_template_change_requires_new_document_space():
+    from rka.api.routes.config import _space_signature
+
+    base = {
+        "base_url": "http://x",
+        "model": "transport-model",
+        "dim": 1024,
+        "embedding_space_id": "qwen-q8-sha-a",
+    }
+    a = EmbeddingConfig(
+        backend="openai_compat",
+        config={**base, "document_template": "{text}"},
+    )
+    b = EmbeddingConfig(
+        backend="openai_compat",
+        config={**base, "document_template": "Document: {text}"},
+    )
+    assert _space_signature(a) != _space_signature(b)
+
+
 # --------------------------------------------------------------------------
 # explicit backfill trigger
 # --------------------------------------------------------------------------
@@ -328,14 +717,30 @@ async def test_backfill_trigger_returns_job_when_backend_present(api_client):
     client, _ = api_client
 
     class _Stub:
-        dim = 4
+        dim = 768
         model_name = "stub"
 
         async def embed_batch(self, texts, **kw):
-            return [[0.0] * 4 for _ in texts]
+            return [[0.0] * 768 for _ in texts]
 
     transport = client._transport
-    transport.app.state.embeddings = _Stub()
+    from rka.services.embedding_index import (
+        embedding_space_signature,
+        reconcile_embedding_index,
+    )
+
+    db = transport.app.state.db
+    cfg = {"backend": "fastembed", "config": {"model_name": "stub", "dim": 768}}
+    reconciled = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="stub",
+        dim=768,
+    )
+    stub = _Stub()
+    stub.index_generation = reconciled.state.generation
+    stub.space_signature = reconciled.state.space_signature
+    transport.app.state.embeddings = stub
 
     r = await client.post("/api/config/embedding/backfill?entity_types=claim")
     assert r.status_code == 202
@@ -347,3 +752,232 @@ async def test_backfill_trigger_returns_job_when_backend_present(api_client):
         f"/api/config/embedding/backfill/status?job_id={body['job_id']}"
     )
     assert status.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_manual_backfill_resumes_failed_bound_generation(api_client):
+    client, _ = api_client
+    app = client._transport.app
+    db = app.state.db
+    from rka.services.embedding_index import (
+        embedding_space_signature,
+        get_embedding_index_state,
+        reconcile_embedding_index,
+    )
+
+    class _Stub:
+        dim = 768
+        model_name = "stub"
+
+        async def embed_batch(self, texts, **kw):
+            return [[0.0] * 768 for _ in texts]
+
+    cfg = {"backend": "fastembed", "config": {"model_name": "stub", "dim": 768}}
+    reconciled = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="stub",
+        dim=768,
+    )
+    await db.execute(
+        "UPDATE embedding_index_state SET status = 'failed' WHERE singleton = 1"
+    )
+    stub = _Stub()
+    stub.index_generation = reconciled.state.generation
+    stub.space_signature = reconciled.state.space_signature
+    app.state.embeddings = stub
+
+    response = await client.post("/api/config/embedding/backfill?entity_types=claim")
+
+    assert response.status_code == 202
+    state = await get_embedding_index_state(db)
+    assert state is not None
+    assert state.status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_manual_backfill_rejects_stale_process_generation(api_client):
+    client, _ = api_client
+    app = client._transport.app
+    db = app.state.db
+    from rka.services.embedding_index import (
+        embedding_space_signature,
+        get_embedding_index_state,
+        reconcile_embedding_index,
+    )
+
+    class _Stub:
+        dim = 768
+        model_name = "old-model"
+
+    old_cfg = {
+        "backend": "fastembed",
+        "config": {"model_name": "old-model", "dim": 768},
+    }
+    old = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(old_cfg),
+        model_name="old-model",
+        dim=768,
+    )
+    stub = _Stub()
+    stub.index_generation = old.state.generation
+    stub.space_signature = old.state.space_signature
+    app.state.embeddings = stub
+
+    new_cfg = {
+        "backend": "fastembed",
+        "config": {"model_name": "new-model", "dim": 768},
+    }
+    current = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(new_cfg),
+        model_name="new-model",
+        dim=768,
+    )
+
+    response = await client.post("/api/config/embedding/backfill")
+
+    assert response.status_code == 409
+    assert response.json()["error"] == "embedding_generation_changed"
+    state = await get_embedding_index_state(db)
+    assert state is not None
+    assert state.generation == current.state.generation
+    assert state.space_signature == current.state.space_signature
+    assert latest_status() is None
+
+
+@pytest.mark.asyncio
+async def test_consistency_gate_failure_updates_backfill_job_status(api_client):
+    client, _ = api_client
+    app = client._transport.app
+    db = app.state.db
+    from rka.api.routes.config import _run_backfill_safely
+    from rka.services.embedding_index import (
+        embedding_space_signature,
+        get_embedding_index_state,
+        reconcile_embedding_index,
+    )
+
+    first_cfg = {
+        "backend": "fastembed",
+        "config": {"model_name": "first", "dim": 768},
+    }
+    await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(first_cfg),
+        model_name="first",
+        dim=768,
+    )
+    next_cfg = {
+        "backend": "fastembed",
+        "config": {"model_name": "next", "dim": 768},
+    }
+    generation = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(next_cfg),
+        model_name="next",
+        dim=768,
+    )
+
+    class _Stub:
+        dim = 768
+        model_name = "next"
+        index_generation = generation.state.generation
+        space_signature = generation.state.space_signature
+
+    class _InconsistentBackfill(BackfillService):
+        async def run_backfill(self, status, progress_callback=None, entity_types=None):
+            await self._db.execute(
+                "INSERT INTO journal (id, type, content, source) "
+                "VALUES ('jrn_late_consistency', 'note', 'source', 'pi')"
+            )
+            await self._db.execute(
+                "INSERT INTO claims "
+                "(id, source_entry_id, claim_type, content, embedding_pending) "
+                "VALUES ('clm_late_consistency', 'jrn_late_consistency', "
+                "'observation', 'not embedded', 1)"
+            )
+            status.state = "complete"
+            return status
+
+    status = register_job()
+    service = _InconsistentBackfill(db=db, embeddings=_Stub())
+
+    await _run_backfill_safely(service, status)
+
+    state = await get_embedding_index_state(db)
+    assert state is not None
+    assert state.status == "failed"
+    assert status.state == "failed"
+    assert "inconsistent" in (status.error or "")
+
+
+@pytest.mark.asyncio
+async def test_overlapping_backfills_recover_after_first_run_fails(api_client):
+    """A queued healthy run must own and recover the same generation."""
+    client, _ = api_client
+    db = client._transport.app.state.db
+    from rka.api.routes.config import _run_backfill_safely
+    from rka.services.embedding_index import (
+        embedding_space_signature,
+        get_embedding_index_state,
+        reconcile_embedding_index,
+    )
+
+    cfg = {
+        "backend": "fastembed",
+        "config": {"model_name": "serialized", "dim": 768},
+    }
+    generation = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="serialized",
+        dim=768,
+        allow_legacy_adoption=False,
+    )
+
+    class _Stub:
+        dim = 768
+        model_name = "serialized"
+        index_generation = generation.state.generation
+        space_signature = generation.state.space_signature
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    class _FailingBackfill(BackfillService):
+        async def run_backfill(self, status, progress_callback=None, entity_types=None):
+            status.state = "running"
+            first_started.set()
+            await release_first.wait()
+            raise RuntimeError("first run failed")
+
+    class _HealthyBackfill(BackfillService):
+        async def run_backfill(self, status, progress_callback=None, entity_types=None):
+            second_started.set()
+            status.state = "complete"
+            return status
+
+    failed_status = register_job()
+    healthy_status = register_job()
+    failing = _FailingBackfill(db=db, embeddings=_Stub())
+    healthy = _HealthyBackfill(db=db, embeddings=_Stub())
+
+    first_task = asyncio.create_task(_run_backfill_safely(failing, failed_status))
+    await asyncio.wait_for(first_started.wait(), timeout=2)
+    second_task = asyncio.create_task(_run_backfill_safely(healthy, healthy_status))
+    await asyncio.sleep(0)
+    assert second_started.is_set() is False
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    state = await get_embedding_index_state(db)
+    assert failed_status.state == "failed"
+    assert healthy_status.state == "complete"
+    assert second_started.is_set() is True
+    assert state is not None
+    assert state.generation == generation.state.generation
+    assert state.status == "ready"

--- a/tests/test_api/test_first_run.py
+++ b/tests/test_api/test_first_run.py
@@ -130,6 +130,39 @@ async def test_second_boot_does_not_overwrite_user_config(tmp_path: Path):
         await lifespan.__aexit__(None, None, None)
 
 
+@pytest.mark.asyncio
+async def test_corrupt_config_starts_lexical_without_overwriting_bytes(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    cfg_path = data_dir / "embedding_config.json"
+    corrupt = b"not-json {{{"
+    cfg_path.write_bytes(corrupt)
+    config = RKAConfig(
+        project_dir=tmp_path,
+        db_path=Path("corrupt_start.db"),
+        data_dir=data_dir,
+        embeddings_enabled=True,
+        llm_enabled=False,
+    )
+    app = create_app(config)
+    lifespan = app.router.lifespan_context(app)
+    await lifespan.__aenter__()
+    try:
+        assert app.state.embeddings is None
+        assert cfg_path.read_bytes() == corrupt
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            capability = (await client.get("/api/capabilities")).json()["embedding"]
+        assert capability["available"] is False
+        assert capability["search_mode"] == "lexical"
+        assert "unreadable" in capability["reason_unavailable"]
+    finally:
+        await lifespan.__aexit__(None, None, None)
+
+
 # ---------------------------------------------------------------------------
 # docker-compose.yml LLM-env-block removal regression lock
 # ---------------------------------------------------------------------------

--- a/tests/test_db/test_migration_055.py
+++ b/tests/test_db/test_migration_055.py
@@ -1,0 +1,31 @@
+"""Migration 055 adds one constrained embedding-index lifecycle row."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_embedding_index_state_singleton_constraints(db) -> None:
+    await db.execute(
+        """INSERT INTO embedding_index_state
+           (singleton, generation, space_signature, model_name, dimensions, status)
+           VALUES (1, 1, 'sig-a', 'model-a', 768, 'ready')"""
+    )
+    row = await db.fetchone(
+        "SELECT generation, status FROM embedding_index_state WHERE singleton = 1"
+    )
+    assert row == {"generation": 1, "status": "ready"}
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            """INSERT INTO embedding_index_state
+               (singleton, generation, space_signature, model_name, dimensions, status)
+               VALUES (2, 1, 'sig-b', 'model-b', 768, 'ready')"""
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "UPDATE embedding_index_state SET status = 'unknown' WHERE singleton = 1"
+        )

--- a/tests/test_services/test_embedding_audit_symmetry.py
+++ b/tests/test_services/test_embedding_audit_symmetry.py
@@ -123,7 +123,7 @@ async def test_audit_symmetry_backfill_clears_pending_flag(db):
     await db.commit()
 
     svc = BackfillService(db=db, embeddings=_FakeEmb(dim=4), batch_size=2)
-    result = await svc.run_backfill(status)
+    result = await svc.run_backfill(status, entity_types=("claim",))
     assert result.state == "complete"
 
     # Read-side: every processed claim now has embedding_pending=0.

--- a/tests/test_services/test_embedding_backends.py
+++ b/tests/test_services/test_embedding_backends.py
@@ -3,7 +3,7 @@
 Each backend is exercised against a mocked `httpx` transport (for the
 HTTP backends) so the suite runs offline. The FastEmbed backend is
 covered by a Protocol-conformance test that doesn't touch the model
-loader (we don't pull ~130 MB at test time).
+loader (we don't download model weights at test time).
 """
 
 from __future__ import annotations
@@ -152,12 +152,147 @@ async def test_openai_compat_embed_batch_preserves_order():
 
 
 @pytest.mark.asyncio
+async def test_openai_compat_orders_batch_by_response_index():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"embedding": [2.0, 2.0], "index": 1},
+                    {"embedding": [1.0, 1.0], "index": 0},
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://x"
+    )
+    backend = OpenAICompatBackend(
+        base_url="http://x", model="m", dim=2, http_client=client
+    )
+
+    assert await backend.embed_batch(["first", "second"]) == [
+        [1.0, 1.0],
+        [2.0, 2.0],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_rejects_duplicate_or_missing_batch_indices():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"embedding": [1.0, 1.0], "index": 0},
+                    {"embedding": [2.0, 2.0], "index": 0},
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://x"
+    )
+    backend = OpenAICompatBackend(
+        base_url="http://x", model="m", dim=2, http_client=client
+    )
+
+    with pytest.raises(ValueError, match="invalid embedding index"):
+        await backend.embed_batch(["first", "second"])
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_applies_query_and_document_templates():
+    captured: list[list[str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured.append(body["input"])
+        return httpx.Response(
+            200,
+            json={"data": [{"embedding": [0.1] * 3, "index": 0}]},
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://x"
+    )
+    b = OpenAICompatBackend(
+        base_url="http://x",
+        model="transport-alias",
+        dim=3,
+        query_template="Instruct: retrieve research context.\nQuery: {text}",
+        document_template="{text}",
+        embedding_space_id="qwen-space-v1",
+        http_client=client,
+    )
+
+    await b.embed("why map nine types to three?", is_query=True)
+    await b.embed("decision record", is_query=False)
+
+    assert captured == [
+        [
+            "Instruct: retrieve research context.\n"
+            "Query: why map nine types to three?"
+        ],
+        ["decision record"],
+    ]
+    # Provenance uses the vector-space identity; HTTP requests still use the
+    # transport alias (asserted separately by the request-capture tests).
+    assert b.model_name == "qwen-space-v1"
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_templates_apply_to_batches():
+    captured: dict[str, list[str]] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured["inputs"] = body["input"]
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"embedding": [float(i)] * 2, "index": i}
+                    for i in range(len(body["input"]))
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://x"
+    )
+    b = OpenAICompatBackend(
+        base_url="http://x",
+        model="m",
+        dim=2,
+        query_template="Query: {text}",
+        http_client=client,
+    )
+    await b.embed_batch(["alpha", "beta"], is_query=True)
+    assert captured["inputs"] == ["Query: alpha", "Query: beta"]
+
+
+def test_openai_compat_rejects_invalid_templates():
+    with pytest.raises(ValueError, match="exactly one"):
+        OpenAICompatBackend(
+            base_url="http://x", model="m", query_template="missing placeholder"
+        )
+    with pytest.raises(ValueError, match="exactly one"):
+        OpenAICompatBackend(
+            base_url="http://x", model="m", document_template="{text} {text}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_openai_compat_sends_authorization_header_when_api_key_present():
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["auth"] = request.headers.get("Authorization")
-        return httpx.Response(200, json={"data": [{"embedding": [0.1] * 3}]})
+        return httpx.Response(
+            200,
+            json={"data": [{"embedding": [0.1] * 3, "index": 0}]},
+        )
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://x")
     b = OpenAICompatBackend(
@@ -174,7 +309,10 @@ async def test_openai_compat_omits_authorization_when_api_key_absent():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["auth"] = request.headers.get("Authorization")
-        return httpx.Response(200, json={"data": [{"embedding": [0.1] * 3}]})
+        return httpx.Response(
+            200,
+            json={"data": [{"embedding": [0.1] * 3, "index": 0}]},
+        )
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://x")
     b = OpenAICompatBackend(
@@ -343,7 +481,7 @@ def test_fastembed_backend_skips_prefix_for_non_nomic_model():
 # Pre-v2.7.0.1, FastEmbedBackend constructed TextEmbedding(model_name=...) with
 # no threads or cache_dir, leaving onnxruntime to default intra_op_num_threads
 # to container CPU count (10 on Apple Silicon under Docker) and writing the
-# 130 MB model to an ephemeral cache that didn't survive container recreate.
+# model to an ephemeral cache that didn't survive container recreate.
 # Empirical signature (2026-06-03): peak worker memory rose 7.17 → 7.87 GiB
 # when the VM ceiling went 7.75 → 9.21 GiB — unbounded growth, not undersized
 # VM. The fix caps threads at 2 (configurable) and persists cache to /data.
@@ -535,8 +673,6 @@ async def test_fastembed_embed_raises_on_dim_drift_after_construction():
     b = FastEmbedBackend(model_name="custom-model", dim=4)
     # Bypass the real model loader; inject a fake that returns 768-dim vectors.
     b._model = _FakeModel(dim=768)
-
-    import asyncio
 
     with pytest.raises(EmbeddingConfigError, match="dim mismatch"):
         await b.embed("hi")

--- a/tests/test_services/test_embedding_backfill.py
+++ b/tests/test_services/test_embedding_backfill.py
@@ -202,6 +202,32 @@ async def test_run_backfill_marks_failed_on_batch_embed_error(db):
 
 
 @pytest.mark.asyncio
+async def test_run_backfill_rejects_short_embedding_batch(db):
+    class ShortBatchEmbedder(FakeEmbedder):
+        async def embed_batch(
+            self,
+            texts: list[str],
+            *,
+            is_query: bool = False,
+        ) -> list[list[float]]:
+            self.calls.append(list(texts))
+            return []
+
+    clear_registry()
+    await _setup_vec_claims_at_dim(db, dim=4)
+    await _insert_journal(db, jid="jrn_t5_short_batch")
+    await _insert_pending_claims(db, jid="jrn_t5_short_batch", count=1)
+    status = register_job()
+    svc = BackfillService(db=db, embeddings=ShortBatchEmbedder(dim=4))
+
+    result = await svc.run_backfill(status, entity_types=("claim",))
+
+    assert result.state == "failed"
+    assert result.processed == 0
+    assert "returned 0 vectors for 1 inputs" in (result.error or "")
+
+
+@pytest.mark.asyncio
 async def test_run_backfill_resumes_remaining_after_partial_completion(db):
     """If a backfill fails mid-stream, a second run picks up the remainder.
 
@@ -644,10 +670,12 @@ async def test_metadata_not_written_when_vec_available_false(db, monkeypatch):
     svc = BackfillService(db=db, embeddings=FakeEmbedder(dim=4), batch_size=3)
     result = await svc.run_backfill(status, entity_types=("claim",))
 
-    # The backfill reports the rows as "processed" (they completed without
-    # error), but the metadata table receives NO inserts because the
-    # vec_available guard skipped both the vec_* and metadata writes.
-    assert result.state == "complete"
+    # Fail explicitly before calling the backend. A false "complete" result
+    # would strand a durable reindex generation while no vectors can be stored.
+    assert result.state == "failed"
+    assert "sqlite-vec" in (result.error or "")
+    assert result.processed == 0
+    assert svc._embeddings.calls == []
     metadata_rows = await db.fetchone(
         "SELECT COUNT(*) AS n FROM embedding_metadata "
         "WHERE entity_type = 'claim' AND entity_id IN "

--- a/tests/test_services/test_embedding_config.py
+++ b/tests/test_services/test_embedding_config.py
@@ -151,6 +151,28 @@ def test_backup_overwritten_on_each_save(tmp_path: Path):
     assert backup_payload["config"]["model_name"] == "v2"
 
 
+def test_repairing_corrupt_live_config_preserves_good_backup(tmp_path: Path):
+    svc = EmbeddingConfigService(config_dir=tmp_path)
+    svc.save_config(
+        EmbeddingConfig(backend="fastembed", config={"model_name": "v1", "dim": 768}),
+        actor="pi",
+    )
+    svc.save_config(
+        EmbeddingConfig(backend="fastembed", config={"model_name": "v2", "dim": 768}),
+        actor="pi",
+    )
+    original_backup = svc.backup_path.read_text()
+    svc.config_path.write_text("corrupt {{{")
+
+    svc.save_config(
+        EmbeddingConfig(backend="fastembed", config={"model_name": "v3", "dim": 768}),
+        actor="repair",
+    )
+
+    assert svc.load_config().config["model_name"] == "v3"
+    assert svc.backup_path.read_text() == original_backup
+
+
 # ---------------------------------------------------------------------------
 # Atomic write semantics
 # ---------------------------------------------------------------------------

--- a/tests/test_services/test_embedding_index.py
+++ b/tests/test_services/test_embedding_index.py
@@ -1,0 +1,413 @@
+"""Crash/restart and concurrency gates for durable embedding generations."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from rka.infra.embeddings import EmbeddingService
+from rka.services.embedding_index import (
+    EmbeddingGenerationMismatch,
+    embedding_space_signature,
+    finish_embedding_transition,
+    get_embedding_index_state,
+    legacy_index_adoption_safe,
+    reconcile_embedding_index,
+)
+from rka.services.embedding_reshape import current_vec_table_dim
+
+
+class _Backend:
+    def __init__(self, model_name: str, dim: int = 768) -> None:
+        self._model_name = model_name
+        self._dim = dim
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    async def embed(self, text: str, *, is_query: bool = False) -> list[float]:
+        return [0.0] * self._dim
+
+    async def embed_batch(
+        self,
+        texts: list[str],
+        *,
+        is_query: bool = False,
+    ) -> list[list[float]]:
+        return [[0.0] * self._dim for _ in texts]
+
+
+class _FlakyBackend(_Backend):
+    def __init__(self) -> None:
+        super().__init__("flaky", dim=4)
+        self.fail = True
+
+    async def embed(self, text: str, *, is_query: bool = False) -> list[float]:
+        if self.fail:
+            raise RuntimeError("backend offline")
+        return [0.0] * self.dim
+
+
+def _config(
+    model: str,
+    *,
+    dim: int = 768,
+    document_template: str = "{text}",
+) -> dict:
+    return {
+        "backend": "openai_compat",
+        "config": {
+            "base_url": "http://127.0.0.1:1",
+            "model": model,
+            "dim": dim,
+            "document_template": document_template,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_availability_recovers_after_successful_probe() -> None:
+    backend = _FlakyBackend()
+    service = EmbeddingService(backend=backend)
+
+    with pytest.raises(RuntimeError, match="offline"):
+        await service.embed("query")
+    assert service.runtime_available is False
+    assert service.runtime_error_code == "embedding_backend_unavailable"
+
+    backend.fail = False
+    assert await service.embed("query") == [0.0] * 4
+    assert service.runtime_available is True
+    assert service.runtime_error_code is None
+
+
+async def _seed_claim(db, claim_id: str = "clm_generation") -> None:
+    await db.execute(
+        """INSERT INTO journal (id, type, content, source)
+           VALUES ('jrn_generation', 'note', 'source', 'pi')"""
+    )
+    await db.execute(
+        """INSERT INTO claims
+           (id, source_entry_id, claim_type, content, embedding_pending)
+           VALUES (?, 'jrn_generation', 'observation', 'claim text', 0)""",
+        [claim_id],
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_legacy_index_is_adopted_without_rebuild(db) -> None:
+    cfg = _config("model-a")
+    result = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="model-a",
+        dim=768,
+    )
+    assert result.state.generation == 1
+    assert result.state.status == "ready"
+    assert result.transitioned is False
+
+
+@pytest.mark.asyncio
+async def test_online_recovery_reshapes_matching_offline_generation(db) -> None:
+    """A generation created without sqlite-vec must repair its old schema later."""
+    cfg = _config("model-1024", dim=1024)
+    db._vec_loaded = False
+    try:
+        offline = await reconcile_embedding_index(
+            db,
+            space_signature=embedding_space_signature(cfg),
+            model_name="model-1024",
+            dim=1024,
+        )
+    finally:
+        db._vec_loaded = True
+
+    assert offline.state.status == "reindexing"
+    assert offline.transitioned is True
+    assert await current_vec_table_dim(db, "vec_claims") == 768
+
+    resumed = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="model-1024",
+        dim=1024,
+    )
+
+    assert resumed.state.generation == offline.state.generation
+    assert resumed.state.status == "reindexing"
+    assert resumed.resumed is True
+    assert all(did_reshape for did_reshape, _pending in resumed.reshape.values())
+    assert {
+        await current_vec_table_dim(db, table_name)
+        for table_name in resumed.reshape
+    } == {1024}
+
+
+@pytest.mark.asyncio
+async def test_orphan_legacy_vector_forces_clean_rebuild(db) -> None:
+    cfg = _config("model-a")
+    blob = struct.pack("768f", *([0.0] * 768))
+    await db.execute(
+        "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+        ["clm_orphan", "proj_default", blob],
+    )
+
+    result = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="model-a",
+        dim=768,
+    )
+
+    assert result.transitioned is True
+    assert result.state.status == "reindexing"
+    assert await db.fetchone("SELECT id FROM vec_claims LIMIT 1") is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_vector_metadata_pair_without_source_forces_rebuild(db) -> None:
+    cfg = _config("model-a")
+    blob = struct.pack("768f", *([0.0] * 768))
+    await db.execute(
+        "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+        ["clm_ghost", "proj_default", blob],
+    )
+    await db.execute(
+        """INSERT INTO embedding_metadata
+           (project_id, entity_type, entity_id, content_hash, model_name, dimensions)
+           VALUES ('proj_default', 'claim', 'clm_ghost', 'hash', 'model-a', 768)"""
+    )
+
+    result = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="model-a",
+        dim=768,
+    )
+
+    assert result.transitioned is True
+    assert await db.fetchone(
+        "SELECT id FROM vec_claims WHERE id = 'clm_ghost'"
+    ) is None
+    assert await db.fetchone(
+        "SELECT entity_id FROM embedding_metadata WHERE entity_id = 'clm_ghost'"
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_stale_hash_legacy_index_is_rebuilt_instead_of_adopted(
+    db,
+) -> None:
+    cfg = _config("model-a")
+    await _seed_claim(db)
+    blob = struct.pack("768f", *([0.0] * 768))
+    await db.execute(
+        "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+        ["clm_generation", "proj_default", blob],
+    )
+    await db.execute(
+        """INSERT INTO embedding_metadata
+           (project_id, entity_type, entity_id, content_hash, model_name, dimensions)
+           VALUES ('proj_default', 'claim', 'clm_generation', 'hash', 'model-a', 768)"""
+    )
+
+    result = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="model-a",
+        dim=768,
+    )
+
+    assert result.transitioned is True
+    assert result.resumed is False
+    assert result.state.status == "reindexing"
+    assert await db.fetchone(
+        "SELECT id FROM vec_claims WHERE id = 'clm_generation'"
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_hash_verified_partial_legacy_index_is_preserved_for_repair(db) -> None:
+    cfg = _config("model-a")
+    await _seed_claim(db)
+    blob = struct.pack("768f", *([0.0] * 768))
+    await db.execute(
+        "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+        ["clm_generation", "proj_default", blob],
+    )
+    await db.execute(
+        """INSERT INTO embedding_metadata
+           (project_id, entity_type, entity_id, content_hash, model_name, dimensions)
+           VALUES ('proj_default', 'claim', 'clm_generation', ?, 'model-a', 768)""",
+        [EmbeddingService.content_hash("claim text")],
+    )
+
+    result = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg),
+        model_name="model-a",
+        dim=768,
+    )
+
+    assert result.transitioned is False
+    assert result.resumed is True
+    assert result.state.status == "reindexing"
+    assert await db.fetchone(
+        "SELECT id FROM vec_claims WHERE id = 'clm_generation'"
+    ) == {"id": "clm_generation"}
+
+
+def test_custom_document_contract_cannot_adopt_legacy_metadata() -> None:
+    assert legacy_index_adoption_safe(_config("model-a")) is True
+    assert (
+        legacy_index_adoption_safe(
+            _config("model-a", document_template="Document: {text}")
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_dim_space_transition_clears_claim_vector_and_metadata(db) -> None:
+    cfg_a = _config("model-a")
+    initial = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_a),
+        model_name="model-a",
+        dim=768,
+    )
+    await _seed_claim(db)
+    blob = struct.pack("768f", *([0.0] * 768))
+    await db.execute(
+        "INSERT INTO vec_claims (id, project_id, embedding) VALUES (?, ?, ?)",
+        ["clm_generation", "proj_default", blob],
+    )
+    await db.execute(
+        """INSERT INTO embedding_metadata
+           (project_id, entity_type, entity_id, content_hash, model_name, dimensions)
+           VALUES ('proj_default', 'claim', 'clm_generation', 'hash', 'model-a', 768)"""
+    )
+
+    cfg_b = _config("model-b")
+    changed = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_b),
+        model_name="model-b",
+        dim=768,
+    )
+
+    assert changed.transitioned is True
+    assert changed.state.generation == initial.state.generation + 1
+    assert changed.state.status == "reindexing"
+    assert await db.fetchone("SELECT id FROM vec_claims LIMIT 1") is None
+    assert await db.fetchone("SELECT entity_id FROM embedding_metadata LIMIT 1") is None
+    assert await db.fetchone(
+        "SELECT embedding_pending FROM claims WHERE id = 'clm_generation'"
+    ) == {"embedding_pending": 1}
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_write_is_rejected(db) -> None:
+    cfg_a = _config("model-a")
+    first = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_a),
+        model_name="model-a",
+        dim=768,
+    )
+    stale = EmbeddingService(db=db, backend=_Backend("model-a"))
+    stale.space_signature = first.state.space_signature
+    stale.bind_index_generation(first.state.generation)
+    await _seed_claim(db)
+
+    cfg_b = _config("model-b")
+    await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_b),
+        model_name="model-b",
+        dim=768,
+    )
+
+    with pytest.raises(EmbeddingGenerationMismatch):
+        await stale.store_embedding(
+            "claim",
+            "clm_generation",
+            "claim text",
+            embedding=[0.0] * 768,
+        )
+    assert await db.fetchone("SELECT id FROM vec_claims LIMIT 1") is None
+
+
+@pytest.mark.asyncio
+async def test_restart_resumes_generation_without_clearing_partial_progress(db) -> None:
+    cfg_a = _config("model-a")
+    await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_a),
+        model_name="model-a",
+        dim=768,
+    )
+    cfg_b = _config("model-b")
+    changed = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_b),
+        model_name="model-b",
+        dim=768,
+    )
+    await _seed_claim(db)
+    service = EmbeddingService(db=db, backend=_Backend("model-b"))
+    service.space_signature = changed.state.space_signature
+    service.bind_index_generation(changed.state.generation)
+    await service.store_embedding(
+        "claim",
+        "clm_generation",
+        "claim text",
+        embedding=[0.0] * 768,
+    )
+
+    resumed = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_b),
+        model_name="model-b",
+        dim=768,
+    )
+    assert resumed.resumed is True
+    assert resumed.state.generation == changed.state.generation
+    assert await db.fetchone(
+        "SELECT id FROM vec_claims WHERE id = 'clm_generation'"
+    ) == {"id": "clm_generation"}
+
+
+@pytest.mark.asyncio
+async def test_finish_refuses_ready_while_eligible_entity_is_pending(db) -> None:
+    cfg_a = _config("model-a")
+    await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_a),
+        model_name="model-a",
+        dim=768,
+    )
+    cfg_b = _config("model-b")
+    changed = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(cfg_b),
+        model_name="model-b",
+        dim=768,
+    )
+    await _seed_claim(db)
+
+    assert await finish_embedding_transition(
+        db,
+        generation=changed.state.generation,
+        success=True,
+    )
+    state = await get_embedding_index_state(db)
+    assert state is not None
+    assert state.status == "failed"

--- a/tests/test_services/test_embedding_reshape.py
+++ b/tests/test_services/test_embedding_reshape.py
@@ -11,6 +11,7 @@ import pytest
 from rka.services.embedding_reshape import (
     current_vec_claims_dim,
     current_vec_table_dim,
+    embedding_space_mismatch,
     reshape_all_vec_tables_if_needed,
     reshape_vec_claims,
     reshape_vec_claims_if_needed,
@@ -294,3 +295,46 @@ async def test_reshape_all_vec_tables_if_needed_idempotent_no_op(db):
         assert did_reshape is False, (
             f"second call must be a no-op for {table_name}"
         )
+
+
+@pytest.mark.asyncio
+async def test_force_rebuild_prevents_same_dimension_space_mixing(db):
+    """A space change rebuilds all vec tables even when dim is unchanged."""
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+
+    await db.execute(
+        "INSERT INTO embedding_metadata "
+        "(project_id, entity_type, entity_id, content_hash, model_name, dimensions) "
+        "VALUES ('proj_default', 'journal', 'jrn_old', 'hash', 'old-space', 768)"
+    )
+    await db.commit()
+
+    results = await reshape_all_vec_tables_if_needed(db, dim=768, force=True)
+
+    assert all(did_rebuild for did_rebuild, _pending in results.values())
+    row = await db.fetchone(
+        "SELECT COUNT(*) AS n FROM embedding_metadata WHERE model_name = 'old-space'"
+    )
+    assert row["n"] == 0
+    for table_name in results:
+        assert await current_vec_table_dim(db, table_name) == 768
+
+
+@pytest.mark.asyncio
+async def test_embedding_space_mismatch_detects_restart_recovery_need(db):
+    if not db.vec_available:
+        pytest.skip("sqlite-vec extension not loaded")
+
+    assert not await embedding_space_mismatch(db, model_name="current-space", dim=768)
+    await db.execute(
+        "INSERT INTO embedding_metadata "
+        "(project_id, entity_type, entity_id, content_hash, model_name, dimensions) "
+        "VALUES ('proj_default', 'journal', 'jrn_current', 'hash', "
+        "'current-space', 768)"
+    )
+    await db.commit()
+
+    assert not await embedding_space_mismatch(db, model_name="current-space", dim=768)
+    assert await embedding_space_mismatch(db, model_name="new-space", dim=768)
+    assert await embedding_space_mismatch(db, model_name="current-space", dim=1024)

--- a/tests/test_services/test_note_worker.py
+++ b/tests/test_services/test_note_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 
 import pytest
@@ -235,6 +236,214 @@ class TestNoteQueue:
         # Note should show failed enrichment status
         refreshed = await svc_no_llm.get(note.id)
         assert refreshed.enrichment_status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_generation_change_rejects_inflight_worker_write(
+        self, db: Database
+    ):
+        from rka.services.embedding_index import (
+            embedding_space_signature,
+            reconcile_embedding_index,
+        )
+
+        class BlockingBackend:
+            model_name = "model-a"
+            dim = 768
+
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+                self.release = asyncio.Event()
+
+            async def embed(self, _text: str, *, is_query: bool = False):
+                self.started.set()
+                await self.release.wait()
+                return [0.0] * self.dim
+
+            async def embed_batch(self, texts, *, is_query: bool = False):
+                return [await self.embed(text, is_query=is_query) for text in texts]
+
+        await _ensure_project(db, "proj_generation", "Generation")
+        cfg_a = {
+            "backend": "openai_compat",
+            "config": {"model": "model-a", "dim": 768},
+        }
+        initial = await reconcile_embedding_index(
+            db,
+            space_signature=embedding_space_signature(cfg_a),
+            model_name="model-a",
+            dim=768,
+        )
+        backend = BlockingBackend()
+        embeddings = EmbeddingService(db=db, backend=backend)
+        embeddings.space_signature = initial.state.space_signature
+        embeddings.bind_index_generation(initial.state.generation)
+        note_svc = NoteService(
+            db,
+            embeddings=embeddings,
+            project_id="proj_generation",
+        )
+        note = await note_svc.create(
+            JournalEntryCreate(content="generation fence", source="executor")
+        )
+        await db.execute(
+            "UPDATE jobs SET max_attempts = 1 WHERE entity_id = ?",
+            [note.id],
+        )
+        worker = EnrichmentWorker(
+            db=db,
+            embeddings=embeddings,
+            max_attempts=1,
+        )
+
+        task = asyncio.create_task(worker.run_once())
+        await asyncio.wait_for(backend.started.wait(), timeout=2)
+        cfg_b = {
+            "backend": "openai_compat",
+            "config": {"model": "model-b", "dim": 768},
+        }
+        await reconcile_embedding_index(
+            db,
+            space_signature=embedding_space_signature(cfg_b),
+            model_name="model-b",
+            dim=768,
+        )
+        backend.release.set()
+        assert await task is True
+
+        job = await db.fetchone(
+            "SELECT status, last_error FROM jobs WHERE entity_id = ?",
+            [note.id],
+        )
+        assert job is not None
+        assert job["status"] == "failed"
+        assert "generation changed" in job["last_error"]
+        assert await db.fetchone(
+            "SELECT id FROM vec_journal WHERE id = ?", [note.id]
+        ) is None
+        assert await db.fetchone(
+            """SELECT entity_id FROM embedding_metadata
+               WHERE entity_type = 'journal' AND entity_id = ?""",
+            [note.id],
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_generation_change_reloads_config_and_repairs_inflight_note(
+        self, db: Database, tmp_path
+    ):
+        from unittest.mock import patch
+
+        from rka.services.embedding_config import EmbeddingConfig, EmbeddingConfigService
+        from rka.services.embedding_index import (
+            embedding_space_signature,
+            reconcile_embedding_index,
+        )
+
+        class BlockingBackend:
+            model_name = "model-a"
+            dim = 768
+
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+                self.release = asyncio.Event()
+
+            async def embed(self, _text: str, *, is_query: bool = False):
+                self.started.set()
+                await self.release.wait()
+                return [0.0] * self.dim
+
+            async def embed_batch(self, texts, *, is_query: bool = False):
+                return [await self.embed(text, is_query=is_query) for text in texts]
+
+        class ReadyBackend:
+            model_name = "model-b"
+            dim = 768
+
+            async def embed(self, _text: str, *, is_query: bool = False):
+                return [1.0] * self.dim
+
+            async def embed_batch(self, texts, *, is_query: bool = False):
+                return [[1.0] * self.dim for _text in texts]
+
+        def config(model: str) -> EmbeddingConfig:
+            return EmbeddingConfig(
+                backend="openai_compat",
+                config={
+                    "base_url": "http://127.0.0.1:1",
+                    "model": model,
+                    "dim": 768,
+                },
+            )
+
+        await _ensure_project(db, "proj_generation_retry", "Generation Retry")
+        cfg_svc = EmbeddingConfigService(config_dir=tmp_path)
+        saved_a = cfg_svc.save_config(config("model-a"), actor="test")
+        state_a = await reconcile_embedding_index(
+            db,
+            space_signature=embedding_space_signature(saved_a),
+            model_name="model-a",
+            dim=768,
+        )
+        blocking = BlockingBackend()
+        service_a = EmbeddingService(db=db, backend=blocking)
+        service_a.space_signature = state_a.state.space_signature
+        service_a.bind_index_generation(state_a.state.generation)
+        service_b = EmbeddingService(db=db, backend=ReadyBackend())
+
+        note_svc = NoteService(
+            db,
+            embeddings=service_a,
+            project_id="proj_generation_retry",
+        )
+        note = await note_svc.create(
+            JournalEntryCreate(content="repair this generation race", source="executor")
+        )
+        await db.execute(
+            "UPDATE jobs SET max_attempts = 1 WHERE entity_id = ?",
+            [note.id],
+        )
+
+        def build(payload, db=None):  # noqa: ARG001
+            model = payload["config"].get("model")
+            return service_a if model == "model-a" else service_b
+
+        worker = EnrichmentWorker(
+            db=db,
+            embeddings=service_a,
+            data_dir=tmp_path,
+            max_attempts=1,
+        )
+        with patch(
+            "rka.infra.embeddings.EmbeddingService.from_config",
+            side_effect=build,
+        ):
+            task = asyncio.create_task(worker.run_once())
+            await asyncio.wait_for(blocking.started.wait(), timeout=2)
+            saved_b = cfg_svc.save_config(config("model-b"), actor="test")
+            state_b = await reconcile_embedding_index(
+                db,
+                space_signature=embedding_space_signature(saved_b),
+                model_name="model-b",
+                dim=768,
+            )
+            blocking.release.set()
+            assert await task is True
+
+        job = await db.fetchone(
+            "SELECT status, attempts, last_error FROM jobs WHERE entity_id = ?",
+            [note.id],
+        )
+        metadata = await db.fetchone(
+            """SELECT model_name, dimensions FROM embedding_metadata
+               WHERE project_id = ? AND entity_type = 'journal' AND entity_id = ?""",
+            ["proj_generation_retry", note.id],
+        )
+        assert job == {"status": "completed", "attempts": 1, "last_error": None}
+        assert worker.embeddings is service_b
+        assert service_b.index_generation == state_b.state.generation
+        assert metadata == {"model_name": "model-b", "dimensions": 768}
+        assert await db.fetchone(
+            "SELECT id FROM vec_journal WHERE id = ?", [note.id]
+        ) == {"id": note.id}
 
     @pytest.mark.asyncio
     async def test_create_note_without_llm_no_jobs(self, db: Database):

--- a/tests/test_services/test_search.py
+++ b/tests/test_services/test_search.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 import pytest_asyncio
 
@@ -112,6 +114,56 @@ class TestFTS5Search:
         results = await search_svc.search("timing", limit=20)
         types = {r.entity_type for r in results}
         assert len(types) >= 2  # Should find journal + literature + mission + decision
+
+    @pytest.mark.asyncio
+    async def test_reindexing_uses_lexical_without_query_embedding(
+        self, search_svc: SearchService
+    ):
+        class ReindexingEmbeddings:
+            embed_calls = 0
+
+            async def index_search_ready(self) -> bool:
+                return False
+
+            async def embed(self, query: str):  # pragma: no cover - must not run
+                self.embed_calls += 1
+                raise AssertionError(f"unexpected query embedding: {query}")
+
+        embeddings = ReindexingEmbeddings()
+        search_svc.embeddings = embeddings
+        search_svc._vector_search = AsyncMock()
+
+        results = await search_svc.search("timing attacks", limit=10)
+
+        assert "jrn_001" in [result.entity_id for result in results]
+        assert embeddings.embed_calls == 0
+        search_svc._vector_search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_generation_change_after_query_embedding_skips_vector_read(
+        self, search_svc: SearchService
+    ):
+        class ChangingEmbeddings:
+            def __init__(self) -> None:
+                self.readiness = iter((True, False))
+                self.embed_calls = 0
+
+            async def index_search_ready(self) -> bool:
+                return next(self.readiness)
+
+            async def embed(self, _query: str):
+                self.embed_calls += 1
+                return [0.0] * 768
+
+        embeddings = ChangingEmbeddings()
+        search_svc.embeddings = embeddings
+        search_svc._vector_search = AsyncMock()
+
+        results = await search_svc.search("timing attacks", limit=10)
+
+        assert "jrn_001" in [result.entity_id for result in results]
+        assert embeddings.embed_calls == 1
+        search_svc._vector_search.assert_not_awaited()
 
 
 class TestQuerySanitization:

--- a/tests/test_services/test_worker.py
+++ b/tests/test_services/test_worker.py
@@ -166,3 +166,85 @@ class TestWorkerStartupFallsBackToEnvWhenConfigAbsent:
             env_fallback_model="any",
         )
         assert result is None
+
+    def test_corrupt_persisted_config_fails_closed(self, tmp_path: Path) -> None:
+        from rka.services.embedding_config import EmbeddingConfigError
+
+        EnrichmentWorker = _import_worker()
+        (tmp_path / "embedding_config.json").write_text("not-json {{{")
+
+        with (
+            patch("rka.infra.embeddings.EmbeddingService") as fallback,
+            pytest.raises(EmbeddingConfigError),
+        ):
+            EnrichmentWorker._resolve_embeddings(
+                db=MagicMock(),
+                data_dir=tmp_path,
+                embeddings_enabled=True,
+                env_fallback_model="must-not-be-used",
+            )
+
+        fallback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_refreshes_when_generation_changes(db, tmp_path: Path) -> None:
+    from rka.services.embedding_config import EmbeddingConfig, EmbeddingConfigService
+    from rka.services.embedding_index import (
+        embedding_space_signature,
+        reconcile_embedding_index,
+    )
+
+    EnrichmentWorker = _import_worker()
+    cfg_svc = EmbeddingConfigService(config_dir=tmp_path)
+
+    def config(model: str) -> EmbeddingConfig:
+        return EmbeddingConfig(
+            backend="fastembed",
+            config={"model_name": model, "dim": 768},
+        )
+
+    saved_a = cfg_svc.save_config(config("model-a"), actor="test")
+    state_a = await reconcile_embedding_index(
+        db,
+        space_signature=embedding_space_signature(saved_a),
+        model_name="model-a",
+        dim=768,
+    )
+    fake_a = MagicMock(model_name="model-a", dim=768)
+    fake_b = MagicMock(model_name="model-b", dim=768)
+
+    def build(payload, db=None):  # noqa: ARG001
+        return fake_a if payload["config"]["model_name"] == "model-a" else fake_b
+
+    worker = EnrichmentWorker(
+        db=db,
+        embeddings=None,
+        data_dir=tmp_path,
+        embeddings_enabled=True,
+    )
+    with patch(
+        "rka.infra.embeddings.EmbeddingService.from_config",
+        side_effect=build,
+    ):
+        await worker._refresh_embeddings_before_job()
+        assert worker.embeddings is fake_a
+        fake_a.bind_index_generation.assert_called_once_with(
+            state_a.state.generation,
+            space_signature=state_a.state.space_signature,
+        )
+
+        saved_b = cfg_svc.save_config(config("model-b"), actor="test")
+        state_b = await reconcile_embedding_index(
+            db,
+            space_signature=embedding_space_signature(saved_b),
+            model_name="model-b",
+            dim=768,
+        )
+        await worker._refresh_embeddings_before_job()
+
+    assert worker.embeddings is fake_b
+    fake_b.bind_index_generation.assert_called_once_with(
+        state_b.state.generation,
+        space_signature=state_b.state.space_signature,
+    )

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -454,6 +454,12 @@ export interface EmbeddingConfig {
     model_name?: string
     api_key?: string
     dim?: number
+    timeout_seconds?: number
+    query_template?: string
+    document_template?: string
+    embedding_space_id?: string
+    threads?: number
+    cache_dir?: string
   }
   updated_at?: string | null
   updated_by?: string | null

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -396,7 +396,7 @@ function EmbeddingsConfigCard() {
         toast.success(`Re-embed started (job ${jobId})`)
         setActiveJobId(jobId)
       } else {
-        toast.success("Config saved (no re-embed needed — only api_key changed)")
+        toast.success("Config saved (document index unchanged)")
       }
       setConfirmOpen(false)
     },
@@ -450,24 +450,38 @@ function EmbeddingsConfigCard() {
   }, [backfill?.state])
 
   const buildPayload = (): EmbeddingConfigT => {
+    const preserved = config?.backend === backend ? { ...config.config } : {}
+    // The GET response contains only the redaction marker, never the saved
+    // secret. Omission means "preserve" on PUT; a newly typed value replaces it.
+    delete preserved.api_key
     if (backend === "fastembed") {
       return {
         backend: "fastembed",
-        config: { model_name: modelName, dim: Number(dim) || 768 },
+        config: {
+          ...preserved,
+          model_name: modelName,
+          dim: Number(dim) || 768,
+        },
       }
     }
     if (backend === "ollama") {
       return {
         backend: "ollama",
-        config: { base_url: baseUrl, model, dim: Number(dim) || 0 },
+        config: {
+          ...preserved,
+          base_url: baseUrl,
+          model,
+          dim: Number(dim) || 0,
+        },
       }
     }
     return {
       backend: "openai_compat",
       config: {
+        ...preserved,
         base_url: baseUrl,
         model,
-        api_key: apiKey || undefined,
+        ...(apiKey ? { api_key: apiKey } : {}),
         dim: Number(dim) || 0,
       },
     }
@@ -691,7 +705,7 @@ function EmbeddingsConfigCard() {
         {activeJobId && backfill && (
           <div className="rounded-md border p-3 space-y-2">
             <div className="flex items-center justify-between text-xs">
-              <span className="font-semibold">Re-embedding claims</span>
+              <span className="font-semibold">Re-embedding research records</span>
               <Badge variant="outline">{backfill.state}</Badge>
             </div>
             <div className="w-full bg-muted rounded h-2 overflow-hidden">
@@ -706,7 +720,7 @@ function EmbeddingsConfigCard() {
               />
             </div>
             <p className="text-[11px] text-muted-foreground">
-              {backfill.processed ?? 0} / {backfill.total ?? 0} claims •{" "}
+              {backfill.processed ?? 0} / {backfill.total ?? 0} records •{" "}
               {Math.round(backfill.elapsed_seconds ?? 0)}s elapsed
             </p>
             {backfill.state === "failed" && backfill.error && (
@@ -719,13 +733,13 @@ function EmbeddingsConfigCard() {
         <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Re-embed all claims?</DialogTitle>
+              <DialogTitle>Save embedding configuration?</DialogTitle>
               <DialogDescription>
-                Saving this config will drop existing embeddings and re-embed
-                every claim under the new backend. With qwen3-8b on LM Studio
-                this takes ~7–14 minutes for 827 claims. FTS continues to work
-                during the re-embed; semantic search is degraded until it
-                completes.
+                RKA will test the configuration before saving it. A compatible
+                change repairs only missing records; a same-dimension embedding
+                space change rebuilds derived vectors while retrieval stays
+                lexical. A populated cross-dimension change is rejected until
+                supervised offline maintenance is available.
               </DialogDescription>
             </DialogHeader>
             <DialogFooter>
@@ -738,7 +752,7 @@ function EmbeddingsConfigCard() {
                 className="gap-2"
               >
                 {saveMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
-                Re-embed claims
+                Save configuration
               </Button>
             </DialogFooter>
           </DialogContent>


### PR DESCRIPTION
## Summary

- add a provider-neutral portable embedding contract with separate query/document templates and explicit `embedding_space_id`
- persist one durable embedding generation, reject mixed-generation writes, and degrade search to lexical mode while semantic retrieval is unavailable or rebuilding
- make configuration changes transactional, preserve same-dimension online rebuilds, require supervised offline handling for populated dimension changes, and serialize API backfills
- reload the durable embedding configuration and retry once when an in-flight worker edit loses a generation race
- add migration 055, ADR 0017, operator documentation, Settings support, and focused crash/restart/concurrency coverage

## Verification

- focused embedding/config/search/worker gate: `201 passed`
- Core gate: `3188 passed, 294 deselected`
- REST/MCP snapshot checker: both snapshots `ok`
- Ruff on audited implementation/test files and `git diff --check`: clean
- Web production build: passed
- disposable full-profile startup smoke: passed (REST, MCP, migrations, worker, sqlite-vec, dashboard)
- clean installed-wheel smoke outside the checkout: passed
- production Docker image build and dependency boundary: passed (`fastembed`/`sqlite_vec` present; `litellm`/`instructor` absent)
- LM Studio reachability from host and the disposable Docker image: `text-embedding-qwen3-embedding-4b`, 2560 dimensions

## Public contract

The REST snapshot change is intentional and additive: embedding capability reporting now exposes the effective search mode so clients can distinguish semantic readiness from lexical degradation. The MCP snapshot is unchanged.

## Boundaries and limitations

- the existing first-run FastEmbed default is unchanged
- Qwen remains an evaluated candidate, not an approved default; the two-machine hardware/retrieval-quality gate has not been claimed
- populated cross-dimension transitions still require supervised offline re-indexing
- backfill serialization follows ADR 0017's single API-writer process boundary
- this PR adds no model downloader, GPU manager, inference supervisor, Writer, Workbench, or Agentic behavior

This PR must not be merged until separately authorized by the PI.
