### PR TITLE
Fix journal lifecycle and bulk update writes

### DIFF
--- a/contracts/rka-mcp-v1.json
+++ b/contracts/rka-mcp-v1.json
@@ -707,6 +707,43 @@
     "bulk_update": {
       "category": "core",
       "input_schema": {
+        "$defs": {
+          "BulkUpdateItem": {
+            "additionalProperties": true,
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "entity_type": {
+                "enum": [
+                  "note",
+                  "journal",
+                  "decision",
+                  "literature"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "entity_type",
+              "id"
+            ],
+            "type": "object"
+          }
+        },
         "additionalProperties": false,
         "properties": {
           "operation": {
@@ -719,8 +756,7 @@
           },
           "updates": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/$defs/BulkUpdateItem"
             },
             "minItems": 1,
             "type": "array"
@@ -5165,6 +5201,17 @@
             ],
             "default": null
           },
+          "pinned": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
           "project_id": {
             "type": "string"
           },
@@ -5216,6 +5263,23 @@
                   "pi",
                   "web_ui",
                   "llm"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "draft",
+                  "active",
+                  "superseded",
+                  "retracted"
                 ],
                 "type": "string"
               },
@@ -5762,8 +5826,7 @@
               },
               "updates": {
                 "items": {
-                  "additionalProperties": true,
-                  "type": "object"
+                  "$ref": "#/$defs/BulkUpdateItem"
                 },
                 "minItems": 1,
                 "type": "array"
@@ -5772,6 +5835,41 @@
             "required": [
               "project_id",
               "updates"
+            ],
+            "type": "object"
+          },
+          "BulkUpdateItem": {
+            "additionalProperties": true,
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "entity_type": {
+                "enum": [
+                  "note",
+                  "journal",
+                  "decision",
+                  "literature"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "entity_type",
+              "id"
             ],
             "type": "object"
           },
@@ -8566,6 +8664,17 @@
                 ],
                 "default": null
               },
+              "pinned": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
               "project_id": {
                 "type": "string"
               },
@@ -8617,6 +8726,23 @@
                       "pi",
                       "web_ui",
                       "llm"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "draft",
+                      "active",
+                      "superseded",
+                      "retracted"
                     ],
                     "type": "string"
                   },

--- a/docs/CORE_RETRIEVAL_BASELINE.md
+++ b/docs/CORE_RETRIEVAL_BASELINE.md
@@ -44,6 +44,13 @@ Only IDs in formal search-result or graph-node fields count as retrieved.
 Identifiers merely mentioned in snippets, labels, or edge text do not improve
 recall.
 
+For claims, the stored signals named `stale` and `staleness` are not aliases.
+`stale=true` is a hard structural invalidation, such as a superseded source.
+`staleness` is the freshness-review state; `green` means there is no open
+freshness warning and does not make a structurally stale claim current. Clients
+must use the entity resolver's derived `currentness` result when deciding
+whether knowledge is current.
+
 ## Gate and thresholds
 
 Quality and isolation are strict:

--- a/rka/mcp/_enums.py
+++ b/rka/mcp/_enums.py
@@ -207,6 +207,16 @@ JournalStatusLit = Literal[
     "retracted",
 ]
 
+# Entity aliases accepted by the compatibility-safe bulk-update adapter.
+# ``note`` is the historical MCP spelling; ``journal`` is the canonical
+# entity name used by the typed/query surfaces. Both route to /api/notes.
+BulkEntityTypeLit = Literal[
+    "note",
+    "journal",
+    "decision",
+    "literature",
+]
+
 # Validation-gate subtype — string-set validated in
 # ``rka/services/researcher_tools.py`` and the legacy
 # ``rka_create_gate`` MCP tool.

--- a/rka/mcp/operation_args.py
+++ b/rka/mcp/operation_args.py
@@ -66,6 +66,9 @@ from rka.models.semantic_patch import (
     SemanticPatchProposalTransition,
 )
 from rka.models.outline import OutlineProposalRequest
+from rka.models.decision import DecisionUpdate
+from rka.models.journal import JournalEntryUpdate
+from rka.models.literature import LiteratureUpdate
 
 # NOTE: enum aliases from ``rka.mcp._enums`` are imported on a per-batch
 # basis. Batch A (query ops) doesn't directly type any enum field — query
@@ -141,6 +144,7 @@ from rka.mcp._enums import (  # noqa: E402, F811
 
 # Batch C imports — Update/Lifecycle/Submit enums.
 from rka.mcp._enums import (  # noqa: E402, F811
+    BulkEntityTypeLit,
     CheckpointResolvedByLit,
     ChkTypeLit,
     DecisionStatusLit,
@@ -3975,6 +3979,20 @@ class UpdateNoteArgs(ProjectScopedArgs):
         Optional[ImportanceLit],
         Field(default=None, description="New importance level."),
     ] = None
+    status: Annotated[
+        Optional[JournalStatusLit],
+        Field(
+            default=None,
+            description=(
+                "New journal lifecycle status "
+                "(draft|active|superseded|retracted)."
+            ),
+        ),
+    ] = None
+    pinned: Annotated[
+        Optional[bool],
+        Field(default=None, description="Whether the journal entry is pinned."),
+    ] = None
     tags: Annotated[
         Optional[list[str]],
         Field(default=None, description="Replacement tag list."),
@@ -4015,6 +4033,8 @@ class UpdateNoteArgs(ProjectScopedArgs):
             self.type,
             self.confidence,
             self.importance,
+            self.status,
+            self.pinned,
             self.tags,
             self.phase,
             self.verbatim_input,
@@ -4026,7 +4046,8 @@ class UpdateNoteArgs(ProjectScopedArgs):
         if all(f is None for f in mutable_fields):
             raise ValueError(
                 "update_note: at least one mutable field must be non-None "
-                "(content, summary, type, confidence, importance, tags, phase, "
+                "(content, summary, type, confidence, importance, status, pinned, "
+                "tags, phase, "
                 "verbatim_input, source, related_decisions, related_literature, "
                 "related_mission)."
             )
@@ -4380,30 +4401,77 @@ class UpdateMissionStatusArgs(ProjectScopedArgs):
     ] = None
 
 
+class BulkUpdateItem(BaseModel):
+    """One compatibility-safe item in a best-effort bulk update.
+
+    The typed contract historically advertised flat items while the legacy
+    adapter expected fields inside ``data``. Accept both shapes so existing
+    callers keep working, but reject mixed or empty payloads before any write.
+    Entity-specific REST models validate and normalize the mutable fields.
+    """
+
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+    entity_type: Annotated[
+        BulkEntityTypeLit,
+        Field(description="note|journal|decision|literature update target."),
+    ]
+    id: Annotated[str, Field(min_length=1, description="Entity id to update.")]
+    data: Annotated[
+        Optional[dict[str, Any]],
+        Field(
+            default=None,
+            description=(
+                "Legacy nested update fields. Prefer flat fields beside id and "
+                "entity_type; do not combine both shapes."
+            ),
+        ),
+    ] = None
+
+    def normalized_data(self) -> dict[str, Any]:
+        """Return entity-model-validated update data in JSON form."""
+        flat_data = dict(self.model_extra or {})
+        if self.data is not None and flat_data:
+            raise ValueError(
+                "bulk_update item cannot combine nested 'data' with flat update fields"
+            )
+        raw_data = self.data if self.data is not None else flat_data
+        model_type = {
+            "note": JournalEntryUpdate,
+            "journal": JournalEntryUpdate,
+            "decision": DecisionUpdate,
+            "literature": LiteratureUpdate,
+        }[self.entity_type]
+        validated = model_type.model_validate(raw_data)
+        normalized = validated.model_dump(mode="json", exclude_none=True)
+        if not normalized:
+            raise ValueError("bulk_update item must include at least one non-null update field")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_shape_and_data(self) -> "BulkUpdateItem":
+        if not self.id.strip():
+            raise ValueError("bulk_update item id cannot be blank")
+        self.normalized_data()
+        return self
+
+
 class BulkUpdateArgs(ProjectScopedArgs):
-    """Update many entities in one atomic call."""
+    """Update many entities as a validated best-effort batch."""
 
     operation: Literal["bulk_update"] = "bulk_update"
 
     updates: Annotated[
-        list[dict[str, Any]],
+        list[BulkUpdateItem],
         Field(
             min_length=1,
             description=(
-                "List of update dicts. Each dict MUST include an 'id' "
-                "key plus the fields to update for that entity."
+                "List of validated updates. Each item requires entity_type and "
+                "id plus one or more flat update fields. Legacy nested data is "
+                "accepted for compatibility."
             ),
         ),
     ]
-
-    @model_validator(mode="after")
-    def _enforce_id_on_every_item(self) -> "BulkUpdateArgs":
-        for idx, item in enumerate(self.updates):
-            if not isinstance(item, dict):
-                raise ValueError(f"bulk_update: updates[{idx}] is not a dict.")
-            if "id" not in item or not item["id"]:
-                raise ValueError(f"bulk_update: updates[{idx}] missing required 'id' key.")
-        return self
 
 
 class SupersedeDecisionArgs(ProjectScopedArgs):
@@ -5354,6 +5422,7 @@ __all__ = [
     "UpdateMissionArgs",
     "UpdateStatusArgs",
     "UpdateMissionStatusArgs",
+    "BulkUpdateItem",
     "BulkUpdateArgs",
     "SupersedeDecisionArgs",
     "PresentDecisionArgs",

--- a/rka/mcp/operations_schema.py
+++ b/rka/mcp/operations_schema.py
@@ -91,6 +91,8 @@ _ENUMS = {
         "methodology",
         "summary",
     ],
+    "journal_status": ["draft", "active", "superseded", "retracted"],
+    "bulk_entity_type": ["note", "journal", "decision", "literature"],
     "decided_by": ["pi", "brain", "executor"],
     "decision_kind": [
         "research_question",
@@ -542,7 +544,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             },
         ],
         "related_operations": ["provenance", "search"],
-        "notes": "Entity prefix is auto-routed (jrn_, dec_, lit_, mis_, clm_, ecl_, chk_).",
+        "notes": (
+            "Entity prefix is auto-routed (jrn_, dec_, lit_, mis_, clm_, ecl_, "
+            "chk_). For claims, stale is hard structural invalidation while "
+            "staleness is the freshness-review state; green does not override "
+            "stale=true. Treat currentness as the canonical currency result."
+        ),
     },
     "journal": {
         "operation": "journal",
@@ -2211,11 +2218,12 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "tool": "rka_execute",
         "category": "journal",
         "role_tag": "BRAIN",
-        "summary": "Update a journal entry (content, type, confidence, links).",
+        "summary": "Update journal content, metadata, lifecycle, pinning, or links.",
         "signature": (
             "rka_execute(operation='update_note', *, project_id, id, "
             "content=None, summary=None, type=None, confidence=None, "
-            "importance=None, tags=None, phase=None, related_decisions=None, "
+            "importance=None, status=None, pinned=None, tags=None, phase=None, "
+            "related_decisions=None, "
             "related_literature=None, related_mission=None)"
         ),
         "required_fields": ["project_id", "id"],
@@ -2225,6 +2233,8 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "type",
             "confidence",
             "importance",
+            "status",
+            "pinned",
             "tags",
             "phase",
             "verbatim_input",
@@ -2233,7 +2243,9 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
             "related_literature",
             "related_mission",
         ],
-        "enums": _e("confidence", "importance", "source", "note_type"),
+        "enums": _e(
+            "confidence", "importance", "source", "note_type", "journal_status"
+        ),
         "examples": [
             {
                 "description": "Promote a finding to verified.",
@@ -2242,6 +2254,16 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     "project_id": "prj_01ABC...",
                     "id": "jrn_01XYZ...",
                     "confidence": "verified",
+                },
+            },
+            {
+                "description": "Supersede and unpin a journal entry.",
+                "call": {
+                    "operation": "update_note",
+                    "project_id": "prj_01ABC...",
+                    "id": "jrn_01XYZ...",
+                    "status": "superseded",
+                    "pinned": False,
                 },
             },
         ],
@@ -3360,11 +3382,11 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
         "tool": "rka_execute",
         "category": "core",
         "role_tag": "BRAIN",
-        "summary": "Update many entities in one atomic call.",
+        "summary": "Update many entities as one validated best-effort batch.",
         "signature": ("rka_execute(operation='bulk_update', *, project_id, updates)"),
         "required_fields": ["project_id", "updates"],
         "optional_fields": [],
-        "enums": {},
+        "enums": {"updates[].entity_type": list(_ENUMS["bulk_entity_type"])},
         "examples": [
             {
                 "description": "Bulk-tag many entities.",
@@ -3372,14 +3394,28 @@ OPERATIONS_SCHEMA: dict[str, dict[str, Any]] = {
                     "operation": "bulk_update",
                     "project_id": "prj_01ABC...",
                     "updates": [
-                        {"id": "jrn_01...", "tags": ["v2"]},
-                        {"id": "jrn_02...", "tags": ["v2"]},
+                        {
+                            "entity_type": "journal",
+                            "id": "jrn_01...",
+                            "tags": ["v2"],
+                        },
+                        {
+                            "entity_type": "journal",
+                            "id": "jrn_02...",
+                            "tags": ["v2"],
+                        },
                     ],
                 },
             },
         ],
         "related_operations": ["update_note", "update_decision"],
-        "notes": None,
+        "notes": (
+            "The canonical item shape is flat: entity_type + id + update fields. "
+            "Legacy nested data={...} is accepted, but mixing both shapes or "
+            "sending an empty update is rejected before any write. Preflight is "
+            "whole-batch; HTTP execution is best-effort and can partially succeed, "
+            "so this operation is not transactional across entities."
+        ),
     },
     # --- missions -------------------------------------------------------
     "create_mission": {

--- a/rka/mcp/server.py
+++ b/rka/mcp/server.py
@@ -836,6 +836,8 @@ async def rka_update_note(
     type: str | None = None,
     confidence: str | None = None,
     importance: str | None = None,
+    status: str | None = None,
+    pinned: bool | None = None,
     verbatim_input: str | None = None,
     related_decisions: list[str] | None = None,
     related_literature: list[str] | None = None,
@@ -856,6 +858,8 @@ async def rka_update_note(
         type: New type — note | log | directive
         confidence: New confidence level — hypothesis | tested | verified | superseded | retracted
         importance: New importance level — critical | high | normal | low
+        status: New lifecycle status — draft | active | superseded | retracted
+        pinned: Whether the journal entry is pinned
         verbatim_input: PI's exact words (preserves intellectual attribution)
         related_decisions: Decision IDs this note relates to
         related_literature: Literature IDs this note references
@@ -868,7 +872,8 @@ async def rka_update_note(
         body = {
             "content": content, "summary": summary, "type": type,
             "confidence": confidence,
-            "importance": importance, "verbatim_input": verbatim_input,
+            "importance": importance, "status": status, "pinned": pinned,
+            "verbatim_input": verbatim_input,
             "related_decisions": related_decisions,
             "related_literature": related_literature,
             "related_mission": related_mission, "tags": tags,
@@ -1642,60 +1647,83 @@ async def rka_bulk_update(
     *,
     project_id: str,
 ) -> str:
-    """PRIMARY FIELD: updates. Bulk update multiple entities in one
-    call.
+    """PRIMARY FIELD: updates. Validated best-effort entity updates.
 
-    Each update must have 'entity_type', 'id', and 'data' fields.
-    Supported entity_types: 'note', 'decision', 'literature'.
+    Canonical items are flat: ``entity_type`` + ``id`` + update fields.
+    The historical nested ``data={...}`` shape remains accepted. The full
+    batch is validated before the first HTTP request, but the requests are
+    independent and can partially succeed; this operation is not atomic.
 
     Args:
-        updates: List of updates (PRIMARY FIELD), e.g. [{"entity_type": "note", "id": "jrn_01...", "data": {"type": "note", "confidence": "verified", "tags": ["v1.6-audit"]}}]
+        updates: List of updates (PRIMARY FIELD), e.g. [{"entity_type":
+            "journal", "id": "jrn_01...", "status": "superseded"}]
     """
-    async with _client(project_id) as c:
-        results = []
-        errors = []
-        for i, upd in enumerate(updates):
-            etype = upd.get("entity_type")
-            eid = upd.get("id")
-            data = upd.get("data", {})
+    prepared: list[tuple[int, str, str, str, dict]] = []
+    errors: list[str] = []
+    for i, upd in enumerate(updates):
+        try:
+            item = _BulkUpdateItem.model_validate(upd)
+            data = item.normalized_data()
+        except Exception as exc:
+            detail = " ".join(str(exc).split())
+            errors.append(f"[{i}] invalid update: {detail[:300]}")
+            continue
+        endpoint = {
+            "note": f"/api/notes/{item.id}",
+            "journal": f"/api/notes/{item.id}",
+            "decision": f"/api/decisions/{item.id}",
+            "literature": f"/api/literature/{item.id}",
+        }[item.entity_type]
+        prepared.append((i, item.entity_type, item.id, endpoint, data))
 
-            if not etype or not eid:
-                errors.append(f"[{i}] missing entity_type or id")
-                continue
+    # Structural/data errors abort the whole batch before any write. Runtime
+    # HTTP failures can still leave earlier valid requests applied, which is
+    # why the public contract explicitly describes this as best-effort.
+    results: list[str] = []
+    if not errors:
+        async with _client(project_id) as c:
+            for i, etype, eid, endpoint, data in prepared:
+                try:
+                    r = await c.put(endpoint, json=data)
+                    if r.status_code >= 300:
+                        errors.append(
+                            f"[{i}] {etype} {eid} -> {r.status_code}: {r.text[:100]}"
+                        )
+                        continue
 
-            endpoint_map = {
-                "note": f"/api/notes/{eid}",
-                "journal": f"/api/notes/{eid}",
-                "decision": f"/api/decisions/{eid}",
-                "literature": f"/api/literature/{eid}",
-            }
-            endpoint = endpoint_map.get(etype)
-            if not endpoint:
-                errors.append(f"[{i}] unknown entity_type: {etype}")
-                continue
+                    readback = r.json()
+                    mismatched = [
+                        key
+                        for key, expected in data.items()
+                        if readback.get(key) != expected
+                    ]
+                    if mismatched:
+                        errors.append(
+                            f"[{i}] {etype} {eid} -> write response mismatch for "
+                            f"fields={','.join(mismatched)} (write may have occurred)"
+                        )
+                        continue
+                    results.append(
+                        f"[{i}] {etype} {eid} OK fields={','.join(data.keys())}"
+                    )
+                except Exception as exc:
+                    errors.append(
+                        f"[{i}] {etype} {eid} -> error: {str(exc)[:100]}"
+                    )
 
-            try:
-                r = await c.put(endpoint, json=data)
-                if r.status_code < 300:
-                    results.append(f"[{i}] {etype} {eid} OK")
-                else:
-                    errors.append(f"[{i}] {etype} {eid} -> {r.status_code}: {r.text[:100]}")
-            except Exception as e:
-                errors.append(f"[{i}] {etype} {eid} -> error: {str(e)[:100]}")
-
-        summary = f"Updated {len(results)}/{len(updates)}"
-        if errors:
-            summary += f" ({len(errors)} errors)"
-        lines = [summary, ""]
-        if results:
-            lines.append("Successes:")
-            lines.extend(results[:20])
-            if len(results) > 20:
-                lines.append(f"  ... and {len(results) - 20} more")
-        if errors:
-            lines.append("Errors:")
-            lines.extend(errors)
-        return "\n".join(lines)
+    summary = f"Updated {len(results)}/{len(updates)}"
+    if errors:
+        summary += f" ({len(errors)} errors)"
+    lines = [summary, ""]
+    if results:
+        lines.append("Successes:")
+        lines.extend(results[:20])
+        if len(results) > 20:
+            lines.append(f"  ... and {len(results) - 20} more")
+    if errors:
+        lines.append("Errors:")
+        lines.extend(errors)
+    return "\n".join(lines)
 
 
 # ============================================================
@@ -7843,6 +7871,7 @@ async def _query_post(project_id: str | None, path: str, body: dict | None = Non
 # ``RKA_LEGACY_TOOLS=1`` opt-in surface; the active @tool() decorators
 # bind to the typed wrappers.
 from rka.mcp.operation_args import (  # noqa: E402  (post-helper-import)
+    BulkUpdateItem as _BulkUpdateItem,
     ExecuteArgsUnion as _ExecuteArgsUnion,
     QueryArgsUnion as _QueryArgsUnion,
 )

--- a/rka/mcp/verb_dispatch.py
+++ b/rka/mcp/verb_dispatch.py
@@ -553,6 +553,8 @@ async def dispatch_review(target: str, *, project_id: str, payload: dict[str, An
             type=p.get("type"),
             confidence=p.get("confidence"),
             importance=p.get("importance"),
+            status=p.get("status"),
+            pinned=p.get("pinned"),
             verbatim_input=p.get("verbatim_input"),
             related_decisions=p.get("related_decisions"),
             related_literature=p.get("related_literature"),

--- a/rka/services/entity_resolver.py
+++ b/rka/services/entity_resolver.py
@@ -24,6 +24,14 @@ Packet contract (``rka-entity-resolution/v1``):
 * optional edge arrays contain only rows whose stored ``project_id`` matches
   the requested project.
 
+Claim currency has two deliberately separate stored signals. ``stale`` is a
+hard structural invalidation (for example, the source decision or promoted
+interpretation was superseded). ``staleness`` is the freshness-review workflow
+state: ``yellow`` warns and ``red`` invalidates, while ``green`` only means no
+freshness-review warning is open. It does not cancel ``stale=True``. Consumers
+must use the derived ``currentness`` object as the canonical currency result
+rather than interpreting either similarly named field in isolation.
+
 ``revision.fingerprint`` is a stable digest of normalized stored state, tags,
 and server-derived claim contradiction state.  It is suitable for change
 detection, not as proof that an entity is scientifically valid.

--- a/tests/test_mcp/test_core_reliability_journal_roundtrip.py
+++ b/tests/test_mcp/test_core_reliability_journal_roundtrip.py
@@ -7,10 +7,11 @@ from pathlib import Path
 import httpx
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 
 from rka.api.app import create_app
 from rka.config import RKAConfig
-from rka.mcp.operation_args import RecordNoteArgs, UpdateNoteArgs
+from rka.mcp.operation_args import BulkUpdateArgs, RecordNoteArgs, UpdateNoteArgs
 from rka.mcp.verb_dispatch import dispatch_execute_typed
 
 
@@ -74,6 +75,284 @@ async def test_mcp_summary_only_note_update_round_trip(
     assert read_back.status_code == 200
     assert read_back.json()["summary"] == "New summary."
     assert read_back.json()["content"] == "Body stays unchanged."
+
+
+@pytest.mark.asyncio
+async def test_mcp_journal_lifecycle_and_pinning_update_round_trip(
+    mcp_env: httpx.AsyncClient,
+) -> None:
+    created = await mcp_env.post(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+        json={
+            "content": "Lifecycle probe.",
+            "source": "brain",
+            "confidence": "verified",
+            "status": "active",
+            "pinned": False,
+        },
+    )
+    assert created.status_code == 201, created.text
+    note_id = created.json()["id"]
+
+    result = await dispatch_execute_typed(
+        UpdateNoteArgs(
+            operation="update_note",
+            project_id="proj_default",
+            id=note_id,
+            status="superseded",
+            pinned=True,
+        )
+    )
+    assert "fields=status,pinned" in result
+
+    read_back = await mcp_env.get(
+        f"/api/notes/{note_id}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert read_back.status_code == 200
+    assert read_back.json()["status"] == "superseded"
+    assert read_back.json()["pinned"] is True
+    assert read_back.json()["source"] == "brain"
+    assert read_back.json()["confidence"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_flat_and_legacy_nested_bulk_update_round_trip(
+    mcp_env: httpx.AsyncClient,
+) -> None:
+    created = await mcp_env.post(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+        json={
+            "content": "Bulk lifecycle probe.",
+            "importance": "critical",
+            "status": "active",
+            "pinned": False,
+        },
+    )
+    assert created.status_code == 201, created.text
+    note_id = created.json()["id"]
+
+    flat_result = await dispatch_execute_typed(
+        BulkUpdateArgs(
+            operation="bulk_update",
+            project_id="proj_default",
+            updates=[
+                {
+                    "entity_type": "journal",
+                    "id": note_id,
+                    "importance": "low",
+                    "status": "superseded",
+                    "tags": ["bulk-verified"],
+                }
+            ],
+        )
+    )
+    assert flat_result.startswith("Updated 1/1")
+    assert "fields=importance,status,tags" in flat_result
+
+    read_back = await mcp_env.get(
+        f"/api/notes/{note_id}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert read_back.status_code == 200
+    assert read_back.json()["importance"] == "low"
+    assert read_back.json()["status"] == "superseded"
+    assert read_back.json()["tags"] == ["bulk-verified"]
+
+    nested_result = await dispatch_execute_typed(
+        BulkUpdateArgs(
+            operation="bulk_update",
+            project_id="proj_default",
+            updates=[
+                {
+                    "entity_type": "note",
+                    "id": note_id,
+                    "data": {"status": "active", "pinned": True},
+                }
+            ],
+        )
+    )
+    assert nested_result.startswith("Updated 1/1")
+
+    final_read_back = await mcp_env.get(
+        f"/api/notes/{note_id}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert final_read_back.status_code == 200
+    assert final_read_back.json()["status"] == "active"
+    assert final_read_back.json()["pinned"] is True
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_validates_and_updates_every_supported_entity_type(
+    mcp_env: httpx.AsyncClient,
+) -> None:
+    decision = await mcp_env.post(
+        "/api/decisions",
+        headers={"X-RKA-Project": "proj_default"},
+        json={
+            "question": "Original decision question?",
+            "phase": "design",
+            "decided_by": "brain",
+        },
+    )
+    assert decision.status_code == 201, decision.text
+    literature = await mcp_env.post(
+        "/api/literature",
+        headers={"X-RKA-Project": "proj_default"},
+        json={"title": "Bulk update paper", "status": "to_read"},
+    )
+    assert literature.status_code == 201, literature.text
+
+    result = await dispatch_execute_typed(
+        BulkUpdateArgs(
+            operation="bulk_update",
+            project_id="proj_default",
+            updates=[
+                {
+                    "entity_type": "decision",
+                    "id": decision.json()["id"],
+                    "rationale": "Updated through validated bulk dispatch.",
+                    "tags": ["bulk-decision"],
+                },
+                {
+                    "entity_type": "literature",
+                    "id": literature.json()["id"],
+                    "status": "read",
+                    "tags": ["bulk-literature"],
+                },
+            ],
+        )
+    )
+    assert result.startswith("Updated 2/2")
+
+    decision_readback = await mcp_env.get(
+        f"/api/decisions/{decision.json()['id']}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert decision_readback.status_code == 200
+    assert decision_readback.json()["rationale"] == (
+        "Updated through validated bulk dispatch."
+    )
+    assert decision_readback.json()["tags"] == ["bulk-decision"]
+
+    literature_readback = await mcp_env.get(
+        f"/api/literature/{literature.json()['id']}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert literature_readback.status_code == 200
+    assert literature_readback.json()["status"] == "read"
+    assert literature_readback.json()["tags"] == ["bulk-literature"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_bulk_preflight_prevents_partial_write(
+    mcp_env: httpx.AsyncClient,
+) -> None:
+    import rka.mcp.server as mcp_server
+
+    created = await mcp_env.post(
+        "/api/notes",
+        headers={"X-RKA-Project": "proj_default"},
+        json={"content": "Must remain active.", "status": "active"},
+    )
+    assert created.status_code == 201, created.text
+    note_id = created.json()["id"]
+
+    result = await mcp_server.rka_bulk_update(
+        updates=[
+            {
+                "entity_type": "journal",
+                "id": note_id,
+                "status": "superseded",
+            },
+            {
+                "entity_type": "journal",
+                "id": "jrn_invalid",
+                "unknown": "field",
+            },
+        ],
+        project_id="proj_default",
+    )
+    assert result.startswith("Updated 0/2 (1 errors)")
+
+    read_back = await mcp_env.get(
+        f"/api/notes/{note_id}",
+        headers={"X-RKA-Project": "proj_default"},
+    )
+    assert read_back.status_code == 200
+    assert read_back.json()["status"] == "active"
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"id": "jrn_probe", "status": "superseded"},
+        {"entity_type": "journal", "id": "jrn_probe"},
+        {
+            "entity_type": "journal",
+            "id": "jrn_probe",
+            "data": {"status": "superseded"},
+            "pinned": True,
+        },
+        {"entity_type": "journal", "id": "jrn_probe", "unknown": "value"},
+    ],
+)
+def test_bulk_update_rejects_ambiguous_or_empty_items(item: dict) -> None:
+    with pytest.raises(ValidationError):
+        BulkUpdateArgs(
+            operation="bulk_update",
+            project_id="proj_default",
+            updates=[item],
+        )
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_does_not_report_success_on_readback_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import rka.mcp.server as mcp_server
+
+    class MismatchResponse:
+        status_code = 200
+        text = ""
+
+        @staticmethod
+        def json() -> dict:
+            return {"id": "jrn_probe", "status": "active"}
+
+    class MismatchClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def put(self, _endpoint: str, *, json: dict):
+            assert json == {"status": "superseded"}
+            return MismatchResponse()
+
+    async def no_session_hook(_project_id):
+        return None
+
+    monkeypatch.setattr(mcp_server, "_client", lambda _project_id: MismatchClient())
+    monkeypatch.setattr(mcp_server, "_maybe_fire_session_start", no_session_hook)
+
+    result = await mcp_server.rka_bulk_update(
+        updates=[
+            {
+                "entity_type": "journal",
+                "id": "jrn_probe",
+                "status": "superseded",
+            }
+        ],
+        project_id="proj_default",
+    )
+
+    assert result.startswith("Updated 0/1 (1 errors)")
+    assert "write response mismatch for fields=status" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_entity_resolver.py
+++ b/tests/test_services/test_entity_resolver.py
@@ -45,18 +45,20 @@ async def _insert_claim(
     project_id: str,
     *,
     verified: int = 1,
+    stale: int = 0,
     staleness: str = "green",
 ) -> None:
     await db.execute(
         """INSERT INTO claims
            (id, source_entry_id, claim_type, content, verified, evidence_status,
             stale, staleness, project_id)
-           VALUES (?, ?, 'result', ?, ?, 'supported', 0, ?, ?)""",
+           VALUES (?, ?, 'result', ?, ?, 'supported', ?, ?, ?)""",
         [
             claim_id,
             source_id,
             f"Claim content for {claim_id}",
             verified,
+            stale,
             staleness,
             project_id,
         ],
@@ -267,6 +269,39 @@ async def test_currentness_fails_closed_on_expired_retracted_and_invalid_metadat
         "expired",
         "invalid_staleness:mystery",
     ]
+
+
+@pytest.mark.asyncio
+async def test_structural_stale_is_not_overridden_by_green_review_state(
+    db: Database,
+) -> None:
+    source_id = "jrn_resolver_structural_stale_source"
+    claim_id = "clm_resolver_structural_stale"
+    await _insert_journal(db, source_id, PROJECT_ID)
+    await _insert_claim(
+        db,
+        claim_id,
+        source_id,
+        PROJECT_ID,
+        stale=1,
+        staleness="green",
+    )
+    await db.commit()
+
+    packet = await EntityResolverService(db).resolve_entities(
+        PROJECT_ID,
+        [claim_id],
+    )
+    claim = packet["entities"][claim_id]
+
+    assert claim["stale"] is True
+    assert claim["staleness"] == "green"
+    assert claim["currentness"] == {
+        "is_current": False,
+        "state": "not_current",
+        "reasons": ["stale"],
+        "warnings": [],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose journal lifecycle status and pinned updates through typed MCP and legacy dispatch
- make bulk_update validate entity-specific payloads and perform the advertised journal, decision, and literature writes
- preflight structural errors before writes and reject false success when the REST response does not reflect requested fields
- document stale versus staleness semantics and make currentness the canonical consumer signal
- add database readback regressions for lifecycle, bulk writes, compatibility, and preservation of omitted metadata

## Verification
- targeted Journal, contract, packaging, model-drift, and resolver tests: 1010 passed
- full Core gate: 3214 passed, 294 deselected
- contract snapshots verified
- git diff --check passed

Research Story work is intentionally excluded and remains on its separate branch.
