### PR TITLE
Publish release-pinned Core container images

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,175 @@
+name: publish-container
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: publish-container-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    if: ${{ github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Check out the released source
+        # actions/checkout v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Python 3.13
+        # actions/setup-python v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.13"
+
+      - name: Validate release provenance and version
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          release_commit="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$release_commit" origin/main; then
+            echo "Release commit $release_commit is not contained in origin/main" >&2
+            exit 1
+          fi
+          version="$(python scripts/validate_container_release.py --tag "$RELEASE_TAG")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "revision=$release_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        # docker/setup-qemu-action v4.3.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        # docker/setup-buildx-action v4.3.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
+
+      - name: Build the amd64 release preflight image
+        # docker/build-push-action v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: rka-core:release-preflight-${{ github.run_id }}-${{ github.run_attempt }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Smoke-test before publishing
+        run: >-
+          python scripts/container_image_smoke.py
+          --image rka-core:release-preflight-${{ github.run_id }}-${{ github.run_attempt }}
+          --expected-version ${{ steps.release.outputs.version }}
+
+      - name: Log in to GHCR
+        # docker/login-action v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags and OCI labels
+        id: meta
+        # docker/metadata-action v6.2.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }}
+            type=semver,pattern={{major}},value=${{ github.event.release.tag_name }}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=RKA Core
+            org.opencontainers.image.description=Local-first research memory and evidence infrastructure
+            org.opencontainers.image.source=https://github.com/rka-project/rka-core
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+            org.opencontainers.image.revision=${{ steps.release.outputs.revision }}
+
+      - name: Build and publish the multi-architecture image
+        id: publish
+        # docker/build-push-action v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Verify the published architectures
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          index="$RUNNER_TEMP/rka-core-image-index.json"
+          docker buildx imagetools inspect --raw "$IMAGE@$DIGEST" > "$index"
+          jq -e '
+            [.manifests[]?.platform? | select(.os == "linux") | .architecture] as $arches
+            | ($arches | index("amd64") != null)
+              and ($arches | index("arm64") != null)
+          ' "$index"
+
+      - name: Smoke-test the published digest
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: >-
+          python scripts/container_image_smoke.py
+          --image "$IMAGE@$DIGEST"
+          --expected-version "$VERSION"
+
+      - name: Attest the published image
+        # actions/attest v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify the provenance attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: >-
+          gh attestation verify
+          "oci://$IMAGE@$DIGEST"
+          --repo "$GITHUB_REPOSITORY"
+
+      - name: Record the immutable release reference
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: echo "Core image digest — \`$IMAGE@$DIGEST\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -130,3 +130,9 @@ jobs:
           print(found);
           assert found == {'fastembed': True, 'sqlite_vec': True,
           'litellm': False, 'instructor': False}"
+
+      - name: Smoke-test the isolated Core image
+        run: >-
+          python scripts/container_image_smoke.py
+          --image rka-core:ci
+          --expected-version 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to RKA are documented here. Format loosely follows
 
 ### Added
 
+- A release-only GHCR workflow now preflight-smokes, builds, publishes, and
+  attests `linux/amd64` and `linux/arm64` Core images. Downstream releases use
+  the emitted manifest digest rather than a mutable container tag.
 - Versioned Core capability discovery now exposes the package and public
   contract versions through REST and the existing five-tool MCP dispatch
   surface. Clients can require a Core contract or runtime capability and

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,11 @@ ENV RKA_DATA_DIR=/data \
     RKA_EMBEDDING_THREADS=2 \
     RKA_EMBEDDING_CACHE_DIR=/data/fastembed_cache
 
+LABEL org.opencontainers.image.title="RKA Core" \
+      org.opencontainers.image.description="Local-first research memory and evidence infrastructure" \
+      org.opencontainers.image.source="https://github.com/rka-project/rka-core" \
+      org.opencontainers.image.licenses="MIT"
+
 EXPOSE 9712
 
 # Health check

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Invoke-RestMethod http://127.0.0.1:9712/api/health
 
 Open [http://127.0.0.1:9712](http://127.0.0.1:9712). The interactive REST documentation is at [http://127.0.0.1:9712/docs](http://127.0.0.1:9712/docs). The MCP binary is `~/.local/bin/rka` on macOS/Linux and `%USERPROFILE%\.local\bin\rka.exe` on Windows. Client-specific Claude and Codex configuration, upgrades, and troubleshooting are documented in [INSTALL.md](INSTALL.md).
 
+Starting with the first successful container-enabled release, Core will also
+publish a multi-architecture image for downstream deployment tools. The image
+is not considered available until the release workflow and public
+anonymous-pull read-back succeed; deployment tools must pin the resulting
+digest. See [Core container image publication](docs/CONTAINER_IMAGE.md).
+
 > The first uncached FastEmbed startup downloads the embedding model. During that download or a generation rebuild after an upgrade/import, health remains available but semantic search can temporarily fall back to lexical retrieval. Check Settings for indexing progress before judging retrieval quality.
 
 ### 2. Begin a project

--- a/docs/CONTAINER_IMAGE.md
+++ b/docs/CONTAINER_IMAGE.md
@@ -1,0 +1,79 @@
+# Core container image publication
+
+RKA Core's canonical container name is:
+
+```text
+ghcr.io/rka-project/rka-core
+```
+
+The image becomes an installation input only after a successful stable GitHub
+Release workflow and the read-back checks below. A source checkout or an image
+tag by itself is not proof that a public release image exists.
+
+## Publication contract
+
+The `publish-container` workflow runs only for a published, non-prerelease
+GitHub Release. It fails unless:
+
+- the release commit is contained in `main`;
+- the tag is exactly `v<project.version>` and the version is stable SemVer;
+- an isolated preflight container becomes healthy without publishing a host
+  port or using persistent host storage;
+- the pushed OCI index contains both `linux/amd64` and `linux/arm64`;
+- the published digest starts successfully under the same isolated smoke; and
+- the GitHub provenance attestation can be verified.
+
+The workflow publishes version, major/minor, major, and `latest` tags for human
+navigation. Those tags are mutable references. Deployment records and RKA App
+release configuration must use the immutable manifest reference emitted in the
+workflow summary:
+
+```text
+ghcr.io/rka-project/rka-core@sha256:<manifest-digest>
+```
+
+BuildKit also publishes SBOM and provenance material. GitHub records a separate
+artifact attestation bound to the same manifest digest.
+
+## First-publication read-back gate
+
+GitHub Container Registry package visibility can depend on organization and
+repository package settings. After the first successful workflow:
+
+1. Read the digest from the completed workflow, not from a local tag.
+2. Confirm the package is linked to `rka-project/rka-core` and is public.
+3. From a logged-out environment, pull the exact digest without credentials.
+4. Inspect the index and confirm `linux/amd64` and `linux/arm64` are present.
+5. Verify the attestation against the Core repository.
+6. Only then update RKA App's release configuration to pin that digest.
+
+Example read-only checks:
+
+```bash
+docker pull ghcr.io/rka-project/rka-core@sha256:<manifest-digest>
+docker buildx imagetools inspect \
+  ghcr.io/rka-project/rka-core@sha256:<manifest-digest>
+gh attestation verify \
+  oci://ghcr.io/rka-project/rka-core@sha256:<manifest-digest> \
+  --repo rka-project/rka-core
+```
+
+Do not change package visibility as part of an automated retry. Making a GHCR
+package public is an explicit operator decision and cannot be reversed to
+private under GitHub's current visibility model.
+
+## Local validation
+
+Core CI builds the production Dockerfile and invokes:
+
+```bash
+python scripts/container_image_smoke.py \
+  --image rka-core:ci \
+  --expected-version 3.0.0
+```
+
+The smoke test creates one uniquely named, labelled container, publishes no
+host ports, overlays `/data` with tmpfs, verifies `/api/health`, and removes
+only the container whose ownership label it created. It does not use the stock
+Compose project, the live `rka-server` or `rka-worker` names, port 9712, or the
+`rka_rka-data` volume.

--- a/docs/adr/0018-publish-core-container-images-by-release-digest.md
+++ b/docs/adr/0018-publish-core-container-images-by-release-digest.md
@@ -1,0 +1,49 @@
+# ADR 0018: Publish Core container images by release digest
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+
+## Context
+
+RKA App needs a released Core image without copying Core source or depending on
+Core internals. A mutable image tag alone is not a sufficient dependency: it
+does not identify one build, and a failed or unreviewed branch build must not
+become an installation input.
+
+The Core Dockerfile is already part of the independent Core CI gate. What is
+missing is a release-only publication path with explicit source, architecture,
+runtime, and provenance checks.
+
+## Decision
+
+1. Core publishes `ghcr.io/rka-project/rka-core` only from a non-prerelease
+   GitHub Release whose tag is contained in `main`.
+2. The release tag must be exactly `v<project.version>`. The first workflow
+   accepts stable SemVer only; prerelease container publication requires a
+   separate reviewed extension.
+3. The workflow builds Linux `amd64` and `arm64` images. It first builds and
+   starts an isolated `amd64` preflight image with no host port and tmpfs data,
+   then publishes the multi-architecture index and starts the published digest
+   once more.
+4. GitHub Actions dependencies are pinned to immutable commit SHAs. Published
+   images carry OCI source, license, version, and revision metadata, a BuildKit
+   SBOM/provenance record, and a GitHub artifact attestation.
+5. Version, major/minor, major, and `latest` tags are navigation conveniences.
+   Downstream release configuration, including RKA App, must use the manifest
+   digest returned by the successful workflow.
+6. The first publication is not complete until package visibility and an
+   anonymous digest pull are read back. Changing a package to public is a
+   separate, irreversible operator action and is never inferred from a
+   successful push.
+
+## Consequences
+
+- Core owns and can audit the image containing its code and dependencies.
+- RKA App can consume a precise external artifact while retaining a separate
+  repository and release cadence.
+- A GitHub Release may take longer because it includes an `arm64` build,
+  isolated runtime probes, manifest validation, SBOM generation, and
+  attestation verification.
+- The Dockerfile's upstream base references are not yet digest-pinned, so the
+  workflow provides immutable output identity and provenance rather than a
+  claim of bit-for-bit reproducible rebuilding.

--- a/scripts/container_image_smoke.py
+++ b/scripts/container_image_smoke.py
@@ -1,0 +1,146 @@
+"""Start a Core image in an isolated container and verify its public health API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+import uuid
+from typing import Any
+
+LABEL_KEY = "org.rka.core.image-smoke"
+
+
+def _run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _inspect(container: str) -> dict[str, Any]:
+    result = _run("inspect", container)
+    payload = json.loads(result.stdout)
+    if len(payload) != 1:
+        raise RuntimeError(f"expected one container inspection, got {len(payload)}")
+    return payload[0]
+
+
+def _logs(container: str) -> str:
+    result = _run("logs", container, check=False)
+    return (result.stdout + result.stderr).strip()
+
+
+def _cleanup(container: str, token: str) -> None:
+    result = _run("inspect", container, check=False)
+    if result.returncode != 0:
+        return
+
+    payload = json.loads(result.stdout)
+    actual = payload[0].get("Config", {}).get("Labels", {}).get(LABEL_KEY)
+    if actual != token:
+        raise RuntimeError(
+            f"refusing to remove {container}: ownership label is {actual!r}, expected {token!r}"
+        )
+    _run("rm", "--force", "--volumes", container)
+
+
+def smoke(image: str, expected_version: str, timeout: float) -> dict[str, Any]:
+    token = uuid.uuid4().hex
+    container = f"rka-core-image-smoke-{token[:12]}"
+    created = False
+
+    try:
+        _run(
+            "run",
+            "--detach",
+            "--name",
+            container,
+            "--label",
+            f"{LABEL_KEY}={token}",
+            "--env",
+            "RKA_EMBEDDINGS_ENABLED=false",
+            "--tmpfs",
+            "/data:rw,noexec,nosuid,size=256m",
+            image,
+        )
+        created = True
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            details = _inspect(container)
+            state = details.get("State", {})
+            if state.get("Status") == "exited":
+                raise RuntimeError(
+                    f"container exited with code {state.get('ExitCode')}:\n{_logs(container)}"
+                )
+            if state.get("Health", {}).get("Status") == "healthy":
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError(
+                f"container did not become healthy within {timeout:g}s:\n{_logs(container)}"
+            )
+
+        details = _inspect(container)
+        if details.get("HostConfig", {}).get("PortBindings"):
+            raise RuntimeError("image smoke unexpectedly published a host port")
+
+        tmpfs = details.get("HostConfig", {}).get("Tmpfs") or {}
+        if "/data" not in tmpfs:
+            raise RuntimeError(f"expected a tmpfs /data mount, got {tmpfs!r}")
+        persistent_data_mounts = [
+            mount
+            for mount in details.get("Mounts", [])
+            if mount.get("Destination") == "/data" and mount.get("Type") != "tmpfs"
+        ]
+        if persistent_data_mounts:
+            raise RuntimeError(f"unexpected persistent /data mount: {persistent_data_mounts!r}")
+
+        probe = (
+            "import json,os,urllib.request; "
+            "payload=json.load(urllib.request.urlopen('http://127.0.0.1:9712/api/health')); "
+            "print(json.dumps(payload,sort_keys=True)); "
+            "assert payload['status']=='ok'; "
+            "assert payload['version']==os.environ['EXPECTED_VERSION']"
+        )
+        response = _run(
+            "exec",
+            "--env",
+            f"EXPECTED_VERSION={expected_version}",
+            container,
+            "python",
+            "-c",
+            probe,
+        )
+
+        return {
+            "container": container,
+            "health": json.loads(response.stdout),
+            "image": image,
+            "published_host_ports": [],
+            "storage": "tmpfs",
+        }
+    finally:
+        if created:
+            _cleanup(container, token)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--timeout", type=float, default=120)
+    args = parser.parse_args()
+
+    print(
+        json.dumps(smoke(args.image, args.expected_version, args.timeout), indent=2, sort_keys=True)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_container_release.py
+++ b/scripts/validate_container_release.py
@@ -1,0 +1,52 @@
+"""Validate that a Core release tag exactly matches the packaged version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tomllib
+from pathlib import Path
+
+_STABLE_SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def project_version(pyproject: Path) -> str:
+    payload = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    version = payload.get("project", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"missing project.version in {pyproject}")
+    return version
+
+
+def validate_release_tag(tag: str, version: str) -> str:
+    """Return the version when a stable release tag is canonical and exact."""
+
+    if not _STABLE_SEMVER.fullmatch(version):
+        raise ValueError(
+            f"container publication currently accepts stable SemVer only; got {version!r}"
+        )
+
+    expected = f"v{version}"
+    if tag != expected:
+        raise ValueError(
+            f"release tag {tag!r} does not match project version {version!r}; expected {expected!r}"
+        )
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="GitHub release tag, including the leading v")
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "pyproject.toml",
+    )
+    args = parser.parse_args()
+
+    print(validate_release_tag(args.tag, project_version(args.pyproject)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_infra/test_container_release.py
+++ b/tests/test_infra/test_container_release.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from unittest import TestCase
+
+from scripts.validate_container_release import project_version, validate_release_tag
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-container.yml"
+
+
+class ContainerReleaseTests(TestCase):
+    def test_current_core_version_has_an_exact_release_tag(self) -> None:
+        version = project_version(ROOT / "pyproject.toml")
+        self.assertEqual(validate_release_tag(f"v{version}", version), version)
+
+    def test_container_release_rejects_noncanonical_or_mismatched_tags(self) -> None:
+        cases = [
+            ("3.0.0", "3.0.0"),
+            ("v3.0", "3.0.0"),
+            ("v3.0.1", "3.0.0"),
+            ("v3.0.0-rc1", "3.0.0-rc1"),
+            ("v03.0.0", "03.0.0"),
+        ]
+        for tag, version in cases:
+            with self.subTest(tag=tag, version=version), self.assertRaises(ValueError):
+                validate_release_tag(tag, version)
+
+    def test_publication_workflow_is_release_only_digest_first_and_multi_arch(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("types: [published]", workflow)
+        self.assertNotIn("workflow_dispatch", workflow)
+        self.assertIn("github.event.release.prerelease == false", workflow)
+        self.assertIn("python scripts/validate_container_release.py", workflow)
+        self.assertIn("git merge-base --is-ancestor", workflow)
+        self.assertIn("platforms: linux/amd64,linux/arm64", workflow)
+        self.assertIn("subject-digest: ${{ steps.publish.outputs.digest }}", workflow)
+        self.assertIn("push-to-registry: true", workflow)
+        self.assertEqual(workflow.count("scripts/container_image_smoke.py"), 2)
+
+        action_lines = [line.strip() for line in workflow.splitlines() if "uses:" in line]
+        self.assertTrue(action_lines)
+        for line in action_lines:
+            revision = line.rsplit("@", 1)[-1]
+            self.assertEqual(len(revision), 40)
+            self.assertTrue(all(character in "0123456789abcdef" for character in revision))


### PR DESCRIPTION
## Summary

- publish RKA Core to `ghcr.io/rka-project/rka-core` only from a stable, published GitHub Release
- require an exact `v<project.version>` tag whose commit is contained in `main`
- preflight-smoke the image before publishing, then build Linux amd64/arm64, verify the pushed digest, and attach SBOM/provenance attestations
- add an exact-label, no-host-port, tmpfs-backed container smoke used by both normal CI and the release workflow
- document the immutable-digest handoff to `rka-app` and the first-publication visibility/read-back gate

## Safety boundary

- opening this PR does not publish an image; the new workflow responds only to a non-prerelease GitHub Release
- all third-party actions in the publication workflow are pinned to full commit SHAs
- downstream deployment configuration must use the emitted manifest digest, never `latest`
- the local integration run did not use Compose, port 9712, the live container names, or the live data volume

## Validation

- `actionlint v1.7.12 .github/workflows/publish-container.yml .github/workflows/pytest.yml`
- `python3 -m unittest tests.test_infra.test_container_release -v`
- targeted Ruff check and format check for all added Python files
- Python compileall and `git diff --check`
- production Dockerfile built successfully on local arm64 Docker
- isolated image smoke passed with Core 3.0.0 healthy, no published host ports, and tmpfs storage
- the protected local RKA server/worker identities, images, mounts, and 9712 health response matched before and after; all test containers and the uniquely tagged test image were removed

Repository-wide `ruff check .` is not currently a clean gate and reports pre-existing findings outside this PR; the added Python files pass targeted Ruff validation.

## Post-merge release gate

No release or package visibility change is part of this PR. After an explicitly authorized stable Core release, read back the workflow digest, public package visibility, anonymous digest pull, amd64/arm64 index, and attestation before pinning the digest in `rka-app`.
