### PR TITLE
docs: rebaseline ecosystem roadmap around Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ For a complete first-project walkthrough, see [USAGE_GUIDE.md](USAGE_GUIDE.md).
 | **CLI** | Starting services, status, backup, credentials, and workspace bootstrap | [Technical Reference](docs/TECHNICAL_REFERENCE.md) |
 | **REST API** | Custom integrations and application development | [Technical Reference](docs/TECHNICAL_REFERENCE.md), live `/docs` |
 | **ChatGPT connector** | Authenticated access from ChatGPT to a local RKA instance | [Connector Guide](docs/CHATGPT_CONNECTOR.md) |
-| **Writer (separate project)** | Explicitly invoked manuscript assistance using RKA's public contract | [`rka-project/rka-writer`](https://github.com/rka-project/rka-writer) |
+| **Writer (separate project)** | Researcher-controlled authoring graph and convergence workbench using RKA's public contract | [`rka-project/rka-writer`](https://github.com/rka-project/rka-writer) |
+| **App (separate project)** | Installation, lifecycle supervision, and optional user-owned deployment adapters | [`rka-project/rka-app`](https://github.com/rka-project/rka-app) |
 
 ## Architecture
 
@@ -219,25 +220,24 @@ See [Architecture](docs/ARCHITECTURE.md) for the runtime model, data layers, pro
 
 ## Roadmap
 
-The immediate priority is to harden RKA as an independently usable research-
-knowledge core. Writer remains a separate downstream product under the same
-RKA Ecosystem project:
+Core reliability and the stable external contract are established. The active
+ecosystem now advances through three coordinated tracks:
 
-1. **Core reliability** — harden journal correctness, provenance, project
-   isolation, retrieval, claim edges, migrations, export/import, and recovery.
-2. **Stable integration contract** — freeze the supported REST/MCP surface and
-   provide version, capability, and compatibility discovery.
-3. **RKA Writer extraction** — move the Writer skill, manuscript semantics,
-   academic-writing tools, and Workbench to `rka-project/rka-writer`.
-4. **Future Core slimming and ecosystem validation** — slim the Core
-   distribution only in an explicitly approved breaking release, after
-   legacy-state migration and downstream compatibility tests pass.
+1. **Core 3.0 and maintenance** — release the cross-platform Core artifact and
+   continue correctness, retrieval, provenance, recovery, and compatibility.
+2. **Local-first access** — use RKA App for Foundation 0, agent-guided local
+   setup, a fixed-sample read-only public demo, and an optional user-owned
+   deployment template.
+3. **RKA Writer re-baseline** — freeze an Authoring IR and convergence protocol,
+   then validate one fully traceable paragraph before broader drafting or UI
+   implementation.
 
 The earlier Agentic repository/extraction proposal is shelved. Its history is
 preserved, but it is not an active product, dependency, or installation path.
 
-The Workbench, ARA interoperability, and dual-output evaluation remain planned
-Writer/ecosystem work; they are not the immediate Core implementation target.
+Writer and App remain independently released consumers of Core. Hugging Face
+is an optional Core trial path, not a Writer dependency or a replacement for
+local privacy.
 
 The dependency-ordered plan lives in the repository [Roadmap](ROADMAP.md), with
 active work tracked through [GitHub milestones](https://github.com/rka-project/rka-core/milestones).
@@ -271,7 +271,7 @@ RKA is being developed for research workflows at UNC Charlotte. Feedback, compar
 | [Architecture](docs/ARCHITECTURE.md) | Design rationale, components, data model, and knowledge lifecycle |
 | [Technical Reference](docs/TECHNICAL_REFERENCE.md) | CLI, MCP, REST, configuration, and development entry points |
 | [Core Profile](docs/CORE_PROFILE.md) | Supported Core dependencies, test boundary, and startup smoke gate |
-| [Roadmap](ROADMAP.md) | Dependency-ordered milestones for the epistemic pipeline, workbench, and ARA interoperability |
+| [Roadmap](ROADMAP.md) | Active Core, App/access, Writer, and integration tracks with dependency-ordered exit gates |
 | [Embedding Backends](docs/embedding_backends.md) | Local and OpenAI-compatible embedding configuration |
 | [Credential Vault](docs/CRED_VAULT.md) | Secure credential storage and propagation |
 | [ChatGPT Connector](docs/CHATGPT_CONNECTOR.md) | Authenticated remote MCP access |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,319 +1,132 @@
-# RKA Roadmap
+# RKA Ecosystem Roadmap
 
-This roadmap prioritizes a reliable, independently usable RKA research-
-knowledge core. Writer/Workbench is the only active downstream product and is
-released separately as `rka-project/rka-writer`. Agentic orchestration is
-shelved: its existing history is preserved, but no `rka-agentic` repository or
-runtime extraction is planned unless the PI explicitly reactivates it.
+This is the active, outcome-oriented roadmap for the RKA ecosystem. Detailed
+implementation work belongs in repository issues and pull requests; completed
+or superseded programs remain available as history.
 
-The original repository and authority decision is recorded in
-[ADR 0012](docs/adr/0012-rka-ecosystem-repository-boundaries.md), with the
-Agentic portion superseded by
-[ADR 0013](docs/adr/0013-shelve-agentic-and-focus-core-writer.md). The active
-execution source is the
-[RKA Ecosystem Repository Separation Plan](docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md).
-The proposed repository-local milestones, cross-repository Project fields,
-issue slate, and disposition of the previous M6 backlog are recorded in the
-[RKA Ecosystem GitHub Slate](docs/superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md).
+The active ecosystem has three repositories:
 
-The earlier detailed [epistemic pipeline and manuscript workbench
-plan](docs/superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md)
-remains the design and implementation history for the future `rka-writer`
-repository. It is no longer the immediate Core implementation priority.
+- **RKA Core** — local-first research knowledge, provenance, retrieval,
+  integrity, and stable REST/MCP contracts;
+- **RKA App** — installation, lifecycle supervision, and optional deployment
+  adapters around released Core artifacts; and
+- **RKA Writer** — a researcher-controlled authoring graph and convergence
+  workbench that consumes Core through public, project-scoped interfaces.
 
-The M0 authority, stage, proposal, and provider decisions are recorded in
-[ADR 0001](docs/adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md).
-The M1 interpretation boundary is recorded in
-[ADR 0002](docs/adr/0002-interpretation-staging-and-experiment-boundary.md).
-The canonical-claim applicability boundary is recorded in
-[ADR 0003](docs/adr/0003-canonical-claim-scope-contracts.md).
-The experiment/run/observation and exact-locator boundary is recorded in
-[ADR 0004](docs/adr/0004-experiment-run-observation-and-evidence-locator-contracts.md).
-The provisional planning and frozen-branch boundary is recorded in
-[ADR 0005](docs/adr/0005-versioned-manuscript-planning-branches.md).
-The unified human/AI proposal, conflict, and provider boundary is recorded in
-[ADR 0006](docs/adr/0006-unified-semantic-patch-proposals.md).
-The seed-to-contribution guidance, candidate identity, promotion, and exact PI
-ratification boundary is recorded in
-[ADR 0007](docs/adr/0007-seed-to-contribution-guidance-and-promotion.md).
-The claim-centered evaluation, adverse-outcome, mission, and result-unit
-boundary is recorded in
-[ADR 0008](docs/adr/0008-claim-centered-evaluation-contract-and-results-trace.md).
-The progressive-outline hierarchy, writing-rationale, binding-preservation,
-and proposal-first editing boundary is recorded in
-[ADR 0009](docs/adr/0009-progressive-outline-and-unit-editor.md).
-The typed academic-role, evidence-warrant, citation-use, claim-boundary, and
-proportionate-readiness boundary is recorded in
-[ADR 0010](docs/adr/0010-typed-academic-writing-semantics.md).
-The conflict-safe Markdown/LaTeX source, stable-anchor, recovery, and
-public/private drafting boundary is recorded in
-[ADR 0011](docs/adr/0011-conflict-safe-manuscript-source-synchronization.md).
-The ecosystem repository, authority, integration, migration, packaging, and
-release boundaries are recorded in
-[ADR 0012](docs/adr/0012-rka-ecosystem-repository-boundaries.md).
+Agentic orchestration remains shelved under
+[ADR 0013](docs/adr/0013-shelve-agentic-and-focus-core-writer.md). It is not an
+active product, dependency, or roadmap track.
 
-The roadmap is ordered by dependency, not by invented delivery dates. Every
-milestone must satisfy its exit gate before dependent work is treated as ready.
+## Current position
 
-Portable installation and managed model lifecycle still belong to the separate
-future `rka-app`, not to a Core branch. Core's provider and vector-space side of
-that boundary is recorded in
-[ADR 0017](docs/adr/0017-portable-embedding-runtime-boundary.md). The Qwen
-standard-profile candidate remains gated by retrieval quality and real 16 GB
-Mac/Windows measurements; it is not yet a Core or App release default.
+| Program | Current state | Next gate |
+|---|---|---|
+| Core separation E0-E2 | Complete | Preserve the deployed public contract while completing the Core 3.0 release gate. |
+| E3 Agentic extraction | Superseded | A new PI decision is required before any reactivation. |
+| E4 Writer extraction | Repository and legacy staging baseline complete; product design re-baselined | Complete Writer W0 before implementing a new authoring runtime. |
+| E5 Core 3.0 | Active release gate | Release from verified cross-platform artifacts and retain non-destructive legacy export. |
+| E6 ecosystem integration | Pending | Add reproducible Core-only, Core+App, and Core+Writer compatibility checks after the downstream vertical slices exist. |
+| RKA App Foundation 0 | Implementation candidate under review | Merge and pin the first released Core image by digest. |
+| RKA Writer | W0 design phase | Ratify the Authoring IR and validate one fully traceable paragraph. |
 
-The immediate adoption priority is not native desktop packaging or an
-RKA-operated cloud service. It is to lower the cost of evaluating and
-independently running RKA without weakening its local-first, researcher-
-controlled model. Local deployment remains the canonical path. The bounded
-alternatives are an official read-only sample-data demo and a data-free
-Hugging Face Space template that users may duplicate into infrastructure they
-own and administer. The access-and-trial sequence below consumes released Core
-artifacts but does not extend the E0-E6 Core milestone hierarchy.
+The pre-rebaseline roadmap, including the completed Workbench program, is
+preserved in
+[`docs/history/rka-roadmap-pre-rebaseline-2026-09-03.md`](docs/history/rka-roadmap-pre-rebaseline-2026-09-03.md).
 
-One bounded Core follow-up remains separate from the portable-runtime work:
-make explicit/manual embedding repair compare canonical content hashes and
-vector presence, rather than repairing only missing current-model metadata.
-Until then, failed edit embeddings remain owned by the durable worker retry
-path; the backfill endpoint must not be described as a general stale-index
-scrubber.
-
-## Current strategic priority
-
-RKA Core reliability comes first. No new Writer/Workbench or autonomous
-orchestration capability should be added to Core while the boundaries and
-public contracts are being stabilized. Agentic work is outside the active
-roadmap.
-
-| Order | Ecosystem milestone | Outcome | Exit gate summary |
-|---|---|---|---|
-| **E0** | **Boundary freeze and inventory** | Fix authority, repository, API, plugin, and migration ownership before moving code. | Every table, route, MCP operation, skill, and major directory has one owner or explicit legacy disposition. |
-| **E1** | **Core reliability baseline** | Harden journal, provenance, project isolation, retrieval, claim edges, migrations, export/import, and recovery. | Core-only install/tests pass; no cross-project leakage; real backup upgrade and integrity pass. |
-| **E2** | **Stable external contract** | Freeze supported REST/MCP behavior and provide capability/version discovery plus legacy Writer export. | Public-contract-only clients complete core workflows and legacy Writer export round-trips. |
-| **E3** | **Agentic work shelved** | Preserve the historical branch and design record without creating or operating a separate Agentic product. | Active docs and packaging do not direct users to install Agentic; reactivation requires a new PI decision. |
-| **E4** | **Writer repository extraction** | Establish `rka-project/rka-writer`, migrate Writer state, and move Workbench ownership. | Writer runs independently, imports legacy state, and detects stale Core references. |
-| **E5** | **Future Core slimming** | Remove active Writer execution code only in a future explicitly approved breaking release, while preserving compatibility export and migration history. | Core and Writer compatibility suites pass without destructive database changes. |
-| **E6** | **Ecosystem integration** | Maintain Core and Writer releases under one GitHub Project and compatibility matrix. | Core-only and Core+Writer deployments have reproducible smoke tests. |
-
-The detailed deliverables, rollback paths, and decision checkpoints for E0-E6
-are in the active execution plan linked above.
-
-## Local-first access and trial track
-
-This cross-cutting track runs alongside Core reliability and contract work. It
-must not turn RKA Project into the custodian of users' research data or make a
-third-party cloud account a dependency of the local distribution.
-
-| Order | Access milestone | Outcome | Exit gate summary |
-|---|---|---|---|
-| **A0** | **Agent-guided local setup** | Reduce the installation burden for researchers who already use Codex or Claude Code while keeping RKA, its database, and its embedding runtime on their own machine. | Fresh macOS, Windows, and Linux installations complete through an agent-guided path; health, worker, persistence, MCP access, export, and restart recovery are read back; no cloud service is required. |
-| **A1** | **Read-only public demo** | Let a potential user experience retrieval, decision history, provenance, and the research map against fixed sample data before installing RKA. | The demo accepts no uploads or user records, exposes no durable write path, warns against entering private information, and resets reproducibly to the published sample state. |
-| **A2** | **Bring-your-own Hugging Face Space template** | Offer an optional data-free deployment recipe for users who choose to run an independent RKA instance in their own Hugging Face account. | A user-owned private duplicate starts from a pinned Core release; the user controls storage, credentials, cost, upgrades, backup, and deletion; persistence and Codex/Claude Code access are verified; the documentation states that third-party cloud hosting is not equivalent to local privacy. |
-| **A3** | **Residual-friction review** | Decide whether a separate desktop application is justified after observing the remaining local-install and runtime-management burden. | Evidence from A0-A2 identifies a material problem that a native app would solve; any `rka-app` mission receives a separate PI decision, repository scope, privacy review, and release gate before implementation. |
-
-The access track has the following non-negotiable boundaries:
-
-- Local deployment is the recommended path for sensitive, unpublished,
-  regulated, contract-restricted, or otherwise private research material.
-- RKA Project may distribute code, documentation, a fixed read-only demo, and
-  a deployment template. It does not operate personal RKA instances, a shared
-  multi-tenant database, centralized backups, or a user-data control plane.
-- The public demo contains only published sample data and cannot become a
-  place for visitors to store their own records.
-- A duplicated Space belongs to the user. Its account, data, storage,
-  credentials, availability, billing, backup, deletion, and cloud-provider
-  privacy trade-offs remain under that user's control and responsibility.
-- Every optional cloud path must preserve Knowledge Pack export so the user
-  can move to local RKA without depending on Hugging Face or RKA Project.
-- No telemetry or administrator access to user-owned instances is required
-  for normal operation.
-
-## Previous Workbench program status
-
-The following section preserves the completed and audited Workbench program
-history. Its behavioral designs remain inputs to `rka-writer`; they do not
-override the current Core-first E0-E6 sequence.
-
-**M0 through M4 are complete on `main`. M5 / PR 9 (issue #60), the progressive
-outline and manuscript-unit editor, merged in PR
-[#80](https://github.com/infinitywings/rka/pull/80); its independent audit and
-resolution record merged in PR [#81](https://github.com/infinitywings/rka/pull/81).
-PR 9.1 integrity hardening merged in PR
-[#82](https://github.com/infinitywings/rka/pull/82). PR 9.2, the typed
-academic-writing semantic core ([issue #83](https://github.com/infinitywings/rka/issues/83)),
-merged after independent audit in PR
-[#84](https://github.com/infinitywings/rka/pull/84). **PR 10, conflict-safe
-Markdown/LaTeX source synchronization
-([issue #61](https://github.com/infinitywings/rka/issues/61)), now has an
-implementation candidate and passed its automated and browser exit gates; its
-exact commit remains subject to the required independent audit before merge.**
-PR [#78](https://github.com/infinitywings/rka/pull/78) merged
-the seed-through-contribution dependency; ADR 0008 freezes the evaluation
-contract, and the exact release evidence is recorded in
-[`2026-08-15-workbench-m4-pr8-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m4-pr8-exit-evidence.md).
-PR [#79](https://github.com/infinitywings/rka/pull/79) merged the evaluation
-contract and result trace. ADR 0009 now freezes the PR 9 editing contract; its
-implementation plan is
-[`2026-08-15-m5-pr9-progressive-outline.md`](docs/superpowers/plans/2026-08-15-m5-pr9-progressive-outline.md).
-Its migration, REST/MCP, proposal, workbench, restart, and knowledge-pack gates
-and the correction status of the original acceptance run are recorded in
-[`2026-08-15-workbench-m5-pr9-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m5-pr9-exit-evidence.md).
-The merged foundation is recorded in PR
-[#80](https://github.com/infinitywings/rka/pull/80), and the PR 9.1 hardening
-contract is
-[`2026-08-17-m5-pr9-1-integrity-hardening.md`](docs/superpowers/plans/2026-08-17-m5-pr9-1-integrity-hardening.md).
-Its migration, pack, semantic-cursor, no-op-write, frontend-build, and
-real-project-derived validation record is
-[`2026-08-17-workbench-m5-pr9-1-exit-evidence.md`](docs/superpowers/specs/2026-08-17-workbench-m5-pr9-1-exit-evidence.md).
-PR 9.2 is based on the merged PR 9.1 foundation and is specified in
-[`2026-08-17-m5-pr9-2-typed-academic-writing-core.md`](docs/superpowers/plans/2026-08-17-m5-pr9-2-typed-academic-writing-core.md).
-Its migration, typed-binding, MCP, workbench, baseline-comparison, and
-real-project-derived pilot evidence is recorded in
-[`2026-08-17-m5-pr9-2-exit-evidence.md`](docs/superpowers/specs/2026-08-17-m5-pr9-2-exit-evidence.md).
-PR 10 is specified in
-[`2026-08-17-m5-pr10-source-sync.md`](docs/superpowers/plans/2026-08-17-m5-pr10-source-sync.md)
-and governed by ADR 0011. Its migration, source-security, recovery,
-authorization, workbench, responsive-browser, and restart evidence is recorded
-in
-[`2026-08-17-m5-pr10-exit-evidence.md`](docs/superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md).
-The choice-first Writer delta is reconciled, the authority and AI boundary is
-recorded in ADR 0001, the read-only workbench has passed its real-project exit
-gate, and first-class experiment/run/observation/evidence-locator semantics
-have passed their migration, REST/MCP, pack, deletion, change-impact, and
-release gates.
-
-The walkthrough and its design revisions are recorded in
-[`2026-08-14-delaysteer-workbench-walkthrough.md`](docs/superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md).
-The authority and stage contracts have researcher approval. PR 1 now includes
-the candidate schema and immutable audit history, exact source locators,
-duplicate/conflict hints, explicit promotion and revocation, deterministic
-review UI, REST/MCP/knowledge-pack parity, a full-suite release gate, an
-isolated Docker smoke test, and a disposable DelaySteer browser pilot. PR 2
-adds immutable canonical scope revisions, typed applicability conditions,
-explicit extension and falsifier policy, independent scope/evidence/source/
-contradiction axes, stale-content detection, fail-closed Writer eligibility,
-and complete REST/MCP/pack/graph/workbench projections. Its release gate passed
-the full Python suite, production web build, isolated container smoke test,
-revision-conflict check, and browser walkthrough of missing, incomplete, ready,
-and stale states.
-
-This PR 4 slice projects interpretation and scope readiness in the Context Capsule,
-stores workbench stage and review selection in shareable URLs, and provides
-direct evidence-to-scope/source/interpretation trace exits. Its release gate
-covers deep links, Back recovery, mismatched filter recovery, independent
-epistemic labels, and browser console health. The evidence is recorded in
-[`2026-08-14-workbench-scope-navigation-walkthrough.md`](docs/superpowers/specs/2026-08-14-workbench-scope-navigation-walkthrough.md).
-
-The real-project admission pass now covers DelaySteer, InvarLLM, CPSEval, and
-detectability through an online database backup. Project isolation passed, and
-the workbench correctly refused to invent scopes or spines: the first two
-projects have no native manuscript, while CPSEval and detectability have native
-manuscripts but empty spines; all four still contain only legacy claims with
-missing canonical scopes. The bounded positive path is now complete on a
-disposable CPSEval database copy: one legacy method claim received an exact
-reviewed scope and a one-claim native spine while remaining visibly unverified,
-unassessed, unratified, and checkpoint-blocked. The pilot also exposed and
-closed a narrow-viewport navigation defect. The evidence is recorded in
-[`2026-08-15-cpseval-m2-positive-path.md`](docs/superpowers/specs/2026-08-15-cpseval-m2-positive-path.md).
-No live semantic record changed. The final M2 pass adds explicit project-only,
-loading, unavailable, empty, and capped-count states; keyboard stage
-navigation; a skip link; live-region semantics; and a responsive 390 by 844
-check. The evidence is recorded in
-[`2026-08-15-workbench-m2-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m2-exit-evidence.md).
-The **M3 / PR 5 implementation** now satisfies its release gate. ADR 0005
-freezes the authority, branch, version, and provenance contract. This slice adds
-project-only and manuscript-bound planning, frozen copy-on-write ancestry,
-typed immutable stage versions, exact evidence/context bindings, deterministic
-resume and comparison, parking, pack/delete/change-cursor parity, and a
-provisional workbench branch surface. It does not promote planning into
-canonical manuscript semantics and does not yet add the PR 6 AI broker or
-unified proposal/apply path. Its validation record is
-[`2026-08-15-workbench-m3-pr5-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m3-pr5-exit-evidence.md).
-The **M3 / PR 6 implementation** has satisfied its feature-branch release gate.
-ADR 0006 freezes one immutable proposal envelope for human, host-agent, and
-local LM suggestions; explicit apply/reject/supersede; transactional stale-base
-conflicts; exact context manifests and provider-call events; and REST, MCP,
-workbench, knowledge-pack, deletion, and change-cursor parity. No proposal
-mutates its target before an explicit apply, and AI proposals fail closed when
-they exceed their disclosed target, evidence, or revision boundary. The
-validation record is
-[`2026-08-15-workbench-m3-pr6-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m3-pr6-exit-evidence.md).
-PR 6 merged in [#77](https://github.com/infinitywings/rka/pull/77). ADR 0007
-now freezes the PR 7 stage, candidate-identity, promotion-ledger,
-semantic-proposal, and exact PI-ratification contract. PR 7 now implements that
-contract and has passed fresh-database plus disposable Invarllm browser gates,
-including exact upstream invalidation, RQ promotion, contribution proposal and
-application, exact-text PI ratification, and restart/resume. The validation
-record is
-[`2026-08-15-workbench-m4-pr7-exit-evidence.md`](docs/superpowers/specs/2026-08-15-workbench-m4-pr7-exit-evidence.md).
-
-## Previous Workbench dependency map
+## Dependency map
 
 ```mermaid
 flowchart LR
-  M0["M0 Foundation and validation"] --> M1["M1 Epistemic research substrate"]
-  M0 --> M2["M2 Read-only workbench MVP"]
-  M1 --> M3["M3 Deliberation and safe editing"]
-  M2 --> M3
-  M3 --> M4["M4 Contribution and evaluation workflow"]
-  M4 --> M5["M5 Outline and drafting"]
-  M1 --> M6["M6 Intake, artifact views, and hardening"]
-  M5 --> M6
+    Core["Core 3.0<br/>stable local-first substrate"]
+
+    Core --> App["RKA App / access track"]
+    Core --> Writer["RKA Writer track"]
+
+    App --> F0["F0<br/>single-container runtime"]
+    F0 --> A0["A0<br/>agent-guided local setup"]
+    A0 --> A1["A1<br/>fixed-sample read-only demo"]
+    A1 --> A2["A2<br/>user-owned Space template"]
+    A2 --> A3["A3<br/>residual-friction review"]
+
+    Writer --> W0["W0<br/>Authoring IR and convergence protocol"]
+    W0 --> W1["W1<br/>one fully traceable paragraph"]
+    W1 --> W2["W2<br/>semantic zoom and convergence engine"]
+    W2 --> W3["W3<br/>document integration"]
+    W3 --> W4["W4<br/>quality and isolated review"]
+    W4 --> W5["W5<br/>human evaluation"]
+
+    A1 -. "synthetic Core fixtures only" .-> W1
 ```
 
-M1 and M2 may proceed in parallel after M0. M2 must label missing experiment
-semantics rather than pretending that M1 is already complete.
+RKA App and RKA Writer may progress in parallel after their shared Core
+contract is pinned. The public demo is initially a Core demonstration; Writer
+does not depend on Hugging Face and must not use the demo as storage for
+researcher material.
 
-## Previous Workbench milestones
+## Core release and maintenance track
 
-| Order | Milestone | Outcome | Planned work items | Exit gate |
-|---|---|---|---|---|
-| **M0** | **Foundation and validation** | Reconcile the existing Writer behavior and validate the proposed workbench before schema work. | PR 0A Writer delta reconciliation; PR 0B ADRs and read-only UX prototype; DelaySteer walkthrough. | A researcher can walk through the interface with a real RKA project, trace every displayed item to its source, and approve the authority and stage contracts. |
-| **M1** | **Epistemic research substrate** | Convert noisy journal material into reviewable candidates and bounded evidence without overstating conclusions. | PR 1 Interpretation Staging; PR 2 claim scope contracts; PR 3 experiments, runs, results, and evidence locators. | Candidate-to-claim promotion is explicit and reversible; claims carry scope and falsifier information; positive, negative, and inconclusive results remain traceable and project-isolated. |
-| **M2** | **Read-only manuscript workbench MVP** | Make the current argument and evidence navigable before enabling mutation. | PR 4 workbench shell and Context Capsule. | A researcher can inspect the sentence/paragraph spine, RQs, clusters, claims, sources, manuscript units, evidence, trace paths, and stale-impact warnings without changing canonical state. |
-| **M3** | **Deliberation and safe editing** | Support resumable human/AI collaboration with one auditable mutation path. | PR 5 versioned planning artifacts and branches; PR 6 unified human/AI patch proposals and local-model adapter. | Direct edits and AI proposals use the same semantic diff, validation, conflict, apply/reject, and provenance path; no ratified semantics are silently overwritten. |
-| **M4** | **Contribution and evaluation workflow** | Guide the researcher from framing through bounded contributions and testable evaluation commitments. | PR 7 seed-through-contribution workflow; PR 8 evaluation contract and results trace. | Problem, gap, insight, challenges, innovations, RQs, contributions, and evaluation commitments are linked; PI ratification is explicit; missing evidence becomes visible work. |
-| **M5** | **Outline and drafting** | Turn the ratified spine into an expandable, evidence-linked manuscript. | PR 9 progressive outline and unit editor; PR 9.1 integrity hardening; PR 9.2 typed semantic core; PR 10 narrow Markdown source synchronization. | The researcher can expand and condense hierarchical units, draft in Markdown/LaTeX, navigate provenance, and apply conflict-safe writes without automatic Git operations. |
-| **M6** | **Intake, artifact views, and hardening** | Complete source intake, deterministic ARA-inspired views, grounded foresight, and production-quality reliability. | PR 11 Source Inbox; PR 12A artifact profile and deterministic viewer; PR 12B grounded research foresight; PR 13 end-to-end reliability and usability. | Imported sources are safe and traceable; projections are deterministic rather than authoritative; foresight is advisory; real-project, security, accessibility, migration, and concurrency suites pass. |
+Core remains canonical for projects, journals, literature, decisions,
+missions, claims, evidence, experiments, provenance, freshness, retrieval,
+integrity, migration, backup, and export.
 
-## Previous Workbench tracking convention
+The current Core gate is:
 
-- One GitHub milestone corresponds to each roadmap milestone above.
-- One GitHub issue corresponds to each planned PR-sized work item.
-- The single issue labeled `priority: next` is the immediate implementation
-  target. Move that label only when its exit criteria are satisfied or the
-  dependency order is explicitly revised.
-- Use `roadmap` on every roadmap issue and `area: writer`, `area: substrate`,
-  `area: workbench`, or `area: artifact` to make the work scannable.
-- An issue is complete only when its acceptance criteria and required tests are
-  satisfied. A rendered UI, an LLM response, or green unit tests alone do not
-  establish workflow correctness.
+1. publish a verified Core 3.0 release from immutable, cross-platform
+   artifacts;
+2. preserve the stable public REST/MCP contract and capability discovery;
+3. retain the one-way legacy Writer export without switching Writer authority;
+4. keep Core usable without App or Writer; and
+5. treat new authoring behavior as Writer-owned work.
 
-## Previous Workbench cross-cutting constraints
+Core issues after release are prioritized by correctness, security, project
+isolation, recovery, retrieval quality, and compatibility. New Writer,
+Workbench, desktop, or autonomous-agent behavior does not enter Core.
 
-- RKA remains the semantic authority; workbench and ARA-style views are
-  projections over native RKA objects.
-- Evidence, interpretation, PI ratification, AI suggestion, and public prose
-  remain distinct.
-- No journal entry becomes a claim automatically. Promotion must preserve the
-  exact source locator and decision lineage.
-- Negative, inconclusive, conflicting, and superseded evidence remains visible
-  in the private reasoning substrate.
-- Human and AI edits follow the same versioned proposal and validation path.
-- External content is untrusted input: preview and hash it, never execute it or
-  obey embedded instructions.
-- Readiness is categorical (`Ready`, `Needs review`, `Blocked`, or
-  `Exploratory`), never a paper score or acceptance prediction.
+## Local-first access and trial track
 
-## Previous Workbench first useful release
+This track is owned by RKA App and consumes released Core artifacts.
 
-The first useful release spans M0–M5. It is reached when a researcher can start
-with an insight, develop and ratify a traceable paper spine, connect it to
-claims and evaluation evidence, produce a claim-sized outline, and expand a
-unit into evidence-bounded draft prose through a recoverable, conflict-safe
-workflow. M6 then completes intake, exchange/viewer capabilities, grounded
-foresight, and operational hardening.
+| Stage | Outcome | Exit gate |
+|---|---|---|
+| **F0 — Runtime substrate** | A minimal supervisor runs Core API and worker in one isolated container. | Process failure, shutdown, persistence across container replacement, and non-interference with a live installation are verified. |
+| **A0 — Agent-guided local setup** | Codex or Claude guides installation while data and embedding runtime stay on the researcher's machine. | Fresh macOS, Windows, and Linux installs pass health, persistence, MCP, export, and restart read-back. |
+| **A1 — Fixed-sample public demo** | A visitor explores retrieval, provenance, decisions, research map, and export against published synthetic data. | No upload, durable user record, secret, or private-data path exists; reset is deterministic. |
+| **A2 — User-owned Space template** | A user duplicates a data-free template into an account they administer. | Core version is pinned; ownership, persistence, secrets, cost, backup, export, deletion, and cloud privacy boundaries are documented and verified. |
+| **A3 — Residual-friction review** | Decide whether a native desktop application solves a measured remaining problem. | A separate PI decision names the evidence, scope, privacy boundary, and release gate. |
 
-The detailed design, data model, UI behavior, API/MCP surface, tests, and full
-acceptance criteria remain in the linked implementation plan and are normative
-for the corresponding roadmap issues.
+Local deployment remains the recommended path for sensitive, unpublished,
+regulated, or contract-restricted research. RKA Project does not operate a
+multi-tenant research-data service, personal instances, centralized backups,
+required telemetry, or an administrator data plane.
+
+## Writer track
+
+Writer progressively compiles reviewed research knowledge and explicit
+researcher decisions into a versioned authoring graph. Public prose is produced
+only as a bounded realization of approved sentence intents.
+
+| Stage | Outcome | Exit gate |
+|---|---|---|
+| **W0 — Authoring IR and Core boundary** | Freeze artifact hierarchy, exact dependency edges, lifecycle/readiness, permissions, semantic patches, source maps, and Core bindings. | RFC and focused ADRs are accepted; schemas and sanitized fixtures represent every invariant. |
+| **W1 — One fully traceable paragraph** | Move from one approved paper question through claim, evidence use, narrative move, paragraph contract, sentence intents, term locks, and accepted sentence realizations. | One grounded paragraph is reconstructable; an upstream change marks only affected artifacts stale and never silently rewrites prose. |
+| **W2 — Semantic zoom and convergence** | Add decision queue, branch comparison, locking, impact propagation, session recovery, and oscillation detection. | The researcher can converge from paper to sentence scale without losing accepted decisions. |
+| **W3 — Document integration** | Add Markdown/LaTeX source maps, stable anchors, Git synchronization, PDF compilation, and conflict-safe reconciliation. | Direct edits and upstream changes cannot silently overwrite accepted text. |
+| **W4 — Quality and isolated review** | Add evidence, terminology, claim-scope, numerical, coherence, and reader-facing audits plus explicit reviewer import. | Review stays advisory and isolated from drafting context. |
+| **W5 — Human evaluation** | Compare a conventional LLM prompt, the frozen Writer 0.2 skill, and the workbench. | The workbench improves fidelity, convergence, researcher control, and reader quality without hidden semantic changes. |
+
+Hard requirements across all Writer milestones are: zero silent claim changes,
+zero silent term changes, zero silent evidence reinterpretations, and zero
+silent upstream-triggered rewrites.
+
+## Governance and tracking
+
+- This file records durable sequencing and exit gates.
+- Repository issues and pull requests track work in flight.
+- RFCs hold proposals under discussion; ADRs hold accepted decisions and link
+  to any decision they supersede.
+- Each repository maintains its own detailed roadmap and validation evidence.
+- Cross-repository compatibility is declared and tested; releases are not
+  lockstep.
+
+The current execution plan is
+[`docs/superpowers/plans/2026-09-03-rka-ecosystem-active-roadmap.md`](docs/superpowers/plans/2026-09-03-rka-ecosystem-active-roadmap.md).

--- a/docs/history/rka-roadmap-pre-rebaseline-2026-09-03.md
+++ b/docs/history/rka-roadmap-pre-rebaseline-2026-09-03.md
@@ -1,0 +1,319 @@
+# RKA Roadmap
+
+This roadmap prioritizes a reliable, independently usable RKA research-
+knowledge core. Writer/Workbench is the only active downstream product and is
+released separately as `rka-project/rka-writer`. Agentic orchestration is
+shelved: its existing history is preserved, but no `rka-agentic` repository or
+runtime extraction is planned unless the PI explicitly reactivates it.
+
+The original repository and authority decision is recorded in
+[ADR 0012](../adr/0012-rka-ecosystem-repository-boundaries.md), with the
+Agentic portion superseded by
+[ADR 0013](../adr/0013-shelve-agentic-and-focus-core-writer.md). The active
+execution source is the
+[RKA Ecosystem Repository Separation Plan](../superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md).
+The proposed repository-local milestones, cross-repository Project fields,
+issue slate, and disposition of the previous M6 backlog are recorded in the
+[RKA Ecosystem GitHub Slate](../superpowers/plans/2026-08-25-rka-ecosystem-github-slate.md).
+
+The earlier detailed [epistemic pipeline and manuscript workbench
+plan](../superpowers/plans/2026-08-14-rka-epistemic-pipeline-and-manuscript-workbench.md)
+remains the design and implementation history for the future `rka-writer`
+repository. It is no longer the immediate Core implementation priority.
+
+The M0 authority, stage, proposal, and provider decisions are recorded in
+[ADR 0001](../adr/0001-manuscript-workbench-authority-stage-and-ai-boundary.md).
+The M1 interpretation boundary is recorded in
+[ADR 0002](../adr/0002-interpretation-staging-and-experiment-boundary.md).
+The canonical-claim applicability boundary is recorded in
+[ADR 0003](../adr/0003-canonical-claim-scope-contracts.md).
+The experiment/run/observation and exact-locator boundary is recorded in
+[ADR 0004](../adr/0004-experiment-run-observation-and-evidence-locator-contracts.md).
+The provisional planning and frozen-branch boundary is recorded in
+[ADR 0005](../adr/0005-versioned-manuscript-planning-branches.md).
+The unified human/AI proposal, conflict, and provider boundary is recorded in
+[ADR 0006](../adr/0006-unified-semantic-patch-proposals.md).
+The seed-to-contribution guidance, candidate identity, promotion, and exact PI
+ratification boundary is recorded in
+[ADR 0007](../adr/0007-seed-to-contribution-guidance-and-promotion.md).
+The claim-centered evaluation, adverse-outcome, mission, and result-unit
+boundary is recorded in
+[ADR 0008](../adr/0008-claim-centered-evaluation-contract-and-results-trace.md).
+The progressive-outline hierarchy, writing-rationale, binding-preservation,
+and proposal-first editing boundary is recorded in
+[ADR 0009](../adr/0009-progressive-outline-and-unit-editor.md).
+The typed academic-role, evidence-warrant, citation-use, claim-boundary, and
+proportionate-readiness boundary is recorded in
+[ADR 0010](../adr/0010-typed-academic-writing-semantics.md).
+The conflict-safe Markdown/LaTeX source, stable-anchor, recovery, and
+public/private drafting boundary is recorded in
+[ADR 0011](../adr/0011-conflict-safe-manuscript-source-synchronization.md).
+The ecosystem repository, authority, integration, migration, packaging, and
+release boundaries are recorded in
+[ADR 0012](../adr/0012-rka-ecosystem-repository-boundaries.md).
+
+The roadmap is ordered by dependency, not by invented delivery dates. Every
+milestone must satisfy its exit gate before dependent work is treated as ready.
+
+Portable installation and managed model lifecycle still belong to the separate
+future `rka-app`, not to a Core branch. Core's provider and vector-space side of
+that boundary is recorded in
+[ADR 0017](../adr/0017-portable-embedding-runtime-boundary.md). The Qwen
+standard-profile candidate remains gated by retrieval quality and real 16 GB
+Mac/Windows measurements; it is not yet a Core or App release default.
+
+The immediate adoption priority is not native desktop packaging or an
+RKA-operated cloud service. It is to lower the cost of evaluating and
+independently running RKA without weakening its local-first, researcher-
+controlled model. Local deployment remains the canonical path. The bounded
+alternatives are an official read-only sample-data demo and a data-free
+Hugging Face Space template that users may duplicate into infrastructure they
+own and administer. The access-and-trial sequence below consumes released Core
+artifacts but does not extend the E0-E6 Core milestone hierarchy.
+
+One bounded Core follow-up remains separate from the portable-runtime work:
+make explicit/manual embedding repair compare canonical content hashes and
+vector presence, rather than repairing only missing current-model metadata.
+Until then, failed edit embeddings remain owned by the durable worker retry
+path; the backfill endpoint must not be described as a general stale-index
+scrubber.
+
+## Current strategic priority
+
+RKA Core reliability comes first. No new Writer/Workbench or autonomous
+orchestration capability should be added to Core while the boundaries and
+public contracts are being stabilized. Agentic work is outside the active
+roadmap.
+
+| Order | Ecosystem milestone | Outcome | Exit gate summary |
+|---|---|---|---|
+| **E0** | **Boundary freeze and inventory** | Fix authority, repository, API, plugin, and migration ownership before moving code. | Every table, route, MCP operation, skill, and major directory has one owner or explicit legacy disposition. |
+| **E1** | **Core reliability baseline** | Harden journal, provenance, project isolation, retrieval, claim edges, migrations, export/import, and recovery. | Core-only install/tests pass; no cross-project leakage; real backup upgrade and integrity pass. |
+| **E2** | **Stable external contract** | Freeze supported REST/MCP behavior and provide capability/version discovery plus legacy Writer export. | Public-contract-only clients complete core workflows and legacy Writer export round-trips. |
+| **E3** | **Agentic work shelved** | Preserve the historical branch and design record without creating or operating a separate Agentic product. | Active docs and packaging do not direct users to install Agentic; reactivation requires a new PI decision. |
+| **E4** | **Writer repository extraction** | Establish `rka-project/rka-writer`, migrate Writer state, and move Workbench ownership. | Writer runs independently, imports legacy state, and detects stale Core references. |
+| **E5** | **Future Core slimming** | Remove active Writer execution code only in a future explicitly approved breaking release, while preserving compatibility export and migration history. | Core and Writer compatibility suites pass without destructive database changes. |
+| **E6** | **Ecosystem integration** | Maintain Core and Writer releases under one GitHub Project and compatibility matrix. | Core-only and Core+Writer deployments have reproducible smoke tests. |
+
+The detailed deliverables, rollback paths, and decision checkpoints for E0-E6
+are in the active execution plan linked above.
+
+## Local-first access and trial track
+
+This cross-cutting track runs alongside Core reliability and contract work. It
+must not turn RKA Project into the custodian of users' research data or make a
+third-party cloud account a dependency of the local distribution.
+
+| Order | Access milestone | Outcome | Exit gate summary |
+|---|---|---|---|
+| **A0** | **Agent-guided local setup** | Reduce the installation burden for researchers who already use Codex or Claude Code while keeping RKA, its database, and its embedding runtime on their own machine. | Fresh macOS, Windows, and Linux installations complete through an agent-guided path; health, worker, persistence, MCP access, export, and restart recovery are read back; no cloud service is required. |
+| **A1** | **Read-only public demo** | Let a potential user experience retrieval, decision history, provenance, and the research map against fixed sample data before installing RKA. | The demo accepts no uploads or user records, exposes no durable write path, warns against entering private information, and resets reproducibly to the published sample state. |
+| **A2** | **Bring-your-own Hugging Face Space template** | Offer an optional data-free deployment recipe for users who choose to run an independent RKA instance in their own Hugging Face account. | A user-owned private duplicate starts from a pinned Core release; the user controls storage, credentials, cost, upgrades, backup, and deletion; persistence and Codex/Claude Code access are verified; the documentation states that third-party cloud hosting is not equivalent to local privacy. |
+| **A3** | **Residual-friction review** | Decide whether a separate desktop application is justified after observing the remaining local-install and runtime-management burden. | Evidence from A0-A2 identifies a material problem that a native app would solve; any `rka-app` mission receives a separate PI decision, repository scope, privacy review, and release gate before implementation. |
+
+The access track has the following non-negotiable boundaries:
+
+- Local deployment is the recommended path for sensitive, unpublished,
+  regulated, contract-restricted, or otherwise private research material.
+- RKA Project may distribute code, documentation, a fixed read-only demo, and
+  a deployment template. It does not operate personal RKA instances, a shared
+  multi-tenant database, centralized backups, or a user-data control plane.
+- The public demo contains only published sample data and cannot become a
+  place for visitors to store their own records.
+- A duplicated Space belongs to the user. Its account, data, storage,
+  credentials, availability, billing, backup, deletion, and cloud-provider
+  privacy trade-offs remain under that user's control and responsibility.
+- Every optional cloud path must preserve Knowledge Pack export so the user
+  can move to local RKA without depending on Hugging Face or RKA Project.
+- No telemetry or administrator access to user-owned instances is required
+  for normal operation.
+
+## Previous Workbench program status
+
+The following section preserves the completed and audited Workbench program
+history. Its behavioral designs remain inputs to `rka-writer`; they do not
+override the current Core-first E0-E6 sequence.
+
+**M0 through M4 are complete on `main`. M5 / PR 9 (issue #60), the progressive
+outline and manuscript-unit editor, merged in PR
+[#80](https://github.com/infinitywings/rka/pull/80); its independent audit and
+resolution record merged in PR [#81](https://github.com/infinitywings/rka/pull/81).
+PR 9.1 integrity hardening merged in PR
+[#82](https://github.com/infinitywings/rka/pull/82). PR 9.2, the typed
+academic-writing semantic core ([issue #83](https://github.com/infinitywings/rka/issues/83)),
+merged after independent audit in PR
+[#84](https://github.com/infinitywings/rka/pull/84). **PR 10, conflict-safe
+Markdown/LaTeX source synchronization
+([issue #61](https://github.com/infinitywings/rka/issues/61)), now has an
+implementation candidate and passed its automated and browser exit gates; its
+exact commit remains subject to the required independent audit before merge.**
+PR [#78](https://github.com/infinitywings/rka/pull/78) merged
+the seed-through-contribution dependency; ADR 0008 freezes the evaluation
+contract, and the exact release evidence is recorded in
+[`2026-08-15-workbench-m4-pr8-exit-evidence.md`](../superpowers/specs/2026-08-15-workbench-m4-pr8-exit-evidence.md).
+PR [#79](https://github.com/infinitywings/rka/pull/79) merged the evaluation
+contract and result trace. ADR 0009 now freezes the PR 9 editing contract; its
+implementation plan is
+[`2026-08-15-m5-pr9-progressive-outline.md`](../superpowers/plans/2026-08-15-m5-pr9-progressive-outline.md).
+Its migration, REST/MCP, proposal, workbench, restart, and knowledge-pack gates
+and the correction status of the original acceptance run are recorded in
+[`2026-08-15-workbench-m5-pr9-exit-evidence.md`](../superpowers/specs/2026-08-15-workbench-m5-pr9-exit-evidence.md).
+The merged foundation is recorded in PR
+[#80](https://github.com/infinitywings/rka/pull/80), and the PR 9.1 hardening
+contract is
+[`2026-08-17-m5-pr9-1-integrity-hardening.md`](../superpowers/plans/2026-08-17-m5-pr9-1-integrity-hardening.md).
+Its migration, pack, semantic-cursor, no-op-write, frontend-build, and
+real-project-derived validation record is
+[`2026-08-17-workbench-m5-pr9-1-exit-evidence.md`](../superpowers/specs/2026-08-17-workbench-m5-pr9-1-exit-evidence.md).
+PR 9.2 is based on the merged PR 9.1 foundation and is specified in
+[`2026-08-17-m5-pr9-2-typed-academic-writing-core.md`](../superpowers/plans/2026-08-17-m5-pr9-2-typed-academic-writing-core.md).
+Its migration, typed-binding, MCP, workbench, baseline-comparison, and
+real-project-derived pilot evidence is recorded in
+[`2026-08-17-m5-pr9-2-exit-evidence.md`](../superpowers/specs/2026-08-17-m5-pr9-2-exit-evidence.md).
+PR 10 is specified in
+[`2026-08-17-m5-pr10-source-sync.md`](../superpowers/plans/2026-08-17-m5-pr10-source-sync.md)
+and governed by ADR 0011. Its migration, source-security, recovery,
+authorization, workbench, responsive-browser, and restart evidence is recorded
+in
+[`2026-08-17-m5-pr10-exit-evidence.md`](../superpowers/specs/2026-08-17-m5-pr10-exit-evidence.md).
+The choice-first Writer delta is reconciled, the authority and AI boundary is
+recorded in ADR 0001, the read-only workbench has passed its real-project exit
+gate, and first-class experiment/run/observation/evidence-locator semantics
+have passed their migration, REST/MCP, pack, deletion, change-impact, and
+release gates.
+
+The walkthrough and its design revisions are recorded in
+[`2026-08-14-delaysteer-workbench-walkthrough.md`](../superpowers/specs/2026-08-14-delaysteer-workbench-walkthrough.md).
+The authority and stage contracts have researcher approval. PR 1 now includes
+the candidate schema and immutable audit history, exact source locators,
+duplicate/conflict hints, explicit promotion and revocation, deterministic
+review UI, REST/MCP/knowledge-pack parity, a full-suite release gate, an
+isolated Docker smoke test, and a disposable DelaySteer browser pilot. PR 2
+adds immutable canonical scope revisions, typed applicability conditions,
+explicit extension and falsifier policy, independent scope/evidence/source/
+contradiction axes, stale-content detection, fail-closed Writer eligibility,
+and complete REST/MCP/pack/graph/workbench projections. Its release gate passed
+the full Python suite, production web build, isolated container smoke test,
+revision-conflict check, and browser walkthrough of missing, incomplete, ready,
+and stale states.
+
+This PR 4 slice projects interpretation and scope readiness in the Context Capsule,
+stores workbench stage and review selection in shareable URLs, and provides
+direct evidence-to-scope/source/interpretation trace exits. Its release gate
+covers deep links, Back recovery, mismatched filter recovery, independent
+epistemic labels, and browser console health. The evidence is recorded in
+[`2026-08-14-workbench-scope-navigation-walkthrough.md`](../superpowers/specs/2026-08-14-workbench-scope-navigation-walkthrough.md).
+
+The real-project admission pass now covers DelaySteer, InvarLLM, CPSEval, and
+detectability through an online database backup. Project isolation passed, and
+the workbench correctly refused to invent scopes or spines: the first two
+projects have no native manuscript, while CPSEval and detectability have native
+manuscripts but empty spines; all four still contain only legacy claims with
+missing canonical scopes. The bounded positive path is now complete on a
+disposable CPSEval database copy: one legacy method claim received an exact
+reviewed scope and a one-claim native spine while remaining visibly unverified,
+unassessed, unratified, and checkpoint-blocked. The pilot also exposed and
+closed a narrow-viewport navigation defect. The evidence is recorded in
+[`2026-08-15-cpseval-m2-positive-path.md`](../superpowers/specs/2026-08-15-cpseval-m2-positive-path.md).
+No live semantic record changed. The final M2 pass adds explicit project-only,
+loading, unavailable, empty, and capped-count states; keyboard stage
+navigation; a skip link; live-region semantics; and a responsive 390 by 844
+check. The evidence is recorded in
+[`2026-08-15-workbench-m2-exit-evidence.md`](../superpowers/specs/2026-08-15-workbench-m2-exit-evidence.md).
+The **M3 / PR 5 implementation** now satisfies its release gate. ADR 0005
+freezes the authority, branch, version, and provenance contract. This slice adds
+project-only and manuscript-bound planning, frozen copy-on-write ancestry,
+typed immutable stage versions, exact evidence/context bindings, deterministic
+resume and comparison, parking, pack/delete/change-cursor parity, and a
+provisional workbench branch surface. It does not promote planning into
+canonical manuscript semantics and does not yet add the PR 6 AI broker or
+unified proposal/apply path. Its validation record is
+[`2026-08-15-workbench-m3-pr5-exit-evidence.md`](../superpowers/specs/2026-08-15-workbench-m3-pr5-exit-evidence.md).
+The **M3 / PR 6 implementation** has satisfied its feature-branch release gate.
+ADR 0006 freezes one immutable proposal envelope for human, host-agent, and
+local LM suggestions; explicit apply/reject/supersede; transactional stale-base
+conflicts; exact context manifests and provider-call events; and REST, MCP,
+workbench, knowledge-pack, deletion, and change-cursor parity. No proposal
+mutates its target before an explicit apply, and AI proposals fail closed when
+they exceed their disclosed target, evidence, or revision boundary. The
+validation record is
+[`2026-08-15-workbench-m3-pr6-exit-evidence.md`](../superpowers/specs/2026-08-15-workbench-m3-pr6-exit-evidence.md).
+PR 6 merged in [#77](https://github.com/infinitywings/rka/pull/77). ADR 0007
+now freezes the PR 7 stage, candidate-identity, promotion-ledger,
+semantic-proposal, and exact PI-ratification contract. PR 7 now implements that
+contract and has passed fresh-database plus disposable Invarllm browser gates,
+including exact upstream invalidation, RQ promotion, contribution proposal and
+application, exact-text PI ratification, and restart/resume. The validation
+record is
+[`2026-08-15-workbench-m4-pr7-exit-evidence.md`](../superpowers/specs/2026-08-15-workbench-m4-pr7-exit-evidence.md).
+
+## Previous Workbench dependency map
+
+```mermaid
+flowchart LR
+  M0["M0 Foundation and validation"] --> M1["M1 Epistemic research substrate"]
+  M0 --> M2["M2 Read-only workbench MVP"]
+  M1 --> M3["M3 Deliberation and safe editing"]
+  M2 --> M3
+  M3 --> M4["M4 Contribution and evaluation workflow"]
+  M4 --> M5["M5 Outline and drafting"]
+  M1 --> M6["M6 Intake, artifact views, and hardening"]
+  M5 --> M6
+```
+
+M1 and M2 may proceed in parallel after M0. M2 must label missing experiment
+semantics rather than pretending that M1 is already complete.
+
+## Previous Workbench milestones
+
+| Order | Milestone | Outcome | Planned work items | Exit gate |
+|---|---|---|---|---|
+| **M0** | **Foundation and validation** | Reconcile the existing Writer behavior and validate the proposed workbench before schema work. | PR 0A Writer delta reconciliation; PR 0B ADRs and read-only UX prototype; DelaySteer walkthrough. | A researcher can walk through the interface with a real RKA project, trace every displayed item to its source, and approve the authority and stage contracts. |
+| **M1** | **Epistemic research substrate** | Convert noisy journal material into reviewable candidates and bounded evidence without overstating conclusions. | PR 1 Interpretation Staging; PR 2 claim scope contracts; PR 3 experiments, runs, results, and evidence locators. | Candidate-to-claim promotion is explicit and reversible; claims carry scope and falsifier information; positive, negative, and inconclusive results remain traceable and project-isolated. |
+| **M2** | **Read-only manuscript workbench MVP** | Make the current argument and evidence navigable before enabling mutation. | PR 4 workbench shell and Context Capsule. | A researcher can inspect the sentence/paragraph spine, RQs, clusters, claims, sources, manuscript units, evidence, trace paths, and stale-impact warnings without changing canonical state. |
+| **M3** | **Deliberation and safe editing** | Support resumable human/AI collaboration with one auditable mutation path. | PR 5 versioned planning artifacts and branches; PR 6 unified human/AI patch proposals and local-model adapter. | Direct edits and AI proposals use the same semantic diff, validation, conflict, apply/reject, and provenance path; no ratified semantics are silently overwritten. |
+| **M4** | **Contribution and evaluation workflow** | Guide the researcher from framing through bounded contributions and testable evaluation commitments. | PR 7 seed-through-contribution workflow; PR 8 evaluation contract and results trace. | Problem, gap, insight, challenges, innovations, RQs, contributions, and evaluation commitments are linked; PI ratification is explicit; missing evidence becomes visible work. |
+| **M5** | **Outline and drafting** | Turn the ratified spine into an expandable, evidence-linked manuscript. | PR 9 progressive outline and unit editor; PR 9.1 integrity hardening; PR 9.2 typed semantic core; PR 10 narrow Markdown source synchronization. | The researcher can expand and condense hierarchical units, draft in Markdown/LaTeX, navigate provenance, and apply conflict-safe writes without automatic Git operations. |
+| **M6** | **Intake, artifact views, and hardening** | Complete source intake, deterministic ARA-inspired views, grounded foresight, and production-quality reliability. | PR 11 Source Inbox; PR 12A artifact profile and deterministic viewer; PR 12B grounded research foresight; PR 13 end-to-end reliability and usability. | Imported sources are safe and traceable; projections are deterministic rather than authoritative; foresight is advisory; real-project, security, accessibility, migration, and concurrency suites pass. |
+
+## Previous Workbench tracking convention
+
+- One GitHub milestone corresponds to each roadmap milestone above.
+- One GitHub issue corresponds to each planned PR-sized work item.
+- The single issue labeled `priority: next` is the immediate implementation
+  target. Move that label only when its exit criteria are satisfied or the
+  dependency order is explicitly revised.
+- Use `roadmap` on every roadmap issue and `area: writer`, `area: substrate`,
+  `area: workbench`, or `area: artifact` to make the work scannable.
+- An issue is complete only when its acceptance criteria and required tests are
+  satisfied. A rendered UI, an LLM response, or green unit tests alone do not
+  establish workflow correctness.
+
+## Previous Workbench cross-cutting constraints
+
+- RKA remains the semantic authority; workbench and ARA-style views are
+  projections over native RKA objects.
+- Evidence, interpretation, PI ratification, AI suggestion, and public prose
+  remain distinct.
+- No journal entry becomes a claim automatically. Promotion must preserve the
+  exact source locator and decision lineage.
+- Negative, inconclusive, conflicting, and superseded evidence remains visible
+  in the private reasoning substrate.
+- Human and AI edits follow the same versioned proposal and validation path.
+- External content is untrusted input: preview and hash it, never execute it or
+  obey embedded instructions.
+- Readiness is categorical (`Ready`, `Needs review`, `Blocked`, or
+  `Exploratory`), never a paper score or acceptance prediction.
+
+## Previous Workbench first useful release
+
+The first useful release spans M0–M5. It is reached when a researcher can start
+with an insight, develop and ratify a traceable paper spine, connect it to
+claims and evaluation evidence, produce a claim-sized outline, and expand a
+unit into evidence-bounded draft prose through a recoverable, conflict-safe
+workflow. M6 then completes intake, exchange/viewer capabilities, grounded
+foresight, and operational hardening.
+
+The detailed design, data model, UI behavior, API/MCP surface, tests, and full
+acceptance criteria remain in the linked implementation plan and are normative
+for the corresponding roadmap issues.

--- a/docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md
+++ b/docs/superpowers/plans/2026-08-25-rka-ecosystem-repository-separation.md
@@ -1,8 +1,14 @@
 # RKA Ecosystem Repository Separation Execution Plan
 
-- Status: accepted execution source under ADR 0012; E0 documentation in progress
+- Status: superseded as an active execution source on 2026-09-03; retained as
+  separation history
 - Date: 2026-08-25
 - Decision owner: Chenglong Fu
+- Superseded by:
+  [`2026-09-03-rka-ecosystem-active-roadmap.md`](2026-09-03-rka-ecosystem-active-roadmap.md)
+- Reason: E0-E2 and the initial repository split are complete, Agentic
+  extraction was shelved by ADR 0013, RKA App now exists, and Writer has been
+  re-baselined around the Authoring IR and convergence protocol.
 - Current repository: `infinitywings/rka`
 - Clean planning baseline: `origin/main` at `57fa8f0`
 - Related integrity candidate: `fix/claim-edge-integrity` at `eb9faa3`
@@ -14,6 +20,9 @@
   [`2026-08-25-rka-core-only-baseline.md`](../specs/2026-08-25-rka-core-only-baseline.md)
 - Claim-edge audit and remediation evidence:
   [`2026-08-25-claim-edge-integrity-audit.md`](../specs/2026-08-25-claim-edge-integrity-audit.md)
+
+> This document describes the original separation program. Its Agentic and
+> pre-rebaseline Writer steps are historical, not current authorization.
 
 ## 1. Objective
 

--- a/docs/superpowers/plans/2026-09-03-rka-ecosystem-active-roadmap.md
+++ b/docs/superpowers/plans/2026-09-03-rka-ecosystem-active-roadmap.md
@@ -1,0 +1,107 @@
+# RKA Ecosystem Active Roadmap Plan
+
+- Status: active
+- Date: 2026-09-03
+- Decision owner: Chenglong Fu
+- Governing RKA decision: `dec_01M1MZZXK74SNS0ZNMHE47QJPB`
+- Replaces as execution source:
+  `2026-08-25-rka-ecosystem-repository-separation.md`
+
+## Objective
+
+Align current execution with the completed Core separation, the local-first
+access decision, and the RKA Writer re-baseline without losing validated
+history or compatibility assets.
+
+## Product boundaries
+
+### RKA Core
+
+Owns durable research knowledge and its public contracts. Core completes its
+3.0 release and then continues correctness, retrieval, provenance, integrity,
+recovery, and compatibility maintenance.
+
+### RKA App
+
+Owns Foundation 0, agent-guided installation, lifecycle supervision, and
+optional deployment adapters. The Hugging Face path is a fixed-sample public
+Core demo followed by a data-free, user-owned template. It is not a hosted RKA
+service operated by RKA Project.
+
+### RKA Writer
+
+Owns authoring state, convergence, bounded realization, manuscript source
+mapping, and researcher-facing authoring interaction. It consumes Core only
+through public project-scoped interfaces. The existing repository is
+re-baselined rather than replaced.
+
+### Reviewers
+
+Academic reviewers remain explicit, isolated, and advisory. Their distribution
+is separated from the active Writer product so reviewer policy and release
+weight do not define the authoring runtime.
+
+### Agentic
+
+Shelved. Historical code and decisions remain discoverable. Reactivation
+requires a new PI decision.
+
+## Ordered work
+
+1. **Core 3.0 release gate**
+   - release immutable Core artifacts;
+   - verify public-contract, upgrade, recovery, and legacy-export gates;
+   - record the supported compatibility range.
+2. **RKA App Foundation 0**
+   - merge the isolated supervisor/runtime candidate;
+   - pin the released Core image by digest;
+   - create repository-local A0-A3 tracking.
+3. **Writer repository re-baseline**
+   - freeze the current 0.2 Writer skill as the legacy evaluation baseline;
+   - retain legacy Core import as compatibility infrastructure;
+   - separate Reviewer distribution;
+   - replace the plugin-first repository surface with RFC, ADR, architecture,
+     evaluation, and roadmap documents.
+4. **Writer W0**
+   - accept the Authoring IR RFC;
+   - accept focused ADRs for authority/storage, dependencies/staleness,
+     researcher admission, and Core integration;
+   - add schemas and sanitized fixtures only after those decisions stabilize.
+5. **Writer W1**
+   - implement one central-question-to-paragraph path;
+   - prove exact upstream invalidation and no silent rewrite;
+   - compare against the pinned Writer 0.2 baseline before broadening scope.
+6. **Access A0-A2**
+   - validate agent-guided local installation;
+   - publish the fixed-sample Core demo;
+   - validate duplication into a user-owned instance with explicit persistence
+     and privacy trade-offs.
+7. **Integration E6**
+   - publish a Core/App/Writer compatibility matrix;
+   - add reproducible Core-only, Core+App, and Core+Writer smoke tests;
+   - keep release cadences independent.
+
+App and Writer work may proceed in parallel once the required Core artifact
+and contract versions are pinned. Hugging Face is not a prerequisite for
+Writer W0 or W1.
+
+## Validation gates
+
+- No active documentation presents Agentic extraction as planned work.
+- No active documentation calls RKA App a future repository.
+- The public demo accepts no private research or durable visitor records.
+- Writer implementation does not begin before W0 decisions and fixtures are
+  reviewable.
+- Accepted Writer artifacts never change without an explicit semantic patch or
+  researcher decision.
+- Legacy import and historical design remain recoverable throughout the
+  compatibility window.
+- No repository or remote tracking change is treated as published until its
+  branch, pull request, checks, and resulting default branch are read back.
+
+## Rollback and history
+
+The previous separation plan remains preserved as a superseded historical
+record. Core databases and legacy Writer tables are not dropped. The Writer
+0.2 tag remains a reproducible baseline, and the new Writer design proceeds
+through ordinary commits rather than a history rewrite.


### PR DESCRIPTION
Summary:
- replace the pre-rebaseline roadmap with an active Core, App, and Writer dependency map
- preserve the previous roadmap as history and supersede the old separation plan as an execution source
- define Writer W0-W5 gates around researcher-controlled semantic convergence

Validation:
- rebased onto current origin/main
- changed Markdown links resolve
- git diff --check passes

Governing local RKA decision: dec_01M1MZZXK74SNS0ZNMHE47QJPB